### PR TITLE
Assert stream info structVersion in sounddevice.py

### DIFF
--- a/contrib/audio/sounddevice.py
+++ b/contrib/audio/sounddevice.py
@@ -923,7 +923,7 @@ class _StreamBase:
         info = _lib.Pa_GetStreamInfo(self._ptr)
         if not info:
             raise PortAudioError('Could not obtain stream info')
-        # TODO: assert info.structVersion == 1
+        assert info.structVersion == 1
         self._samplerate = info.sampleRate
         if not oparameters:
             self._latency = info.inputLatency


### PR DESCRIPTION
This change adds a one-line assertion to `contrib/audio/sounddevice.py` to verify that the `structVersion` of the PortAudio stream info is 1. This was previously marked with a TODO.

---
*PR created automatically by Jules for task [12769050068367017950](https://jules.google.com/task/12769050068367017950) started by @KeithCu*