### PR TITLE
🧹 Refactor dialog control creation to reduce duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,12 @@ To improve UI responsiveness and AI navigation in complex documents, we ported p
   - Watchdog: `update_activity_state(phase, ...)`, `start_watchdog_thread(ctx, status_control)` for hang detection (logs and status "Hung: ..." if no activity for threshold).
 - **`SendButtonListener._send_busy`** (`panel_factory.py`): Boolean; True from run start until the `finally` block of `actionPerformed` (single source of truth for "is the AI running?"). Used together with lifecycle-based `_set_button_states(send_enabled, stop_enabled)`.
 - **`core/api.format_error_for_display(e)`**: Returns user-friendly error string for cells/dialogs (e.g. `"Error: Connection refused..."`).
+- **Dialog control helpers** (`plugin/framework/dialogs.py`):
+  - `add_dialog_button(dlg_model, name, label, x, y, width, height, push_button_type=None, enabled=True)`
+  - `add_dialog_label(dlg_model, name, label, x, y, width, height, multiline=True)`
+  - `add_dialog_edit(dlg_model, name, text, x, y, width, height, readonly=False)`
+  - `add_dialog_hyperlink(dlg_model, name, label, url, x, y, width, height)`
+  These encapsulate the boilerplate required to create and insert UNO control models into a dialog model.
 
 ---
 
@@ -321,6 +327,9 @@ To improve UI responsiveness and AI navigation in complex documents, we ported p
 
 ### Optional Controls
 - When wiring controls that might not exist in all XDL versions (e.g. backward compatibility), use **`get_optional(root_window, name)`** from `plugin/framework/uno_helpers.py` (returns control or None). For checkboxes, use **`get_checkbox_state(ctrl)`** / **`set_checkbox_state(ctrl, value)`** and **`is_checkbox_control(ctrl)`** from the same module so LibreOffice control quirks are handled in one place.
+
+### Programmatic Control Creation
+- When creating dialogs or controls programmatically (without XDL), use the helpers in `plugin/framework/dialogs.py` (e.g., `add_dialog_button`). This ensures consistent naming, positioning (still using Map AppFont units by convention if the dialog model is set up that way), and property configuration.
 
 ---
 

--- a/plugin/framework/dialogs.py
+++ b/plugin/framework/dialogs.py
@@ -96,6 +96,68 @@ def copy_to_clipboard(ctx, text):
         return False
 
 
+# ── Dialog control helpers ──────────────────────────────────────────
+
+
+def add_dialog_button(dlg_model, name, label, x, y, width, height, push_button_type=None, enabled=True):
+    """Add a button to a dialog model."""
+    btn = dlg_model.createInstance("com.sun.star.awt.UnoControlButtonModel")
+    btn.Name = name
+    btn.PositionX = x
+    btn.PositionY = y
+    btn.Width = width
+    btn.Height = height
+    btn.Label = label
+    btn.Enabled = enabled
+    if push_button_type is not None:
+        btn.PushButtonType = push_button_type
+    dlg_model.insertByName(name, btn)
+    return btn
+
+
+def add_dialog_label(dlg_model, name, label, x, y, width, height, multiline=True):
+    """Add a fixed text label to a dialog model."""
+    lbl = dlg_model.createInstance("com.sun.star.awt.UnoControlFixedTextModel")
+    lbl.Name = name
+    lbl.PositionX = x
+    lbl.PositionY = y
+    lbl.Width = width
+    lbl.Height = height
+    lbl.MultiLine = multiline
+    lbl.Label = label
+    dlg_model.insertByName(name, lbl)
+    return lbl
+
+
+def add_dialog_edit(dlg_model, name, text, x, y, width, height, readonly=False):
+    """Add an edit (text field) control to a dialog model."""
+    edit = dlg_model.createInstance("com.sun.star.awt.UnoControlEditModel")
+    edit.Name = name
+    edit.PositionX = x
+    edit.PositionY = y
+    edit.Width = width
+    edit.Height = height
+    edit.Text = text
+    edit.ReadOnly = readonly
+    dlg_model.insertByName(name, edit)
+    return edit
+
+
+def add_dialog_hyperlink(dlg_model, name, label, url, x, y, width, height):
+    """Add a clickable hyperlink to a dialog model."""
+    link = dlg_model.createInstance("com.sun.star.awt.UnoControlFixedHyperlinkModel")
+    link.Name = name
+    link.PositionX = x
+    link.PositionY = y
+    link.Width = width
+    link.Height = height
+    link.Label = label
+    link.URL = url
+    link.TextColor = 0x0563C1  # standard link blue
+    dlg_model.insertByName(name, link)
+    return link
+
+
 # ── Message box with Copy button ─────────────────────────────────────
 
 
@@ -116,37 +178,9 @@ def msgbox_with_copy(ctx, title, message, copy_text):
         dlg_model.Width = 250
         dlg_model.Height = 80
 
-        lbl = dlg_model.createInstance(
-            "com.sun.star.awt.UnoControlFixedTextModel")
-        lbl.Name = "Msg"
-        lbl.PositionX = 10
-        lbl.PositionY = 6
-        lbl.Width = 230
-        lbl.Height = 42
-        lbl.MultiLine = True
-        lbl.Label = message
-        dlg_model.insertByName("Msg", lbl)
-
-        copy_btn = dlg_model.createInstance(
-            "com.sun.star.awt.UnoControlButtonModel")
-        copy_btn.Name = "CopyBtn"
-        copy_btn.PositionX = 10
-        copy_btn.PositionY = 56
-        copy_btn.Width = 75
-        copy_btn.Height = 14
-        copy_btn.Label = "Copy URL"
-        dlg_model.insertByName("CopyBtn", copy_btn)
-
-        ok_btn = dlg_model.createInstance(
-            "com.sun.star.awt.UnoControlButtonModel")
-        ok_btn.Name = "OKBtn"
-        ok_btn.PositionX = 190
-        ok_btn.PositionY = 56
-        ok_btn.Width = 50
-        ok_btn.Height = 14
-        ok_btn.Label = "OK"
-        ok_btn.PushButtonType = 1  # OK
-        dlg_model.insertByName("OKBtn", ok_btn)
+        add_dialog_label(dlg_model, "Msg", message, 10, 6, 230, 42)
+        add_dialog_button(dlg_model, "CopyBtn", "Copy URL", 10, 56, 75, 14)
+        add_dialog_button(dlg_model, "OKBtn", "OK", 190, 56, 50, 14, push_button_type=1)
 
         dlg = smgr.createInstanceWithContext(
             "com.sun.star.awt.UnoControlDialog", ctx)
@@ -213,41 +247,15 @@ def status_dialog(ctx, title, build_status_fn, copy_url_fn=None):
         dlg_model.Width = 230
         dlg_model.Height = 110
 
-        lbl = dlg_model.createInstance(
-            "com.sun.star.awt.UnoControlFixedTextModel")
-        lbl.Name = "StatusText"
-        lbl.PositionX = 10
-        lbl.PositionY = 6
-        lbl.Width = 210
-        lbl.Height = 72
-        lbl.MultiLine = True
-        lbl.Label = initial_text
-        dlg_model.insertByName("StatusText", lbl)
+        add_dialog_label(dlg_model, "StatusText", initial_text, 10, 6, 210, 72)
 
         # Copy button (disabled until copy_url_fn returns something)
         has_copy = copy_url_fn is not None
         if has_copy:
-            copy_btn = dlg_model.createInstance(
-                "com.sun.star.awt.UnoControlButtonModel")
-            copy_btn.Name = "CopyBtn"
-            copy_btn.PositionX = 10
-            copy_btn.PositionY = 88
-            copy_btn.Width = 65
-            copy_btn.Height = 14
-            copy_btn.Label = "Copy URL"
-            copy_btn.Enabled = bool(copy_url_fn())
-            dlg_model.insertByName("CopyBtn", copy_btn)
+            add_dialog_button(dlg_model, "CopyBtn", "Copy URL", 10, 88, 65, 14,
+                              enabled=bool(copy_url_fn()))
 
-        ok_btn = dlg_model.createInstance(
-            "com.sun.star.awt.UnoControlButtonModel")
-        ok_btn.Name = "OKBtn"
-        ok_btn.PositionX = 170
-        ok_btn.PositionY = 88
-        ok_btn.Width = 50
-        ok_btn.Height = 14
-        ok_btn.Label = "OK"
-        ok_btn.PushButtonType = 1
-        dlg_model.insertByName("OKBtn", ok_btn)
+        add_dialog_button(dlg_model, "OKBtn", "OK", 170, 88, 50, 14, push_button_type=1)
 
         dlg = smgr.createInstanceWithContext(
             "com.sun.star.awt.UnoControlDialog", ctx)
@@ -326,44 +334,18 @@ def about_dialog(ctx):
         dlg_model.Height = 90
 
         # Info text
-        lbl = dlg_model.createInstance(
-            "com.sun.star.awt.UnoControlFixedTextModel")
-        lbl.Name = "Info"
-        lbl.PositionX = 10
-        lbl.PositionY = 8
-        lbl.Width = 200
-        lbl.Height = 36
-        lbl.MultiLine = True
-        lbl.Label = (
+        info_text = (
             "LocalWriter\n"
             "Version: %s\n"
             "AI-powered extension for LibreOffice" % EXTENSION_VERSION
         )
-        dlg_model.insertByName("Info", lbl)
+        add_dialog_label(dlg_model, "Info", info_text, 10, 8, 200, 36)
 
         # Clickable hyperlink
-        link = dlg_model.createInstance(
-            "com.sun.star.awt.UnoControlFixedHyperlinkModel")
-        link.Name = "GitHubLink"
-        link.PositionX = 10
-        link.PositionY = 48
-        link.Width = 200
-        link.Height = 12
-        link.Label = "GitHub: quazardous/localwriter"
-        link.URL = "https://github.com/quazardous/localwriter"
-        link.TextColor = 0x0563C1  # standard link blue
-        dlg_model.insertByName("GitHubLink", link)
+        add_dialog_hyperlink(dlg_model, "GitHubLink", "GitHub: quazardous/localwriter",
+                             "https://github.com/quazardous/localwriter", 10, 48, 200, 12)
 
-        ok_btn = dlg_model.createInstance(
-            "com.sun.star.awt.UnoControlButtonModel")
-        ok_btn.Name = "OKBtn"
-        ok_btn.PositionX = 160
-        ok_btn.PositionY = 68
-        ok_btn.Width = 50
-        ok_btn.Height = 14
-        ok_btn.Label = "OK"
-        ok_btn.PushButtonType = 1
-        dlg_model.insertByName("OKBtn", ok_btn)
+        add_dialog_button(dlg_model, "OKBtn", "OK", 160, 68, 50, 14, push_button_type=1)
 
         dlg = smgr.createInstanceWithContext(
             "com.sun.star.awt.UnoControlDialog", ctx)

--- a/plugin/modules/http/__init__.py
+++ b/plugin/modules/http/__init__.py
@@ -189,7 +189,7 @@ class HttpModule(ModuleBase):
                        "HTTP server failed to start\nCheck ~/localwriter.log")
 
     def _action_server_status(self):
-        from plugin.framework.dialogs import msgbox
+        from plugin.framework.dialogs import msgbox, add_dialog_label, add_dialog_edit, add_dialog_button
         from plugin.framework.uno_context import get_ctx
 
         ctx = get_ctx()
@@ -216,39 +216,12 @@ class HttpModule(ModuleBase):
             dlg_model.Width = 230
             dlg_model.Height = 80
 
-            lbl = dlg_model.createInstance(
-                "com.sun.star.awt.UnoControlFixedTextModel")
-            lbl.Name = "Msg"
-            lbl.PositionX = 10
-            lbl.PositionY = 6
-            lbl.Width = 210
-            lbl.Height = 24
-            lbl.MultiLine = True
-            lbl.Label = msg
-            dlg_model.insertByName("Msg", lbl)
+            add_dialog_label(dlg_model, "Msg", msg, 10, 6, 210, 24)
 
             # Read-only textfield for the URL — user can select + Ctrl+C
-            url_field = dlg_model.createInstance(
-                "com.sun.star.awt.UnoControlEditModel")
-            url_field.Name = "UrlField"
-            url_field.PositionX = 10
-            url_field.PositionY = 34
-            url_field.Width = 210
-            url_field.Height = 14
-            url_field.ReadOnly = True
-            url_field.Text = url
-            dlg_model.insertByName("UrlField", url_field)
+            add_dialog_edit(dlg_model, "UrlField", url, 10, 34, 210, 14, readonly=True)
 
-            ok_btn = dlg_model.createInstance(
-                "com.sun.star.awt.UnoControlButtonModel")
-            ok_btn.Name = "OKBtn"
-            ok_btn.PositionX = 170
-            ok_btn.PositionY = 58
-            ok_btn.Width = 50
-            ok_btn.Height = 14
-            ok_btn.Label = "OK"
-            ok_btn.PushButtonType = 1
-            dlg_model.insertByName("OKBtn", ok_btn)
+            add_dialog_button(dlg_model, "OKBtn", "OK", 170, 58, 50, 14, push_button_type=1)
 
             dlg = smgr.createInstanceWithContext(
                 "com.sun.star.awt.UnoControlDialog", ctx)


### PR DESCRIPTION
I have refactored the repetitive UI control setup logic in `plugin/framework/dialogs.py` and `plugin/modules/http/__init__.py` by introducing a set of reusable helper functions: `add_dialog_button`, `add_dialog_label`, `add_dialog_edit`, and `add_dialog_hyperlink`. These helpers encapsulate the boilerplate code required to create and configure UNO (Universal Network Objects) control models, significantly improving the maintainability and readability of the codebase.

Key changes:
- **`plugin/framework/dialogs.py`**: Added the helper functions and refactored `msgbox_with_copy`, `status_dialog`, and `about_dialog`.
- **`plugin/modules/http/__init__.py`**: Updated the `_action_server_status` method to use the new helpers.
- **`AGENTS.md`**: Documented the new helpers to provide context for future AI assistants.

Verification:
- Manual code review confirmed that all refactored logic exactly matches the original implementations.
- Ran core unit tests via `pytest` (69 passed) to ensure no regressions in non-UI logic.
- Obtained a #Correct# rating from an internal code review.

---
*PR created automatically by Jules for task [16148031925767347607](https://jules.google.com/task/16148031925767347607) started by @KeithCu*