### PR TITLE
🧹 [Code Health] Remove unused imports from settings_dialog.py

### DIFF
--- a/plugin/framework/settings_dialog.py
+++ b/plugin/framework/settings_dialog.py
@@ -1,4 +1,4 @@
-from plugin.modules.core.services.config import get_config, set_config, get_current_endpoint, as_bool, populate_combobox_with_lru, populate_endpoint_selector, endpoint_from_selector_text, get_image_model, set_image_model, get_api_key_for_endpoint, set_api_key_for_endpoint, populate_image_model_selector, notify_config_changed
+from plugin.modules.core.services.config import get_config, set_config, get_current_endpoint, as_bool, endpoint_from_selector_text, get_image_model, set_image_model, get_api_key_for_endpoint, set_api_key_for_endpoint, notify_config_changed
 
 def get_settings_field_specs(ctx):
     """Return field specs for Settings dialog (single source for dialog and apply keys)."""


### PR DESCRIPTION
🎯 **What:** Removed unused imports `populate_combobox_with_lru`, `populate_endpoint_selector`, and `populate_image_model_selector` from `plugin/framework/settings_dialog.py`.
💡 **Why:** These imports were not used in the file, causing clutter and reducing readability. Removing them improves code health.
✅ **Verification:** Verified by running the test suite (`PYTHONPATH=. pytest --ignore=tests/legacy`), all tests passed successfully. Code review confirmed the fix is correct.
✨ **Result:** A cleaner `settings_dialog.py` file with improved maintainability and no behavior changes.

---
*PR created automatically by Jules for task [99330278053434173](https://jules.google.com/task/99330278053434173) started by @KeithCu*