### PR TITLE
Streamline native test harness and centralize UNO mocks

### DIFF
--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -16,47 +16,120 @@ from typing import Any, Dict, List
 from plugin.framework.uno_helpers import get_active_document
 
 
+def test(func):
+    """Decorator to mark a function as a test in the native test runner."""
+    func._is_test = True
+    return func
+
+def setup(func):
+    """Decorator to mark a function as the setup routine for a test module."""
+    func._is_setup = True
+    return func
+
+def teardown(func):
+    """Decorator to mark a function as the teardown routine for a test module."""
+    func._is_teardown = True
+    return func
+
 def _run_suite(
     ctx: Any,
     suites: List[Dict[str, Any]],
     name: str,
-    func,
-    *func_args,
+    module,
+    *args,
 ) -> None:
-    """Run a single test suite function and append its result to suites.
+    """Run a test module using the decorator-based native runner.
 
-    The suite function is expected to return (passed_count, failed_count, log_list).
-    Any unexpected exception is converted into a single failed test with traceback.
+    Collects functions marked with @setup, @teardown, and @test.
+    Executes setup(ctx), then all tests(ctx), then teardown(ctx).
     """
     total_passed = 0
     total_failed = 0
+    log = []
+
+    setup_func = None
+    teardown_func = None
+    test_funcs = []
+
+    # Discover decorators, iterating over module dict to preserve insertion (definition) order
+    for attr_name, attr in module.__dict__.items():
+        if callable(attr):
+            if getattr(attr, "_is_setup", False):
+                setup_func = attr
+            elif getattr(attr, "_is_teardown", False):
+                teardown_func = attr
+            elif getattr(attr, "_is_test", False):
+                test_funcs.append(attr)
+
+    # Note: For backwards compatibility, if we didn't find any @test functions,
+    # check if there's a traditional monolithic test function
+    if not test_funcs:
+        # Fallback to the old run_*_tests approach for modules not yet migrated
+        fallback_func_name = f"run_{name.split('.')[-1].replace('_tests', '').replace('test_', '')}_tests"
+        if name == "calc.tests":
+            fallback_func_name = "run_calc_tests"
+        if name == "draw.tests":
+            fallback_func_name = "run_draw_tests"
+
+        fallback_func = getattr(module, fallback_func_name, None)
+        if fallback_func:
+            try:
+                passed, failed, result_log = fallback_func(ctx, *args)
+                suites.append({
+                    "name": name,
+                    "passed": int(passed or 0),
+                    "failed": int(failed or 0),
+                    "log": list(result_log or []),
+                })
+            except Exception as e:
+                suites.append({
+                    "name": name,
+                    "passed": 0,
+                    "failed": 1,
+                    "log": [f"EXCEPTION: {e}", traceback.format_exc()],
+                })
+            return
 
     try:
-        passed, failed, log = func(ctx, *func_args)
-        total_passed += int(passed or 0)
-        total_failed += int(failed or 0)
-        suites.append(
-            {
-                "name": name,
-                "passed": total_passed,
-                "failed": total_failed,
-                "log": list(log or []),
-            }
-        )
-    except Exception as e:  # noqa: BLE001
-        # Treat any unexpected exception as a single failed test in this suite.
+        if setup_func:
+            log.append(f"Running setup: {setup_func.__name__}")
+            setup_func(ctx)
+
+        for test_func in test_funcs:
+            try:
+                log.append(f"Running test: {test_func.__name__}")
+                test_func()
+                total_passed += 1
+                log.append(f"OK: {test_func.__name__}")
+            except AssertionError as e:
+                total_failed += 1
+                log.append(f"FAIL: {test_func.__name__} (AssertionError: {e})")
+                log.append(traceback.format_exc())
+            except Exception as e:
+                total_failed += 1
+                log.append(f"FAIL: {test_func.__name__} (Exception: {e})")
+                log.append(traceback.format_exc())
+
+    except Exception as e:
         total_failed += 1
-        suites.append(
-            {
-                "name": name,
-                "passed": 0,
-                "failed": total_failed,
-                "log": [
-                    "EXCEPTION: %s" % (e,),
-                    traceback.format_exc(),
-                ],
-            }
-        )
+        log.append(f"SUITE ABORTED EXCEPTION: {e}")
+        log.append(traceback.format_exc())
+    finally:
+        if teardown_func:
+            try:
+                log.append(f"Running teardown: {teardown_func.__name__}")
+                teardown_func(ctx)
+            except Exception as e:
+                total_failed += 1
+                log.append(f"TEARDOWN EXCEPTION: {e}")
+                log.append(traceback.format_exc())
+
+    suites.append({
+        "name": name,
+        "passed": total_passed,
+        "failed": total_failed,
+        "log": log,
+    })
 
 
 def run_all_tests(ctx: Any) -> str:
@@ -91,18 +164,18 @@ def run_all_tests(ctx: Any) -> str:
 
     # Framework tests
     try:
-        from plugin.tests.core_tests import run_framework_tests
-        _run_suite(ctx, suites, "framework.core_tests", run_framework_tests)
+        import plugin.tests.core_tests as core_tests
+        _run_suite(ctx, suites, "framework.core_tests", core_tests)
     except ImportError:
         pass
 
     # Writer markdown / format-preserving tests
     try:
         from plugin.framework.document import is_writer  # local import to avoid hard dependency if unused
-        from plugin.tests.format_tests import run_markdown_tests
+        import plugin.tests.format_tests as format_tests
 
         writer_doc = model if (model is not None and is_writer(model)) else None
-        _run_suite(ctx, suites, "writer.format_tests", run_markdown_tests, writer_doc)
+        _run_suite(ctx, suites, "writer.format_tests", format_tests, writer_doc)
     except ImportError:
         # Suite not available in this build; skip silently.
         pass
@@ -110,31 +183,31 @@ def run_all_tests(ctx: Any) -> str:
     # Writer core / navigation tests
     try:
         from plugin.framework.document import is_writer  # local import
-        from plugin.tests.test_writer import run_writer_tests
+        import plugin.tests.test_writer as test_writer
 
         # Writer core tests mutate the document and assume an empty starting state,
         # so we pass None to force it to create its own hidden temporary document.
-        _run_suite(ctx, suites, "writer.core_tests", run_writer_tests)
+        _run_suite(ctx, suites, "writer.core_tests", test_writer)
     except ImportError:
         pass
 
     # Calc API / tool tests
     try:
         from plugin.framework.document import is_calc  # local import
-        from plugin.tests.test_calc import run_calc_tests
+        import plugin.tests.test_calc as test_calc
 
         calc_doc = model if (model is not None and is_calc(model)) else None
-        _run_suite(ctx, suites, "calc.tests", run_calc_tests, calc_doc)
+        _run_suite(ctx, suites, "calc.tests", test_calc, calc_doc)
     except ImportError:
         pass
 
     # Draw / Impress tests
     try:
         from plugin.framework.document import is_draw  # local import
-        from plugin.tests.test_draw import run_draw_tests
+        import plugin.tests.test_draw as test_draw
 
         draw_doc = model if (model is not None and is_draw(model)) else None
-        _run_suite(ctx, suites, "draw.tests", run_draw_tests, draw_doc)
+        _run_suite(ctx, suites, "draw.tests", test_draw, draw_doc)
     except ImportError:
         pass
 

--- a/plugin/tests/core_tests.py
+++ b/plugin/tests/core_tests.py
@@ -1,109 +1,81 @@
-import traceback
-
 from plugin.framework.document import DocumentCache
 from plugin.framework.uno_helpers import get_desktop
+from plugin.testing_runner import setup, teardown, test
 
 
-def run_framework_tests(ctx, doc=None):
-    """Entry point for testing the core framework functionality inside LibreOffice."""
-    passed = 0
-    failed = 0
-    log = []
+_test_doc1 = None
+_test_doc2 = None
+_test_ctx = None
 
-    def ok(msg):
-        log.append("OK: " + msg)
 
-    def fail(msg):
-        log.append("FAIL: " + msg)
+@setup
+def setup_framework_tests(ctx):
+    global _test_doc1, _test_doc2, _test_ctx
+    _test_ctx = ctx
 
-    try:
-        log.append("Starting Framework Tests...")
+    desktop = get_desktop(ctx)
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
 
-        desktop = get_desktop(ctx)
-        from com.sun.star.beans import PropertyValue
-        hidden_prop = PropertyValue()
-        hidden_prop.Name = "Hidden"
-        hidden_prop.Value = True
+    _test_doc1 = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
+    _test_doc2 = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
+    assert _test_doc1 is not None and _test_doc2 is not None, "Could not create test documents"
 
-        doc1 = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
-        doc2 = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
 
-        try:
-            cache1 = DocumentCache.get(doc1)
-            cache1_again = DocumentCache.get(doc1)
-            if cache1 is cache1_again:
-                passed += 1
-                ok("DocumentCache returns same instance for same model")
-            else:
-                failed += 1
-                fail("DocumentCache returned different instances for same model")
+@teardown
+def teardown_framework_tests(ctx):
+    global _test_doc1, _test_doc2, _test_ctx
+    if _test_doc1:
+        _test_doc1.close(True)
+    if _test_doc2:
+        _test_doc2.close(True)
+    _test_doc1 = None
+    _test_doc2 = None
+    _test_ctx = None
 
-            cache2 = DocumentCache.get(doc2)
-            if cache1 is not cache2:
-                passed += 1
-                ok("DocumentCache returns different instance for different model")
-            else:
-                failed += 1
-                fail("DocumentCache returned same instance for different model")
 
-            DocumentCache.invalidate(doc1)
-            DocumentCache.invalidate(doc2)
-            cache1_new = DocumentCache.get(doc1)
-            if cache1 is not cache1_new:
-                passed += 1
-                ok("DocumentCache.invalidate clears cache for document")
-            else:
-                failed += 1
-                fail("DocumentCache.invalidate failed")
-        except Exception as e:
-            failed += 1
-            fail(f"DocumentCache test failed: {e}")
+@test
+def test_document_cache():
+    cache1 = DocumentCache.get(_test_doc1)
+    cache1_again = DocumentCache.get(_test_doc1)
+    assert cache1 is cache1_again, "DocumentCache returned different instances for same model"
 
-        try:
-            # EventBus test (callbacks are invoked with **data only, not event name)
-            from plugin.framework.event_bus import EventBus
-            events = EventBus()
-            event_received = []
-            def handler(**kwargs):
-                event_received.append(kwargs)
-            events.subscribe("test_event", handler)
-            events.emit("test_event", data=123)
-            if len(event_received) == 1 and event_received[0].get("data") == 123:
-                passed += 1
-                ok("EventBus subscribe and emit passed")
-            else:
-                failed += 1
-                fail(f"EventBus failed: {event_received}")
-        except Exception as e:
-            failed += 1
-            fail(f"EventBus test failed: {e}")
+    cache2 = DocumentCache.get(_test_doc2)
+    assert cache1 is not cache2, "DocumentCache returned same instance for different model"
 
-        try:
-            # ServiceRegistry test
-            from plugin.framework.service_registry import ServiceRegistry
-            registry = ServiceRegistry()
-            class DummyService:
-                pass
-            svc = DummyService()
-            registry.register_instance("dummy", svc)
-            if registry.get("dummy") is svc:
-                passed += 1
-                ok("ServiceRegistry register and get passed")
-            else:
-                failed += 1
-                fail("ServiceRegistry failed")
-        except Exception as e:
-            failed += 1
-            fail(f"ServiceRegistry test failed: {e}")
+    DocumentCache.invalidate(_test_doc1)
+    DocumentCache.invalidate(_test_doc2)
+    cache1_new = DocumentCache.get(_test_doc1)
+    assert cache1 is not cache1_new, "DocumentCache.invalidate failed"
 
-        finally:
-            if doc1:
-                doc1.close(True)
-            if doc2:
-                doc2.close(True)
 
-    except Exception as e:
-        failed += 1
-        fail(f"Exception during framework tests setup: {e}\n{traceback.format_exc()}")
+@test
+def test_event_bus():
+    from plugin.framework.event_bus import EventBus
+    events = EventBus()
+    event_received = []
 
-    return passed, failed, log
+    def handler(**kwargs):
+        event_received.append(kwargs)
+
+    events.subscribe("test_event", handler)
+    events.emit("test_event", data=123)
+
+    assert len(event_received) == 1, "Handler not called exactly once"
+    assert event_received[0].get("data") == 123, f"EventBus failed, received: {event_received}"
+
+
+@test
+def test_service_registry():
+    from plugin.framework.service_registry import ServiceRegistry
+    registry = ServiceRegistry()
+
+    class DummyService:
+        pass
+
+    svc = DummyService()
+    registry.register_instance("dummy", svc)
+
+    assert registry.get("dummy") is svc, "ServiceRegistry failed"

--- a/plugin/tests/format_tests.py
+++ b/plugin/tests/format_tests.py
@@ -99,732 +99,465 @@ def _find_text(doc, ctx, params):
         return {"status": "error", "message": str(e)}
 
 
-# ---------------------------------------------------------------------------
-# In-LibreOffice test runner (called from main.py menu: Run markdown tests)
-# ---------------------------------------------------------------------------
+from plugin.testing_runner import setup, teardown, test
 
-def run_markdown_tests(ctx, model=None):
-    """
-    Run format_support tests with real UNO. Called from main.py when user chooses Run markdown tests.
-    ctx: UNO ComponentContext. model: optional XTextDocument (Writer); if None or not Writer, a new doc is created.
-    Returns (passed_count, failed_count, list of message strings).
-    """
-    log = []
-    passed = 0
-    failed = 0
 
-    def ok(msg):
-        log.append("OK: %s" % msg)
+_test_doc = None
+_test_ctx = None
 
-    def fail(msg):
-        log.append("FAIL: %s" % msg)
+
+@setup
+def setup_markdown_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
 
     desktop = get_desktop(ctx)
-    doc = model
-    if doc is None or not hasattr(doc, "getText"):
-        try:
-            doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, ())
-        except Exception as e:
-            return 0, 1, ["Could not create Writer document: %s" % e]
-    if not doc or not hasattr(doc, "getText"):
-        return 0, 1, ["No Writer document available."]
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
 
-    debug_log(ctx, "format_tests: run start (model=%s)" % ("supplied" if model is doc else "new"))
+    _test_doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
+    assert _test_doc is not None, "Could not create Writer document"
+    assert hasattr(_test_doc, "getText"), "Not a valid Writer document"
 
-    try:
-        md = document_to_markdown(doc, ctx, None, scope="full")
-        if isinstance(md, str):
-            passed += 1
-            ok("document_to_markdown(scope='full') returned string (len=%d)" % len(md))
-        else:
-            failed += 1
-            fail("document_to_markdown did not return string: %s" % type(md))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: document_to_markdown raised: %s" % e)
-
-    try:
-        result = _get_document_content(doc, ctx, {"scope": "full"})
-        data = result
-        if data.get("status") == "ok" and "content" in data:
-            passed += 1
-            ok("tool_get_document_content returned status=ok and content (len=%d)" % len(data.get("content", "")))
-        else:
-            failed += 1
-            fail("tool_get_document_content: %s" % str(result)[:200])
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: tool_get_document_content raised: %s" % e)
+    debug_log(ctx, "format_tests: run start")
 
 
-    def _read_doc_text(d):
-        raw = d.getText().createTextCursor()
-        raw.gotoStart(False)
-        raw.gotoEnd(True)
-        return raw.getString()
+@teardown
+def teardown_markdown_tests(ctx):
+    global _test_doc, _test_ctx
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+    _test_ctx = None
 
 
-    # Test: get_document_content returns document_length
-    try:
-        result = _get_document_content(doc, ctx, {"scope": "full"})
-        data = result
-        doc_len_actual = len(_read_doc_text(doc))
-        if data.get("status") == "ok" and "document_length" in data and data["document_length"] == doc_len_actual:
-            passed += 1
-            ok("tool_get_document_content returns document_length (%d)" % doc_len_actual)
-        else:
-            failed += 1
-            fail("tool_get_document_content document_length: got %s, doc len=%d" % (data.get("document_length"), doc_len_actual))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: get_document_content document_length raised: %s" % e)
+def _read_doc_text(d):
+    raw = d.getText().createTextCursor()
+    raw.gotoStart(False)
+    raw.gotoEnd(True)
+    return raw.getString()
 
+
+@test
+def test_document_to_markdown():
+    md = document_to_markdown(_test_doc, _test_ctx, None, scope="full")
+    assert isinstance(md, str), f"document_to_markdown did not return string: {type(md)}"
+
+
+@test
+def test_tool_get_document_content():
+    result = _get_document_content(_test_doc, _test_ctx, {"scope": "full"})
+    assert result.get("status") == "ok", f"tool_get_document_content failed: {result}"
+    assert "content" in result, "Missing content"
+
+
+@test
+def test_get_document_content_returns_document_length():
+    result = _get_document_content(_test_doc, _test_ctx, {"scope": "full"})
+    doc_len_actual = len(_read_doc_text(_test_doc))
+    assert result.get("status") == "ok", f"tool_get_document_content failed: {result}"
+    assert result.get("document_length") == doc_len_actual, f"Length mismatch: {result.get('document_length')} vs {doc_len_actual}"
+
+
+@test
+def test_apply_at_end_via_insert_markdown():
     test_content = "Format test\n\nThis was inserted by the test."
     insert_needle = "Format test"
 
-    # Test: apply at end via _insert_markdown_at_position
-    try:
-        len_before = _doc_text_length_raw(doc)
-        _insert_markdown_at_position(doc, ctx, test_content, "end")
-        full_text = _read_doc_text(doc)
-        len_after = len(full_text)
-        content_found = insert_needle in full_text
-        debug_log(ctx, "format_tests: apply at end len_before=%s len_after=%s content_found=%s" % (
-            len_before, len_after, content_found))
-        if content_found:
-            passed += 1
-            ok("apply at end: content found (len_after=%d)" % len_after)
-        else:
-            failed += 1
-            fail("apply at end: content not found (len_before=%d len_after=%d)" % (len_before, len_after))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: apply at end raised: %s" % e)
-        debug_log(ctx, "format_tests: apply at end raised: %s" % e)
-
-    # Test: production path (_apply_document_content target='end')
-    try:
-        result = _apply_document_content(doc, ctx, {
-            "content": test_content,
-            "target": "end",
-        })
-        data = result
-        if data.get("status") != "ok":
-            failed += 1
-            fail("_apply_document_content: %s" % str(result)[:200])
-        else:
-            full_text = _read_doc_text(doc)
-            if insert_needle in full_text:
-                passed += 1
-                ok("_apply_document_content(target='end'): status=ok and content in document (len=%d)" % len(full_text))
-            else:
-                failed += 1
-                fail("_apply_document_content returned ok but content not in document (len=%d)" % len(full_text))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: _apply_document_content raised: %s" % e)
-
-    # Test D: formatting (bold, italic) - VISIBLE TEST
-    try:
-        formatted_input = "<h1>Heading</h1><p><b>Bold text</b> and <i>italic text</i></p>"
-
-        len_before = _doc_text_length_raw(doc)
-        result = _apply_document_content(doc, ctx, {
-            "content": formatted_input,
-            "target": "end",
-        })
-        data = result
-        if data.get("status") != "ok":
-            failed += 1
-            fail("formatted content: tool returned error: %s" % str(result)[:200])
-        else:
-            full_text = _read_doc_text(doc)
-            len_after = len(full_text)
-            # Check if ANY of the formatting keywords appear (raw or formatted)
-            has_heading = "Heading" in full_text
-            has_bold = "Bold" in full_text
-            has_italic = "italic" in full_text
-            
-            if has_heading or has_bold or has_italic:
-                passed += 1
-                ok("formatted content: INSERTED (len %d→%d, has_heading=%s, has_bold=%s, has_italic=%s)" % (
-                    len_before, len_after, has_heading, has_bold, has_italic))
-            else:
-                failed += 1
-                fail("formatted content: NOT FOUND (len %d→%d)" % (len_before, len_after))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: formatted content test raised: %s" % e)
-
-    # Test E: search-and-replace path
-    try:
-        # Insert a known string, then replace it with content
-        marker = "REPLACE_ME_MARKER"
-        text = doc.getText()
-        cursor = text.createTextCursor()
-        cursor.gotoEnd(False)
-        text.insertString(cursor, "\n" + marker, False)
-        
-        replacement = "<b>replaced</b>"
-        
-        result = _apply_document_content(doc, ctx, {
-            "content": replacement,
-            "target": "search",
-            "search": marker,
-        })
-        data = result
-        full_text = _read_doc_text(doc)
-        if data.get("status") == "ok" and "replaced" in full_text and marker not in full_text:
-            passed += 1
-            ok("search-and-replace: marker replaced with content")
-        else:
-            failed += 1
-            fail("search-and-replace: status=%s, marker_gone=%s, replaced_found=%s" % (
-                data.get("status"), marker not in full_text, "replaced" in full_text))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: search-and-replace test raised: %s" % e)
-
-    # Test G: Real list input support
-    try:
-        # Pass a REAL list, expect joined content
-        list_input = ["item_a", "item_b"]
-        len_before = _doc_text_length_raw(doc)
-        result = _apply_document_content(doc, ctx, {
-            "content": list_input,
-            "target": "end",
-        })
-        data = result
-        full_text = _read_doc_text(doc)
-        
-        has_content = "item_a" in full_text and "item_b" in full_text
-        
-        if data.get("status") == "ok" and has_content:
-            passed += 1
-            ok("list input accommodation: handled list input successfully")
-        else:
-            failed += 1
-            fail("list input accommodation: status=%s, has_content=%s (input was %s)" % (
-                data.get("status"), has_content, list_input))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: list input test raised: %s" % e)
-
-    # Test H: target="full" — replace entire document
-    try:
-        full_replacement = "<h1>Full Replace Test</h1><p>Only this content should remain.</p>"
-        result = _apply_document_content(doc, ctx, {"content": full_replacement, "target": "full"})
-        data = result
-        full_text = _read_doc_text(doc)
-        if data.get("status") == "ok" and "Full Replace" in full_text:
-            passed += 1
-            ok("target='full': replaced entire document (len=%d)" % len(full_text))
-        else:
-            failed += 1
-            fail("target='full': status=%s, content check failed (len=%d)" % (data.get("status"), len(full_text)))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: target=full test raised: %s" % e)
-
-    # Test I: target="range" with start=0, end=document_length
-    try:
-        doc_len = _doc_text_length_raw(doc)
-        range_content = "<h2>Range Replace</h2><p>Replaced [0, %d).</p>" % doc_len
-        result = _apply_document_content(doc, ctx, {"content": range_content, "target": "range", "start": 0, "end": doc_len})
-        data = result
-        full_text = _read_doc_text(doc)
-        if data.get("status") == "ok" and "Range Replace" in full_text:
-            passed += 1
-            ok("target='range' [0, doc_len): replaced content (len=%d)" % len(full_text))
-        else:
-            failed += 1
-            fail("target='range': status=%s (len=%d)" % (data.get("status"), len(full_text)))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: target=range test raised: %s" % e)
-
-    # Test J: get_document_content scope="range"
-    try:
-        full_text = _read_doc_text(doc)
-        if len(full_text) >= 10:
-            result = _get_document_content(doc, ctx, {"scope": "range", "start": 0, "end": 10})
-            data = result
-            if data.get("status") == "ok" and data.get("start") == 0 and data.get("end") == 10 and "content" in data:
-                passed += 1
-                ok("get_document_content scope='range' (0,10): returns start, end and content")
-            else:
-                failed += 1
-                fail("get_document_content scope=range: %s" % str(result)[:200])
-        else:
-            passed += 1
-            ok("get_document_content scope=range: skipped (doc too short)")
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: get_document_content scope=range raised: %s" % e)
-
-    # Test K: _find_text
-    try:
-        marker_find = "FIND_ME_UNIQUE_xyz"
-        text = doc.getText()
-        cursor = text.createTextCursor()
-        cursor.gotoEnd(False)
-        text.insertString(cursor, "\n" + marker_find, False)
-        
-        result = _find_text(doc, ctx, {
-            "search": marker_find,
-            "case_sensitive": True
-        })
-        data = result
-        
-        if data.get("status") == "ok" and "ranges" in data:
-            ranges = data["ranges"]
-            if len(ranges) == 1:
-                r = ranges[0]
-                text_at_range = _read_doc_text(doc)[r["start"]:r["end"]]
-                if text_at_range == marker_find:
-                    passed += 1
-                    ok("find_text: found correct range")
-                else:
-                    failed += 1
-                    fail("find_text: range text mismatch. Expected '%s', got '%s'" % (marker_find, text_at_range))
-            else:
-                failed += 1
-                fail("find_text: expected 1 match, got %d" % len(ranges))
-        else:
-            failed += 1
-            fail("find_text: status=%s" % data.get("status"))
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: find_text raised: %s" % e)
-
-    # Test L: HTML linebreak preservation
-    try:
-        plain_input = "Line 1\nLine 2\n\nParagraph 2"
-        len_before = _doc_text_length_raw(doc)
-        result = _apply_document_content(doc, ctx, {
-            "content": plain_input,
-            "target": "end",
-        })
-        full_text = _read_doc_text(doc)
-        # Check if all words are present. 
-        # If the fix works, these will be separated.
-        # If it failed, they might be merged, but still present.
-        # The real validation is that it doesn't error and content is there.
-        has_content = "Line 1" in full_text and "Line 2" in full_text and "Paragraph 2" in full_text
-        
-        if has_content:
-            passed += 1
-            ok("HTML linebreak preservation: content inserted")
-        else:
-            failed += 1
-            fail("HTML linebreak preservation: content missing")
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: HTML linebreak preservation test raised: %s" % e)
-
-    # Test U: CRLF normalization integration
-    try:
-        crlf_input = "Line A\r\nLine B"
-        # We use a unique marker to find it back
-        marker_u = "UNIQUE_CRLF_TEST"
-        payload = crlf_input + "\n" + marker_u
-        
-        _apply_document_content(doc, ctx, {
-            "content": payload,
-            "target": "end",
-        })
-        
-        # Now find it
-        res_find = _find_text(doc, ctx, {"search": marker_u})
-        if res_find.get("status") == "ok" and res_find.get("ranges"):
-            r = res_find["ranges"][0]
-            # Look at the text just before the marker
-            # The payload was "Line A\r\nLine B\nUNIQUE_CRLF_TEST"
-            # Normalized it should be "Line A\nLine B\nUNIQUE_CRLF_TEST"
-            # Length should be 7 + 7 + 16 = 30? No. 
-            # "Line A" (6) + "\n" (1) + "Line B" (6) + "\n" (1) + "UNIQUE_CRLF_TEST" (16) = 30 chars.
-            # If CRLF was preserved it would be 31.
-            
-            # Get content from start of payload to end of marker
-            # We don't know the exact starting offset easily without searching for "Line A"
-            res_find_start = _find_text(doc, ctx, {"search": "Line A"})
-            if res_find_start.get("status") == "ok" and res_find_start.get("ranges"):
-                # Find the last "Line A"
-                r_start = res_find_start["ranges"][-1]
-                total_range_text = _read_doc_text(doc)[r_start["start"]:r["end"]]
-                expected_norm = "Line A\nLine B\nUNIQUE_CRLF_TEST"
-                if total_range_text == expected_norm:
-                    passed += 1
-                    ok("CRLF normalization: 'Line A\\r\\nLine B' correctly normalized to '\\n'")
-                else:
-                    failed += 1
-                    fail("CRLF normalization: expected %s, got %s" % (repr(expected_norm), repr(total_range_text)))
-            else:
-                failed += 1
-                fail("CRLF normalization: could not find 'Line A' for verification")
-        else:
-            failed += 1
-            fail("CRLF normalization: could not find test payload")
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: CRLF normalization test raised: %s" % e)
-    fp_passed, fp_failed = _run_format_preserving_tests(doc, ctx, ok, fail, log)
-    passed += fp_passed
-    failed += fp_failed
-
-    # --- Tool integration tests (target=search/range/full + HTML wrapping check) ---
-    passed, failed = _run_tool_integration_tests(ctx, doc, passed, failed, log)
+    _insert_markdown_at_position(_test_doc, _test_ctx, test_content, "end")
+    full_text = _read_doc_text(_test_doc)
+    assert insert_needle in full_text, "Content not found after apply at end"
 
 
+@test
+def test_apply_document_content_target_end():
+    test_content = "Format test\n\nThis was inserted by the test."
+    insert_needle = "Format test"
 
-    return passed, failed, log
+    result = _apply_document_content(_test_doc, _test_ctx, {
+        "content": test_content,
+        "target": "end",
+    })
+    assert result.get("status") == "ok", f"_apply_document_content failed: {result}"
+    full_text = _read_doc_text(_test_doc)
+    assert insert_needle in full_text, "Content not found after _apply_document_content"
 
 
-def _run_format_preserving_tests(doc, ctx, ok, fail, log):
-    """Tests for _replace_text_preserving_format and _content_has_markup.
-    Returns (passed_count, failed_count)."""
-    passed = 0
-    failed = 0
-    text = doc.getText()
+@test
+def test_formatted_content():
+    formatted_input = "<h1>Heading</h1><p><b>Bold text</b> and <i>italic text</i></p>"
+    result = _apply_document_content(_test_doc, _test_ctx, {
+        "content": formatted_input,
+        "target": "end",
+    })
+    assert result.get("status") == "ok", f"formatted content failed: {result}"
 
-    # --- Test M: _content_has_markup auto-detection ---
-    try:
-        assert _content_has_markup("**bold**") == True
-        assert _content_has_markup("<b>bold</b>") == True
-        assert _content_has_markup("# Heading") == True
-        assert _content_has_markup("| col1 | col2 |") == True
-        assert _content_has_markup("Jane Doe") == False
-        assert _content_has_markup("Hello world, this is plain text.") == False
-        assert _content_has_markup("") == False
-        assert _content_has_markup(None) == False
-        passed += 1
-        ok("_content_has_markup: all detection cases correct")
-    except (AssertionError, Exception) as e:
-        failed += 1
-        fail("_content_has_markup: %s" % e)
+    full_text = _read_doc_text(_test_doc)
+    has_heading = "Heading" in full_text
+    has_bold = "Bold" in full_text
+    has_italic = "italic" in full_text
+    assert has_heading or has_bold or has_italic, "Formatting keywords not found"
+
+
+@test
+def test_search_and_replace():
+    marker = "REPLACE_ME_MARKER"
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
+    cursor.gotoEnd(False)
+    text.insertString(cursor, "\n" + marker, False)
+
+    replacement = "<b>replaced</b>"
+
+    result = _apply_document_content(_test_doc, _test_ctx, {
+        "content": replacement,
+        "target": "search",
+        "search": marker,
+    })
+    full_text = _read_doc_text(_test_doc)
+    assert result.get("status") == "ok", f"search-and-replace failed: {result}"
+    assert "replaced" in full_text, "'replaced' not found"
+    assert marker not in full_text, "marker not gone"
+
+
+@test
+def test_list_input_accommodation():
+    list_input = ["item_a", "item_b"]
+    result = _apply_document_content(_test_doc, _test_ctx, {
+        "content": list_input,
+        "target": "end",
+    })
+    full_text = _read_doc_text(_test_doc)
+    assert result.get("status") == "ok", f"list input failed: {result}"
+    assert "item_a" in full_text and "item_b" in full_text, "list input content missing"
+
+
+@test
+def test_target_full():
+    full_replacement = "<h1>Full Replace Test</h1><p>Only this content should remain.</p>"
+    result = _apply_document_content(_test_doc, _test_ctx, {"content": full_replacement, "target": "full"})
+    full_text = _read_doc_text(_test_doc)
+    assert result.get("status") == "ok", f"target=full failed: {result}"
+    assert "Full Replace" in full_text, "'Full Replace' not found"
+
+
+@test
+def test_target_range():
+    doc_len = _doc_text_length_raw(_test_doc)
+    range_content = "<h2>Range Replace</h2><p>Replaced [0, %d).</p>" % doc_len
+    result = _apply_document_content(_test_doc, _test_ctx, {"content": range_content, "target": "range", "start": 0, "end": doc_len})
+    full_text = _read_doc_text(_test_doc)
+    assert result.get("status") == "ok", f"target=range failed: {result}"
+    assert "Range Replace" in full_text, "'Range Replace' not found"
+
+
+@test
+def test_get_document_content_scope_range():
+    full_text = _read_doc_text(_test_doc)
+    if len(full_text) >= 10:
+        result = _get_document_content(_test_doc, _test_ctx, {"scope": "range", "start": 0, "end": 10})
+        assert result.get("status") == "ok", f"get_document_content scope=range failed: {result}"
+        assert result.get("start") == 0 and result.get("end") == 10 and "content" in result, "Malformed response"
+
+
+@test
+def test_find_text():
+    marker_find = "FIND_ME_UNIQUE_xyz"
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
+    cursor.gotoEnd(False)
+    text.insertString(cursor, "\n" + marker_find, False)
+
+    result = _find_text(_test_doc, _test_ctx, {
+        "search": marker_find,
+        "case_sensitive": True
+    })
+    assert result.get("status") == "ok", f"find_text failed: {result}"
+    ranges = result.get("ranges", [])
+    assert len(ranges) == 1, f"Expected 1 match, got {len(ranges)}"
+    r = ranges[0]
+    text_at_range = _read_doc_text(_test_doc)[r["start"]:r["end"]]
+    assert text_at_range == marker_find, f"find_text mismatch. Expected '{marker_find}', got '{text_at_range}'"
+
+
+@test
+def test_html_linebreak_preservation():
+    plain_input = "Line 1\nLine 2\n\nParagraph 2"
+    result = _apply_document_content(_test_doc, _test_ctx, {
+        "content": plain_input,
+        "target": "end",
+    })
+    full_text = _read_doc_text(_test_doc)
+    assert "Line 1" in full_text and "Line 2" in full_text and "Paragraph 2" in full_text, "HTML linebreak preservation failed"
+
+
+@test
+def test_crlf_normalization():
+    crlf_input = "Line A\r\nLine B"
+    marker_u = "UNIQUE_CRLF_TEST"
+    payload = crlf_input + "\n" + marker_u
     
-    # Helper: create text with per-character background colors and return the range
-    COLORS = [0xFF0000, 0x00FF00, 0x0000FF, 0xFFFF00, 0xFF00FF]  # Red Green Blue Yellow Magenta
+    _apply_document_content(_test_doc, _test_ctx, {
+        "content": payload,
+        "target": "end",
+    })
 
-    def _create_colored_text(chars):
-        """Insert chars at end of doc, color each char, return an XTextCursor spanning them."""
-        # Insert a newline separator
-        sep_cursor = text.createTextCursor()
-        sep_cursor.gotoEnd(False)
-        text.insertString(sep_cursor, "\n", False)
+    res_find = _find_text(_test_doc, _test_ctx, {"search": marker_u})
+    assert res_find.get("status") == "ok" and res_find.get("ranges"), "Could not find test payload"
+    r = res_find["ranges"][0]
 
-        def get_accurate_offset():
-            c = text.createTextCursor()
-            c.gotoStart(False)
-            c.gotoEnd(True)
-            return len(_normalize(c.getString()))
+    res_find_start = _find_text(_test_doc, _test_ctx, {"search": "Line A"})
+    assert res_find_start.get("status") == "ok" and res_find_start.get("ranges"), "Could not find 'Line A' for verification"
+    r_start = res_find_start["ranges"][-1]
 
-        start_off = get_accurate_offset()
-
-        for i, ch in enumerate(chars):
-            # Insert the character
-            ins = text.createTextCursor()
-            ins.gotoEnd(False)
-            text.insertString(ins, ch, False)
-            # Color the character we just inserted
-            cc = text.createTextCursor()
-            cc.gotoEnd(False)
-            cc.goLeft(1, True)
-            cc.setPropertyValue("CharBackColor", COLORS[i % len(COLORS)])
-
-        # Create range using the offsets
-        range_cursor = text.createTextCursor()
-        range_cursor.gotoStart(False)
-        _move_cursor_by_offset(range_cursor, start_off)
-        _move_cursor_by_offset(range_cursor, len(chars), expand=True)
-        return range_cursor
+    total_range_text = _read_doc_text(_test_doc)[r_start["start"]:r["end"]]
+    expected_norm = "Line A\nLine B\nUNIQUE_CRLF_TEST"
+    assert total_range_text == expected_norm, f"Expected {repr(expected_norm)}, got {repr(total_range_text)}"
 
 
-    def _get_char_colors(range_cursor):
-        """Read CharBackColor for each character in the range. Returns list of ints."""
-        colors = []
-        pos = text.createTextCursorByRange(range_cursor.getStart())
-        range_text = range_cursor.getString()
-        for i in range(len(range_text)):
-            cc = text.createTextCursorByRange(pos)
-            cc.goRight(1, True)
-            try:
-                colors.append(cc.getPropertyValue("CharBackColor"))
-            except Exception:
-                colors.append(-1)
-            pos = text.createTextCursorByRange(cc.getEnd())
-        return colors
+@test
+def test_content_has_markup_auto_detection():
+    assert _content_has_markup("**bold**") == True
+    assert _content_has_markup("<b>bold</b>") == True
+    assert _content_has_markup("# Heading") == True
+    assert _content_has_markup("| col1 | col2 |") == True
+    assert _content_has_markup("Jane Doe") == False
+    assert _content_has_markup("Hello world, this is plain text.") == False
+    assert _content_has_markup("") == False
+    assert _content_has_markup(None) == False
 
-    # --- Test N: Same-length replacement preserves per-char colors ---
-    try:
-        old_chars = "ABCDE"
-        rng = _create_colored_text(old_chars)
-        expected_colors = [COLORS[i % len(COLORS)] for i in range(len(old_chars))]
-        # Verify setup: coloring must be correct before we replace
-        actual_before = _get_char_colors(rng)
-        if actual_before != expected_colors:
-            failed += 1
-            fail("same-length replacement: SETUP FAILED colors before replace: expected %s got %s" % (expected_colors, actual_before))
-        else:
-            _replace_text_preserving_format(doc, rng, "PQRST", ctx)
-            sd = doc.createSearchDescriptor()
-            sd.SearchString = "PQRST"
-            found = doc.findFirst(sd)
-            if found:
-                actual_colors = _get_char_colors(found)
-                if actual_colors == expected_colors and found.getString() == "PQRST":
-                    passed += 1
-                    ok("same-length replacement: text='PQRST', all 5 colors preserved")
-                else:
-                    failed += 1
-                    fail("same-length replacement: colors expected %s got %s, text='%s'" % (expected_colors, actual_colors, found.getString()))
-            else:
-                failed += 1
-                fail("same-length replacement: 'PQRST' not found after replace")
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: same-length format-preserving test raised: %s" % e)
 
-    # --- Test O: Longer replacement, extra chars inherit last color ---
-    try:
-        old_chars = "ABC"
-        rng = _create_colored_text(old_chars)
-        expected_setup = [COLORS[0], COLORS[1], COLORS[2]]
-        actual_before = _get_char_colors(rng)
-        if actual_before != expected_setup:
-            failed += 1
-            fail("longer replacement: SETUP FAILED colors before replace: expected %s got %s" % (expected_setup, actual_before))
-        else:
-            expected_colors = [
-                COLORS[0], COLORS[1], COLORS[2],  # overlap: inherit from A, B, C
-                COLORS[2], COLORS[2],              # extra chars: inherit from last (C = Blue)
-            ]
-            _replace_text_preserving_format(doc, rng, "MNOPQ", ctx)
-            sd = doc.createSearchDescriptor()
-            sd.SearchString = "MNOPQ"
-            found = doc.findFirst(sd)
-            if found:
-                actual_colors = _get_char_colors(found)
-                if actual_colors == expected_colors and found.getString() == "MNOPQ":
-                    passed += 1
-                    ok("longer replacement: text='MNOPQ', 3 original + 2 inherited colors correct")
-                else:
-                    failed += 1
-                    fail("longer replacement: colors expected %s got %s, text='%s'" % (expected_colors, actual_colors, found.getString()))
-            else:
-                failed += 1
-                fail("longer replacement: 'MNOPQ' not found after replace")
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: longer format-preserving test raised: %s" % e)
+# Helper: create text with per-character background colors and return the range
+COLORS = [0xFF0000, 0x00FF00, 0x0000FF, 0xFFFF00, 0xFF00FF]  # Red Green Blue Yellow Magenta
 
-    # --- Test P: Shorter replacement, leftover chars deleted ---
-    try:
-        old_chars = "ABCDE"
-        rng = _create_colored_text(old_chars)
-        expected_setup = [COLORS[i % len(COLORS)] for i in range(5)]
-        actual_before = _get_char_colors(rng)
-        if actual_before != expected_setup:
-            failed += 1
-            fail("shorter replacement: SETUP FAILED colors before replace: expected %s got %s" % (expected_setup, actual_before))
-        else:
-            expected_colors = [COLORS[0], COLORS[1]]  # only first 2 colors survive
-            _replace_text_preserving_format(doc, rng, "UV", ctx)
-            sd = doc.createSearchDescriptor()
-            sd.SearchString = "UV"
-            found = doc.findFirst(sd)
-            if found:
-                actual_colors = _get_char_colors(found)
-                result_text = found.getString()
-                if actual_colors == expected_colors and result_text == "UV":
-                    passed += 1
-                    ok("shorter replacement: text='UV', 2 colors preserved, 3 chars deleted")
-                else:
-                    failed += 1
-                    fail("shorter replacement: text=%s colors expected %s got %s" % (repr(result_text), expected_colors, actual_colors))
-            else:
-                failed += 1
-                fail("shorter replacement: 'UV' not found after replace")
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: shorter format-preserving test raised: %s" % e)
+def _create_colored_text(chars):
+    """Insert chars at end of doc, color each char, return an XTextCursor spanning them."""
+    text = _test_doc.getText()
+    sep_cursor = text.createTextCursor()
+    sep_cursor.gotoEnd(False)
+    text.insertString(sep_cursor, "\n", False)
 
+    def get_accurate_offset():
+        c = text.createTextCursor()
+        c.gotoStart(False)
+        c.gotoEnd(True)
+        return len(_normalize(c.getString()))
+
+    start_off = get_accurate_offset()
+
+    for i, ch in enumerate(chars):
+        ins = text.createTextCursor()
+        ins.gotoEnd(False)
+        text.insertString(ins, ch, False)
+        cc = text.createTextCursor()
+        cc.gotoEnd(False)
+        cc.goLeft(1, True)
+        cc.setPropertyValue("CharBackColor", COLORS[i % len(COLORS)])
+
+    range_cursor = text.createTextCursor()
+    range_cursor.gotoStart(False)
+    _move_cursor_by_offset(range_cursor, start_off)
+    _move_cursor_by_offset(range_cursor, len(chars), expand=True)
+    return range_cursor
+
+
+def _get_char_colors(range_cursor):
+    """Read CharBackColor for each character in the range. Returns list of ints."""
+    text = _test_doc.getText()
+    colors = []
+    pos = text.createTextCursorByRange(range_cursor.getStart())
+    range_text = range_cursor.getString()
+    for i in range(len(range_text)):
+        cc = text.createTextCursorByRange(pos)
+        cc.goRight(1, True)
+        try:
+            colors.append(cc.getPropertyValue("CharBackColor"))
+        except Exception:
+            colors.append(-1)
+        pos = text.createTextCursorByRange(cc.getEnd())
+    return colors
+
+
+@test
+def test_same_length_replacement_preserves_colors():
+    old_chars = "ABCDE"
+    rng = _create_colored_text(old_chars)
+    expected_colors = [COLORS[i % len(COLORS)] for i in range(len(old_chars))]
     
-    # --- Test T: Long replacement triggers processEvents (no crash) ---
+    actual_before = _get_char_colors(rng)
+    assert actual_before == expected_colors, f"SETUP FAILED: expected {expected_colors} got {actual_before}"
+
+    _replace_text_preserving_format(_test_doc, rng, "PQRST", _test_ctx)
+    sd = _test_doc.createSearchDescriptor()
+    sd.SearchString = "PQRST"
+    found = _test_doc.findFirst(sd)
+    assert found, "'PQRST' not found after replace"
+    actual_colors = _get_char_colors(found)
+    assert actual_colors == expected_colors and found.getString() == "PQRST", f"Expected {expected_colors}, got {actual_colors}, text='{found.getString()}'"
+
+
+@test
+def test_longer_replacement_inherits_last_color():
+    old_chars = "ABC"
+    rng = _create_colored_text(old_chars)
+    expected_setup = [COLORS[0], COLORS[1], COLORS[2]]
+    actual_before = _get_char_colors(rng)
+    assert actual_before == expected_setup, f"SETUP FAILED: expected {expected_setup} got {actual_before}"
+
+    expected_colors = [
+        COLORS[0], COLORS[1], COLORS[2],  # overlap: inherit from A, B, C
+        COLORS[2], COLORS[2],             # extra chars: inherit from last (C = Blue)
+    ]
+    _replace_text_preserving_format(_test_doc, rng, "MNOPQ", _test_ctx)
+    sd = _test_doc.createSearchDescriptor()
+    sd.SearchString = "MNOPQ"
+    found = _test_doc.findFirst(sd)
+    assert found, "'MNOPQ' not found after replace"
+    actual_colors = _get_char_colors(found)
+    assert actual_colors == expected_colors and found.getString() == "MNOPQ", f"Expected {expected_colors}, got {actual_colors}, text='{found.getString()}'"
+
+
+@test
+def test_shorter_replacement_leftover_deleted():
+    old_chars = "ABCDE"
+    rng = _create_colored_text(old_chars)
+    expected_setup = [COLORS[i % len(COLORS)] for i in range(5)]
+    actual_before = _get_char_colors(rng)
+    assert actual_before == expected_setup, f"SETUP FAILED: expected {expected_setup} got {actual_before}"
+
+    expected_colors = [COLORS[0], COLORS[1]]  # only first 2 colors survive
+    _replace_text_preserving_format(_test_doc, rng, "UV", _test_ctx)
+    sd = _test_doc.createSearchDescriptor()
+    sd.SearchString = "UV"
+    found = _test_doc.findFirst(sd)
+    assert found, "'UV' not found after replace"
+    actual_colors = _get_char_colors(found)
+    result_text = found.getString()
+    assert actual_colors == expected_colors and result_text == "UV", f"Expected {expected_colors}, got {actual_colors}, text={repr(result_text)}"
+
+
+@test
+def test_long_replacement_process_events():
+    long_len = 50
+    old_chars = "X" * long_len
+    rng = _create_colored_text(old_chars)
+
+    new_chars = "Y" * long_len
+    _replace_text_preserving_format(_test_doc, rng, new_chars, _test_ctx)
+
+    sd = _test_doc.createSearchDescriptor()
+    sd.SearchString = new_chars
+    found = _test_doc.findFirst(sd)
+    assert found and found.getString() == new_chars, "Failed to replace %d chars" % long_len
+
+
+def _insert_colored_word(word):
+    """Insert word at end of doc with per-char background colors. Returns (start_offset, end_offset)."""
+    text = _test_doc.getText()
+    sep = text.createTextCursor()
+    sep.gotoEnd(False)
+    text.insertString(sep, "\n", False)
+
+    def get_accurate_offset():
+        c = text.createTextCursor()
+        c.gotoStart(False)
+        c.gotoEnd(True)
+        return len(_normalize(c.getString()))
+
+    start_off = get_accurate_offset()
+    for i, ch in enumerate(word):
+        ins = text.createTextCursor()
+        ins.gotoEnd(False)
+        text.insertString(ins, ch, False)
+        cc = text.createTextCursor()
+        cc.gotoEnd(False)
+        cc.goLeft(1, True)
+        cc.setPropertyValue("CharBackColor", COLORS[i % len(COLORS)])
+    end_off = get_accurate_offset()
+    return start_off, end_off
+
+
+def _get_colors_at_range(start_off, length):
+    """Read CharBackColor for `length` chars starting at absolute offset start_off."""
+    from plugin.framework.document import get_text_cursor_at_range
+    text = _test_doc.getText()
+    colors = []
+    pos_cursor = text.createTextCursor()
+    pos_cursor.gotoStart(False)
+    _move_cursor_by_offset(pos_cursor, start_off)
+    for _ in range(length):
+        cc = text.createTextCursorByRange(pos_cursor)
+        cc.goRight(1, True)
+        try:
+            colors.append(cc.getPropertyValue("CharBackColor"))
+        except Exception:
+            colors.append(-1)
+        pos_cursor = text.createTextCursorByRange(cc.getEnd())
+    return colors
+
+
+def _check_colors_at_search(search_str, expected_colors):
+    """Find search_str in doc and check its per-char colors."""
+    text = _test_doc.getText()
+    sd = _test_doc.createSearchDescriptor()
+    sd.SearchString = search_str
+    found = _test_doc.findFirst(sd)
+    if not found:
+        return False, "not found in document"
+    tmp = text.createTextCursorByRange(found.getStart())
+    tmp.gotoStart(True)
+    start_off = len(_normalize(tmp.getString()))
+    actual = _get_colors_at_range(start_off, len(search_str))
+    if actual == expected_colors:
+        return True, ""
+    return False, "expected %s got %s" % (expected_colors, actual)
+
+
+@test
+def test_apply_document_content_target_search_preserves_colors():
+    word = "zBertPicklez"   # unique sentinel around the name
+    start_off, end_off = _insert_colored_word(word)
+    expected_colors = [COLORS[i % len(COLORS)] for i in range(len(word))]
+
+    result = _apply_document_content(_test_doc, _test_ctx, {
+        "content": "zBertTicklez",
+        "target": "search",
+        "search": "zBertPicklez",
+    })
+    assert result.get("status") == "ok", f"tool target=search failed: {result}"
+    ok_flag, detail = _check_colors_at_search("zBertTicklez", expected_colors)
+    assert ok_flag, f"colors not preserved: {detail}"
+
+
+@test
+def test_apply_document_content_target_range_preserves_colors():
+    word = "zNormaFlintez"
+    start_off, end_off = _insert_colored_word(word)
+    expected_colors = [COLORS[i % len(COLORS)] for i in range(len(word))]
+
+    result = _apply_document_content(_test_doc, _test_ctx, {
+        "content": "zNormaGlintez",
+        "target": "range",
+        "start": start_off,
+        "end": end_off,
+    })
+    assert result.get("status") == "ok", f"tool target=range failed: {result}"
+    ok_flag, detail = _check_colors_at_search("zNormaGlintez", expected_colors)
+    assert ok_flag, f"colors not preserved: {detail}"
+
+
+@test
+def test_apply_document_content_target_full_preserves_colors():
+    desktop = get_desktop(_test_ctx)
+    small_doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, ())
+    assert small_doc and hasattr(small_doc, "getText"), "Could not create small doc"
+
     try:
-        # Create a string long enough to exercise replacement; kept small (50) so tests run quickly.
-        long_len = 50
-        old_chars = "X" * long_len
-        rng = _create_colored_text(old_chars)
-        
-        # Replace with same length string
-        # context_msg = "Profiling 500 char replacement..."
-        # import cProfile, pstats, io
-        # pr = cProfile.Profile()
-        # pr.enable()
-        
-        new_chars = "Y" * long_len
-        _replace_text_preserving_format(doc, rng, new_chars, ctx)
-        
-        # pr.disable()
-        # s = io.StringIO()
-        # ps = pstats.Stats(pr, stream=s).sort_stats('cumulative')
-        # ps.print_stats(20)
-        # log.append("PROFILE STATS:\n%s" % s.getvalue())
-        
-        sd = doc.createSearchDescriptor()
-        sd.SearchString = new_chars
-        found = doc.findFirst(sd)
-        if found and found.getString() == new_chars:
-            passed += 1
-            ok("processEvents test: replaced %d chars successfully" % long_len)
-        else:
-            failed += 1
-            fail("processEvents test: failed to replace %d chars" % long_len)
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: processEvents test raised: %s" % e)
-
-    return passed, failed
-
-
-def _run_tool_integration_tests(ctx, doc, passed, failed, log):
-    """Integration tests: call _apply_document_content end-to-end with plain text
-    and verify that CharBackColor is preserved. These cover the full stack including
-    the _ensure_html_linebreaks ordering fix and all three target paths.
-
-    Each test uses a fresh colored word so there are no search collisions.
-    """
-    ok = lambda msg: log.append("OK: %s" % msg)
-    fail = lambda msg: log.append("FAIL: %s" % msg)
-
-    text = doc.getText()
-    COLORS = [0xFF0000, 0x00FF00, 0x0000FF, 0xFFFF00, 0xFF00FF]
-
-    def _insert_colored_word(word):
-        """Insert word at end of doc with per-char background colors. Returns (start_offset, end_offset)."""
-        sep = text.createTextCursor()
-        sep.gotoEnd(False)
-        text.insertString(sep, "\n", False)
-
-        # We still need offsets for target='range' tests.
-        # Measure objectively from doc start.
-        def get_accurate_offset():
-            c = text.createTextCursor()
-            c.gotoStart(False)
-            c.gotoEnd(True)
-            return len(_normalize(c.getString()))
-
-        start_off = get_accurate_offset()
-        for i, ch in enumerate(word):
-            ins = text.createTextCursor()
-            ins.gotoEnd(False)
-            text.insertString(ins, ch, False)
-            cc = text.createTextCursor()
-            cc.gotoEnd(False)
-            cc.goLeft(1, True)
-            cc.setPropertyValue("CharBackColor", COLORS[i % len(COLORS)])
-        end_off = get_accurate_offset()
-        return start_off, end_off
-
-    def _get_colors_at_range(start_off, length):
-        """Read CharBackColor for `length` chars starting at absolute offset start_off."""
-        from plugin.framework.document import get_text_cursor_at_range
-        colors = []
-        pos_cursor = text.createTextCursor()
-        pos_cursor.gotoStart(False)
-        _move_cursor_by_offset(pos_cursor, start_off)
-        for _ in range(length):
-            cc = text.createTextCursorByRange(pos_cursor)
-            cc.goRight(1, True)
-            try:
-                colors.append(cc.getPropertyValue("CharBackColor"))
-            except Exception:
-                colors.append(-1)
-            pos_cursor = text.createTextCursorByRange(cc.getEnd())
-        return colors
-
-    def _check_colors_at_search(search_str, expected_colors):
-        """Find search_str in doc and check its per-char colors."""
-        sd = doc.createSearchDescriptor()
-        sd.SearchString = search_str
-        found = doc.findFirst(sd)
-        if not found:
-            return False, "not found in document"
-        # Build start offset by measuring from doc start
-        tmp = text.createTextCursorByRange(found.getStart())
-        tmp.gotoStart(True)
-        start_off = len(_normalize(tmp.getString()))
-        actual = _get_colors_at_range(start_off, len(search_str))
-        if actual == expected_colors:
-            return True, ""
-        return False, "expected %s got %s" % (expected_colors, actual)
-
-    # --- Test Q: _apply_document_content(target='search') preserves colors ---
-    # Simulates: AI is asked "change Bert Pickle to Bert Tickle"
-    try:
-        word = "zBertPicklez"   # unique sentinel around the name
-        start_off, end_off = _insert_colored_word(word)
-        expected_colors = [COLORS[i % len(COLORS)] for i in range(len(word))]
-
-        result = _apply_document_content(doc, ctx, {
-            "content": "zBertTicklez",
-            "target": "search",
-            "search": "zBertPicklez",
-        })
-        if result.get("status") != "ok":
-            failed += 1; fail("tool target=search: tool returned error: %s" % result)
-        else:
-            ok_flag, detail = _check_colors_at_search("zBertTicklez", expected_colors)
-            if ok_flag:
-                passed += 1
-                ok("tool target=search plain text: 'zBertPicklez'→'zBertTicklez', all colors preserved")
-            else:
-                failed += 1
-                fail("tool target=search plain text: colors not preserved: %s" % detail)
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: tool target=search integration test raised: %s" % e)
-
-    # --- Test R: _apply_document_content(target='range') preserves colors ---
-    # Simulates: AI uses find_text then apply with target=range
-    try:
-        word = "zNormaFlintez"
-        start_off, end_off = _insert_colored_word(word)
-        expected_colors = [COLORS[i % len(COLORS)] for i in range(len(word))]
-
-        result = _apply_document_content(doc, ctx, {
-            "content": "zNormaGlintez",
-            "target": "range",
-            "start": start_off,
-            "end": end_off,
-        })
-        if result.get("status") != "ok":
-            failed += 1; fail("tool target=range: tool returned error: %s" % result)
-        else:
-            ok_flag, detail = _check_colors_at_search("zNormaGlintez", expected_colors)
-            if ok_flag:
-                passed += 1
-                ok("tool target=range plain text: 'zNormaFlintez'→'zNormaGlintez', all colors preserved")
-            else:
-                failed += 1
-                fail("tool target=range plain text: colors not preserved: %s" % detail)
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: tool target=range integration test raised: %s" % e)
-
-    # --- Test S: _apply_document_content(target='full') preserves colors ---
-    # Simulates: AI replaces the entire (small) document with a plain text edit
-    # Use a fresh single-paragraph doc so doc_len == word length
-    try:
-        desktop = get_desktop(ctx)
-        small_doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, ())
-        if not small_doc or not hasattr(small_doc, "getText"):
-            raise RuntimeError("Could not create small doc for target=full test")
         small_text = small_doc.getText()
         word = "zGordonCrumpz"
         new_word = "zGordonStumpz"
-        # Insert the colored word into the fresh small doc
         for i, ch in enumerate(word):
             ins = small_text.createTextCursor()
             ins.gotoEnd(False)
@@ -835,48 +568,37 @@ def _run_tool_integration_tests(ctx, doc, passed, failed, log):
             cc.setPropertyValue("CharBackColor", COLORS[i % len(COLORS)])
         expected_colors = [COLORS[i % len(COLORS)] for i in range(len(word))]
 
-        result = _apply_document_content(small_doc, ctx, {
+        result = _apply_document_content(small_doc, _test_ctx, {
             "content": new_word,
             "target": "full",
         })
-        if result.get("status") != "ok":
-            failed += 1; fail("tool target=full: tool returned error: %s" % result)
-        else:
-            sd = small_doc.createSearchDescriptor()
-            sd.SearchString = new_word
-            found = small_doc.findFirst(sd)
-            if not found:
-                failed += 1
-                fail("tool target=full plain text: '%s' not found after replace" % new_word)
-            else:
-                small_txt = small_doc.getText()
-                tmp = small_txt.createTextCursorByRange(found.getStart())
-                tmp.gotoStart(True)
-                start_off2 = len(_normalize(tmp.getString()))
-                actual_colors = []
-                pos_c = small_txt.createTextCursor()
-                pos_c.gotoStart(False)
-                _move_cursor_by_offset(pos_c, start_off2)
-                for _ in range(len(new_word)):
-                    cc2 = small_txt.createTextCursorByRange(pos_c)
-                    cc2.goRight(1, True)
-                    try:
-                        actual_colors.append(cc2.getPropertyValue("CharBackColor"))
-                    except Exception:
-                        actual_colors.append(-1)
-                    pos_c = small_txt.createTextCursorByRange(cc2.getEnd())
-                if actual_colors == expected_colors:
-                    passed += 1
-                    ok("tool target=full plain text: '%s'→'%s', all colors preserved" % (word, new_word))
-                else:
-                    failed += 1
-                    fail("tool target=full plain text: colors expected %s got %s" % (expected_colors, actual_colors))
+        assert result.get("status") == "ok", f"tool target=full failed: {result}"
+
+        sd = small_doc.createSearchDescriptor()
+        sd.SearchString = new_word
+        found = small_doc.findFirst(sd)
+        assert found, f"'{new_word}' not found after replace"
+
+        small_txt = small_doc.getText()
+        tmp = small_txt.createTextCursorByRange(found.getStart())
+        tmp.gotoStart(True)
+        start_off2 = len(_normalize(tmp.getString()))
+        actual_colors = []
+        pos_c = small_txt.createTextCursor()
+        pos_c.gotoStart(False)
+        _move_cursor_by_offset(pos_c, start_off2)
+        for _ in range(len(new_word)):
+            cc2 = small_txt.createTextCursorByRange(pos_c)
+            cc2.goRight(1, True)
+            try:
+                actual_colors.append(cc2.getPropertyValue("CharBackColor"))
+            except Exception:
+                actual_colors.append(-1)
+            pos_c = small_txt.createTextCursorByRange(cc2.getEnd())
+
+        assert actual_colors == expected_colors, f"colors expected {expected_colors} got {actual_colors}"
+    finally:
         try:
             small_doc.close(True)
         except Exception:
             pass
-    except Exception as e:
-        failed += 1
-        log.append("FAIL: tool target=full integration test raised: %s" % e)
-
-    return passed, failed

--- a/plugin/tests/test_calc.py
+++ b/plugin/tests/test_calc.py
@@ -15,363 +15,218 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import traceback
-import json
-from plugin.framework.document import is_calc
 from plugin.framework.uno_helpers import get_desktop
+from plugin.testing_runner import setup, teardown, test
 
-def run_calc_tests(ctx, doc):
-    """Entry point for testing the calc module functionality inside LibreOffice."""
-    passed = 0
-    failed = 0
-    log = []
 
-    def ok(msg):
-        log.append("OK: " + msg)
+_test_doc = None
+_test_ctx = None
 
-    def fail(msg):
-        log.append("FAIL: " + msg)
 
-    try:
-        log.append("Starting Calc Tests...")
+@setup
+def setup_calc_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
 
-        # Test: address_utils
-        from plugin.modules.calc.address_utils import (
-            column_to_index, index_to_column, parse_address,
-            parse_range_string, format_address
-        )
+    desktop = get_desktop(ctx)
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
 
-        try:
-            assert column_to_index("A") == 0
-            assert column_to_index("AA") == 26
-            assert index_to_column(0) == "A"
-            assert index_to_column(26) == "AA"
-            assert parse_address("A1") == (0, 0)
-            assert parse_address("B10") == (1, 9)
-            assert format_address(0, 0) == "A1"
+    _test_doc = desktop.loadComponentFromURL("private:factory/scalc", "_blank", 0, (hidden_prop,))
+    assert _test_doc is not None, "Could not create hidden test calc document"
 
-            # Round-trip
-            for addr in ("A1", "B10", "Z1", "AA100"):
-                col, row = parse_address(addr)
-                assert format_address(col, row) == addr
 
-            try:
-                parse_address("Invalid")
-                fail("address_utils: Expected ValueError for 'Invalid'")
-            except ValueError:
-                pass
+@teardown
+def teardown_calc_tests(ctx):
+    global _test_doc, _test_ctx
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+    _test_ctx = None
 
-            assert parse_range_string("A1:B2") == ((0, 0), (1, 1))
-            assert parse_range_string("C3") == ((2, 2), (2, 2))
 
-            try:
-                parse_range_string("A1:Z")
-                fail("address_utils: Expected ValueError for 'A1:Z'")
-            except ValueError:
-                pass
+@test
+def test_address_utils():
+    from plugin.modules.calc.address_utils import (
+        column_to_index, index_to_column, parse_address,
+        parse_range_string, format_address
+    )
 
-            passed += 1
-            ok("address_utils tests passed")
-        except Exception as e:
-            failed += 1
-            fail(f"address_utils tests failed: {e}")
+    assert column_to_index("A") == 0
+    assert column_to_index("AA") == 26
+    assert index_to_column(0) == "A"
+    assert index_to_column(26) == "AA"
+    assert parse_address("A1") == (0, 0)
+    assert parse_address("B10") == (1, 9)
+    assert format_address(0, 0) == "A1"
 
-        # Test: error_detector data
-        from plugin.modules.calc.error_detector import ERROR_TYPES, ERROR_PATTERNS
-        try:
-            assert 502 in ERROR_TYPES
-            assert len(ERROR_PATTERNS) > 0
-            for code, info in ERROR_TYPES.items():
-                assert "name" in info
-                assert "description" in info
-            passed += 1
-            ok("error_detector data integrity passed")
-        except Exception as e:
-            failed += 1
-            fail(f"error_detector data integrity failed: {e}")
-
-        # Test: cells _parse_color
-        from plugin.modules.calc.cells import _parse_color
-        try:
-            assert _parse_color("red") == 0xFF0000
-            assert _parse_color("RED") == 0xFF0000
-            assert _parse_color("#00FF00") == 0x00FF00
-            assert _parse_color("#000") == 0x000000
-            assert _parse_color("invalid") is None
-            passed += 1
-            ok("color parsing passed")
-        except Exception as e:
-            failed += 1
-            fail(f"color parsing failed: {e}")
-
-        # --- UNO Integrations Tests ---
-        # Instead of mocking, we will create a hidden Calc document to run our tests on.
-        desktop = get_desktop(ctx)
-        from com.sun.star.beans import PropertyValue
-        hidden_prop = PropertyValue()
-        hidden_prop.Name = "Hidden"
-        hidden_prop.Value = True
-
-        test_doc = desktop.loadComponentFromURL("private:factory/scalc", "_blank", 0, (hidden_prop,))
-        if not test_doc:
-            raise Exception("Could not create hidden test calc document")
-
-        from plugin.main import get_tools
-        from plugin.framework.tool_context import ToolContext
-
-        def execute_calc_tool(name, args):
-            tctx = ToolContext(test_doc, None, "calc", {}, "test")
-            try:
-                res = get_tools().execute(name, tctx, **args)
-            except (KeyError, ValueError) as e:
-                res = {"status": "error", "error": str(e)}
-            return res
-
-        active_sheet = test_doc.getCurrentController().getActiveSheet()
-
-        try:
-            # Test: write_formula_range
-            res = execute_calc_tool("write_formula_range", {"range_name": "A1", "formula_or_values": "Hello"})
-            if res.get("status") == "ok" and active_sheet.getCellByPosition(0, 0).getString() == "Hello":
-                passed += 1
-                ok("write_formula_range basic passed")
-            else:
-                failed += 1
-                fail(f"write_formula_range basic failed: {res}")
-        except Exception as e:
-            failed += 1
-            fail(f"write_formula_range basic test failed: {e}")
-
-        try:
-            # Test: batch write (multi-range list)
-            execute_calc_tool("write_formula_range", {"range_name": ["B1", "B2"], "formula_or_values": "Batch"})
-            if active_sheet.getCellByPosition(1, 0).getString() == "Batch" and active_sheet.getCellByPosition(1, 1).getString() == "Batch":
-                passed += 1
-                ok("write_formula_range batch passed")
-            else:
-                failed += 1
-                fail("write_formula_range batch failed")
-        except Exception as e:
-            failed += 1
-            fail(f"write_formula_range batch test failed: {e}")
-
-        try:
-            # Test: set_cell_style
-            execute_calc_tool("set_cell_style", {"range_name": "A1", "bold": True, "bg_color": "yellow"})
-            cell = active_sheet.getCellByPosition(0, 0)
-            from com.sun.star.awt.FontWeight import BOLD
-            if cell.getPropertyValue("CharWeight") == BOLD and cell.getPropertyValue("CellBackColor") == 0xFFFF00:
-                passed += 1
-                ok("set_cell_style passed")
-            else:
-                failed += 1
-                fail(f"set_cell_style failed: weight={cell.getPropertyValue('CharWeight')}, color={cell.getPropertyValue('CellBackColor')}")
-        except Exception as e:
-            failed += 1
-            fail(f"set_cell_style test failed: {e}")
-
-        try:
-            # Test reading back format properties via get_cell_details (A1 was styled bold + yellow above)
-            from com.sun.star.awt.FontWeight import BOLD
-            from plugin.modules.calc.bridge import CalcBridge
-            from plugin.modules.calc.inspector import CellInspector
-            b = CalcBridge(test_doc)
-            insp = CellInspector(b)
-            details = insp.get_cell_details("A1")
-
-            # background_color 0xFFFF00 = yellow, bold = BOLD
-            bg_ok = details.get("background_color") == 0xFFFF00
-            bold_ok = details.get("bold") == BOLD
-
-            if bg_ok and bold_ok:
-                passed += 1
-                ok("get_cell_details formatting readback passed")
-            else:
-                failed += 1
-                fail(f"get_cell_details format readback failed: {details}")
-        except Exception as e:
-            failed += 1
-            fail(f"get_cell_details format readback test failed: {e}")
-
-        try:
-            # Test: merge_cells
-            execute_calc_tool("merge_cells", {"range_name": ["C1:D1", "E1:F1"]})
-            rng1 = active_sheet.getCellRangeByPosition(2, 0, 3, 0)
-            rng2 = active_sheet.getCellRangeByPosition(4, 0, 5, 0)
-            if rng1.getIsMerged() and rng2.getIsMerged():
-                passed += 1
-                ok("merge_cells passed")
-            else:
-                failed += 1
-                fail("merge_cells failed")
-        except Exception as e:
-            failed += 1
-            fail(f"merge_cells test failed: {e}")
-
-        try:
-            # Test: clear_range
-            active_sheet.getCellByPosition(6, 0).setString("ClearMe")
-            active_sheet.getCellByPosition(7, 0).setString("ClearMe")
-            execute_calc_tool("clear_range", {"range_name": ["G1", "H1"]})
-            if active_sheet.getCellByPosition(6, 0).getString() == "" and active_sheet.getCellByPosition(7, 0).getString() == "":
-                passed += 1
-                ok("clear_range passed")
-            else:
-                failed += 1
-                fail("clear_range failed")
-        except Exception as e:
-            failed += 1
-            fail(f"clear_range test failed: {e}")
-
-        try:
-            # Test: unknown tool
-            res = execute_calc_tool("bad_tool", {})
-            if res.get("status") == "error":
-                passed += 1
-                ok("unknown tool handling passed")
-            else:
-                failed += 1
-                fail(f"unknown tool handling failed: {res}")
-        except Exception as e:
-            failed += 1
-            fail(f"unknown tool handling test failed: {e}")
-
-        try:
-            # Test: formulas error detector
-            from plugin.modules.calc.formulas import DetectErrors
-            active_sheet.getCellByPosition(8, 0).setFormula("=1/0")
-            tctx = ToolContext(test_doc, None, "calc", {}, "test")
-            res = DetectErrors().execute(tctx, range_name="I1")
-            if res.get("status") == "ok" and res.get("result", {}).get("error_count", 0) > 0:
-                errors = res.get("result", {}).get("errors", [])
-                err0 = errors[0].get("error", {}) if errors else {}
-                if len(errors) > 0 and err0.get("code") == "#DIV/0!":
-                    passed += 1
-                    ok("detect_and_explain_errors #DIV/0! passed")
-                else:
-                    failed += 1
-                    fail(f"detect_and_explain_errors #DIV/0! failed: {errors}")
-            else:
-                failed += 1
-                fail(f"detect_and_explain_errors failed: {res}")
-        except Exception as e:
-            failed += 1
-            fail(f"detect_and_explain_errors #DIV/0! test failed: {e}")
-
-        try:
-            from plugin.modules.calc.formulas import DetectErrors
-            active_sheet.getCellByPosition(9, 0).setFormula("=UNKNOWN_NAME()")
-            tctx = ToolContext(test_doc, None, "calc", {}, "test")
-            res2 = DetectErrors().execute(tctx, range_name="J1")
-            if res2.get("status") == "ok" and res2.get("result", {}).get("error_count", 0) > 0:
-                errors = res2.get("result", {}).get("errors", [])
-                err0 = errors[0].get("error", {}) if errors else {}
-                if len(errors) > 0 and err0.get("code") == "#NAME?":
-                    passed += 1
-                    ok("detect_and_explain_errors #NAME? passed")
-                else:
-                    failed += 1
-                    fail(f"detect_and_explain_errors #NAME? failed: {errors}")
-            else:
-                failed += 1
-                fail(f"detect_and_explain_errors #NAME? failed: {res2}")
-        except Exception as e:
-            failed += 1
-            fail(f"detect_and_explain_errors #NAME? test failed: {e}")
-
-        try:
-            # Test: analyzer get_sheet_summary
-            from plugin.modules.calc.bridge import CalcBridge
-            from plugin.modules.calc.analyzer import SheetAnalyzer
-            bridge = CalcBridge(test_doc)
-            analyzer = SheetAnalyzer(bridge)
-            active_sheet.getCellByPosition(0, 5).setString("TestEnd")
-            summary = analyzer.get_sheet_summary()
-            if summary.get("sheet_name") == active_sheet.getName() and summary.get("row_count") >= 6:
-                passed += 1
-                ok("get_sheet_summary passed")
-            else:
-                failed += 1
-                fail(f"get_sheet_summary failed: {summary}")
-        except Exception as e:
-            failed += 1
-            fail(f"get_sheet_summary test failed: {e}")
-
-        try:
-            # Test: create_sheet (tool name is create_sheet, not add_sheet)
-            res = execute_calc_tool("create_sheet", {"sheet_name": "NewSheet"})
-            if res.get("status") == "ok" and test_doc.getSheets().hasByName("NewSheet"):
-                passed += 1
-                ok("create_sheet passed")
-            else:
-                failed += 1
-                fail(f"create_sheet failed: {res}")
-
-            # TODO: implement rename_sheet and delete_sheet tools one day; tests kept for later
-            # res = execute_calc_tool("rename_sheet", {"old_name": "NewSheet", "new_name": "RenamedSheet"})
-            # if res.get("status") == "ok" and test_doc.getSheets().hasByName("RenamedSheet"):
-            #     passed += 1
-            #     ok("rename_sheet passed")
-            # else:
-            #     failed += 1
-            #     fail(f"rename_sheet failed: {res}")
-            #
-            # res = execute_calc_tool("delete_sheet", {"sheet_name": "RenamedSheet"})
-            # if res.get("status") == "ok" and not test_doc.getSheets().hasByName("RenamedSheet"):
-            #     passed += 1
-            #     ok("delete_sheet passed")
-            # else:
-            #     failed += 1
-            #     fail(f"delete_sheet failed: {res}")
-        except Exception as e:
-            failed += 1
-            fail(f"sheet manipulation tests failed: {e}")
-
-        try:
-            # Test: add_row and add_column
-            execute_calc_tool("add_row", {"sheet_name": active_sheet.getName(), "row_index": 1, "count": 1})
-            # we just test it didn't crash for now
-            passed += 1
-            ok("add_row passed")
-
-            execute_calc_tool("add_column", {"sheet_name": active_sheet.getName(), "col_index": 1, "count": 1})
-            passed += 1
-            ok("add_column passed")
-        except Exception as e:
-            failed += 1
-            fail(f"row/col addition tests failed: {e}")
-
-        try:
-            # Test formula references extraction
-            from plugin.modules.calc.analyzer import SheetAnalyzer
-            # Instead of a non-existent method, let's use actual methods or omit.
-            # _extract_references doesn't exist, we will omit the failing extract_references test
-            # to be safe, but add a placeholder ok.
-            passed += 1
-            ok("formula references skipped as _extract_references is private/missing")
-        except Exception as e:
-            failed += 1
-            fail(f"formula references extraction failed: {e}")
-
-        test_doc.close(True)
-
-    except Exception as e:
-        failed += 1
-        fail(f"Exception during tests setup: {e}\n{traceback.format_exc()}")
-
-    return passed, failed, log
-
-def run_calc_integration_tests(ctx, doc):
-    passed = 0
-    failed = 0
-    log = []
+    # Round-trip
+    for addr in ("A1", "B10", "Z1", "AA100"):
+        col, row = parse_address(addr)
+        assert format_address(col, row) == addr
 
     try:
-        log.append("Starting Calc Integration Tests...")
-        passed += 1
-        log.append("OK: Basic setup test passed.")
-    except Exception as e:
-        failed += 1
-        log.append(f"FAIL: Exception during tests: {e}\n{traceback.format_exc()}")
+        parse_address("Invalid")
+        assert False, "Expected ValueError for 'Invalid'"
+    except ValueError:
+        pass
 
-    return passed, failed, log
+    assert parse_range_string("A1:B2") == ((0, 0), (1, 1))
+    assert parse_range_string("C3") == ((2, 2), (2, 2))
+
+    try:
+        parse_range_string("A1:Z")
+        assert False, "Expected ValueError for 'A1:Z'"
+    except ValueError:
+        pass
+
+
+@test
+def test_error_detector_data():
+    from plugin.modules.calc.error_detector import ERROR_TYPES, ERROR_PATTERNS
+    assert 502 in ERROR_TYPES
+    assert len(ERROR_PATTERNS) > 0
+    for code, info in ERROR_TYPES.items():
+        assert "name" in info
+        assert "description" in info
+
+
+@test
+def test_cells_parse_color():
+    from plugin.modules.calc.cells import _parse_color
+    assert _parse_color("red") == 0xFF0000
+    assert _parse_color("RED") == 0xFF0000
+    assert _parse_color("#00FF00") == 0x00FF00
+    assert _parse_color("#000") == 0x000000
+    assert _parse_color("invalid") is None
+
+
+def _execute_calc_tool(name, args):
+    from plugin.main import get_tools
+    from plugin.framework.tool_context import ToolContext
+    tctx = ToolContext(_test_doc, None, "calc", {}, "test")
+    try:
+        res = get_tools().execute(name, tctx, **args)
+    except (KeyError, ValueError) as e:
+        res = {"status": "error", "error": str(e)}
+    return res
+
+
+@test
+def test_write_formula_range():
+    active_sheet = _test_doc.getCurrentController().getActiveSheet()
+    res = _execute_calc_tool("write_formula_range", {"range_name": "A1", "formula_or_values": "Hello"})
+    assert res.get("status") == "ok", f"write_formula_range failed: {res}"
+    assert active_sheet.getCellByPosition(0, 0).getString() == "Hello", "Value mismatch"
+
+    # Batch write
+    _execute_calc_tool("write_formula_range", {"range_name": ["B1", "B2"], "formula_or_values": "Batch"})
+    assert active_sheet.getCellByPosition(1, 0).getString() == "Batch", "Batch write cell 1 failed"
+    assert active_sheet.getCellByPosition(1, 1).getString() == "Batch", "Batch write cell 2 failed"
+
+
+@test
+def test_set_cell_style_and_details():
+    active_sheet = _test_doc.getCurrentController().getActiveSheet()
+    _execute_calc_tool("set_cell_style", {"range_name": "A1", "bold": True, "bg_color": "yellow"})
+    cell = active_sheet.getCellByPosition(0, 0)
+    from com.sun.star.awt.FontWeight import BOLD
+    assert cell.getPropertyValue("CharWeight") == BOLD, "Bold not set"
+    assert cell.getPropertyValue("CellBackColor") == 0xFFFF00, "Background color not set"
+
+    from plugin.modules.calc.bridge import CalcBridge
+    from plugin.modules.calc.inspector import CellInspector
+    b = CalcBridge(_test_doc)
+    insp = CellInspector(b)
+    details = insp.get_cell_details("A1")
+
+    assert details.get("background_color") == 0xFFFF00, f"Details readback bg color failed: {details}"
+    assert details.get("bold") == BOLD, f"Details readback bold failed: {details}"
+
+
+@test
+def test_merge_cells():
+    active_sheet = _test_doc.getCurrentController().getActiveSheet()
+    _execute_calc_tool("merge_cells", {"range_name": ["C1:D1", "E1:F1"]})
+    rng1 = active_sheet.getCellRangeByPosition(2, 0, 3, 0)
+    rng2 = active_sheet.getCellRangeByPosition(4, 0, 5, 0)
+    assert rng1.getIsMerged(), "C1:D1 not merged"
+    assert rng2.getIsMerged(), "E1:F1 not merged"
+
+
+@test
+def test_clear_range():
+    active_sheet = _test_doc.getCurrentController().getActiveSheet()
+    active_sheet.getCellByPosition(6, 0).setString("ClearMe")
+    active_sheet.getCellByPosition(7, 0).setString("ClearMe")
+    _execute_calc_tool("clear_range", {"range_name": ["G1", "H1"]})
+    assert active_sheet.getCellByPosition(6, 0).getString() == "", "G1 not cleared"
+    assert active_sheet.getCellByPosition(7, 0).getString() == "", "H1 not cleared"
+
+
+@test
+def test_unknown_tool():
+    res = _execute_calc_tool("bad_tool", {})
+    assert res.get("status") == "error", f"unknown tool handling failed: {res}"
+
+
+@test
+def test_formulas_error_detector():
+    from plugin.modules.calc.formulas import DetectErrors
+    from plugin.framework.tool_context import ToolContext
+
+    active_sheet = _test_doc.getCurrentController().getActiveSheet()
+    active_sheet.getCellByPosition(8, 0).setFormula("=1/0")
+    tctx = ToolContext(_test_doc, None, "calc", {}, "test")
+    res = DetectErrors().execute(tctx, range_name="I1")
+
+    assert res.get("status") == "ok", f"detect_and_explain_errors failed: {res}"
+    assert res.get("result", {}).get("error_count", 0) > 0, "No errors detected"
+    errors = res.get("result", {}).get("errors", [])
+    err0 = errors[0].get("error", {}) if errors else {}
+    assert err0.get("code") == "#DIV/0!", f"Expected #DIV/0!, got: {errors}"
+
+    active_sheet.getCellByPosition(9, 0).setFormula("=UNKNOWN_NAME()")
+    res2 = DetectErrors().execute(tctx, range_name="J1")
+    assert res2.get("status") == "ok", f"detect_and_explain_errors #NAME? failed: {res2}"
+    assert res2.get("result", {}).get("error_count", 0) > 0, "No errors detected"
+    errors = res2.get("result", {}).get("errors", [])
+    err0 = errors[0].get("error", {}) if errors else {}
+    assert err0.get("code") == "#NAME?", f"Expected #NAME?, got: {errors}"
+
+
+@test
+def test_analyzer_get_sheet_summary():
+    from plugin.modules.calc.bridge import CalcBridge
+    from plugin.modules.calc.analyzer import SheetAnalyzer
+
+    active_sheet = _test_doc.getCurrentController().getActiveSheet()
+    bridge = CalcBridge(_test_doc)
+    analyzer = SheetAnalyzer(bridge)
+    active_sheet.getCellByPosition(0, 5).setString("TestEnd")
+    summary = analyzer.get_sheet_summary()
+
+    assert summary.get("sheet_name") == active_sheet.getName(), "Sheet name mismatch"
+    assert summary.get("row_count") >= 6, f"Row count mismatch: {summary}"
+
+
+@test
+def test_create_sheet():
+    res = _execute_calc_tool("create_sheet", {"sheet_name": "NewSheet"})
+    assert res.get("status") == "ok", f"create_sheet failed: {res}"
+    assert _test_doc.getSheets().hasByName("NewSheet"), "Sheet not created"
+
+
+@test
+def test_add_row_and_column():
+    active_sheet = _test_doc.getCurrentController().getActiveSheet()
+    _execute_calc_tool("add_row", {"sheet_name": active_sheet.getName(), "row_index": 1, "count": 1})
+    _execute_calc_tool("add_column", {"sheet_name": active_sheet.getName(), "col_index": 1, "count": 1})
+    # we just test it didn't crash for now
+
+
+@test
+def test_calc_integration_tests():
+    pass

--- a/plugin/tests/test_draw.py
+++ b/plugin/tests/test_draw.py
@@ -15,166 +15,102 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import json
-from plugin.main import get_tools
 from plugin.framework.logging import debug_log
 from plugin.framework.uno_helpers import get_desktop
+from plugin.testing_runner import setup, teardown, test
 
-def run_draw_tests(ctx, model=None):
-    """
-    Run Draw tool tests with real UNO.
-    ctx: UNO ComponentContext. model: optional XDrawingDocument; if None or not Draw, a new doc is created.
-    Returns (passed_count, failed_count, list of message strings).
-    """
-    log = []
-    passed = 0
-    failed = 0
 
-    def ok(msg):
-        log.append("OK: %s" % msg)
+_test_doc = None
+_test_ctx = None
 
-    def fail(msg):
-        log.append("FAIL: %s" % msg)
 
-    try:
-        smgr = ctx.getServiceManager()
-        desktop = get_desktop(ctx)
-        doc = model
-        
-        # Ensure we have a Draw document
-        if doc is None or not hasattr(doc, "getDrawPages"):
-            try:
-                # sdraw for Draw, simpress for Impress. Both use getDrawPages.
-                doc = desktop.loadComponentFromURL("private:factory/sdraw", "_blank", 0, ())
-            except Exception as e:
-                return 0, 1, ["Could not create Draw document: %s" % e]
-        
-        if not doc or not hasattr(doc, "getDrawPages"):
-            return 0, 1, ["No Draw document available."]
+@setup
+def setup_draw_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
 
-        debug_log("draw_tests: starting tests", context="DrawTests")
+    desktop = get_desktop(ctx)
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
 
-        # Helper for executing tests
-        def exec_tool(name, args):
-            from plugin.framework.tool_context import ToolContext
-            tctx = ToolContext(doc, ctx, "draw", {}, "test")
-            import json
-            res = get_tools().execute(name, tctx, **args)
-            return json.dumps(res) if isinstance(res, dict) else res
+    _test_doc = desktop.loadComponentFromURL("private:factory/sdraw", "_blank", 0, (hidden_prop,))
+    assert _test_doc is not None, "Could not create Draw document"
+    assert hasattr(_test_doc, "getDrawPages"), "Not a valid Draw document"
 
-        # Test: list_pages (returns pages and count, not result)
-        try:
-            result = exec_tool("list_pages", {})
-            data = json.loads(result)
-            if data.get("status") == "ok":
-                num_pages = data.get("count", len(data.get("pages", [])))
-                passed += 1
-                ok(f"list_pages success: {num_pages} pages")
-            else:
-                failed += 1
-                fail(f"list_pages failed: {result}")
-        except Exception as e:
-            failed += 1
-            log.append(f"FAIL: list_pages raised: {e}")
+    debug_log("draw_tests: starting tests", context="DrawTests")
 
-        # Test: create_shape (Rectangle)
-        shape_id = None
-        try:
-            result = exec_tool("create_shape", {
-                "shape_type": "rectangle",
-                "x": 2000, "y": 2000, "width": 5000, "height": 3000,
-                "text": "Hello Draw",
-                "bg_color": "#FF0000"
-            })
-            data = json.loads(result)
-            if data.get("status") == "ok":
-                passed += 1
-                ok("create_shape (Rectangle) success")
-                # Note: create_shape currently returns message, not shape_index
-                # We'll get it from summary
-            else:
-                failed += 1
-                fail(f"create_shape failed: {result}")
-        except Exception as e:
-            failed += 1
-            log.append(f"FAIL: create_shape raised: {e}")
 
-        # Test: get_draw_summary
-        try:
-            result = exec_tool("get_draw_summary", {"page_index": 0})
-            data = json.loads(result)
-            if data.get("status") == "ok":
-                passed += 1
-                ok("get_draw_summary success")
-                shapes = data.get("shapes", [])
-                if any("RectangleShape" in s.get("type", "") for s in shapes):
-                    passed += 1
-                    ok("Summary contains the created rectangle")
-                    # Find the index of the rectangle we just created
-                    for s in shapes:
-                        if "RectangleShape" in s.get("type", ""):
-                            shape_id = s.get("index")
-                else:
-                    failed += 1
-                    fail("Summary missing the created rectangle")
-            else:
-                failed += 1
-                fail(f"get_draw_summary failed: {result}")
-        except Exception as e:
-            failed += 1
-            log.append(f"FAIL: get_draw_summary raised: {e}")
+@teardown
+def teardown_draw_tests(ctx):
+    global _test_doc, _test_ctx
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+    _test_ctx = None
 
-        # Test: edit_shape (Move/Resize/Color)
-        if shape_id is not None:
-            try:
-                result = exec_tool("edit_shape", {
-                    "shape_index": shape_id,
-                    "x": 3000, "y": 3000,
-                    "bg_color": "#00FF00"
-                })
-                data = json.loads(result)
-                if data.get("status") == "ok":
-                    passed += 1
-                    ok("edit_shape success")
-                else:
-                    failed += 1
-                    fail(f"edit_shape failed: {result}")
-            except Exception as e:
-                failed += 1
-                log.append(f"FAIL: edit_shape raised: {e}")
 
-        # Test: delete_shape
-        if shape_id is not None:
-            try:
-                result = exec_tool("delete_shape", {"shape_index": shape_id})
-                data = json.loads(result)
-                if data.get("status") == "ok":
-                    passed += 1
-                    ok("delete_shape success")
-                else:
-                    failed += 1
-                    fail(f"delete_shape failed: {result}")
-            except Exception as e:
-                failed += 1
-                log.append(f"FAIL: delete_shape raised: {e}")
+def _exec_tool(name, args):
+    from plugin.main import get_tools
+    from plugin.framework.tool_context import ToolContext
+    tctx = ToolContext(_test_doc, _test_ctx, "draw", {}, "test")
+    res = get_tools().execute(name, tctx, **args)
+    return json.dumps(res) if isinstance(res, dict) else res
 
-        # Test: get_draw_context_for_chat (returns "Draw Document" or "Impress Presentation" and "Total Pages" or "Total Slides")
-        try:
-            from plugin.framework.document import get_draw_context_for_chat
-            ctx_str = get_draw_context_for_chat(doc, 8000, ctx)
-            has_doc_type = "Draw Document" in ctx_str or "Impress Presentation" in ctx_str
-            has_total = "Total" in ctx_str and ("Pages" in ctx_str or "Slides" in ctx_str)
-            if has_doc_type and has_total:
-                passed += 1
-                ok("get_draw_context_for_chat returns summary")
-            else:
-                failed += 1
-                fail("get_draw_context_for_chat missing expected headers")
-        except Exception as e:
-            failed += 1
-            log.append(f"FAIL: get_draw_context_for_chat raised: {e}")
 
-    except Exception as e:
-        failed += 1
-        log.append(f"CRITICAL failure in Draw test runner: {e}")
+@test
+def test_list_pages():
+    result = _exec_tool("list_pages", {})
+    data = json.loads(result)
+    assert data.get("status") == "ok", f"list_pages failed: {result}"
+    num_pages = data.get("count", len(data.get("pages", [])))
+    assert num_pages > 0, "No pages found"
 
-    return passed, failed, log
+
+@test
+def test_create_and_verify_shape():
+    # 1. Create shape
+    result = _exec_tool("create_shape", {
+        "shape_type": "rectangle",
+        "x": 2000, "y": 2000, "width": 5000, "height": 3000,
+        "text": "Hello Draw",
+        "bg_color": "#FF0000"
+    })
+    data = json.loads(result)
+    assert data.get("status") == "ok", f"create_shape failed: {result}"
+
+    # 2. Get draw summary to find shape_id
+    result = _exec_tool("get_draw_summary", {"page_index": 0})
+    data = json.loads(result)
+    assert data.get("status") == "ok", f"get_draw_summary failed: {result}"
+    shapes = data.get("shapes", [])
+
+    shape_id = None
+    for s in shapes:
+        if "RectangleShape" in s.get("type", ""):
+            shape_id = s.get("index")
+    assert shape_id is not None, "Summary missing the created rectangle"
+
+    # 3. Edit shape
+    result = _exec_tool("edit_shape", {
+        "shape_index": shape_id,
+        "x": 3000, "y": 3000,
+        "bg_color": "#00FF00"
+    })
+    data = json.loads(result)
+    assert data.get("status") == "ok", f"edit_shape failed: {result}"
+
+    # 4. Delete shape
+    result = _exec_tool("delete_shape", {"shape_index": shape_id})
+    data = json.loads(result)
+    assert data.get("status") == "ok", f"delete_shape failed: {result}"
+
+
+@test
+def test_get_draw_context_for_chat():
+    from plugin.framework.document import get_draw_context_for_chat
+    ctx_str = get_draw_context_for_chat(_test_doc, 8000, _test_ctx)
+    has_doc_type = "Draw Document" in ctx_str or "Impress Presentation" in ctx_str
+    has_total = "Total" in ctx_str and ("Pages" in ctx_str or "Slides" in ctx_str)
+    assert has_doc_type and has_total, "get_draw_context_for_chat missing expected headers"

--- a/plugin/tests/test_image_service_refactor.py
+++ b/plugin/tests/test_image_service_refactor.py
@@ -3,17 +3,18 @@ import os
 import unittest
 import json
 import base64
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch
 
 # Add parent directory to path to import core
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from plugin.framework.image_utils import EndpointImageProvider
 from plugin.modules.http.client import LlmClient
+from plugin.tests.testing_utils import MockContext, create_mock_client, create_mock_http_response
 
 class TestEndpointImageProvider(unittest.TestCase):
     def setUp(self):
-        self.mock_ctx = MagicMock()
+        self.mock_ctx = MockContext()
         self.api_config = {"model": "test-model"}
         with patch('plugin.framework.image_utils.LlmClient') as mock_client_cls:
             self.provider = EndpointImageProvider(self.api_config, self.mock_ctx)
@@ -64,11 +65,8 @@ class TestEndpointImageProvider(unittest.TestCase):
         # Mock standard connection and response
         mock_conn = MagicMock()
         self.mock_client._get_connection.return_value = mock_conn
-        mock_http_resp = MagicMock()
-        mock_http_resp.status = 200
         b64_data = base64.b64encode(b"standard-b64-data").decode()
-        resp_data = {"data": [{"b64_json": b64_data}]}
-        mock_http_resp.read.return_value = json.dumps(resp_data).encode()
+        mock_http_resp = create_mock_http_response(200, {"data": [{"b64_json": b64_data}]})
         mock_conn.getresponse.return_value = mock_http_resp
 
         result = self.provider.generate("test prompt")
@@ -129,10 +127,7 @@ class TestEndpointImageProvider(unittest.TestCase):
         # Mock standard connection and response that returns no images in data
         mock_conn = MagicMock()
         self.mock_client._get_connection.return_value = mock_conn
-        mock_http_resp = MagicMock()
-        mock_http_resp.status = 200
-        resp_data = {"data": []} # No images
-        mock_http_resp.read.return_value = json.dumps(resp_data).encode()
+        mock_http_resp = create_mock_http_response(200, {"data": []}) # No images
         mock_conn.getresponse.return_value = mock_http_resp
 
         # This should NOT crash now, even if fallback fails to find anything.
@@ -146,12 +141,12 @@ class TestEndpointImageProvider(unittest.TestCase):
     @patch('plugin.framework.image_utils.LlmClient')
     def test_edit_image_openrouter_sends_multimodal_message(self, mock_client_cls):
         """When OpenRouter and source_image are set, make_chat_request receives message content with text + image_url."""
-        mock_client = MagicMock()
+        mock_client = create_mock_client()
         mock_client.config.get.side_effect = lambda k, d=None: True if k == "is_openrouter" else d
         mock_client_cls.return_value = mock_client
         mock_client.make_chat_request.return_value = ("POST", "/chat", "{}", {})
         mock_client.request_with_tools.return_value = {"images": []}
-        provider = EndpointImageProvider({"model": "test"}, MagicMock())
+        provider = EndpointImageProvider({"model": "test"}, MockContext())
         provider.client = mock_client
 
         b64 = "abc123"
@@ -169,17 +164,14 @@ class TestEndpointImageProvider(unittest.TestCase):
     @patch('plugin.framework.image_utils.LlmClient')
     def test_edit_image_standard_endpoint_passes_source_image(self, mock_client_cls):
         """When not OpenRouter and source_image is set, make_image_request is called with source_image (img2img)."""
-        mock_client = MagicMock()
-        mock_client.config.get.return_value = False
+        mock_client = create_mock_client()
         mock_client.make_image_request.return_value = ("POST", "/images", "{}", {})
         mock_conn = MagicMock()
         mock_client._get_connection.return_value = mock_conn
-        mock_http_resp = MagicMock()
-        mock_http_resp.status = 200
-        mock_http_resp.read.return_value = json.dumps({"data": [{"b64_json": base64.b64encode(b"edited").decode()}]}).encode()
+        mock_http_resp = create_mock_http_response(200, {"data": [{"b64_json": base64.b64encode(b"edited").decode()}]})
         mock_conn.getresponse.return_value = mock_http_resp
         mock_client_cls.return_value = mock_client
-        provider = EndpointImageProvider({"model": "test"}, MagicMock())
+        provider = EndpointImageProvider({"model": "test"}, MockContext())
         provider.client = mock_client
 
         b64 = "xyz789"
@@ -194,7 +186,7 @@ class TestEndpointImageProvider(unittest.TestCase):
     def test_make_image_request_body_includes_image_url_when_source_image(self, mock_debug, mock_init):
         """LlmClient.make_image_request adds image_url (data URL) to body when source_image is provided."""
         config = {"endpoint": "https://api.example.com", "model": "test-model"}
-        client = LlmClient(config, MagicMock())
+        client = LlmClient(config, MockContext())
         method, path, body, headers = client.make_image_request("a cat", source_image="b64data")
         data = json.loads(body.decode("utf-8"))
         self.assertIn("image_url", data)

--- a/plugin/tests/test_writer.py
+++ b/plugin/tests/test_writer.py
@@ -1,237 +1,161 @@
-import traceback
-
 from plugin.framework.document import (
     DocumentCache,
     build_heading_tree,
     resolve_locator,
     get_paragraph_ranges,
+    get_document_length,
 )
 from plugin.framework.uno_helpers import get_desktop
+from plugin.testing_runner import setup, teardown, test
 
 
-def run_writer_tests(ctx, doc=None):
-    """Entry point for testing the core writer module functionality inside LibreOffice."""
-    passed = 0
-    failed = 0
-    log = []
+_test_doc = None
+_test_ctx = None
 
-    def ok(msg):
-        log.append("OK: " + msg)
 
-    def fail(msg):
-        log.append("FAIL: " + msg)
+@setup
+def setup_writer_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
 
-    try:
-        log.append("Starting Writer Tests...")
+    desktop = get_desktop(ctx)
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
+    _test_doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
+    assert _test_doc is not None, "Could not create hidden test writer document"
 
-        # Always create a hidden test writer document to avoid mutating user's open document
-        close_doc = True
-        desktop = get_desktop(ctx)
-        from com.sun.star.beans import PropertyValue
-        hidden_prop = PropertyValue()
-        hidden_prop.Name = "Hidden"
-        hidden_prop.Value = True
-        doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
-        if not doc:
-            raise Exception("Could not create hidden test writer document")
+    # 1. Setup doc content
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
 
-        cache3 = DocumentCache.get(doc)
+    # H1
+    text.insertString(cursor, "H1", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 1")
+    text.insertControlCharacter(cursor, 0, False) # PARAGRAPH_BREAK
 
-        # 1. Setup doc content
-        try:
-            text = doc.getText()
-            cursor = text.createTextCursor()
+    # P1
+    text.insertString(cursor, "P1", False)
+    cursor.setPropertyValue("ParaStyleName", "Default Paragraph Style")
+    text.insertControlCharacter(cursor, 0, False)
 
-            # H1
-            text.insertString(cursor, "H1", False)
-            cursor.setPropertyValue("ParaStyleName", "Heading 1")
-            text.insertControlCharacter(cursor, 0, False) # PARAGRAPH_BREAK
+    # H1.1
+    text.insertString(cursor, "H1.1", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 2")
+    text.insertControlCharacter(cursor, 0, False)
 
-            # P1
-            text.insertString(cursor, "P1", False)
-            cursor.setPropertyValue("ParaStyleName", "Default Paragraph Style")
-            text.insertControlCharacter(cursor, 0, False)
+    # P2
+    text.insertString(cursor, "P2", False)
+    cursor.setPropertyValue("ParaStyleName", "Default Paragraph Style")
+    text.insertControlCharacter(cursor, 0, False)
 
-            # H1.1
-            text.insertString(cursor, "H1.1", False)
-            cursor.setPropertyValue("ParaStyleName", "Heading 2")
-            text.insertControlCharacter(cursor, 0, False)
+    # H2
+    text.insertString(cursor, "H2", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 1")
 
-            # P2
-            text.insertString(cursor, "P2", False)
-            cursor.setPropertyValue("ParaStyleName", "Default Paragraph Style")
-            text.insertControlCharacter(cursor, 0, False)
+    # Populate cache.length so DummyDocSvc and cache test can use it
+    get_document_length(_test_doc)
 
-            # H2
-            text.insertString(cursor, "H2", False)
-            cursor.setPropertyValue("ParaStyleName", "Heading 1")
-        except Exception as e:
-            failed += 1
-            fail(f"Writer Test Setup failed: {type(e).__name__}: {e!r}")
-            return passed, failed, log
 
-        # Populate cache.length so DummyDocSvc and cache test can use it
-        from plugin.framework.document import get_document_length
-        get_document_length(doc)
+@teardown
+def teardown_writer_tests(ctx):
+    global _test_doc, _test_ctx
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+    _test_ctx = None
 
-        try:
-            # Test Proximity Service
-            from plugin.modules.writer.proximity import ProximityService
-            from plugin.modules.writer.bookmarks import BookmarkService
-            from plugin.modules.writer.tree import TreeService
-            from plugin.framework.events import EventBus
 
-            events = EventBus()
-            class DummyDocSvc:
-                def get_document_length(self, model):
-                    return cache3.length
+@test
+def test_proximity_service():
+    from plugin.modules.writer.proximity import ProximityService
+    from plugin.modules.writer.bookmarks import BookmarkService
+    from plugin.modules.writer.tree import TreeService
+    from plugin.framework.events import EventBus
 
-            # Using real instances except for doc_svc which only needs get_document_length
-            doc_svc = DummyDocSvc()
-            bm = BookmarkService(doc_svc, events)
-            tree_svc = TreeService(doc_svc, bm, events)
-            prox = ProximityService(doc_svc, tree_svc, bm, events)
+    events = EventBus()
 
-            res = prox.get_context_at_offset(doc, 0)
-            if res and res["paragraph_index"] == 0:
-                passed += 1
-                ok("ProximityService get_context_at_offset passed")
-            else:
-                failed += 1
-                fail(f"ProximityService get_context_at_offset failed: {res}")
-        except Exception as e:
-            failed += 1
-            fail(f"ProximityService test failed: {e}\n{traceback.format_exc()}")
+    cache3 = DocumentCache.get(_test_doc)
 
-        try:
-            # Test format_support content_has_markup
-            from plugin.modules.writer.format_support import content_has_markup
-            if content_has_markup("**bold**") and not content_has_markup("plain text"):
-                passed += 1
-                ok("content_has_markup passed")
-            else:
-                failed += 1
-                fail("content_has_markup failed")
-        except Exception as e:
-            failed += 1
-            fail(f"content_has_markup test failed: {e}")
+    class DummyDocSvc:
+        def get_document_length(self, model):
+            return cache3.length
 
-        try:
-            # Test Bookmarks & Indexing
-            from plugin.modules.writer.bookmarks import ensure_heading_bookmarks
-            ensure_heading_bookmarks(doc)
-            bookmarks = doc.getBookmarks()
-            bnames = bookmarks.getElementNames()
-            if len(bnames) == 3: # H1, H1.1, H2
-                passed += 1
-                ok("ensure_heading_bookmarks created 3 bookmarks")
-            else:
-                failed += 1
-                fail(f"ensure_heading_bookmarks created {len(bnames)} bookmarks instead of 3")
+    doc_svc = DummyDocSvc()
+    bm = BookmarkService(doc_svc, events)
+    tree_svc = TreeService(doc_svc, bm, events)
+    prox = ProximityService(doc_svc, tree_svc, bm, events)
 
-            # Running ensure_heading_bookmarks again should not duplicate
-            ensure_heading_bookmarks(doc)
-            bnames = doc.getBookmarks().getElementNames()
-            if len(bnames) == 3:
-                passed += 1
-                ok("ensure_heading_bookmarks did not duplicate bookmarks")
-            else:
-                failed += 1
-                fail(f"ensure_heading_bookmarks duplicated bookmarks, total: {len(bnames)}")
-        except Exception as e:
-            failed += 1
-            fail(f"ensure_heading_bookmarks test failed: {e}")
+    res = prox.get_context_at_offset(_test_doc, 0)
+    assert res is not None and res["paragraph_index"] == 0, f"ProximityService get_context_at_offset failed: {res}"
 
-        try:
-            # 3. Test paragraph ranges
-            ranges = get_paragraph_ranges(doc)
-            if len(ranges) == 5:
-                passed += 1
-                ok("get_paragraph_ranges found 5 paragraphs")
-            else:
-                failed += 1
-                fail(f"get_paragraph_ranges expected 5 paragraphs, got {len(ranges)}")
-        except Exception as e:
-            failed += 1
-            fail(f"get_paragraph_ranges test failed: {e}")
 
-        try:
-            # 4. Test heading tree
-            tree = build_heading_tree(doc)
-            if "children" in tree and len(tree["children"]) == 2:
-                h1 = tree["children"][0]
-                h2 = tree["children"][1]
-                if h1["text"] == "H1" and len(h1["children"]) == 1 and h1["children"][0]["text"] == "H1.1" and h2["text"] == "H2" and h2["body_paragraphs"] == 0:
-                    passed += 1
-                    ok("build_heading_tree constructed correct tree")
-                else:
-                    failed += 1
-                    fail(f"build_heading_tree structure incorrect: {tree}")
-            else:
-                failed += 1
-                fail("build_heading_tree did not find 2 root children")
-        except Exception as e:
-            failed += 1
-            fail(f"build_heading_tree test failed: {e}")
+@test
+def test_content_has_markup():
+    from plugin.modules.writer.format_support import content_has_markup
+    assert content_has_markup("**bold**"), "content_has_markup failed to detect **bold**"
+    assert not content_has_markup("plain text"), "content_has_markup falsely detected plain text"
 
-        try:
-            # 5. Test resolve locator
-            res1 = resolve_locator(doc, "paragraph:1")
-            if res1 and res1["para_index"] == 1:
-                passed += 1
-                ok("resolve_locator paragraph:1 passed")
-            else:
-                failed += 1
-                fail(f"resolve_locator paragraph:1 failed: {res1}")
 
-            res2 = resolve_locator(doc, "heading:2") # should be index 4 (H2)
-            if res2 and res2["para_index"] == 4:
-                passed += 1
-                ok("resolve_locator heading:2 passed")
-            else:
-                failed += 1
-                fail(f"resolve_locator heading:2 failed: {res2}")
+@test
+def test_ensure_heading_bookmarks():
+    from plugin.modules.writer.bookmarks import ensure_heading_bookmarks
+    ensure_heading_bookmarks(_test_doc)
+    bookmarks = _test_doc.getBookmarks()
+    bnames = bookmarks.getElementNames()
+    assert len(bnames) == 3, f"ensure_heading_bookmarks created {len(bnames)} bookmarks instead of 3"
 
-            res3 = resolve_locator(doc, "heading:1.1") # should be index 2 (H1.1)
-            if res3 and res3["para_index"] == 2:
-                passed += 1
-                ok("resolve_locator heading:1.1 passed")
-            else:
-                failed += 1
-                fail(f"resolve_locator heading:1.1 failed: {res3}")
-        except Exception as e:
-            failed += 1
-            fail(f"resolve_locator test failed: {e}")
+    # Running ensure_heading_bookmarks again should not duplicate
+    ensure_heading_bookmarks(_test_doc)
+    bnames = _test_doc.getBookmarks().getElementNames()
+    assert len(bnames) == 3, f"ensure_heading_bookmarks duplicated bookmarks, total: {len(bnames)}"
 
-        try:
-            # 6. Test Document Cache length tracking
-            _ = get_document_length(doc)
-            prev_len = cache3.length
-            if prev_len is not None and prev_len > 0:
-                text.insertControlCharacter(cursor, 0, False)
-                text.insertString(cursor, "More text", False)
-                DocumentCache.invalidate(doc)
-                _ = get_document_length(doc)
-                cache3_new = DocumentCache.get(doc)
-                new_len = cache3_new.length
-                if new_len is not None and new_len > prev_len:
-                    passed += 1
-                    ok("DocumentCache length updated after invalidate and get_document_length")
-                else:
-                    failed += 1
-                    fail("DocumentCache length did not update")
-            else:
-                failed += 1
-                fail("DocumentCache length not properly initialized")
-        except Exception as e:
-            failed += 1
-            fail(f"DocumentCache cache tracking test failed: {e}")
 
-        if close_doc:
-            doc.close(True)
+@test
+def test_get_paragraph_ranges():
+    ranges = get_paragraph_ranges(_test_doc)
+    assert len(ranges) == 5, f"get_paragraph_ranges expected 5 paragraphs, got {len(ranges)}"
 
-    except Exception as e:
-        failed += 1
-        fail(f"Exception during tests: {e}\n{traceback.format_exc()}")
 
-    return passed, failed, log
+@test
+def test_build_heading_tree():
+    tree = build_heading_tree(_test_doc)
+    assert "children" in tree and len(tree["children"]) == 2, "build_heading_tree did not find 2 root children"
+    h1 = tree["children"][0]
+    h2 = tree["children"][1]
+    assert h1["text"] == "H1", "H1 text mismatch"
+    assert len(h1["children"]) == 1, "H1 child count mismatch"
+    assert h1["children"][0]["text"] == "H1.1", "H1.1 text mismatch"
+    assert h2["text"] == "H2", "H2 text mismatch"
+    assert h2["body_paragraphs"] == 0, "H2 body paragraphs mismatch"
+
+
+@test
+def test_resolve_locator():
+    res1 = resolve_locator(_test_doc, "paragraph:1")
+    assert res1 and res1["para_index"] == 1, f"resolve_locator paragraph:1 failed: {res1}"
+
+    res2 = resolve_locator(_test_doc, "heading:2") # should be index 4 (H2)
+    assert res2 and res2["para_index"] == 4, f"resolve_locator heading:2 failed: {res2}"
+
+    res3 = resolve_locator(_test_doc, "heading:1.1") # should be index 2 (H1.1)
+    assert res3 and res3["para_index"] == 2, f"resolve_locator heading:1.1 failed: {res3}"
+
+
+@test
+def test_document_cache_length_tracking():
+    cache3 = DocumentCache.get(_test_doc)
+    _ = get_document_length(_test_doc)
+    prev_len = cache3.length
+    assert prev_len is not None and prev_len > 0, "DocumentCache length not properly initialized"
+
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
+    text.insertControlCharacter(cursor, 0, False)
+    text.insertString(cursor, "More text", False)
+    DocumentCache.invalidate(_test_doc)
+    _ = get_document_length(_test_doc)
+    cache3_new = DocumentCache.get(_test_doc)
+    new_len = cache3_new.length
+    assert new_len is not None and new_len > prev_len, "DocumentCache length did not update"

--- a/plugin/tests/test_writer_navigation.py
+++ b/plugin/tests/test_writer_navigation.py
@@ -6,41 +6,7 @@ from plugin.framework.document import (
     resolve_locator,
     get_paragraph_ranges
 )
-
-class ElementStub:
-    def __init__(self, text, outline_level=0, services=None):
-        self.text = text
-        self.outline_level = outline_level
-        self.services = services or ["com.sun.star.text.Paragraph"]
-    def getString(self): return self.text
-    def getPropertyValue(self, name):
-        if name == "OutlineLevel": return self.outline_level
-        raise Exception("Property not found")
-    def supportsService(self, service): return service in self.services
-    def getStart(self): return self # Stub for range
-    def getEnd(self): return self
-    def getText(self): return self
-
-class WriterDocStub:
-    def __init__(self, elements):
-        self.elements = elements
-        self.url = "test://writer"
-    def getText(self): 
-        class TextStub:
-            def __init__(self, el): self.el = el
-            def createEnumeration(self):
-                class EnumStub:
-                    def __init__(self, el): 
-                        self.el = el
-                        self.idx = 0
-                    def hasMoreElements(self): return self.idx < len(self.el)
-                    def nextElement(self):
-                        res = self.el[self.idx]
-                        self.idx += 1
-                        return res
-                return EnumStub(self.el)
-        return TextStub(self.elements)
-    def supportsService(self, s): return s == "com.sun.star.text.TextDocument"
+from plugin.tests.testing_utils import ElementStub, WriterDocStub
 
 class TestWriterNavigation(unittest.TestCase):
     def test_document_cache(self):

--- a/plugin/tests/testing_utils.py
+++ b/plugin/tests/testing_utils.py
@@ -1,0 +1,99 @@
+# testing_utils.py
+# Centralized testing utilities and mocks for WriterAgent tests.
+
+class ElementStub:
+    def __init__(self, text, outline_level=0, services=None):
+        self.text = text
+        self.outline_level = outline_level
+        self.services = services or ["com.sun.star.text.Paragraph"]
+
+    def getString(self):
+        return self.text
+
+    def getPropertyValue(self, name):
+        if name == "OutlineLevel":
+            return self.outline_level
+        raise Exception("Property not found")
+
+    def supportsService(self, service):
+        return service in self.services
+
+    def getStart(self):
+        return self # Stub for range
+
+    def getEnd(self):
+        return self
+
+    def getText(self):
+        return self
+
+class WriterDocStub:
+    def __init__(self, elements):
+        self.elements = elements
+        self.url = "test://writer"
+
+    def getText(self):
+        class TextStub:
+            def __init__(self, el):
+                self.el = el
+
+            def createEnumeration(self):
+                class EnumStub:
+                    def __init__(self, el):
+                        self.el = el
+                        self.idx = 0
+
+                    def hasMoreElements(self):
+                        return self.idx < len(self.el)
+
+                    def nextElement(self):
+                        res = self.el[self.idx]
+                        self.idx += 1
+                        return res
+                return EnumStub(self.el)
+        return TextStub(self.elements)
+
+    def supportsService(self, s):
+        return s == "com.sun.star.text.TextDocument"
+
+class MockDocument:
+    def __init__(self):
+        self.url = "test://mock"
+
+    def supportsService(self, service):
+        return False
+
+class MockTextCursor:
+    def __init__(self):
+        pass
+
+class MockSheet:
+    def __init__(self):
+        pass
+
+class MockContext:
+    """Mock context object used as a stand-in for the UNO ComponentContext outside of LibreOffice."""
+    def __init__(self):
+        self.mock_values = {}
+
+    def getValueByName(self, name):
+        return self.mock_values.get(name)
+
+def create_mock_client():
+    """Creates a pre-configured MagicMock for an LlmClient."""
+    from unittest.mock import MagicMock
+    mock_client = MagicMock()
+    mock_client.config = MagicMock()
+    mock_client.config.get.return_value = False
+    return mock_client
+
+def create_mock_http_response(status_code=200, json_data=None):
+    """Creates a mock HTTP response object."""
+    from unittest.mock import MagicMock
+    import json
+
+    mock_resp = MagicMock()
+    mock_resp.status = status_code
+    if json_data is not None:
+        mock_resp.read.return_value = json.dumps(json_data).encode()
+    return mock_resp


### PR DESCRIPTION
This PR refactors the native LibreOffice test runner to reduce boilerplate code and centralize mock object definitions.

### Changes Made:
1. **Decorator-based Test Runner:** `plugin/testing_runner.py` now exports `@test`, `@setup`, and `@teardown` decorators. `_run_suite` parses modules to build and execute sequences dynamically, rather than enforcing monolithic functions and manual state tracking for passes/fails. Execution order is preserved.
2. **Native Test Migration:** `test_writer.py`, `test_calc.py`, `test_draw.py`, `format_tests.py`, and `core_tests.py` have been fully migrated to the new runner framework, using module-level variables for isolated document state during `setup` and standard Python `assert`s during tests. 
3. **Centralized Mocks:** Abstracted common test stubs (`WriterDocStub`, `ElementStub`, `MockContext`) out of individual test files and into a shared `plugin/tests/testing_utils.py` to DRY up external `pytest` suites, explicitly applying this pattern to `test_writer_navigation.py` and `test_image_service_refactor.py`.

---
*PR created automatically by Jules for task [2560839263422330741](https://jules.google.com/task/2560839263422330741) started by @KeithCu*