### PR TITLE
🧪 Add integration tests for tool call parsing across multiple models

### DIFF
--- a/plugin/tests/test_tool_call_parsers.py
+++ b/plugin/tests/test_tool_call_parsers.py
@@ -21,6 +21,51 @@ def test_hermes_parser_unclosed():
     # Hermes returns None on JSONDecodeError from unclosed JSON
     assert tool_calls is None
 
+def test_hermes_parser_normalization():
+    parser = get_parser("hermes")
+    # provider emitting arguments as an object in-text
+    text = '<tool_call>{"name": "test_tool", "arguments": {"cmd": "ls", "args": ["-l", "-a"]}}</tool_call>'
+    content, tool_calls = parser.parse(text)
+
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "test_tool"
+    assert tool_calls[0]["function"]["arguments"] == '{"cmd": "ls", "args": ["-l", "-a"]}'
+
+def test_hermes_parser_whitespace():
+    parser = get_parser("hermes")
+    # provider emitting whitespace or newlines inside and around the tags
+    text = (
+        'Hello\n'
+        '<tool_call>  \n'
+        '{"name": "test_tool", "arguments": {"cmd": "ls"}} \n'
+        '  </tool_call>'
+    )
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Hello"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "test_tool"
+    assert tool_calls[0]["function"]["arguments"] == '{"cmd": "ls"}'
+
+def test_hermes_parser_multiple():
+    parser = get_parser("hermes")
+    text = (
+        'Here are your calls:\n'
+        '<tool_call>{"name": "tool1", "arguments": {"a": 1}}</tool_call>\n'
+        '<tool_call>{"name": "tool2", "arguments": {"b": 2}}</tool_call>'
+    )
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Here are your calls:"
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert tool_calls[0]["function"]["name"] == "tool1"
+    assert tool_calls[0]["function"]["arguments"] == '{"a": 1}'
+    assert tool_calls[1]["function"]["name"] == "tool2"
+    assert tool_calls[1]["function"]["arguments"] == '{"b": 2}'
+
 def test_deepseek_v3_parser():
     parser = get_parser("deepseek_v3")
     text = (
@@ -35,6 +80,58 @@ def test_deepseek_v3_parser():
     assert len(tool_calls) == 1
     assert tool_calls[0]["function"]["name"] == "get_weather"
 
+def test_deepseek_v3_parser_normalization():
+    parser = get_parser("deepseek_v3")
+    text = (
+        '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n'
+        '```json\n{"city": "Paris", "days": [1, 2, 3]}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    )
+    content, tool_calls = parser.parse(text)
+
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    # DeepSeek just strips whitespace for args, if it's already a valid string, that's fine
+    assert tool_calls[0]["function"]["arguments"] == '{"city": "Paris", "days": [1, 2, 3]}'
+
+def test_deepseek_v3_parser_whitespace():
+    parser = get_parser("deepseek_v3")
+    text = (
+        'Thinking...\n'
+        '<｜tool▁calls▁begin｜>   \n'
+        '<｜tool▁call▁begin｜> function <｜tool▁sep｜> get_weather \n'
+        '```json\n{"city": "Paris"}\n```<｜tool▁call▁end｜>  \n'
+        '<｜tool▁calls▁end｜>'
+    )
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Thinking..."
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert tool_calls[0]["function"]["arguments"] == '{"city": "Paris"}'
+
+def test_deepseek_v3_parser_multiple():
+    parser = get_parser("deepseek_v3")
+    text = (
+        'Thinking...\n'
+        '<｜tool▁calls▁begin｜>'
+        '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n'
+        '```json\n{"city": "Paris"}\n```<｜tool▁call▁end｜>'
+        '<｜tool▁call▁begin｜>function<｜tool▁sep｜>calc\n'
+        '```json\n{"expr": "1+1"}\n```<｜tool▁call▁end｜>'
+        '<｜tool▁calls▁end｜>'
+    )
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Thinking..."
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert tool_calls[0]["function"]["arguments"] == '{"city": "Paris"}'
+    assert tool_calls[1]["function"]["name"] == "calc"
+    assert tool_calls[1]["function"]["arguments"] == '{"expr": "1+1"}'
+
 def test_mistral_parser_v11():
     parser = get_parser("mistral")
     text = 'Result[TOOL_CALLS]get_weather{"city": "Berlin"}'
@@ -44,6 +141,57 @@ def test_mistral_parser_v11():
     assert tool_calls is not None
     assert len(tool_calls) == 1
     assert tool_calls[0]["function"]["name"] == "get_weather"
+
+def test_mistral_parser_normalization():
+    parser = get_parser("mistral")
+    # v11 format
+    text = 'Result[TOOL_CALLS]get_weather{"city": "Berlin", "days": [1, 2]}'
+    _, tool_calls = parser.parse(text)
+
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["arguments"] == '{"city": "Berlin", "days": [1, 2]}'
+
+    # prev11 format
+    text2 = 'Result[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Berlin", "days": [1, 2]}}]'
+    _, tool_calls2 = parser.parse(text2)
+    assert tool_calls2 is not None
+    assert len(tool_calls2) == 1
+    assert tool_calls2[0]["function"]["arguments"] == '{"city": "Berlin", "days": [1, 2]}'
+
+def test_mistral_parser_whitespace():
+    parser = get_parser("mistral")
+    # v11 format with extra spaces
+    text = 'Result[TOOL_CALLS]   get_weather   { "city" : "Berlin" }  '
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Result"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert tool_calls[0]["function"]["arguments"] == '{ "city" : "Berlin" }'
+
+    # prev11 format with extra spaces/newlines
+    text2 = 'Result \n [TOOL_CALLS] \n [ \n { "name" : "get_weather" , "arguments" : {"city": "Berlin"} } \n ] '
+    content2, tool_calls2 = parser.parse(text2)
+    assert content2 == "Result"
+    assert tool_calls2 is not None
+    assert len(tool_calls2) == 1
+    assert tool_calls2[0]["function"]["name"] == "get_weather"
+    assert tool_calls2[0]["function"]["arguments"] == '{"city": "Berlin"}'
+
+def test_mistral_parser_v11_multiple():
+    parser = get_parser("mistral")
+    text = 'Result[TOOL_CALLS]get_weather{"city": "Berlin"}[TOOL_CALLS]calc{"expr": "2+2"}'
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Result"
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert tool_calls[0]["function"]["arguments"] == '{"city": "Berlin"}'
+    assert tool_calls[1]["function"]["name"] == "calc"
+    assert tool_calls[1]["function"]["arguments"] == '{"expr": "2+2"}'
 
 def test_mistral_parser_prev11():
     parser = get_parser("mistral")
@@ -55,6 +203,19 @@ def test_mistral_parser_prev11():
     assert len(tool_calls) == 1
     assert tool_calls[0]["function"]["name"] == "get_weather"
 
+def test_mistral_parser_prev11_multiple():
+    parser = get_parser("mistral")
+    text = 'Result[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Berlin"}}, {"name": "calc", "arguments": {"expr": "2+2"}}]'
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Result"
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert tool_calls[0]["function"]["arguments"] == '{"city": "Berlin"}'
+    assert tool_calls[1]["function"]["name"] == "calc"
+    assert tool_calls[1]["function"]["arguments"] == '{"expr": "2+2"}'
+
 def test_llama_parser():
     parser = get_parser("llama3_json")
     text = 'Output: <|python_tag|>\n{"name": "calc", "arguments": {"expr": "2+2"}}'
@@ -64,6 +225,46 @@ def test_llama_parser():
     assert tool_calls is not None
     assert len(tool_calls) == 1
     assert tool_calls[0]["function"]["name"] == "calc"
+
+def test_llama_parser_normalization():
+    parser = get_parser("llama3_json")
+    text = 'Output: <|python_tag|>\n{"name": "calc", "arguments": {"expr": "2+2", "flags": ["a"]}}'
+    content, tool_calls = parser.parse(text)
+
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "calc"
+    assert tool_calls[0]["function"]["arguments"] == '{"expr": "2+2", "flags": ["a"]}'
+
+def test_llama_parser_whitespace():
+    parser = get_parser("llama3_json")
+    text = (
+        'Output: <|python_tag|>\n\n'
+        '  {  \n'
+        '  "name": "calc", \n'
+        '  "arguments": {"expr": "2+2"} \n'
+        '}  \n'
+    )
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Output:"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "calc"
+    assert tool_calls[0]["function"]["arguments"] == '{"expr": "2+2"}'
+
+def test_llama_parser_multiple():
+    parser = get_parser("llama3_json")
+    text = 'Output: <|python_tag|>\n{"name": "calc", "arguments": {"expr": "2+2"}}\n{"name": "get_weather", "arguments": {"city": "Paris"}}'
+    content, tool_calls = parser.parse(text)
+
+    assert content == "Output:"
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert tool_calls[0]["function"]["name"] == "calc"
+    assert tool_calls[0]["function"]["arguments"] == '{"expr": "2+2"}'
+    assert tool_calls[1]["function"]["name"] == "get_weather"
+    assert tool_calls[1]["function"]["arguments"] == '{"city": "Paris"}'
 
 def test_get_parser_for_model():
     p1 = get_parser_for_model("hermes-2-pro")


### PR DESCRIPTION
What
Added tests in `plugin/tests/test_tool_call_parsers.py` to cover three key scenarios for multiple parsers (Hermes, DeepSeek v3, Mistral, and Llama 3/4):
1. **Multiple Tool Calls**: Tests for parsing out more than one tool call simultaneously from a single text.
2. **Argument Normalization**: Tests ensuring that arguments are properly serialized back into JSON strings if they're detected as JSON objects in text (e.g. from Provider APIs or JSON tagging in pre-v11 Mistral format).
3. **Robustness against whitespace**: Verifies parsers gracefully handle whitespace, newlines, and varying token/tag formatting without breaking.

Why
These parser logic branches lacked integration test coverage that proved their behavior dynamically, despite covering corner cases like tokenizer anomalies and argument serialization mismatches from multiple provider APIs. Adding these tests fulfills requirements listed for "Gaps / extension ideas" without changing any codebase logic.

Verification
All tests within `plugin/tests/test_tool_call_parsers.py` passed cleanly without any modifications or side-effects to the parser module logics (`plugin/contrib/tool_call_parsers/*`).

---
*PR created automatically by Jules for task [10804913519496899404](https://jules.google.com/task/10804913519496899404) started by @KeithCu*