### PR TITLE
fix: remove unsafe ast.literal_eval fallback in tool loop

### DIFF
--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -494,15 +494,10 @@ class ToolCallingMixin:
 
                 try:
                     func_args = json.loads(func_args_str)
-                except (json.JSONDecodeError, TypeError):
-                    try:
-                        import ast
-
-                        func_args = ast.literal_eval(func_args_str)
-                        if not isinstance(func_args, dict):
-                            func_args = {}
-                    except Exception:
+                    if not isinstance(func_args, dict):
                         func_args = {}
+                except (json.JSONDecodeError, TypeError):
+                    func_args = {}
 
                 agent_log(
                     "chat_panel.py:tool_execute",


### PR DESCRIPTION
The chatbot tool loop used ast.literal_eval as a fallback when JSON parsing of tool arguments failed. This could be unsafe if the input is untrusted. This commit removes the fallback and enforces strict JSON parsing with a type check to ensure arguments are a dictionary.