### PR TITLE
🧹 Clean up unused imports in legacy UI

### DIFF
--- a/plugin/framework/legacy_ui.py
+++ b/plugin/framework/legacy_ui.py
@@ -1,7 +1,6 @@
 """Legacy UI functions for settings, input, and Eval Dashboard."""
-from plugin.framework.dialogs import load_framework_dialog, msgbox
-from plugin.framework.uno_helpers import TabListener, get_optional, is_checkbox_control, get_checkbox_state, set_checkbox_state
-from plugin.modules.core.services.config import get_config, set_config, get_current_endpoint, populate_combobox_with_lru
+from plugin.framework.uno_helpers import TabListener, is_checkbox_control, get_checkbox_state, set_checkbox_state
+from plugin.modules.core.services.config import get_config, get_current_endpoint, populate_combobox_with_lru
 import uno
 
 def input_box(ctx, message, title="", default="", x=None, y=None):
@@ -34,7 +33,7 @@ def input_box(ctx, message, title="", default="", x=None, y=None):
 
 def settings_box(ctx, title="", x=None, y=None):
     from plugin.framework.settings_dialog import get_settings_field_specs, apply_settings_result
-    from plugin.modules.core.services.config import get_image_model, set_image_model, populate_image_model_selector, endpoint_from_selector_text, get_api_key_for_endpoint, populate_endpoint_selector, as_bool
+    from plugin.modules.core.services.config import get_image_model, populate_image_model_selector, endpoint_from_selector_text, get_api_key_for_endpoint, populate_endpoint_selector, as_bool
 
     from plugin.framework.logging import agent_log
     import unohelper


### PR DESCRIPTION
🎯 **What:** Removed specific unused imports (`load_framework_dialog`, `msgbox`, `get_optional`, `set_config`, `set_image_model`) from `plugin/framework/legacy_ui.py`.
💡 **Why:** To improve code readability and maintainability by cleaning up dead imports that are not utilized in the file.
✅ **Verification:** Ran `pytest` tests locally in the repository root which showed 69 modern tests passed without introducing any regressions. The removed lines were purely unused references.
✨ **Result:** A cleaner script `plugin/framework/legacy_ui.py` without unnecessary imported names.

---
*PR created automatically by Jules for task [1232836395355410563](https://jules.google.com/task/1232836395355410563) started by @KeithCu*