### PR TITLE
🧹 Code Health: Remove unused imports from plugin/prompt_function.py

### DIFF
--- a/plugin/prompt_function.py
+++ b/plugin/prompt_function.py
@@ -10,10 +10,10 @@ if _ext_root not in sys.path:
 if _plugin_dir not in sys.path:
     sys.path.insert(0, _plugin_dir)
 
-import uno
+
 import unohelper
-import urllib.request
-import urllib.parse
+
+
 # from com.sun.star.lang import XServiceInfo
 # from com.sun.star.sheet import XAddIn
 from org.extension.localwriter.PromptFunction import XPromptFunction


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`uno`, `urllib.request`, `urllib.parse`) from `plugin/prompt_function.py`. The other imports mentioned in the description (`json`, `logging`, `traceback`) were already not present in the file on the master branch.
💡 **Why:** Having unused imports clutters the file and makes it harder to read and maintain. Removing them improves code clarity.
✅ **Verification:** Verified that tests pass and `ruff` linting has fewer errors. Checked that `get_config` and `get_api_config` are indeed used in the file, so they were left alone.
✨ **Result:** Cleaned up unused imports in `plugin/prompt_function.py`.

---
*PR created automatically by Jules for task [4811806644969020693](https://jules.google.com/task/4811806644969020693) started by @KeithCu*