### PR TITLE
test: add direct native tests for writer navigation, search, and bookmarks

### DIFF
--- a/plugin/tests/test_writer_bookmarks.py
+++ b/plugin/tests/test_writer_bookmarks.py
@@ -1,0 +1,142 @@
+try:
+    import uno
+    import pytest
+except ImportError:
+    pass
+
+try:
+    from plugin.testing_runner import setup, teardown, native_test
+    from plugin.framework.uno_helpers import get_desktop
+    from plugin.framework.document import DocumentService
+    from plugin.framework.events import EventBus
+    from plugin.modules.writer.bookmarks import BookmarkService
+except ImportError:
+    setup, teardown, native_test = (lambda f: f), (lambda f: f), (lambda f: f)
+
+_test_doc = None
+_test_ctx = None
+
+@setup
+def setup_bookmark_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+
+    desktop = get_desktop(ctx)
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
+    _test_doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
+
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
+
+    # 0: Heading 1
+    text.insertString(cursor, "Main Heading", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 1")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 1: Paragraph
+    text.insertString(cursor, "A simple paragraph.", False)
+    cursor.setPropertyValue("ParaStyleName", "Standard")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 2: Heading 2
+    text.insertString(cursor, "Sub Heading", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 2")
+    text.insertControlCharacter(cursor, 0, False)
+
+@teardown
+def teardown_bookmark_tests():
+    if _test_doc:
+        _test_doc.close(True)
+
+@native_test
+def test_ensure_heading_bookmarks_and_map():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    events = EventBus()
+    doc_svc = DocumentService(events)
+    bookmark_svc = BookmarkService(doc_svc, events)
+
+    # Initially no bookmarks
+    bms = _test_doc.getBookmarks().getElementNames()
+    assert len([b for b in bms if b.startswith("_mcp_")]) == 0
+
+    # Ensure bookmarks
+    bookmark_map = bookmark_svc.ensure_heading_bookmarks(_test_doc)
+
+    # We have 2 headings (index 0 and 2)
+    assert len(bookmark_map) == 2
+    assert 0 in bookmark_map
+    assert 2 in bookmark_map
+
+    # Verify in document
+    bms = _test_doc.getBookmarks().getElementNames()
+    mcp_bms = [b for b in bms if b.startswith("_mcp_")]
+    assert len(mcp_bms) == 2
+
+    # Verify map retrieval
+    retrieved_map = bookmark_svc.get_mcp_bookmark_map(_test_doc)
+    assert retrieved_map == bookmark_map
+
+@native_test
+def test_find_nearest_heading_bookmark():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    events = EventBus()
+    doc_svc = DocumentService(events)
+    bookmark_svc = BookmarkService(doc_svc, events)
+
+    bookmark_map = bookmark_svc.ensure_heading_bookmarks(_test_doc)
+
+    # Nearest heading before or at index 1 is index 0
+    res = bookmark_svc.find_nearest_heading_bookmark(1, bookmark_map)
+    assert res is not None
+    assert res["heading_para_index"] == 0
+    assert res["bookmark"] == bookmark_map[0]
+
+    # Nearest heading before or at index 2 is index 2
+    res = bookmark_svc.find_nearest_heading_bookmark(2, bookmark_map)
+    assert res is not None
+    assert res["heading_para_index"] == 2
+    assert res["bookmark"] == bookmark_map[2]
+
+@native_test
+def test_cleanup_mcp_bookmarks():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    events = EventBus()
+    doc_svc = DocumentService(events)
+    bookmark_svc = BookmarkService(doc_svc, events)
+
+    # Ensure we have some bookmarks
+    bookmark_svc.ensure_heading_bookmarks(_test_doc)
+
+    # Clean them up
+    removed_count = bookmark_svc.cleanup_mcp_bookmarks(_test_doc)
+    assert removed_count == 2
+
+    # Verify they are gone from document
+    bms = _test_doc.getBookmarks().getElementNames()
+    mcp_bms = [b for b in bms if b.startswith("_mcp_")]
+    assert len(mcp_bms) == 0
+
+    # Verify cache is cleared implicitly on next read
+    empty_map = bookmark_svc.get_mcp_bookmark_map(_test_doc)
+    assert len(empty_map) == 0

--- a/plugin/tests/test_writer_navigation.py
+++ b/plugin/tests/test_writer_navigation.py
@@ -1,11 +1,38 @@
 import unittest
+import sys
+
+# Mock uno for the pure python tests in this file specifically to allow import without native runner
+try:
+    import uno
+except ImportError:
+    class BaseStub:
+        pass
+    import types
+    sys.modules['uno'] = types.ModuleType('uno')
+    sys.modules['unohelper'] = types.ModuleType('unohelper')
+    sys.modules['unohelper'].Base = BaseStub
+    sys.modules['com'] = types.ModuleType('com')
+    sys.modules['com.sun'] = types.ModuleType('sun')
+    sys.modules['com.sun.star'] = types.ModuleType('star')
+    sys.modules['com.sun.star.awt'] = types.ModuleType('awt')
+
+    class MockListener(object):
+        pass
+
+    sys.modules['com.sun.star.awt'].XActionListener = MockListener
+    sys.modules['com.sun.star.datatransfer'] = types.ModuleType('datatransfer')
+    sys.modules['com.sun.star.datatransfer.clipboard'] = types.ModuleType('clipboard')
+    class MockClipboardListener(object):
+        pass
+    sys.modules['com.sun.star.datatransfer.clipboard'].XClipboardListener = MockClipboardListener
+
+from plugin.tests.testing_utils import ElementStub, WriterDocStub
 from plugin.framework.document import (
     DocumentCache,
     build_heading_tree,
     resolve_locator,
     get_paragraph_ranges
 )
-from plugin.tests.testing_utils import ElementStub, WriterDocStub
 
 class TestWriterNavigation(unittest.TestCase):
     def test_document_cache(self):
@@ -71,6 +98,146 @@ class TestWriterNavigation(unittest.TestCase):
         
         res = resolve_locator(doc, "heading:2.1")
         self.assertEqual(res["para_index"], 3) # H2.1 is at index 3
+
+
+try:
+    from plugin.testing_runner import setup, teardown, native_test
+    from plugin.framework.uno_helpers import get_desktop
+    from plugin.modules.writer.navigation import NavigateHeading, GetSurroundings
+except ImportError:
+    setup, teardown, native_test = (lambda f: f), (lambda f: f), (lambda f: f)
+
+_test_doc = None
+_test_ctx = None
+
+@setup
+def setup_nav_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+
+    desktop = get_desktop(ctx)
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
+    _test_doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
+
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
+
+    # 0: Heading 1
+    text.insertString(cursor, "Chapter 1", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 1")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 1: Paragraph
+    text.insertString(cursor, "This is the first chapter.", False)
+    cursor.setPropertyValue("ParaStyleName", "Standard")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 2: Heading 2
+    text.insertString(cursor, "Section 1.1", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 2")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 3: Paragraph
+    text.insertString(cursor, "This is a subsection.", False)
+    cursor.setPropertyValue("ParaStyleName", "Standard")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 4: Heading 1
+    text.insertString(cursor, "Chapter 2", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 1")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 5: Paragraph
+    text.insertString(cursor, "This is the second chapter.", False)
+    cursor.setPropertyValue("ParaStyleName", "Standard")
+    text.insertControlCharacter(cursor, 0, False)
+
+@teardown
+def teardown_nav_tests():
+    if _test_doc:
+        _test_doc.close(True)
+
+class MockContext:
+    def __init__(self, doc, ctx):
+        self.doc = doc
+        self.ctx = ctx
+        self.services = MockServices(doc)
+
+class MockServices:
+    def __init__(self, doc):
+        from plugin.framework.document import DocumentService
+        from plugin.framework.events import EventBus
+        from plugin.modules.writer.proximity import ProximityService
+        from plugin.modules.writer.bookmarks import BookmarkService
+        from plugin.modules.writer.tree import TreeService
+        from plugin.modules.writer.structural import ListSections
+
+        self.events = EventBus()
+        self.document = DocumentService(self.events)
+        self.writer_bookmarks = BookmarkService(self.document, self.events)
+        self.writer_tree = TreeService(self.document, self.writer_bookmarks, self.events)
+        self.writer_structural = ListSections() # Simplified mock structural logic
+        self.writer_proximity = ProximityService(self.document, self.writer_tree, self.writer_bookmarks)
+
+@native_test
+def test_navigate_heading():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    tool = NavigateHeading()
+    ctx = MockContext(_test_doc, _test_ctx)
+
+    # First we need to make sure bookmarks are generated
+    ctx.services.writer_bookmarks.ensure_heading_bookmarks(_test_doc)
+
+    # Navigate to Chapter 2 (next heading from Chapter 1)
+    res = tool.execute(ctx, locator="heading:1", direction="next")
+    assert res["status"] == "ok"
+    assert "target" in res
+    assert res["target"]["text"] == "Chapter 2"
+
+    # Navigate to Section 1.1 (first child from Chapter 1)
+    res = tool.execute(ctx, locator="heading:1", direction="first_child")
+    assert res["status"] == "ok"
+    assert "target" in res
+    assert res["target"]["text"] == "Section 1.1"
+
+    # Navigate to Chapter 1 (parent of Section 1.1)
+    res = tool.execute(ctx, locator="heading:1.1", direction="parent")
+    assert res["status"] == "ok"
+    assert "target" in res
+    assert res["target"]["text"] == "Chapter 1"
+
+@native_test
+def test_get_surroundings():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    tool = GetSurroundings()
+    ctx = MockContext(_test_doc, _test_ctx)
+
+    # Get surroundings around paragraph 3 (Section 1.1 paragraph)
+    res = tool.execute(ctx, locator="paragraph:3", radius=1)
+    assert res["status"] == "ok"
+    assert "paragraphs" in res
+
+    # Radius 1 means 3 paragraphs (index 2, 3, 4)
+    paras = res["paragraphs"]
+    assert len(paras) == 3
+    assert paras[0]["text"] == "Section 1.1"
+    assert paras[1]["text"] == "This is a subsection."
+    assert paras[2]["text"] == "Chapter 2"
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugin/tests/test_writer_search.py
+++ b/plugin/tests/test_writer_search.py
@@ -1,0 +1,168 @@
+try:
+    import uno
+    import pytest
+except ImportError:
+    pass
+
+try:
+    from plugin.testing_runner import setup, teardown, native_test
+    from plugin.framework.uno_helpers import get_desktop
+    from plugin.modules.writer.search import SearchInDocument, AdvancedSearch, GetIndexStats
+except ImportError:
+    setup, teardown, native_test = (lambda f: f), (lambda f: f), (lambda f: f)
+
+_test_doc = None
+_test_ctx = None
+
+@setup
+def setup_search_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+
+    desktop = get_desktop(ctx)
+    from com.sun.star.beans import PropertyValue
+    hidden_prop = PropertyValue()
+    hidden_prop.Name = "Hidden"
+    hidden_prop.Value = True
+    _test_doc = desktop.loadComponentFromURL("private:factory/swriter", "_blank", 0, (hidden_prop,))
+
+    text = _test_doc.getText()
+    cursor = text.createTextCursor()
+
+    # 0: Heading
+    text.insertString(cursor, "Introduction to testing", False)
+    cursor.setPropertyValue("ParaStyleName", "Heading 1")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 1: Paragraph
+    text.insertString(cursor, "This is the first paragraph. We will find this needle in a haystack.", False)
+    cursor.setPropertyValue("ParaStyleName", "Standard")
+    text.insertControlCharacter(cursor, 0, False)
+
+    # 2: Paragraph
+    text.insertString(cursor, "Another paragraph. Needles are sharp. We also have some testing data here.", False)
+    text.insertControlCharacter(cursor, 0, False)
+
+@teardown
+def teardown_search_tests():
+    if _test_doc:
+        _test_doc.close(True)
+
+class MockContext:
+    def __init__(self, doc, ctx):
+        self.doc = doc
+        self.ctx = ctx
+        self.services = MockServices(doc)
+
+class MockWriterIndexService:
+    def search_boolean(self, doc, query, max_results=20, context_paragraphs=1):
+        if "error" in query:
+            raise ValueError("Test error from search_boolean")
+        return {
+            "matches": [{"paragraph_index": 1, "text": "This is the first paragraph", "context": []}],
+            "count": 1
+        }
+    def get_index_stats(self, doc):
+        return {"stems": 100, "paragraphs": 3}
+
+class MockServices:
+    def __init__(self, doc):
+        from plugin.framework.document import DocumentService
+        from plugin.framework.events import EventBus
+        self.events = EventBus()
+        self.document = DocumentService(self.events)
+        self.writer_index = MockWriterIndexService()
+
+@native_test
+def test_search_in_document_basic():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    tool = SearchInDocument()
+    ctx = MockContext(_test_doc, _test_ctx)
+
+    # Simple search
+    res = tool.execute(ctx, pattern="needle")
+    assert res["status"] == "ok"
+    assert res["count"] == 2
+    assert len(res["matches"]) == 2
+
+    match1 = res["matches"][0]
+    assert match1["text"] == "needle"
+    assert match1["paragraph_index"] == 1
+
+    match2 = res["matches"][1]
+    assert match2["text"] == "needle"
+    assert match2["paragraph_index"] == 2
+
+@native_test
+def test_search_in_document_case_sensitive():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    tool = SearchInDocument()
+    ctx = MockContext(_test_doc, _test_ctx)
+
+    res = tool.execute(ctx, pattern="Needle", case_sensitive=True)
+    assert res["status"] == "ok"
+    assert res["count"] == 1
+    assert res["matches"][0]["paragraph_index"] == 2
+    assert res["matches"][0]["text"] == "Needle"
+
+@native_test
+def test_search_in_document_regex():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    tool = SearchInDocument()
+    ctx = MockContext(_test_doc, _test_ctx)
+
+    res = tool.execute(ctx, pattern=r"Needles? are \w+", regex=True)
+    assert res["status"] == "ok"
+    assert res["count"] == 1
+    assert res["matches"][0]["text"] == "Needles are sharp"
+
+@native_test
+def test_advanced_search_tool():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    tool = AdvancedSearch()
+    ctx = MockContext(_test_doc, _test_ctx)
+
+    res = tool.execute(ctx, query="test AND data")
+    assert res["status"] == "ok"
+    assert res["count"] == 1
+    assert res["matches"][0]["paragraph_index"] == 1
+
+@native_test
+def test_get_index_stats():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    tool = GetIndexStats()
+    ctx = MockContext(_test_doc, _test_ctx)
+
+    res = tool.execute(ctx)
+    assert res["status"] == "ok"
+    assert res["stems"] == 100


### PR DESCRIPTION
Fixes a test gap in Writer core logic:

What:
Added specific tests for text searching, bookmark creation/retrieval, and jumping logic in LibreOffice Writer modules.

Why:
Writer is a highly complex module. Missing test coverage for core search (`plugin/modules/writer/search.py`), navigation (`plugin/modules/writer/navigation.py`), and bookmark logic (`plugin/modules/writer/bookmarks.py`) made the code vulnerable to regressions.

Result:
New native tests exist that safely mock document elements and can verify end-to-end execution of these operations, while avoiding failures in pure Python test environments without an active LibreOffice instance.

---
*PR created automatically by Jules for task [8797359144766984213](https://jules.google.com/task/8797359144766984213) started by @KeithCu*