### PR TITLE
🧹 [Code Health] Remove unused imports in plugin/modules/launcher/base.py

### DIFF
--- a/plugin/modules/launcher/base.py
+++ b/plugin/modules/launcher/base.py
@@ -18,9 +18,7 @@
 
 import os
 from abc import ABC
-import uno
-import unohelper
-from plugin.framework.uno_helpers import get_desktop, get_active_document
+from plugin.framework.uno_helpers import get_active_document
 from plugin.framework.document import get_document_path
 
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports `uno`, `unohelper`, and `get_desktop` from `plugin/modules/launcher/base.py`.
💡 **Why:** To improve code hygiene and resolve `ruff` linting violations.
✅ **Verification:** Verified that `uv run --extra dev ruff check plugin/modules/launcher/base.py` passes with no errors and `uv run --extra dev pytest plugin/tests/` passes without regressions.
✨ **Result:** A cleaner file with fewer unused dependencies.

---
*PR created automatically by Jules for task [14924781024274560422](https://jules.google.com/task/14924781024274560422) started by @KeithCu*