### PR TITLE
🧹 Expand config and event bus tests

### DIFF
--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -288,6 +288,9 @@ def remove_config(ctx, key):
 
 # Listeners are called when config is changed (e.g. after Settings dialog).
 # Sidebar uses weakref in its callback so panels can be GC'd without unregistering.
+# FIXME: These duplicated pieces of functionality (add_config_listener / notify_config_changed)
+# could be combined into the shared EventBus. This custom pub/sub code can be removed
+# and changed to use EventBus. When that happens, update dependent UI code and remove the test code.
 _config_listeners = []
 
 

--- a/plugin/tests/test_config_sync.py
+++ b/plugin/tests/test_config_sync.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import json
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -11,9 +13,12 @@ mock_unohelper.Base = MockUnoBase
 sys.modules['unohelper'] = mock_unohelper
 
 # Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
-from plugin.framework.config import get_image_model, set_image_model
+from plugin.framework.config import (
+    get_image_model, set_image_model, get_api_key_for_endpoint, set_api_key_for_endpoint,
+    add_config_listener, notify_config_changed, _config_listeners
+)
 
 class TestConfigSync(unittest.TestCase):
     def setUp(self):
@@ -68,6 +73,93 @@ class TestConfigSync(unittest.TestCase):
         self.config_data["image_provider"] = "endpoint"
         self.config_data["image_model"] = "end-1"
         self.assertEqual(get_image_model(self.ctx), "end-1")
+
+    def test_get_api_key_for_endpoint_missing(self):
+        self.assertEqual(get_api_key_for_endpoint(self.ctx, "http://localhost:11434"), "")
+
+    def test_get_api_key_for_endpoint_existing(self):
+        self.config_data["api_keys_by_endpoint"] = {"http://localhost:11434": "test-key-123"}
+        self.assertEqual(get_api_key_for_endpoint(self.ctx, "http://localhost:11434"), "test-key-123")
+
+        # Test endpoint normalization
+        self.assertEqual(get_api_key_for_endpoint(self.ctx, "http://localhost:11434/"), "test-key-123")
+
+    def test_set_api_key_for_endpoint(self):
+        # Starts empty
+        set_api_key_for_endpoint(self.ctx, "http://localhost:11434", "new-key")
+        self.assertEqual(self.config_data.get("api_keys_by_endpoint", {}).get("http://localhost:11434"), "new-key")
+
+        # Updates existing, normalizes endpoint
+        set_api_key_for_endpoint(self.ctx, "http://localhost:11434/", "updated-key")
+        self.assertEqual(self.config_data.get("api_keys_by_endpoint", {}).get("http://localhost:11434"), "updated-key")
+
+    def test_add_config_listener_and_notify(self):
+        # Temporarily clear listeners to isolate the test
+        original_listeners = list(_config_listeners)
+        _config_listeners.clear()
+        try:
+            called = []
+            def my_callback(ctx):
+                called.append(ctx)
+
+            add_config_listener(my_callback)
+
+            # Since notify_config_changed is mocked in setUp, we need to temporarily stop the patch
+            # to test its actual implementation
+            self.notify_patcher.stop()
+            try:
+                notify_config_changed(self.ctx)
+                self.assertEqual(len(called), 1)
+                self.assertEqual(called[0], self.ctx)
+
+                # Test exception swallowing
+                def bad_callback(ctx):
+                    raise ValueError("Simulated error")
+                add_config_listener(bad_callback)
+
+                notify_config_changed(self.ctx)
+                self.assertEqual(len(called), 2) # First callback still gets called again
+            finally:
+                self.mock_notify = self.notify_patcher.start()
+        finally:
+            _config_listeners.clear()
+            _config_listeners.extend(original_listeners)
+
+
+class TestConfigSyncFileIO(unittest.TestCase):
+    def setUp(self):
+        self.ctx = MagicMock()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config_path = os.path.join(self.temp_dir.name, "writeragent.json")
+
+        def mock_config_path(ctx):
+            return self.config_path
+
+        self.path_patcher = patch('plugin.framework.config._config_path', side_effect=mock_config_path)
+        self.path_patcher.start()
+
+    def tearDown(self):
+        self.path_patcher.stop()
+        self.temp_dir.cleanup()
+
+    def test_set_api_key_file_io(self):
+        # Ensure file is written correctly
+        set_api_key_for_endpoint(self.ctx, "http://api.openai.com", "sk-1234")
+
+        self.assertTrue(os.path.exists(self.config_path))
+        with open(self.config_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        self.assertIn("api_keys_by_endpoint", data)
+        self.assertEqual(data["api_keys_by_endpoint"].get("http://api.openai.com"), "sk-1234")
+
+        # Ensure we can read it back via actual config functions
+        self.assertEqual(get_api_key_for_endpoint(self.ctx, "http://api.openai.com"), "sk-1234")
+
+    def test_get_api_key_file_io_missing_file(self):
+        # Should handle missing file gracefully
+        self.assertEqual(get_api_key_for_endpoint(self.ctx, "http://api.openai.com"), "")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/plugin/tests/test_event_bus.py
+++ b/plugin/tests/test_event_bus.py
@@ -75,3 +75,49 @@ def test_emit_swallows_exception():
 
     # Exception was swallowed, good handler still ran
     assert received == ["good"]
+
+def test_emit_no_subscribers():
+    bus = EventBus()
+    # Should simply return without error
+    bus.emit("nonexistent:event", data=123)
+
+def test_unsubscribe_nonexistent_event():
+    bus = EventBus()
+    def handler():
+        pass
+
+    # Should simply return without error
+    bus.unsubscribe("nonexistent:event", handler)
+
+def test_unsubscribe_nonexistent_handler():
+    bus = EventBus()
+    def handler1():
+        pass
+    def handler2():
+        pass
+
+    bus.subscribe("test:event", handler1)
+    # Should simply return without error, not touching handler1
+    bus.unsubscribe("test:event", handler2)
+
+    # Verify handler1 is still subscribed
+    assert len(bus._subscribers.get("test:event", [])) == 1
+
+def test_multiple_subscribers():
+    bus = EventBus()
+    received1 = []
+    received2 = []
+
+    def handler1(event_data):
+        received1.append(event_data)
+
+    def handler2(event_data):
+        received2.append(event_data)
+
+    bus.subscribe("test:event", handler1)
+    bus.subscribe("test:event", handler2)
+
+    bus.emit("test:event", event_data="hello")
+
+    assert received1 == ["hello"]
+    assert received2 == ["hello"]


### PR DESCRIPTION
What: Expand tests for `plugin/framework/config.py` and `plugin/framework/event_bus.py` to ensure core state-keeping functions and notifications are properly verified.
Why: The complex rules for merging defaults, handling `api_keys_by_endpoint`, and notifying observers via the global `EventBus` are core to the Settings UI keeping state with the sidebar.
How: Added mock file system testing for configuration reads/writes, detailed testing for API key endpoints, comprehensive test cases for listener functionality, and edge-case testing for the event bus. Also added a `FIXME` comment to centralize custom listener code into the unified `EventBus` in the future.
Verification: Evaluated natively via `pytest`. All tests passed successfully.
Result: The application configuration and events architecture now has stronger test coverage with guarantees against edge-case failures.

---
*PR created automatically by Jules for task [7152513730649978257](https://jules.google.com/task/7152513730649978257) started by @KeithCu*