### PR TITLE
🧹 [code health] Remove unused deque import in http client

### DIFF
--- a/plugin/modules/http/client.py
+++ b/plugin/modules/http/client.py
@@ -29,13 +29,12 @@ import datetime
 
 # LiteLLM: streaming_handler.py ~L198 safety_checker(), issue #5158
 REPEATED_STREAMING_CHUNK_LIMIT = 20
-from collections import deque
 
 # accumulate_delta is required for tool-calling: it merges streaming deltas into message_snapshot so full tool_calls (with function.arguments) are available.
 from plugin.framework.streaming_deltas import accumulate_delta
 from plugin.framework.constants import APP_REFERER, APP_TITLE, USER_AGENT
 
-from plugin.framework.logging import debug_log, update_activity_state, init_logging
+from plugin.framework.logging import debug_log, init_logging
 
 
 def format_error_message(e):


### PR DESCRIPTION
🎯 **What:** Removed unused `deque` import and cleaned up another unused import (`update_activity_state`) in `plugin/modules/http/client.py`.
💡 **Why:** Improves code hygiene, readability, and reduces unnecessary imports as reported by static analysis tools.
✅ **Verification:** Ran `uv run --extra dev ruff check` to ensure code is clean and `uv run --extra dev pytest plugin/tests/` to verify no functionality was broken. Verified the lines were successfully removed.
✨ **Result:** Cleaner codebase with no functional changes.

---
*PR created automatically by Jules for task [3944451140765194552](https://jules.google.com/task/3944451140765194552) started by @KeithCu*