### PR TITLE
Add Request Timeout parameter to Settings dialog

### DIFF
--- a/extension/WriterAgentDialogs/SettingsDialog.xdl.tpl
+++ b/extension/WriterAgentDialogs/SettingsDialog.xdl.tpl
@@ -15,7 +15,9 @@
 
   <!-- === Page 1: General Settings === -->
   <dlg:text dlg:id="label_endpoint" dlg:page="1" dlg:left="8" dlg:top="26" dlg:width="150" dlg:height="10" dlg:value="Endpoint URL (/v1 added):" dlg:align="left"/>
-  <dlg:combobox dlg:id="endpoint" dlg:page="1" dlg:left="165" dlg:top="24" dlg:width="265" dlg:height="14" dlg:tabstop="true" dlg:spin="true" dlg:dropdown="true" dlg:value="" dlg:border="1"/>
+  <dlg:combobox dlg:id="endpoint" dlg:page="1" dlg:left="165" dlg:top="24" dlg:width="165" dlg:height="14" dlg:tabstop="true" dlg:spin="true" dlg:dropdown="true" dlg:value="" dlg:border="1"/>
+  <dlg:text dlg:id="label_request_timeout" dlg:page="1" dlg:left="335" dlg:top="26" dlg:width="52" dlg:height="10" dlg:value="Timeout (s):" dlg:align="left"/>
+  <dlg:textfield dlg:id="request_timeout" dlg:page="1" dlg:left="390" dlg:top="24" dlg:width="40" dlg:height="14" dlg:tabstop="true" dlg:value="120"/>
 
   <dlg:text dlg:id="label_api_key" dlg:page="1" dlg:left="8" dlg:top="42" dlg:width="150" dlg:height="10" dlg:value="API Key:" dlg:align="left"/>
   <dlg:textfield dlg:id="api_key" dlg:page="1" dlg:left="165" dlg:top="40" dlg:width="265" dlg:height="14" dlg:tabstop="true" dlg:value=""/>

--- a/plugin/framework/settings_dialog.py
+++ b/plugin/framework/settings_dialog.py
@@ -23,6 +23,7 @@ def get_settings_field_specs(ctx):
     current_endpoint_for_specs = get_current_endpoint(ctx)
     field_specs = [
         {"name": "endpoint", "value": str(get_config(ctx, "endpoint") or "")},
+        {"name": "request_timeout", "value": str(get_config(ctx, "request_timeout")), "type": "int"},
         {"name": "text_model", "value": str(get_config(ctx, "text_model") or get_config(ctx, "model") or "")},
         {"name": "image_model", "value": str(get_image_model(ctx))},
         {"name": "stt_model", "value": str(get_config(ctx, "stt_model") or "")},


### PR DESCRIPTION
This PR adds a 'Request Timeout' setting to the General tab of the Settings dialog. This allows users to configure the HTTP request timeout, which is useful when working with slow models or large requests.