### PR TITLE
🧪 [add writer ops tests]

### DIFF
--- a/plugin/tests/test_writer.py
+++ b/plugin/tests/test_writer.py
@@ -211,3 +211,100 @@ def test_document_cache_length_tracking():
     cache3_new = DocumentCache.get(_test_doc)
     new_len = cache3_new.length
     assert new_len is not None and new_len > prev_len, "DocumentCache length did not update"
+
+
+@native_test
+def test_get_text_cursor_at_range():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+    from plugin.modules.writer.ops import get_text_cursor_at_range
+
+    text = _test_doc.getText()
+    full_text_str = text.getString()
+
+    # Just grab a known length from the doc string
+    start_idx = 0
+    end_idx = min(3, len(full_text_str))
+
+    cursor = get_text_cursor_at_range(_test_doc, start_idx, end_idx)
+    assert cursor is not None, "get_text_cursor_at_range returned None"
+
+    selected_text = cursor.getString()
+    expected_text = full_text_str[start_idx:end_idx]
+
+    assert selected_text == expected_text, f"get_text_cursor_at_range mismatch. Expected '{expected_text}', got '{selected_text}'"
+
+
+@native_test
+def test_find_paragraph_for_range():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+    from plugin.modules.writer.ops import find_paragraph_for_range
+
+    para_ranges = get_paragraph_ranges(_test_doc)
+    text = _test_doc.getText()
+
+    assert len(para_ranges) >= 2, "Test document doesn't have enough paragraphs."
+
+    # Take the start of the second paragraph
+    p1 = para_ranges[1]
+
+    # We create a cursor at the start of p1
+    cursor = text.createTextCursorByRange(p1.getStart())
+
+    idx = find_paragraph_for_range(cursor, para_ranges, text)
+    assert idx == 1, f"find_paragraph_for_range expected index 1, got {idx}"
+
+
+@native_test
+def test_get_selection_range():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+    from plugin.modules.writer.ops import get_selection_range
+
+    controller = _test_doc.getCurrentController()
+    view_cursor = controller.getViewCursor()
+    view_cursor.gotoStart(False)
+    view_cursor.goRight(3, True)
+
+    start_offset, end_offset = get_selection_range(_test_doc)
+
+    # Start should be 0, end should be 3
+    assert start_offset == 0, f"Expected start_offset 0, got {start_offset}"
+    assert end_offset == 3, f"Expected end_offset 3, got {end_offset}"
+
+
+@native_test
+def test_insert_html_at_cursor():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+    from plugin.modules.writer.ops import insert_html_at_cursor
+
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
+    cursor.gotoEnd(False)
+
+    html_content = "<b>Test HTML Insert</b>"
+
+    success = insert_html_at_cursor(cursor, html_content)
+    assert success is True, "insert_html_at_cursor failed to return True"
+
+    # Verify content was inserted. HTML tags shouldn't appear but the text should.
+    doc_text = text.getString()
+    assert "Test HTML Insert" in doc_text, "Inserted HTML text not found in document"


### PR DESCRIPTION
What: Added native LibreOffice tests for functions in `plugin/modules/writer/ops.py`.
Why: To ensure that core LibreOffice Writer operations like obtaining selection ranges, text cursors, and inserting HTML work correctly without regressions.
Verification: The code review process checked that the test functions interact with `_test_doc` correctly. 
Result: `plugin/tests/test_writer.py` now includes specific native tests for `get_text_cursor_at_range`, `find_paragraph_for_range`, `get_selection_range`, and `insert_html_at_cursor`.

---
*PR created automatically by Jules for task [9159489072931397414](https://jules.google.com/task/9159489072931397414) started by @KeithCu*