### PR TITLE
Refactor options_handler.py and prompt_function.py to remove dead code

### DIFF
--- a/check_dead.py
+++ b/check_dead.py
@@ -1,0 +1,16 @@
+import re
+
+def check_file(filepath):
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    methods = re.findall(r'def\s+([a-zA-Z_0-9]+)\s*\(', content)
+    for m in methods:
+        if m.startswith('__'):
+            continue
+        count = len(re.findall(r'\b' + m + r'\b', content))
+        if count == 1:
+            print(f"Potentially dead method in {filepath}: {m}")
+
+check_file("plugin/options_handler.py")
+check_file("plugin/prompt_function.py")

--- a/check_handler_methods.py
+++ b/check_handler_methods.py
@@ -1,0 +1,14 @@
+import re
+
+with open("plugin/options_handler.py", "r") as f:
+    content = f.read()
+
+methods = re.findall(r'def\s+([a-zA-Z_0-9]+)\s*\(', content)
+called = set(re.findall(r'self\.([a-zA-Z_0-9]+)\(', content))
+called.update(re.findall(r'self\._handler\.([a-zA-Z_0-9]+)\(', content))
+called.update(re.findall(r'self\._state\.([a-zA-Z_0-9]+)\(', content))
+
+print("Defined methods:")
+for m in methods:
+    if m not in called and not m.startswith('__') and m not in ['callHandlerMethod', 'getSupportedMethodNames', 'itemStateChanged', 'disposing', 'actionPerformed', 'supportsService', 'getImplementationName', 'getSupportedServiceNames']:
+        print(f"Potentially dead method: {m}")

--- a/check_methods.py
+++ b/check_methods.py
@@ -1,0 +1,31 @@
+import ast
+
+def get_defined_methods(filepath):
+    with open(filepath, "r") as f:
+        tree = ast.parse(f.read())
+
+    methods = []
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef):
+                    methods.append(item.name)
+    return methods
+
+def get_called_methods(filepath):
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    import re
+    called = re.findall(r'self\.([a-zA-Z_0-9]+)\(', content)
+    called += re.findall(r'self\._handler\.([a-zA-Z_0-9]+)\(', content)
+    return set(called)
+
+methods = get_defined_methods("plugin/options_handler.py")
+called = get_called_methods("plugin/options_handler.py")
+
+print("Methods defined:", methods)
+print("Methods called:", called)
+for m in methods:
+    if m not in called and not m.startswith('__') and m not in ['callHandlerMethod', 'getSupportedMethodNames', 'itemStateChanged', 'disposing', 'actionPerformed', 'supportsService', 'getImplementationName', 'getSupportedServiceNames']:
+        print("POSSIBLY DEAD:", m)

--- a/check_options_handler_methods2.py
+++ b/check_options_handler_methods2.py
@@ -1,0 +1,15 @@
+import re
+
+with open("plugin/options_handler.py", "r") as f:
+    content = f.read()
+
+# Let's see if any other methods are really unused.
+# Like _read_select, _populate_select, etc.
+
+methods = re.findall(r'def\s+([a-zA-Z_0-9]+)\s*\(', content)
+
+for m in methods:
+    if m.startswith('__'): continue
+    occurrences = content.count(m)
+    if occurrences == 1:
+        print(f"Dead method: {m}")

--- a/check_options_methods.py
+++ b/check_options_methods.py
@@ -1,0 +1,8 @@
+import re
+
+with open("plugin/options_handler.py", "r") as f:
+    content = f.read()
+
+# Let's count the occurrences of `XServiceInfo` in the file.
+print("XServiceInfo occurrences:", content.count("XServiceInfo"))
+print("XContainerWindowEventHandler occurrences:", content.count("XContainerWindowEventHandler"))

--- a/check_service_info.py
+++ b/check_service_info.py
@@ -1,0 +1,4 @@
+from plugin.options_handler import OptionsHandler
+from plugin.prompt_function import PromptFunction
+
+print("OptionsHandler methods:", dir(OptionsHandler))

--- a/fix_exceptions.py
+++ b/fix_exceptions.py
@@ -1,0 +1,9 @@
+import re
+
+with open("plugin/prompt_function.py", "r") as f:
+    content = f.read()
+
+content = content.replace("except:\n            # Fallback to stdout", "except Exception:\n            # Fallback to stdout")
+
+with open("plugin/prompt_function.py", "w") as f:
+    f.write(content)

--- a/fix_prompt_function.py
+++ b/fix_prompt_function.py
@@ -1,0 +1,33 @@
+import re
+
+with open("plugin/prompt_function.py", "r") as f:
+    content = f.read()
+
+# Methods to remove (XAddIn methods)
+methods_to_remove = [
+    "getProgrammaticFunctionName",
+    "getDisplayFunctionName",
+    "getFunctionDescription",
+    "getArgumentDescription",
+    "getArgumentName",
+    "hasFunctionWizard",
+    "getArgumentCount",
+    "getArgumentIsOptional",
+    "getProgrammaticCategoryName",
+    "getDisplayCategoryName",
+    "getLocale",
+    "setLocale",
+    "load",
+    "unload"
+]
+
+for method in methods_to_remove:
+    pattern = r"(\s+def " + method + r"\(self.*?\):.*?)(?=\n\s+def |\n\s+# |\Z)"
+    content = re.sub(pattern, "", content, flags=re.DOTALL)
+
+# Let's also remove test_registration
+pattern_test = r"(\n# Test function registration\ndef test_registration\(\).*)"
+content = re.sub(pattern_test, "", content, flags=re.DOTALL)
+
+with open("plugin/prompt_function.py", "w") as f:
+    f.write(content)

--- a/get_classes.py
+++ b/get_classes.py
@@ -1,0 +1,11 @@
+import ast
+
+with open("plugin/options_handler.py", "r") as f:
+    tree = ast.parse(f.read())
+
+for node in tree.body:
+    if isinstance(node, ast.ClassDef):
+        print(f"Class: {node.name}")
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef):
+                pass

--- a/plugin/prompt_function.py
+++ b/plugin/prompt_function.py
@@ -47,7 +47,7 @@ def debug_log(message):
             debug_file = os.path.expanduser("~/libreoffice_prompt_debug.log")
             with open(debug_file, "a", encoding="utf-8") as f:
                 f.write(f"{message}\n")
-        except:
+        except Exception:
             # Fallback to stdout
             print(f"DEBUG: {message}")
             sys.stdout.flush()
@@ -57,78 +57,6 @@ class PromptFunction(unohelper.Base, XPromptFunction):
         debug_log("=== PromptFunction.__init__ called ===")
         self.ctx = ctx
         self.client = None
-
-    def getProgrammaticFunctionName(self, aDisplayName):
-        debug_log(f"=== getProgrammaticFunctionName called with: '{aDisplayName}' ===")
-        if aDisplayName == "PROMPT":
-            return "prompt"
-        return ""
-
-    def getDisplayFunctionName(self, aProgrammaticName):
-        debug_log(f"=== getDisplayFunctionName called with: '{aProgrammaticName}' ===")
-        if aProgrammaticName == "prompt":
-            return "PROMPT"
-        return ""
-
-    def getFunctionDescription(self, aProgrammaticName):
-        if aProgrammaticName == "prompt":
-            return "Generates text using an LLM."
-        return ""
-
-    def getArgumentDescription(self, aProgrammaticName, nArgument):
-        if aProgrammaticName == "prompt":
-            if nArgument == 0:
-                return "The prompt to send to the LLM."
-            elif nArgument == 1:
-                return "The system prompt to use."
-            elif nArgument == 2:
-                return "The model to use."
-            elif nArgument == 3:
-                return "The maximum number of tokens to generate."
-        return ""
-        
-    def getArgumentName(self, aProgrammaticName, nArgument):
-        if aProgrammaticName == "prompt":
-            if nArgument == 0:
-                return "message"
-            elif nArgument == 1:
-                return "system_prompt"
-            elif nArgument == 2:
-                return "model"
-            elif nArgument == 3:
-                return "max_tokens"
-        return ""
-
-    def hasFunctionWizard(self, aProgrammaticName):
-        return True
-
-    def getArgumentCount(self, aProgrammaticName):
-        if aProgrammaticName == "prompt":
-            return 4
-        return 0
-
-    def getArgumentIsOptional(self, aProgrammaticName, nArgument):
-        if aProgrammaticName == "prompt":
-            return nArgument > 0
-        return False
-
-    def getProgrammaticCategoryName(self, aProgrammaticName):
-        return "Add-In"
-
-    def getDisplayCategoryName(self, aProgrammaticName):
-        return "Add-In"
-
-    def getLocale(self):
-        return self.ctx.ServiceManager.createInstance("com.sun.star.lang.Locale", ("en", "US", ""))
-
-    def setLocale(self, locale):
-        pass
-
-    def load(self, xSomething):
-        pass
-
-    def unload(self):
-        pass
 
     def prompt(self, message, systemPrompt, model, maxTokens):
         debug_log(f"=== PromptFunction.PROMPT({message}) called ===")
@@ -181,16 +109,3 @@ g_ImplementationHelper.addImplementation(
     "org.extension.writeragent.PromptFunction",
     ("com.sun.star.sheet.AddIn",),
 )
-
-# Test function registration
-def test_registration():
-    """Test if the function is properly registered"""
-    debug_log("=== Testing function registration ===")
-    try:
-        # This will be called when LibreOffice loads the extension
-        debug_log("Function registration test completed")
-    except Exception as e:
-        debug_log(f"Registration test failed: {e}")
-
-# Call test on module load
-test_registration()

--- a/rm_opt_handler.py
+++ b/rm_opt_handler.py
@@ -1,0 +1,10 @@
+import re
+
+with open("plugin/options_handler.py", "r") as f:
+    content = f.read()
+
+import sys
+print(content.count("XServiceInfo"))
+
+# Look at XContainerWindowEventHandler:
+print("XContainerWindowEventHandler:", content.count("XContainerWindowEventHandler"))

--- a/test_remove_options_methods.py
+++ b/test_remove_options_methods.py
@@ -1,0 +1,9 @@
+import re
+
+with open("plugin/options_handler.py", "r") as f:
+    content = f.read()
+
+# We'll see if `XServiceInfo` is actually imported.
+import_pattern = r'from com\.sun\.star\.lang import XServiceInfo'
+
+print("Is XServiceInfo imported?", bool(re.search(import_pattern, content)))

--- a/test_remove_prompt_methods.py
+++ b/test_remove_prompt_methods.py
@@ -1,0 +1,29 @@
+import re
+
+with open("plugin/prompt_function.py", "r") as f:
+    content = f.read()
+
+methods_to_remove = [
+    "getProgrammaticFunctionName",
+    "getDisplayFunctionName",
+    "getFunctionDescription",
+    "getArgumentDescription",
+    "getArgumentName",
+    "hasFunctionWizard",
+    "getArgumentCount",
+    "getArgumentIsOptional",
+    "getProgrammaticCategoryName",
+    "getDisplayCategoryName",
+    "getLocale",
+    "setLocale",
+    "load",
+    "unload"
+]
+
+for method in methods_to_remove:
+    # Match the method and its body until the next def or end of class
+    pattern = r"(\s+def " + method + r"\(self.*?\):.*?)(?=\n\s+def |\n\s+# |\Z)"
+    content = re.sub(pattern, "", content, flags=re.DOTALL)
+
+with open("plugin/prompt_function.py", "w") as f:
+    f.write(content)


### PR DESCRIPTION
Removed the dead methods from `plugin/prompt_function.py`. The legacy `XAddIn` methods were removed as only the `prompt` method defined in `idl/XPromptFunction.idl` is utilized. Additionally, I removed the `test_registration` setup embedded at the bottom of the script. 

I extensively checked `plugin/options_handler.py` and validated that no dead methods are present. All present functions correspond to required implementations for UNO interfaces (`XContainerWindowEventHandler`, `XActionListener`, `XItemListener`, `XServiceInfo`) and are explicitly registered/called, or they are internal logic helpers directly utilized in the file.

---
*PR created automatically by Jules for task [16448263252487911897](https://jules.google.com/task/16448263252487911897) started by @KeithCu*