### PR TITLE
🔒 Restrict CORS policy to local loopback origins in local HTTP server

### DIFF
--- a/plugin/modules/http/mcp_protocol.py
+++ b/plugin/modules/http/mcp_protocol.py
@@ -563,7 +563,7 @@ class MCPProtocolHandler:
 
     # ── Debug helpers ────────────────────────────────────────────────
 
-    def _debug_call_tool(self, tool_name, arguments):
+    def _debug_call_tool(self, tool_name, arguments, document_url=None):
         if not tool_name:
             return {"error": "Missing 'tool' parameter"}
         result = self._execute_with_backpressure(
@@ -635,7 +635,11 @@ class MCPProtocolHandler:
             data, ensure_ascii=False, default=str).encode("utf-8"))
 
     def _send_cors_headers(self, handler):
-        handler.send_header("Access-Control-Allow-Origin", "*")
+        origin = handler.headers.get("Origin")
+        if origin:
+            import re
+            if re.match(r"^https?://(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$", origin):
+                handler.send_header("Access-Control-Allow-Origin", origin)
         handler.send_header("Access-Control-Allow-Methods",
                             "GET, POST, DELETE, OPTIONS")
         handler.send_header("Access-Control-Allow-Headers",

--- a/plugin/modules/http/server.py
+++ b/plugin/modules/http/server.py
@@ -107,7 +107,11 @@ class GenericRequestHandler(BaseHTTPRequestHandler):
             data, ensure_ascii=False, default=str).encode("utf-8"))
 
     def _send_cors_headers(self):
-        self.send_header("Access-Control-Allow-Origin", "*")
+        origin = self.headers.get("Origin")
+        if origin:
+            import re
+            if re.match(r"^https?://(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$", origin):
+                self.send_header("Access-Control-Allow-Origin", origin)
         self.send_header("Access-Control-Allow-Methods",
                          "GET, POST, DELETE, OPTIONS")
         self.send_header("Access-Control-Allow-Headers",

--- a/test_cors.py
+++ b/test_cors.py
@@ -1,0 +1,25 @@
+import re
+
+def is_safe_origin(origin):
+    # Safe domains: localhost, 127.0.0.1, [::1]
+    # Optionally followed by :PORT
+    pattern = re.compile(r"^https?://(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$")
+    return bool(pattern.match(origin))
+
+origins = [
+    "http://localhost",
+    "https://localhost",
+    "http://localhost:3000",
+    "https://localhost:8443",
+    "http://127.0.0.1",
+    "https://127.0.0.1",
+    "http://127.0.0.1:8080",
+    "http://[::1]",
+    "http://[::1]:3000",
+    "http://localhost.attacker.com",
+    "https://127.0.0.1.badguy.com",
+    "http://example.com"
+]
+
+for o in origins:
+    print(f"{o}: {is_safe_origin(o)}")


### PR DESCRIPTION
🎯 **What:** The HTTP and MCP protocol local servers were sending a permissive `Access-Control-Allow-Origin: *` header, allowing any origin to make cross-origin requests to the local extension.

⚠️ **Risk:** By allowing any origin (`*`), malicious or unauthorized websites loaded in a user's browser could exploit the running server to interact with the LibreOffice instance on the user's machine. The extension could be commanded remotely via the MCP/HTTP server API, leading to potential arbitrary command execution within LibreOffice or exposure of sensitive local document contents to an attacker.

🛡️ **Solution:** Modified `_send_cors_headers` in both `plugin/modules/http/server.py` and `plugin/modules/http/mcp_protocol.py` to inspect the `Origin` header. An origin is only allowed (echoed back in the `Access-Control-Allow-Origin` header) if it strictly matches a local loopback pattern (`localhost`, `127.0.0.1`, `[::1]`) via regex. Unrecognized origins are rejected, enforcing same-origin and safe local-origin policies only.

---
*PR created automatically by Jules for task [9139118366221979653](https://jules.google.com/task/9139118366221979653) started by @KeithCu*