### PR TITLE
🧪 [test expansion] Add cross-thread execution coverage for main_thread.py

### DIFF
--- a/plugin/tests/test_main_thread.py
+++ b/plugin/tests/test_main_thread.py
@@ -1,9 +1,22 @@
 import threading
+import queue
+import pytest
+from unittest.mock import patch, MagicMock
 
 from plugin.framework.main_thread import (
     _WorkItem,
-    execute_on_main_thread
+    execute_on_main_thread,
+    post_to_main_thread,
+    _work_queue
 )
+
+@pytest.fixture(autouse=True)
+def empty_work_queue():
+    while not _work_queue.empty():
+        try:
+            _work_queue.get_nowait()
+        except queue.Empty:
+            break
 
 def test_work_item():
     def func(x): return x * 2
@@ -23,3 +36,108 @@ def test_execute_on_main_thread_direct():
 
     res = execute_on_main_thread(func)
     assert res == 42
+
+
+@patch("plugin.framework.main_thread._get_async_callback")
+@patch("plugin.framework.main_thread._poke_vcl")
+def test_execute_on_main_thread_background(mock_poke, mock_get_async):
+    """
+    Test where caller is not threading.main_thread(), mock _get_async_callback
+    to force AsyncCallback path, and validate results/exceptions are returned.
+    """
+    mock_get_async.return_value = MagicMock()
+
+    def func_to_run(x):
+        if x == 0:
+            raise ValueError("Zero not allowed")
+        return x * 10
+
+    def mock_poke_vcl():
+        # Simulate VCL event loop calling notify()
+        try:
+            item = _work_queue.get_nowait()
+            try:
+                item.result = item.fn(*item.args, **item.kwargs)
+            except Exception as e:
+                item.exception = e
+            finally:
+                item.event.set()
+        except queue.Empty:
+            pass
+
+    mock_poke.side_effect = mock_poke_vcl
+
+    results = {}
+    exceptions = {}
+
+    def bg_thread(val):
+        try:
+            res = execute_on_main_thread(func_to_run, val)
+            results[val] = res
+        except Exception as e:
+            exceptions[val] = e
+
+    t1 = threading.Thread(target=bg_thread, args=(5,))
+    t2 = threading.Thread(target=bg_thread, args=(0,))
+
+    t1.start()
+    t2.start()
+
+    t1.join(timeout=2.0)
+    t2.join(timeout=2.0)
+
+    assert results.get(5) == 50
+    assert isinstance(exceptions.get(0), ValueError)
+    assert str(exceptions[0]) == "Zero not allowed"
+
+
+@patch("plugin.framework.main_thread._get_async_callback")
+@patch("plugin.framework.main_thread._poke_vcl")
+def test_execute_on_main_thread_timeout(mock_poke, mock_get_async):
+    """
+    Test that forces item.event.wait(timeout) to time out and asserts
+    the raised TimeoutError message includes the function name.
+    """
+    mock_get_async.return_value = MagicMock()
+    # mock_poke does nothing, so the work item is never executed
+
+    def slow_func():
+        pass
+
+    exc_caught = None
+    def bg_thread():
+        nonlocal exc_caught
+        try:
+            execute_on_main_thread(slow_func, timeout=0.1)
+        except Exception as e:
+            exc_caught = e
+
+    t = threading.Thread(target=bg_thread)
+    t.start()
+    t.join(timeout=1.0)
+
+    assert isinstance(exc_caught, TimeoutError)
+    assert "slow_func" in str(exc_caught)
+    assert "timed out after 0.1s" in str(exc_caught)
+
+
+@patch("plugin.framework.main_thread._get_async_callback")
+@patch("plugin.framework.main_thread._poke_vcl")
+def test_post_to_main_thread_fire_and_forget(mock_poke, mock_get_async):
+    """
+    Test for post_to_main_thread() that ensures it enqueues the work item
+    without blocking (and still calls _poke_vcl()).
+    """
+    mock_get_async.return_value = MagicMock()
+
+    def my_func():
+        pass
+
+    post_to_main_thread(my_func)
+
+    # Check that it enqueued the item
+    item = _work_queue.get_nowait()
+    assert item.fn is my_func
+
+    # Check that it called _poke_vcl
+    mock_poke.assert_called_once()


### PR DESCRIPTION
# What
Added three new integration tests to `plugin/tests/test_main_thread.py`:
1. `test_execute_on_main_thread_background`: Validates that tasks invoked via `execute_on_main_thread` correctly route through the work queue, process results, and propagate exceptions back to the background threads cleanly.
2. `test_execute_on_main_thread_timeout`: Forces a timeout condition and asserts that `TimeoutError` accurately reports the name of the function being executed along with the timeout value.
3. `test_post_to_main_thread_fire_and_forget`: Validates that `post_to_main_thread` successfully enqueues the work item and invokes `_poke_vcl` without blocking the invoking thread.

# Why
The test coverage for `execute_on_main_thread` only verified the fast path (when already on the main thread). The cross-thread dispatching logic itself (which relies on `threading.Event`, queues, and `AsyncCallback` mocks) lacked automated regression protection.

# Verification
1. `pytest plugin/tests/test_main_thread.py` passes successfully.
2. An `autouse=True` test fixture is present to safely flush `_work_queue` before each test so that forced timeouts do not pollute subsequent tests in the suite.

---
*PR created automatically by Jules for task [9908042764138207200](https://jules.google.com/task/9908042764138207200) started by @KeithCu*