### PR TITLE
Add native integration test for chatbot tool loop

### DIFF
--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -173,6 +173,13 @@ def run_all_tests(ctx: Any) -> str:
     except ImportError:
         pass
 
+    # Chatbot integration tests
+    try:
+        import plugin.tests.test_chatbot_integration as test_chatbot_integration
+        _run_suite(ctx, suites, "chatbot.test_chatbot_integration", test_chatbot_integration)
+    except ImportError:
+        pass
+
     # Writer markdown / format-preserving tests
     try:
         from plugin.framework.document import is_writer  # local import to avoid hard dependency if unused

--- a/plugin/tests/test_chatbot_integration.py
+++ b/plugin/tests/test_chatbot_integration.py
@@ -1,0 +1,155 @@
+from plugin.framework.uno_helpers import get_desktop
+from plugin.testing_runner import setup, teardown, native_test
+from plugin.modules.chatbot.panel import ChatSession, SendButtonListener
+
+_test_doc = None
+_test_ctx = None
+
+@setup
+def setup_integration_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+
+    desktop = get_desktop(ctx)
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
+
+    _test_doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
+    assert _test_doc is not None, "Could not create hidden test writer document"
+
+    # Insert some initial text to work on
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
+    text.insertString(cursor, "Hello World. This is a test document.", False)
+
+@teardown
+def teardown_integration_tests(ctx):
+    global _test_doc, _test_ctx
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+    _test_ctx = None
+
+@native_test
+def test_tool_loop_integration():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    # Initialize a ChatSession
+    session = ChatSession(system_prompt="You are a helpful assistant.")
+
+    # Mock some basic controls to bypass UI interactions
+    class MockControl:
+        def __init__(self, text=""):
+            self.text = text
+            self.Label = "Send"
+            self.Enabled = True
+        def getModel(self):
+            return self
+        def getText(self):
+            return self.text
+        def setText(self, text):
+            self.text = text
+
+    send_control = MockControl()
+    stop_control = MockControl()
+    query_control = MockControl("Please change 'World' to 'Universe'.")
+    response_control = MockControl()
+    status_control = MockControl()
+
+    listener = SendButtonListener(
+        _test_ctx,
+        None,
+        send_control,
+        stop_control,
+        query_control,
+        response_control,
+        None,
+        None,
+        status_control,
+        session
+    )
+
+    # We will override _get_document_model to return _test_doc directly
+    listener._get_document_model = lambda: _test_doc
+
+    # Ready for testing
+
+    # 3. Mock the LlmClient
+    class MockLlmClient:
+        def __init__(self, *args, **kwargs):
+            self.config = {}
+            self.stop_requested = False
+
+        def stream_request_with_tools(
+            self, messages, max_tokens, tools, append_callback, append_thinking_callback, stop_checker
+        ):
+            # Formulate the response containing the tool call for apply_document_content
+            tool_calls = [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "apply_document_content",
+                        "arguments": '{"target": "search", "old_content": "World", "content": ["Universe"]}'
+                    }
+                }
+            ]
+
+            # Simulate streaming chunks
+            append_callback("I am thinking...")
+
+            # Since the client caller expects a return value (not a generator) for `stream_request_with_tools` in `_spawn_llm_worker` of `ToolCallingMixin`:
+            # `response = client.stream_request_with_tools(...)`
+            # Wait, `client.stream_request_with_tools` actually *returns* the response dictionary in `ToolCallingMixin`.
+            # It's NOT iterated over! Let me check `ToolCallingMixin._spawn_llm_worker` logic.
+            # "response = client.stream_request_with_tools(...) ; q.put(('stream_done', response))"
+            # It DOES return a dict. The code reviewer is wrong about the stream_ method returning an iterable in this particular file (`ToolCallingMixin`),
+            # but maybe `LlmClient` interface requires returning a dict.
+            return {"content": "I am modifying the document.", "tool_calls": tool_calls, "finish_reason": "tool_calls"}
+
+        def stream_chat_response(
+            self, messages, max_tokens, append_callback, append_thinking_callback, stop_checker
+        ):
+            append_callback("I am done.")
+
+    # Assign mock client
+    listener.client = MockLlmClient()
+
+
+    import threading
+    import time
+    from com.sun.star.awt import Selection
+
+    # 4. Run the Tool Loop
+    # We don't want to use actionPerformed directly because it triggers async worker
+    # and UI loops which can deadlock tests. We manually invoke the _do_send logic,
+    # but we bypass the threaded worker and queue in a controlled way, or we just call
+    # it and use a proper event pump.
+    # Since run_stream_drain_loop uses a while loop that blocks the thread until job_done,
+    # and it uses toolkit.processEventsToIdle() to pump the UI, it's actually synchronous
+    # and blocking on the calling thread until the queue says "stream_done" or "ready".
+    #
+    # Wait, actionPerformed starts `_do_send` which calls `_start_tool_calling_async`,
+    # which starts the worker thread and THEN calls `run_stream_drain_loop` which is a BLOCKING while loop!
+    # So `actionPerformed` will block until the turn is completely done, while keeping the UI responsive.
+
+    # Let's run it. It will block until finished.
+    listener.actionPerformed(None)
+
+    assert listener._terminal_status == "Ready", f"Integration test failed: Loop status is {listener._terminal_status}, expected Ready"
+
+    # 5. Verify Document Edit
+    doc_text = _test_doc.getText().getString()
+    assert "Universe" in doc_text, "Document text was not modified successfully by apply_document_content"
+    assert "World" not in doc_text, "Original text was not replaced"
+
+    # Check that Undo Manager has "AI Edit" (Wait, user said to skip testing undo grouping for now)
+    # um = _test_doc.getUndoManager()
+    # print(um.getAllUndoActionTitles())


### PR DESCRIPTION
What: Added an integration test for the chatbot sidebar tool-loop.
Why: To verify that the multi-round tool-calling loop (simulating an LLM stream) properly extracts the tool call, dispatches the tool via `ToolRegistry`, and mutates the live document state correctly.
How: Created `plugin/tests/test_chatbot_integration.py`, initializing a `ChatSession` against a hidden `TextDocument`. Mocked `LlmClient` to yield an `apply_document_content` tool call, and triggered the UI drain loop via `actionPerformed` synchronously, then verified the `TextDocument` changes.

---
*PR created automatically by Jules for task [7974372599644636075](https://jules.google.com/task/7974372599644636075) started by @KeithCu*