### PR TITLE
Remove unused import as_bool in panel_factory.py

### DIFF
--- a/plugin/modules/chatbot/panel_factory.py
+++ b/plugin/modules/chatbot/panel_factory.py
@@ -277,7 +277,7 @@ class ChatPanelElement(unohelper.Base, XUIElement):
     def _update_backend_indicator(self, root_window=None):
         """Set backend indicator label from config (visible when external backend enabled)."""
         try:
-            from plugin.framework.config import get_config, as_bool
+            from plugin.framework.config import get_config
             root = root_window or (getattr(self, "m_panelRootWindow", None))
             if not root or not hasattr(root, "getControl"):
                 return


### PR DESCRIPTION
Removed the unused import `as_bool` from the `_update_backend_indicator` method in `plugin/modules/chatbot/panel_factory.py`. This improves code maintainability and reduces noise.