### PR TITLE
🔒 Restrict debug endpoint to localhost only

### DIFF
--- a/plugin/modules/http/mcp_protocol.py
+++ b/plugin/modules/http/mcp_protocol.py
@@ -184,6 +184,13 @@ class MCPProtocolHandler:
 
     def handle_debug_post(self, handler):
         """POST /debug — execute debug actions."""
+        # Security: restrict debug actions to localhost
+        client_ip = handler.client_address[0]
+        if client_ip not in ("127.0.0.1", "::1", "localhost"):
+            log.warning("Blocked remote access to /debug from %s", client_ip)
+            self._send_json(handler, 403, {"error": "Forbidden: Debug actions restricted to localhost"})
+            return
+
         body = self._read_body(handler)
         if body is None:
             return


### PR DESCRIPTION
🎯 **What:** The `/debug` HTTP endpoint in `plugin/modules/http/mcp_protocol.py` (specifically `handle_debug_post`) was accessible without authentication from any IP address that could connect to the server. This allowed actions like `eval`, `exec`, and configuration modification to be triggered remotely.

⚠️ **Risk:** Critical remote code execution vulnerability. Since the server runs with the privileges of the user running LibreOffice, an attacker could execute arbitrary Python code, access local files, or modify application configuration if the port was exposed to a network.

🛡️ **Solution:** Implemented a security check in `handle_debug_post` that restricts access strictly to loopback addresses (`127.0.0.1`, `::1`, and `localhost`). Any request originating from a non-localhost IP will now receive a `403 Forbidden` response and log a warning message.

---
*PR created automatically by Jules for task [13384959721549259160](https://jules.google.com/task/13384959721549259160) started by @KeithCu*