### PR TITLE
🧹 [test coverage: Add audio hardware and API fallback tests]

### DIFF
--- a/plugin/tests/test_audio_recorder.py
+++ b/plugin/tests/test_audio_recorder.py
@@ -1,15 +1,14 @@
 import os
 import wave
 import pytest
+import time
 from unittest.mock import MagicMock, patch
 from plugin.modules.chatbot.audio_recorder import AudioRecorder
 
-def test_audio_recorder_creates_file():
-    # Mock sounddevice to avoid dependency issues
+def test_audio_recorder_creates_file_mocked():
+    # Keep the original mocked test to ensure basic state logic works
     with patch.dict("sys.modules", {"sounddevice": MagicMock()}):
         recorder = AudioRecorder()
-
-        # Ensure we cleanup after test
         temp_file = None
         try:
             recorder.start_recording()
@@ -27,27 +26,22 @@ def test_audio_recorder_creates_file():
             assert recorder.wav_file is None
             assert recorder.stream is None
 
-            # Check if it's a valid wav file (at least header is written)
             with wave.open(temp_file, 'rb') as wf:
                 assert wf.getnchannels() == recorder.channels
                 assert wf.getframerate() == recorder.fs
-
         finally:
             if temp_file and os.path.exists(temp_file):
                 os.remove(temp_file)
 
-def test_audio_recorder_multiple_recordings():
+def test_audio_recorder_multiple_recordings_mocked():
     with patch.dict("sys.modules", {"sounddevice": MagicMock()}):
         recorder = AudioRecorder()
-
         files = []
         try:
-            # First recording
             recorder.start_recording()
             files.append(recorder.temp_filename)
             recorder.stop_recording()
 
-            # Second recording
             recorder.start_recording()
             files.append(recorder.temp_filename)
             recorder.stop_recording()
@@ -60,3 +54,51 @@ def test_audio_recorder_multiple_recordings():
             for f in files:
                 if os.path.exists(f):
                     os.remove(f)
+
+def test_audio_recorder_real_hardware():
+    """
+    Integration test to verify real audio hardware interaction.
+    If no audio hardware is found, it safely skips rather than failing the suite.
+    """
+    try:
+        import sounddevice as sd
+        # Query devices to see if there is any input device available.
+        devices = sd.query_devices()
+        input_device_available = any(d.get('max_input_channels', 0) > 0 for d in devices)
+        if not input_device_available:
+            pytest.skip("No audio input devices found.")
+    except Exception as e:
+        pytest.skip(f"sounddevice cannot be loaded or queried: {e}")
+
+    recorder = AudioRecorder()
+    temp_file = None
+    try:
+        try:
+            recorder.start_recording()
+        except RuntimeError as e:
+            # e.g., "Error querying device -1" or generic backend failure
+            pytest.skip(f"Audio hardware failed to initialize: {e}")
+
+        temp_file = recorder.temp_filename
+        assert temp_file is not None
+        assert os.path.exists(temp_file)
+
+        # Record for a short duration
+        time.sleep(0.5)
+
+        returned_file = recorder.stop_recording()
+        assert returned_file == temp_file
+
+        # Verify it wrote a valid header and potentially some frames
+        with wave.open(temp_file, 'rb') as wf:
+            assert wf.getnchannels() == recorder.channels
+            assert wf.getframerate() == recorder.fs
+    finally:
+        # Stop recording if we crashed mid-flight
+        if recorder.recording:
+            try:
+                recorder.stop_recording()
+            except Exception:
+                pass
+        if temp_file and os.path.exists(temp_file):
+            os.remove(temp_file)

--- a/plugin/tests/test_llm_client_modality.py
+++ b/plugin/tests/test_llm_client_modality.py
@@ -1,0 +1,128 @@
+import pytest
+import json
+import socket
+from unittest.mock import patch, MagicMock, mock_open
+from plugin.modules.http.client import (
+    LlmClient,
+    is_audio_unsupported_error,
+    format_error_message
+)
+
+def test_is_audio_unsupported_error():
+    # Common messages indicating lack of audio support
+    assert is_audio_unsupported_error("unsupported content type for input audio") is True
+    # "unsupported modality" test based on function signature
+    assert is_audio_unsupported_error("unsupported modality") is True
+    assert is_audio_unsupported_error("audio not supported") is True
+    assert is_audio_unsupported_error("modality not supported") is True
+
+    # Specific API error bodies (passed via _format_http_error_response)
+    assert is_audio_unsupported_error("model cannot process audio") is True
+    assert is_audio_unsupported_error("No endpoints found that support input audio") is True
+
+    # Just a general error
+    assert is_audio_unsupported_error("Connection timed out") is False
+    assert is_audio_unsupported_error("HTTP Error 401") is False
+
+def test_format_error_message():
+    import urllib.error
+    import http.client
+
+    # HTTP errors
+    err = urllib.error.HTTPError("url", 401, "Unauthorized", {}, None)
+    assert "Invalid API Key" in format_error_message(err)
+
+    err = urllib.error.HTTPError("url", 403, "Forbidden", {}, None)
+    assert "Forbidden" in format_error_message(err)
+
+    # Socket / Connection errors
+    err = urllib.error.URLError("Connection refused")
+    assert "Connection Refused" in format_error_message(err)
+
+    # Check timeout
+    err = socket.timeout("timed out")
+    assert "Timed Out" in format_error_message(err) or "timed out" in format_error_message(err).lower()
+
+@patch("plugin.modules.http.client.sync_request")
+def test_transcribe_audio_uses_sync_request_fallback(mock_sync):
+    """
+    Test that transcribe_audio uses the multipart/form-data fallback via sync_request
+    when the model does not have native audio.
+    """
+    # Mock return value
+    mock_sync.return_value = {"text": "Hello world from STT"}
+
+    # Mock ctx
+    ctx = MagicMock()
+
+    # We must patch has_native_audio in the namespace where transcribe_audio calls it
+    # Looking at the code: from plugin.framework.config import has_native_audio
+    with patch("plugin.framework.config.has_native_audio", return_value=False):
+        client = LlmClient({"endpoint": "http://test", "stt_model": "whisper-1"}, ctx)
+
+        # Call with a dummy path using mock_open
+        m = mock_open(read_data=b"dummy audio data")
+        with patch("builtins.open", m):
+            result = client.transcribe_audio("dummy.wav")
+
+        assert result == "Hello world from STT"
+        assert mock_sync.called
+        args, kwargs = mock_sync.call_args
+
+        # Assert url
+        assert args[0] == "http://test/v1/audio/transcriptions"
+
+        # Assert headers content type was set to multipart
+        headers = kwargs.get("headers", {})
+        assert "multipart/form-data" in headers.get("Content-Type", "")
+
+@patch("plugin.modules.http.client.LlmClient.chat_completion_sync")
+def test_transcribe_audio_uses_native_audio(mock_sync_chat):
+    """
+    Test that transcribe_audio calls the native chat pipeline when the STT model
+    is recognized as supporting native audio.
+    """
+    mock_sync_chat.return_value = "Native multimodal transcript"
+    ctx = MagicMock()
+
+    with patch("plugin.framework.config.has_native_audio", return_value=True):
+        client = LlmClient({"endpoint": "http://test", "stt_model": "gemini-flash"}, ctx)
+
+        m = mock_open(read_data=b"dummy audio data")
+        with patch("builtins.open", m):
+            result = client.transcribe_audio("dummy.wav")
+
+        assert result == "Native multimodal transcript"
+        assert mock_sync_chat.called
+
+def test_llm_client_chat_with_tools_normalizes():
+    """
+    Test that request_with_tools normalizes standard chat completion responses.
+    """
+    ctx = MagicMock()
+    client = LlmClient({"endpoint": "http://test", "model": "test-model"}, ctx)
+
+    # Mock HTTP response
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read.return_value = json.dumps({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "Sure, calling tool.",
+                "tool_calls": [{"id": "1", "type": "function", "function": {"name": "hello"}}]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    }).encode("utf-8")
+
+    mock_conn = MagicMock()
+    mock_conn.getresponse.return_value = mock_response
+
+    with patch.object(client, "_get_connection", return_value=mock_conn):
+        result = client.request_with_tools([{"role": "user", "content": "Hi"}])
+
+        assert result["role"] == "assistant"
+        assert result["content"] == "Sure, calling tool."
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "hello"


### PR DESCRIPTION
### What
* Added an unmocked integration test in `plugin/tests/test_audio_recorder.py` to test actual interaction with `sounddevice` / PortAudio, gracefully skipping if hardware is unavailable.
* Added `plugin/tests/test_llm_client_modality.py` to mock and verify `LlmClient`'s error formatting and translation logic (e.g., `is_audio_unsupported_error`).
* Added tests for the fallback to `sync_request` for the `/audio/transcriptions` API.

### Why
To improve test coverage for the core chatbox loop and LLM API client without incurring API costs, and to ensure actual interaction with audio binaries works correctly without masking it behind mock layers. 

### Verification
* `pytest plugin/tests/test_audio_recorder.py plugin/tests/test_llm_client_modality.py` passed successfully.
* Cleaned up stray script to unblock general pytest collection.

### Result
Added test suites for core logic paths without breaking headless CI.

---
*PR created automatically by Jules for task [4194036162996310889](https://jules.google.com/task/4194036162996310889) started by @KeithCu*