### PR TITLE
docs: Fix broken image links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ A cell formula to call the model directly from within your spreadsheet:
 `=PROMPT(message, [system_prompt], [model], [max_tokens])`
 
 Opus 4.6 one-shotted this Arch Linux resume:
-![Opus 4.6 Resume](Opus46Resume.png)
+![Opus 4.6 Resume](Showcase/Opus46Resume.png)
 Sonnet 4.6 one-shotted this "pretty spreadsheet"
-![Chat Sidebar with Dashboard](contrib/img/Sonnet46Spreadsheet.png)
+![Chat Sidebar with Dashboard](Showcase/Sonnet46Spreadsheet.png)
 
 ### 10. Audio Support & Voice Recording
 Integrated cross-platform audio recording directly in the chat sidebar.
@@ -258,4 +258,4 @@ Copyright (c) 2026 KeithCu (modifications and relicensing)
 
 *Architecture diagram created by Sonnet 4.6.*
 
-![Architecture](contrib/img/Sonnet46ArchDiagram.jpg)
+![Architecture](Showcase/Sonnet46ArchDiagram.jpg)


### PR DESCRIPTION
This PR fixes broken image links in the `README.md` file. The paths for three images (`Opus46Resume.png`, `Sonnet46Spreadsheet.png`, and `Sonnet46ArchDiagram.jpg`) have been updated to correctly point to the `Showcase/` directory.

---
*PR created automatically by Jules for task [18421938903358972111](https://jules.google.com/task/18421938903358972111) started by @KeithCu*