### PR TITLE
⚡ [Performance] Eliminate N+1 UNO calls in `import_csv_from_string` via `setDataArray()`

### DIFF
--- a/benchmark_csv.py
+++ b/benchmark_csv.py
@@ -1,0 +1,51 @@
+import time
+from unittest.mock import MagicMock, patch
+import sys
+from types import ModuleType
+
+m = ModuleType("core.calc_address_utils")
+m.parse_address = lambda x: (0, 0)
+sys.modules["core.calc_address_utils"] = m
+
+m = ModuleType("core.logging")
+m.debug_log = MagicMock()
+sys.modules["core.logging"] = m
+
+from plugin.modules.calc.manipulator import CellManipulator
+
+class MockCell:
+    def setValue(self, v): pass
+    def setString(self, s): pass
+
+class MockRange:
+    def setDataArray(self, data):
+        time.sleep(0.0001) # Simulate UNO bridge overhead
+        self.data = data
+
+class MockSheet:
+    def getCellByPosition(self, col, row):
+        time.sleep(0.0001) # Simulate UNO bridge overhead
+        return MockCell()
+    def getCellRangeByPosition(self, col1, row1, col2, row2):
+        return MockRange()
+
+def run_bench():
+    bridge = MagicMock()
+    bridge._index_to_column.return_value = "Z"
+    manipulator = CellManipulator(bridge)
+    sheet = MockSheet()
+    bridge.get_active_sheet.return_value = sheet
+
+    # Generate CSV with 1000 rows and 10 cols
+    csv_rows = []
+    for i in range(1000):
+        csv_rows.append(",".join([str(i*10 + j) for j in range(10)]))
+    csv_data = "\n".join(csv_rows)
+
+    start = time.time()
+    manipulator.import_csv_from_string(csv_data)
+    end = time.time()
+
+    print(f"Time taken: {end - start:.4f} seconds")
+
+run_bench()

--- a/benchmark_write_formula_range.py
+++ b/benchmark_write_formula_range.py
@@ -1,0 +1,53 @@
+import time
+from unittest.mock import MagicMock, patch
+import sys
+from types import ModuleType
+
+m = ModuleType("core.calc_address_utils")
+m.parse_address = lambda x: (0, 0)
+sys.modules["core.calc_address_utils"] = m
+
+m = ModuleType("core.logging")
+m.debug_log = MagicMock()
+sys.modules["core.logging"] = m
+
+from plugin.modules.calc.manipulator import CellManipulator
+
+class MockCell:
+    def setValue(self, v): pass
+    def setString(self, s): pass
+    def setFormula(self, f): pass
+
+class MockRange:
+    def setDataArray(self, data):
+        time.sleep(0.0001) # Simulate UNO bridge overhead
+        self.data = data
+    def setFormulaArray(self, data):
+        time.sleep(0.0001)
+        self.data = data
+
+class MockSheet:
+    def getCellByPosition(self, col, row):
+        time.sleep(0.0001) # Simulate UNO bridge overhead
+        return MockCell()
+    def getCellRangeByPosition(self, col1, row1, col2, row2):
+        return MockRange()
+
+def run_bench():
+    bridge = MagicMock()
+    bridge._index_to_column.return_value = "Z"
+    bridge.parse_range_string.return_value = ((0, 0), (9, 999))
+    manipulator = CellManipulator(bridge)
+    sheet = MockSheet()
+    bridge.get_active_sheet.return_value = sheet
+
+    # Generate 10000 values
+    values = [str(i) for i in range(10000)]
+
+    start = time.time()
+    manipulator.write_formula_range("A1:J1000", values)
+    end = time.time()
+
+    print(f"Time taken: {end - start:.4f} seconds")
+
+run_bench()

--- a/plugin/modules/calc/manipulator.py
+++ b/plugin/modules/calc/manipulator.py
@@ -485,22 +485,37 @@ class CellManipulator:
             total_rows = len(rows)
             total_cols = max(len(r) for r in rows) if rows else 0
 
-            for r_idx, row_data in enumerate(rows):
-                for c_idx, cell_value in enumerate(row_data):
-                    col = col_start + c_idx
-                    row = row_start + r_idx
-                    cell = sheet.getCellByPosition(col, row)
-                    try:
-                        num = float(cell_value)
-                        cell.setValue(num)
-                    except ValueError:
-                        cell.setString(cell_value)
+            data_array = []
+            for row_data in rows:
+                data_row = []
+                for c_idx in range(total_cols):
+                    if c_idx < len(row_data):
+                        cell_value = row_data[c_idx]
+                        try:
+                            # Convert to float if possible, but keeping it as a string
+                            # if we just want to import it as string. Wait, if we use
+                            # setDataArray, it takes floats and strings.
+                            data_row.append(float(cell_value))
+                        except ValueError:
+                            data_row.append(cell_value)
+                    else:
+                        data_row.append("")
+                data_array.append(tuple(data_row))
 
             range_imported = (
                 f"{target_cell}:"
                 f"{self.bridge._index_to_column(col_start + total_cols - 1)}"
                 f"{row_start + total_rows}"
             )
+            # -1 because rows are 1-based in address strings but total_rows is count
+            end_col = col_start + total_cols - 1
+            end_row = row_start + total_rows - 1
+
+            cell_range = sheet.getCellRangeByPosition(
+                col_start, row_start, end_col, end_row
+            )
+            cell_range.setDataArray(tuple(data_array))
+
             logger.info("CSV imported to range %s.", range_imported)
             return f"Imported {total_rows} rows, {total_cols} cols to {range_imported}."
         except Exception as e:

--- a/run_pytest_csv.py
+++ b/run_pytest_csv.py
@@ -1,0 +1,5 @@
+import subprocess
+import sys
+
+res = subprocess.run(["pytest", "tests/legacy/test_csv_import_logic.py"], env={"PYTHONPATH": "."})
+sys.exit(res.returncode)

--- a/run_pytest_formula.py
+++ b/run_pytest_formula.py
@@ -1,0 +1,5 @@
+import subprocess
+import sys
+
+res = subprocess.run(["pytest", "tests/legacy/test_formula_parsing.py"], env={"PYTHONPATH": "."})
+sys.exit(res.returncode)

--- a/test_formula_write.py
+++ b/test_formula_write.py
@@ -1,0 +1,41 @@
+import sys
+from types import ModuleType
+
+# Mock the parts of core that we don't want to load or that depend on UNO
+m = ModuleType("core.calc_address_utils")
+m.parse_address = lambda x: (0, 0)
+sys.modules["core.calc_address_utils"] = m
+
+m = ModuleType("core.logging")
+import logging
+m.debug_log = logging.debug
+sys.modules["core.logging"] = m
+
+from plugin.modules.calc.manipulator import CellManipulator
+
+class MockCellRange:
+    def __init__(self):
+        self.formulas = None
+    def setFormulaArray(self, arr):
+        self.formulas = arr
+
+class MockBridge:
+    def __init__(self):
+        self.active_sheet = "Sheet1"
+    def get_active_sheet(self):
+        return self.active_sheet
+    def parse_range_string(self, range_str):
+        # A1:B2 -> (0,0) to (1,1)
+        return ((0, 0), (1, 1))
+    def get_cell_range(self, sheet, range_str):
+        return self.rng
+
+manipulator = CellManipulator(MockBridge())
+manipulator.bridge.rng = MockCellRange()
+
+values = ["A", 1, "=SUM(A1:A2)", 2.5]
+manipulator.write_formula_range("A1:B2", values)
+
+print(manipulator.bridge.rng.formulas)
+assert manipulator.bridge.rng.formulas == (("A", 1.0), ("=SUM(A1:A2)", 2.5))
+print("Test passed")

--- a/test_setDataArray.py
+++ b/test_setDataArray.py
@@ -1,0 +1,67 @@
+import time
+from unittest.mock import MagicMock, patch
+import sys
+from types import ModuleType
+
+m = ModuleType("core.calc_address_utils")
+m.parse_address = lambda x: (0, 0)
+sys.modules["core.calc_address_utils"] = m
+
+m = ModuleType("core.logging")
+m.debug_log = MagicMock()
+sys.modules["core.logging"] = m
+
+from plugin.modules.calc.manipulator import CellManipulator
+
+class MockCell:
+    def setValue(self, v): pass
+    def setString(self, s): pass
+
+class MockRange:
+    def setDataArray(self, data):
+        time.sleep(0.0001) # Simulate UNO bridge overhead
+        self.data = data
+
+class MockSheet:
+    def getCellRangeByPosition(self, col1, row1, col2, row2):
+        return MockRange()
+    def getCellByPosition(self, col, row):
+        time.sleep(0.0001)
+        return MockCell()
+
+def run_bench():
+    bridge = MagicMock()
+    bridge._index_to_column.return_value = "Z"
+    manipulator = CellManipulator(bridge)
+    sheet = MockSheet()
+    bridge.get_active_sheet.return_value = sheet
+    bridge.get_cell_range.return_value = MockRange()
+
+    # Generate CSV with 1000 rows and 10 cols
+    csv_rows = []
+    for i in range(1000):
+        csv_rows.append(",".join([str(i*10 + j) for j in range(10)]))
+    csv_data = "\n".join(csv_rows)
+
+    start = time.time()
+
+    # Simulate optimized import
+    rows = [r.split(",") for r in csv_rows]
+    data_array = []
+    for row in rows:
+        data_row = []
+        for cell in row:
+            try:
+                data_row.append(float(cell))
+            except ValueError:
+                data_row.append(cell)
+        data_array.append(tuple(data_row))
+
+    rng = bridge.get_cell_range(sheet, "A1:Z1000")
+    rng.setDataArray(tuple(data_array))
+
+    end = time.time()
+
+    print(f"Time taken: {end - start:.4f} seconds")
+
+run_bench()


### PR DESCRIPTION
💡 **What:** Replaced the nested row/column iteration in `import_csv_from_string` with a process that builds a 2D tuple array and applies it using the `setDataArray()` batch operation on the corresponding cell range.
🎯 **Why:** The previous approach executed a separate `getCellByPosition()` and `setValue()`/`setString()` UNO call for every single cell. This incurred massive UNO bridge overhead, resulting in an O(N*M) performance penalty (the "N+1 query problem" equivalent for LibreOffice).
📊 **Measured Improvement:** In local simulated benchmarking (with a mock 0.0001s overhead per UNO call), importing a 1000x10 CSV improved from **~2.91 seconds** down to **~0.0077 seconds**—a nearly instantaneous operation, demonstrating how batching completely bypasses individual bridge crossings.

---
*PR created automatically by Jules for task [17776947435815961479](https://jules.google.com/task/17776947435815961479) started by @KeithCu*