### PR TITLE
🧹 [Code Health] Remove unused imports across the entire codebase

### DIFF
--- a/plugin/contrib/aihordeclient/__init__.py
+++ b/plugin/contrib/aihordeclient/__init__.py
@@ -23,9 +23,9 @@
 
 
 from datetime import date, datetime
-from pathlib import Path
+
 from time import sleep
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Union
 from urllib.error import HTTPError, URLError
 from urllib.request import Request
 from plugin.framework.translation_tool import opustm_hf_translate, OPUSTM_SOURCE_LANGUAGES  # noqa F401
@@ -39,10 +39,8 @@ import gettext
 import json
 import locale
 import math
-import os
 import socket
 import tempfile
-import time
 
 _ = gettext.gettext
 

--- a/plugin/contrib/smolagents/agents.py
+++ b/plugin/contrib/smolagents/agents.py
@@ -91,7 +91,6 @@ from .models import (
     parse_json_if_needed,
 )
 from .monitoring import (
-    YELLOW_HEX,
     AgentLogger,
     LogLevel,
     Monitor,

--- a/plugin/contrib/smolagents/default_tools.py
+++ b/plugin/contrib/smolagents/default_tools.py
@@ -22,7 +22,7 @@ from .local_python_executor import (
     MAX_EXECUTION_TIME_SECONDS,
     evaluate_python_code,
 )
-from .tools import PipelineTool, Tool
+from .tools import Tool
 
 USE_MARKDOWN = False
 

--- a/plugin/contrib/tool_call_parsers/__init__.py
+++ b/plugin/contrib/tool_call_parsers/__init__.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Tuple, Type
 
 from plugin.contrib.tool_call_parsers.openai_compat import (
-    ChatCompletionMessageToolCall,
+    ChatCompletionMessageToolCall as ChatCompletionMessageToolCall,
 )
 
 logger = logging.getLogger(__name__)

--- a/plugin/contrib/tool_call_parsers/deepseek_v3_1_parser.py
+++ b/plugin/contrib/tool_call_parsers/deepseek_v3_1_parser.py
@@ -11,7 +11,7 @@ Based on VLLM's DeepSeekV31ToolParser.extract_tool_calls()
 
 import re
 import uuid
-from typing import List, Optional
+from typing import List
 
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 

--- a/plugin/contrib/tool_call_parsers/deepseek_v3_parser.py
+++ b/plugin/contrib/tool_call_parsers/deepseek_v3_parser.py
@@ -15,7 +15,7 @@ Based on VLLM's DeepSeekV3ToolParser.extract_tool_calls()
 
 import re
 import uuid
-from typing import List, Optional
+from typing import List
 
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 

--- a/plugin/contrib/tool_call_parsers/glm45_parser.py
+++ b/plugin/contrib/tool_call_parsers/glm45_parser.py
@@ -16,7 +16,7 @@ import ast
 import json
 import re
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 

--- a/plugin/contrib/tool_call_parsers/glm47_parser.py
+++ b/plugin/contrib/tool_call_parsers/glm47_parser.py
@@ -10,7 +10,7 @@ Based on VLLM's Glm47MoeModelToolParser (extends Glm4MoeModelToolParser).
 
 import re
 
-from plugin.contrib.tool_call_parsers import ParseResult, register_parser
+from plugin.contrib.tool_call_parsers import register_parser
 from plugin.contrib.tool_call_parsers.glm45_parser import Glm45ToolCallParser
 
 

--- a/plugin/contrib/tool_call_parsers/hermes_parser.py
+++ b/plugin/contrib/tool_call_parsers/hermes_parser.py
@@ -8,7 +8,7 @@ Based on VLLM's Hermes2ProToolParser.extract_tool_calls()
 import json
 import re
 import uuid
-from typing import List, Optional, Tuple
+from typing import List
 
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 

--- a/plugin/contrib/tool_call_parsers/kimi_k2_parser.py
+++ b/plugin/contrib/tool_call_parsers/kimi_k2_parser.py
@@ -12,8 +12,7 @@ Based on VLLM's KimiK2ToolParser.extract_tool_calls()
 """
 
 import re
-import uuid
-from typing import List, Optional
+from typing import List
 
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 

--- a/plugin/contrib/tool_call_parsers/llama_parser.py
+++ b/plugin/contrib/tool_call_parsers/llama_parser.py
@@ -11,7 +11,7 @@ Based on VLLM's Llama3JsonToolParser.extract_tool_calls()
 import json
 import re
 import uuid
-from typing import List, Optional
+from typing import List
 
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 

--- a/plugin/contrib/tool_call_parsers/longcat_parser.py
+++ b/plugin/contrib/tool_call_parsers/longcat_parser.py
@@ -8,7 +8,7 @@ Based on VLLM's LongcatFlashToolParser (extends Hermes2ProToolParser).
 import json
 import re
 import uuid
-from typing import List, Optional
+from typing import List
 
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 

--- a/plugin/contrib/tool_call_parsers/mistral_parser.py
+++ b/plugin/contrib/tool_call_parsers/mistral_parser.py
@@ -11,8 +11,7 @@ The [TOOL_CALLS] token is the bot_token used by Mistral models.
 
 import json
 import re
-import uuid
-from typing import List, Optional
+from typing import List
 
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 

--- a/plugin/framework/async_stream.py
+++ b/plugin/framework/async_stream.py
@@ -22,7 +22,6 @@ to keep the LibreOffice UI responsive (processEventsToIdle).
 """
 import queue
 import threading
-import json
 
 from plugin.framework.logging import debug_log
 

--- a/plugin/framework/document.py
+++ b/plugin/framework/document.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import uno
-import re
 import time
 from plugin.modules.calc.bridge import CalcBridge
 from plugin.modules.calc.analyzer import SheetAnalyzer

--- a/plugin/framework/image_tools.py
+++ b/plugin/framework/image_tools.py
@@ -19,12 +19,10 @@ import os
 import shutil
 import logging
 import uno
-import unohelper
 from pathlib import Path
 from com.sun.star.text.TextContentAnchorType import AS_CHARACTER, AT_FRAME
 from com.sun.star.awt import Size, Point
 from com.sun.star.beans import PropertyValue
-from com.sun.star.beans.PropertyAttribute import TRANSIENT
 
 logger = logging.getLogger(__name__)
 

--- a/plugin/framework/legacy_ui.py
+++ b/plugin/framework/legacy_ui.py
@@ -82,12 +82,12 @@ def input_box(ctx, message, title="", default="", x=None, y=None):
 
 def settings_box(ctx, title="Settings", x=None, y=None):
     from plugin.framework.settings_dialog import get_settings_field_specs, apply_settings_result
-    from plugin.framework.config import get_image_model, get_stt_model, populate_combobox_with_lru, populate_image_model_selector, endpoint_from_selector_text, get_api_key_for_endpoint, populate_endpoint_selector, as_bool
+    from plugin.framework.config import populate_combobox_with_lru, populate_image_model_selector, endpoint_from_selector_text, get_api_key_for_endpoint, populate_endpoint_selector, as_bool
 
     from plugin.framework.logging import debug_log
     debug_log("settings_box entry", context="Settings")
     import unohelper
-    from com.sun.star.awt import XActionListener, XItemListener, XTextListener
+    from com.sun.star.awt import XItemListener, XTextListener
 
     smgr = ctx.getServiceManager()
     debug_log("Calling get_settings_field_specs", context="Settings")

--- a/plugin/framework/translation_tool.py
+++ b/plugin/framework/translation_tool.py
@@ -25,7 +25,6 @@
 # https://github.com/ikks/aihorde-client/blob/main/LICENSE
 
 import json
-from urllib.request import Request
 from plugin.modules.http.client import sync_request
 
 API_TRANSLATE_GRADIO = "https://igortamara-opus-translate.hf.space/call/translate"

--- a/plugin/framework/uno_helpers.py
+++ b/plugin/framework/uno_helpers.py
@@ -17,7 +17,6 @@
 import uno
 import unohelper
 from com.sun.star.awt import XActionListener
-from com.sun.star.beans import PropertyValue
 
 
 def get_desktop(ctx=None):

--- a/plugin/modules/agent_backend/acp_connection.py
+++ b/plugin/modules/agent_backend/acp_connection.py
@@ -24,7 +24,6 @@ import json
 import os
 import subprocess
 import threading
-import time
 
 from plugin.framework.logging import debug_log
 

--- a/plugin/modules/agent_backend/hermes_proxy.py
+++ b/plugin/modules/agent_backend/hermes_proxy.py
@@ -32,7 +32,6 @@ Hermes docs: https://github.com/NousResearch/hermes-agent
 import json
 import os
 import shutil
-import subprocess
 import threading
 import time
 

--- a/plugin/modules/chatbot/panel.py
+++ b/plugin/modules/chatbot/panel.py
@@ -447,7 +447,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
 
         # Agent backend (Aider, Hermes): use external agent instead of built-in LLM
         try:
-            from plugin.framework.config import get_config, as_bool
+            from plugin.framework.config import get_config
             agent_backend_id = str(get_config(self.ctx, "agent_backend.backend_id") or "builtin").strip().lower()
             if agent_backend_id and agent_backend_id != "builtin":
                 debug_log("_do_send: using agent backend %s" % agent_backend_id, context="Chat")

--- a/plugin/modules/chatbot/send_handlers.py
+++ b/plugin/modules/chatbot/send_handlers.py
@@ -10,7 +10,6 @@ alternate send flows that would otherwise bloat that class:
 """
 
 import queue
-import threading
 
 
 class SendHandlersMixin:

--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -7,7 +7,6 @@ multi-round tool-calling loop plus simple streaming fallback.
 import inspect
 import json
 import queue
-import threading
 
 from plugin.framework.async_stream import (
     run_stream_completion_async,

--- a/plugin/modules/draw/bridge.py
+++ b/plugin/modules/draw/bridge.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """In-process UNO bridge for LibreOffice Draw."""
 
-import uno
 import logging
 
 logger = logging.getLogger(__name__)

--- a/plugin/modules/http/mcp_protocol.py
+++ b/plugin/modules/http/mcp_protocol.py
@@ -25,7 +25,6 @@ import logging
 import threading
 import time
 import uuid
-import queue
 
 from plugin.framework.main_thread import execute_on_main_thread
 

--- a/plugin/modules/writer/tables.py
+++ b/plugin/modules/writer/tables.py
@@ -18,7 +18,6 @@
 
 import logging
 
-from plugin.framework.tool_base import ToolBase
 
 log = logging.getLogger("writeragent.writer")
 

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -1,6 +1,5 @@
 """Pytest configuration. Skip tests that require LibreOffice UNO or optional deps when not available."""
 
-import pytest
 
 
 def pytest_ignore_collect(collection_path, config):

--- a/plugin/tests/eval_runner.py
+++ b/plugin/tests/eval_runner.py
@@ -16,11 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import json
 import time
-import ast
 import traceback
 from plugin.modules.http.client import LlmClient
 from plugin.framework.config import get_api_config
-from plugin.framework.logging import debug_log, agent_log
+from plugin.framework.logging import debug_log
 from plugin.framework.document import get_document_context_for_chat
 from plugin.framework.constants import get_chat_system_prompt_for_document
 from plugin.framework.pricing import fetch_openrouter_pricing, calculate_cost

--- a/plugin/tests/format_tests.py
+++ b/plugin/tests/format_tests.py
@@ -14,19 +14,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import json
 from plugin.modules.writer.format_support import (
     document_to_content,
     insert_content_at_position as _insert_content_at_position,
     content_has_markup as _content_has_markup,
     replace_preserving_format as _replace_text_preserving_format,
-    apply_content_at_search,
-    replace_full_document,
     find_text_ranges,
-    _preserving_search_replace,
     _normalize,
 )
-from plugin.framework.document import get_document_length as _doc_text_length_raw
 from plugin.framework.logging import debug_log
 from plugin.framework.uno_helpers import get_desktop
 
@@ -482,7 +477,6 @@ def _insert_colored_word(word):
 
 def _get_colors_at_range(start_off, length):
     """Read CharBackColor for `length` chars starting at absolute offset start_off."""
-    from plugin.framework.document import get_text_cursor_at_range
     text = _test_doc.getText()
     colors = []
     pos_cursor = text.createTextCursor()

--- a/plugin/tests/smoke_pricing.py
+++ b/plugin/tests/smoke_pricing.py
@@ -1,6 +1,4 @@
 import sys
-import os
-import json
 
 # Mocking ctx for a standalone test
 class MockCtx:
@@ -14,7 +12,7 @@ class MockCtx:
 
 def test_pricing():
     sys.path.append("/home/keithcu/Desktop/Python/writeragent")
-    from plugin.framework.pricing import calculate_cost, fetch_openrouter_pricing, get_model_pricing
+    from plugin.framework.pricing import calculate_cost, fetch_openrouter_pricing
     
     ctx = MockCtx()
     print("Testing pricing fetch...")

--- a/plugin/tests/test_audio_recorder.py
+++ b/plugin/tests/test_audio_recorder.py
@@ -1,6 +1,5 @@
 import os
 import wave
-import pytest
 from unittest.mock import MagicMock, patch
 from plugin.modules.chatbot.audio_recorder import AudioRecorder
 

--- a/plugin/tests/test_claude_acp.py
+++ b/plugin/tests/test_claude_acp.py
@@ -7,11 +7,8 @@
 # (at your option) any later version.
 """Tests for the Claude ACP backend adapter."""
 
-import json
-import os
-import queue
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from plugin.modules.agent_backend.claude_proxy import (
     ClaudeBackend,

--- a/plugin/tests/test_config_service.py
+++ b/plugin/tests/test_config_service.py
@@ -1,15 +1,12 @@
 """Tests for plugin.framework.config (ConfigService + ModuleConfigProxy)."""
 
 import json
-import os
-import tempfile
 
 import pytest
 
 from plugin.framework.config import (
     ConfigService,
     ConfigAccessError,
-    ModuleConfigProxy,
 )
 from plugin.framework.event_bus import EventBus
 

--- a/plugin/tests/test_config_sync.py
+++ b/plugin/tests/test_config_sync.py
@@ -13,7 +13,7 @@ sys.modules['unohelper'] = mock_unohelper
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from plugin.framework.config import get_image_model, set_image_model, get_config, set_config
+from plugin.framework.config import get_image_model, set_image_model
 
 class TestConfigSync(unittest.TestCase):
     def setUp(self):

--- a/plugin/tests/test_csv_import_logic.py
+++ b/plugin/tests/test_csv_import_logic.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock, patch
-import io
 import csv
 
 # Mock the parts of core that we don't want to load or that depend on UNO

--- a/plugin/tests/test_document.py
+++ b/plugin/tests/test_document.py
@@ -1,4 +1,3 @@
-import pytest
 
 from plugin.framework.document import (
     normalize_linebreaks,

--- a/plugin/tests/test_hermes_acp.py
+++ b/plugin/tests/test_hermes_acp.py
@@ -8,12 +8,10 @@
 """Tests for the Hermes ACP backend adapter (stdio JSON-RPC transport)."""
 
 import json
-import os
 import queue
 import threading
 import unittest
-from io import BytesIO
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 from plugin.modules.agent_backend.acp_connection import ACPConnection
 from plugin.modules.agent_backend.hermes_proxy import (

--- a/plugin/tests/test_history_db.py
+++ b/plugin/tests/test_history_db.py
@@ -1,6 +1,3 @@
-import pytest
-import os
-import json
 
 from plugin.framework.history_db import message_to_dict
 

--- a/plugin/tests/test_linebreak_conversion.py
+++ b/plugin/tests/test_linebreak_conversion.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import re
 
 # Add core to path
 sys.path.insert(0, os.getcwd())

--- a/plugin/tests/test_logging.py
+++ b/plugin/tests/test_logging.py
@@ -1,5 +1,3 @@
-import pytest
-import os
 import json
 
 from plugin.framework.logging import (

--- a/plugin/tests/test_main_thread.py
+++ b/plugin/tests/test_main_thread.py
@@ -1,5 +1,3 @@
-import pytest
-import queue
 import threading
 
 from plugin.framework.main_thread import (

--- a/plugin/tests/test_module_base.py
+++ b/plugin/tests/test_module_base.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from plugin.framework.module_base import ModuleBase
 
 class MyModule(ModuleBase):

--- a/plugin/tests/test_rec_audio.py
+++ b/plugin/tests/test_rec_audio.py
@@ -1,5 +1,3 @@
-import subprocess
-import os
 import sys
 
 # Test basic os recording

--- a/plugin/tests/test_streaming_fuzz.py
+++ b/plugin/tests/test_streaming_fuzz.py
@@ -2,8 +2,7 @@ import json
 import unittest
 from unittest.mock import MagicMock, patch
 
-from plugin.modules.http.client import LlmClient, _normalize_message_content
-from plugin.framework.streaming_deltas import accumulate_delta
+from plugin.modules.http.client import LlmClient
 
 def _make_sse_lines(*chunks, done=True):
     """Build SSE byte lines from chunk dicts. Used to mock response stream."""
@@ -176,7 +175,6 @@ class TestStreamingFuzz(unittest.TestCase):
         """Simulate an error in the worker thread to ensure run_stream_drain_loop correctly drains it without breaking processEventsToIdle() loop."""
         from plugin.framework.async_stream import run_stream_drain_loop
         import queue
-        import time
 
         class DummyToolkit:
             def processEventsToIdle(self):

--- a/plugin/tests/test_tool_call_parsers.py
+++ b/plugin/tests/test_tool_call_parsers.py
@@ -1,5 +1,3 @@
-import json
-import pytest
 from plugin.contrib.tool_call_parsers import (
     get_parser,
     get_parser_for_model,

--- a/plugin/tests/test_uno_context.py
+++ b/plugin/tests/test_uno_context.py
@@ -1,6 +1,5 @@
 import sys
 from unittest.mock import MagicMock
-import pytest
 
 from plugin.framework.uno_context import set_fallback_ctx, get_ctx
 

--- a/plugin/tests/test_writer_navigation.py
+++ b/plugin/tests/test_writer_navigation.py
@@ -1,5 +1,4 @@
 import unittest
-import json
 from plugin.framework.document import (
     DocumentCache,
     build_heading_tree,

--- a/scripts/audio/arecord_test.py
+++ b/scripts/audio/arecord_test.py
@@ -1,5 +1,4 @@
 import subprocess
-import time
 
 print("Testing arecord...")
 try:

--- a/scripts/bench_broker.py
+++ b/scripts/bench_broker.py
@@ -23,7 +23,6 @@ sys.path.insert(0, ROOT)
 def collect_tools():
     """Instantiate all ToolBase subclasses from the codebase."""
     from plugin.framework.tool_base import ToolBase
-    from plugin.framework.schema_convert import to_openai_schema
     import importlib
     import inspect
     import pkgutil

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -15,7 +15,6 @@ Usage:
 import argparse
 import json
 import os
-import re
 import sys
 
 # Ensure project root is importable

--- a/scripts/manifest_registry.py
+++ b/scripts/manifest_registry.py
@@ -1,7 +1,6 @@
 """Registry/XCU generation: Addons.xcu, Accelerators.xcu, SettingsDialog tabs, manifest.xml, description.xml."""
 
 import os
-import re
 import xml.etree.ElementTree as ET
 
 from manifest_xdl import _dlg, _oor, _pretty_name, _DLG_NS, _XS_NS
@@ -518,7 +517,6 @@ def generate_settings_dialog_tabs(modules, tpl_path, output_path):
         pages.append(f"  <!-- === Page {page_num}: {name.title()} Settings === -->\n{page_str}")
         page_num += 1
 
-    import re
     # Replace markers
     # For tabs, we keep everything before tab_marker, and everything starting with "<!-- === Page 1:"
     # For pages, we keep everything up to page_marker, and everything starting with "\n  <!-- OK Button" or "</dlg:bulletinboard>"

--- a/scripts/prompt_optimization/eval_core.py
+++ b/scripts/prompt_optimization/eval_core.py
@@ -12,7 +12,6 @@ from typing import Any, Iterable, List, Tuple
 
 import dspy
 
-from dataset import to_dspy_examples
 from metric import TOKEN_PENALTY_LAMBDA
 from program import build_program
 

--- a/scripts/prompt_optimization/program.py
+++ b/scripts/prompt_optimization/program.py
@@ -12,8 +12,7 @@ if str(repo_root) not in sys.path:
     sys.path.insert(0, str(repo_root))
 
 import dspy
-from tools_lo import set_document, get_content_as_html, get_document_content, apply_document_content, find_text, get_tools_subset
-from dataset import ALL_EXAMPLES
+from tools_lo import set_document, get_content_as_html, get_tools_subset
 
 # Default instruction (Writer system prompt). MIPROv2 will propose alternatives.
 try:

--- a/scripts/prompt_optimization/run_eval.py
+++ b/scripts/prompt_optimization/run_eval.py
@@ -19,7 +19,6 @@ import argparse
 import json
 import os
 import sys
-import uuid
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -33,8 +32,7 @@ import dspy
 
 from dataset import ALL_EXAMPLES, to_dspy_examples
 from program import build_program
-from metric import TOKEN_PENALTY_LAMBDA
-from eval_core import ExampleEval, run_eval_on_examples, summarize_results
+from eval_core import run_eval_on_examples, summarize_results
 import tools_lo
 
 DEFAULT_API_BASE = "https://openrouter.ai/api/v1"

--- a/scripts/prompt_optimization/run_eval_multi.py
+++ b/scripts/prompt_optimization/run_eval_multi.py
@@ -27,7 +27,7 @@ from typing import Any, Iterable, Sequence
 import dspy
 
 from dataset import ALL_EXAMPLES, to_dspy_examples
-from eval_core import ExampleEval, run_eval_on_examples, summarize_results
+from eval_core import ExampleEval
 from model_configs import MODEL_BY_ID, ModelConfig, get_default_models
 from program import build_program
 import tools_lo as _tools_lo

--- a/scripts/prompt_optimization/tools_lo.py
+++ b/scripts/prompt_optimization/tools_lo.py
@@ -5,7 +5,6 @@ import subprocess
 import threading
 import queue
 import time
-import uuid
 import json
 
 _lo_queue = queue.Queue()


### PR DESCRIPTION
🧹 [Code Health] Remove unused imports across the entire codebase

What:
Removed dozens of unused imports across the `plugin/`, `scripts/`, and `tests/` directories using `ruff`. Explicitly aliased intended public exports in `__init__.py` files (e.g., `ChatCompletionMessageToolCall as ChatCompletionMessageToolCall`) to comply with PEP-484 so they are not wrongly flagged as unused.

Why:
To clean up the codebase and adhere to best practices by removing stale or abandoned imports, without breaking required functionality or intended API exports.

Verification:
Ran `uv run ruff check --select F401 .` to ensure no unused imports exist (except those strictly required in vendored `contrib/` libraries, which are excluded from automated fixes). Verified no test regressions using `pytest`.

Result:
A cleaner, healthier codebase with fewer stale references.

---
*PR created automatically by Jules for task [17257324807384382205](https://jules.google.com/task/17257324807384382205) started by @KeithCu*