### PR TITLE
✅ [Test] Add pytest coverage for chatbot routing and web research tools

### DIFF
--- a/plugin/tests/test_chatbot_handlers.py
+++ b/plugin/tests/test_chatbot_handlers.py
@@ -1,0 +1,182 @@
+import json
+import queue
+import sys
+from unittest.mock import MagicMock, patch
+
+from plugin.modules.chatbot.send_handlers import SendHandlersMixin
+from plugin.modules.chatbot.web_research import WebResearchTool
+from plugin.tests.testing_utils import MockContext, MockDocument
+from plugin.contrib.smolagents.models import ChatMessage, ChatMessageToolCall, ChatMessageToolCallFunction, MessageRole
+
+class DummyChatbotPanel(SendHandlersMixin):
+    def __init__(self):
+        self.ctx = MockContext()
+        self.ctx.getServiceManager = MagicMock()
+        self.stop_requested = False
+        self.responses = []
+        self.status_history = []
+        self._terminal_status = None
+
+        # UI Mocks
+        self.aspect_ratio_selector = MagicMock()
+        self.aspect_ratio_selector.getText.return_value = "Landscape (16:9)"
+
+        self.image_model_selector = MagicMock()
+        self.image_model_selector.getText.return_value = "dall-e-3"
+
+        self.base_size_input = MagicMock()
+        self.base_size_input.getText.return_value = "1024"
+
+    def _append_response(self, text):
+        self.responses.append(text)
+
+    def _set_status(self, text):
+        self.status_history.append(text)
+
+    # We need to mock _get_doc_type_str since SendHandlersMixin uses it implicitly in some places
+    def _get_doc_type_str(self, model):
+        return "Writer"
+
+
+def test_do_send_direct_image():
+    panel = DummyChatbotPanel()
+    model = MockDocument()
+
+    # We need to mock plugin.main explicitly to avoid import errors due to missing LibreOffice UNO dependencies
+    # during testing.
+    mock_main = MagicMock()
+    mock_registry = MagicMock()
+    mock_registry.execute.return_value = {"status": "done", "message": "Image generated successfully"}
+    mock_registry._services = MagicMock()
+    mock_main.get_tools.return_value = mock_registry
+
+    with patch.dict('sys.modules', {'plugin.main': mock_main}):
+        with patch("plugin.framework.worker_pool.run_in_background") as mock_run_bg:
+            # Synchronous execution of background worker
+            def fake_run_bg(func):
+                func()
+            mock_run_bg.side_effect = fake_run_bg
+
+            with patch("plugin.framework.async_stream.run_stream_drain_loop") as mock_run_stream:
+                # Trigger stream done immediately
+                def fake_drain_loop(q, toolkit, job_done, apply_chunk, on_stream_done, on_stopped, on_error, on_status_fn, ctx, stop_checker, **kwargs):
+                    while not q.empty():
+                        item = q.get()
+                        if item[0] == "chunk":
+                            apply_chunk(item[1])
+                        elif item[0] == "stream_done":
+                            on_stream_done(item[1])
+                        elif item[0] == "status":
+                            on_status_fn(item[1])
+                        elif item[0] == "error":
+                            on_error(item[1])
+                mock_run_stream.side_effect = fake_drain_loop
+
+                panel.ctx.getServiceManager.return_value.createInstanceWithContext.return_value = MagicMock()
+
+                panel._do_send_direct_image("A cute dog", model)
+
+                # Verify responses
+                assert "\nYou: A cute dog\n" in panel.responses
+                assert "AI: Creating image...\n" in panel.responses
+                assert any("generate_image: Image generated successfully" in r for r in panel.responses)
+
+                # Verify tool registry was called
+                mock_registry.execute.assert_called_once()
+                args, kwargs = mock_registry.execute.call_args
+                assert args[0] == "generate_image"
+                assert kwargs["prompt"] == "A cute dog"
+                assert kwargs["aspect_ratio"] == "landscape_16_9"
+                assert kwargs["base_size"] == 1024
+                assert kwargs["image_model"] == "dall-e-3"
+
+def test_web_research_tool():
+    # Setup mock context
+    ctx = MagicMock()
+    ctx.ctx = MockContext()
+    ctx.status_callback = MagicMock()
+    ctx.append_thinking_callback = MagicMock()
+    ctx.stop_checker = lambda: False
+
+    # Track the steps of our mock model
+    call_count = [0]
+
+    # We will mock WriterAgentSmolModel's generate method to simulate a ReAct loop
+    # Step 1: Model decides to call duckduckgo search
+    # Step 2: Model decides to visit a webpage
+    # Step 3: Model returns final answer
+
+    def mock_generate(self, messages, stop_sequences=None, tools_to_call_from=None, **kwargs):
+        call_count[0] += 1
+
+        if call_count[0] == 1:
+            # Call web_search tool
+            tc = ChatMessageToolCall(
+                id="call_1",
+                type="function",
+                function=ChatMessageToolCallFunction(
+                    name="web_search",
+                    arguments='{"query": "Latest Python release"}'
+                )
+            )
+            return ChatMessage(role=MessageRole.ASSISTANT, content="", tool_calls=[tc])
+
+        elif call_count[0] == 2:
+            # Look at messages to see what happened
+            # The last message should be the tool response
+            last_msg = messages[-1]
+            assert last_msg.role == MessageRole.TOOL_RESPONSE
+
+            # Call visit_webpage tool
+            tc = ChatMessageToolCall(
+                id="call_2",
+                type="function",
+                function=ChatMessageToolCallFunction(
+                    name="visit_webpage",
+                    arguments='{"url": "https://python.org/downloads"}'
+                )
+            )
+            return ChatMessage(role=MessageRole.ASSISTANT, content="", tool_calls=[tc])
+
+        else:
+            # Return final answer
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="The latest Python release is 3.12.3",
+                tool_calls=[]
+            )
+
+
+    with patch("plugin.framework.smol_model.WriterAgentSmolModel.generate", new=mock_generate):
+        # We also need to mock requests.get/post that the default tools use under the hood
+        # We can just mock the output of the VisitWebpageTool entirely to avoid making HTTP requests.
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = b"""
+            <html>
+                <body>
+                    <a class='result-snippet' href='https://python.org/downloads'>Python 3.12.3 is released</a>
+                    <div id="content">Python 3.12.3 is released today</div>
+                </body>
+            </html>"""
+            mock_resp.headers.get_content_charset.return_value = "utf-8"
+            mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+            with patch("requests.get") as mock_get:
+                mock_get_resp = MagicMock()
+                mock_get_resp.status_code = 200
+                mock_get_resp.text = "<html><body><h1>Python 3.12.3 is available!</h1></body></html>"
+                mock_get.return_value = mock_get_resp
+
+                tool = WebResearchTool()
+                result = tool.execute(ctx, "What is the latest Python release?", "User said hello previously")
+
+                assert result["status"] == "ok"
+                assert "3.12.3" in result["result"]
+
+                # Check that callbacks were called
+                ctx.status_callback.assert_any_call("Sub-agent starting web search: What is the latest Python release?")
+                ctx.status_callback.assert_any_call("Search: Latest Python release...")
+                ctx.status_callback.assert_any_call("Read: python.org...")
+                assert ctx.append_thinking_callback.called


### PR DESCRIPTION
What: Test the non-UNO routing and tools of the Chatbot Sidebar, primarily `SendHandlersMixin._do_send_direct_image` and `WebResearchTool.execute`.
Why: To ensure routing behavior between tools is stable and to verify ReAct sub-agent functionality in `WebResearchTool` operates as expected without causing API side-effects or regressions in future commits.
How: 
- `test_chatbot_handlers.py` was created utilizing standard Python `unittest.mock`. 
- ReAct loops were mocked by returning distinct `ChatMessageToolCall`s in sequential loops via a mocked `WriterAgentSmolModel.generate`. 
- Mocked HTTP libraries were used (`urllib.request.urlopen`, `requests.get`) to assert the underlying tools could process basic responses.

---
*PR created automatically by Jules for task [3311445034948940174](https://jules.google.com/task/3311445034948940174) started by @KeithCu*