### PR TITLE
test: expand AI Horde image provider callback coverage

### DIFF
--- a/plugin/tests/test_image_status_callback.py
+++ b/plugin/tests/test_image_status_callback.py
@@ -51,5 +51,78 @@ class TestImageStatusCallback(unittest.TestCase):
                 status_callback.assert_any_call("Horde: Generating... (50%)")
                 print("Status callback successfully invoked!")
 
+    def test_provider_failure_shape(self):
+        mock_ctx = MagicMock()
+        mock_ctx.ServiceManager.createInstanceWithContext.return_value = MagicMock()
+        config = {"aihorde_api_key": "test_key", "image_provider": "aihorde"}
+        service = ImageService(mock_ctx, config)
+
+        provider = service.get_provider("aihorde")
+        informer = provider.client.informer
+
+        def mock_generate_image_error(options):
+            informer.update_status("Starting...", 0)
+            raise ValueError("Test provider failure")
+
+        with patch.object(service, 'get_provider', return_value=provider):
+            with patch.object(provider.client, 'generate_image', side_effect=mock_generate_image_error):
+                paths, error = service.generate_image("test prompt", status_callback=MagicMock())
+
+                self.assertEqual(paths, [])
+                self.assertIn("Test provider failure", error)
+
+    def test_callback_optionality(self):
+        mock_ctx = MagicMock()
+        mock_ctx.ServiceManager.createInstanceWithContext.return_value = MagicMock()
+        config = {"aihorde_api_key": "test_key", "image_provider": "aihorde"}
+        service = ImageService(mock_ctx, config)
+
+        provider = service.get_provider("aihorde")
+        informer = provider.client.informer
+
+        def mock_generate_image(options):
+            # This should not crash even without a callback
+            informer.update_status("Starting...", 0)
+            informer.show_error("Some warning")
+            return ["/tmp/image.png"]
+
+        with patch.object(service, 'get_provider', return_value=provider):
+            with patch.object(provider.client, 'generate_image', side_effect=mock_generate_image):
+                result = service.generate_image("test prompt", status_callback=None)
+
+                self.assertEqual(result, (["/tmp/image.png"], ""))
+
+    def test_ordering_and_formatting(self):
+        from unittest.mock import call
+        mock_ctx = MagicMock()
+        mock_ctx.ServiceManager.createInstanceWithContext.return_value = MagicMock()
+        config = {"aihorde_api_key": "test_key", "image_provider": "aihorde"}
+        service = ImageService(mock_ctx, config)
+
+        status_callback = MagicMock()
+        provider = service.get_provider("aihorde")
+        informer = provider.client.informer
+
+        def mock_generate_image(options):
+            informer.update_status("Initializing", 0)
+            informer.update_status("Processing", 50)
+            informer.update_status("Refining", 10)
+            informer.update_status("Finishing", 100)
+            return ["/tmp/image.png"]
+
+        with patch.object(service, 'get_provider', return_value=provider):
+            with patch.object(provider.client, 'generate_image', side_effect=mock_generate_image):
+                result = service.generate_image("test prompt", status_callback=status_callback)
+
+                self.assertEqual(result, (["/tmp/image.png"], ""))
+
+                expected_calls = [
+                    call("Horde: Initializing (0%)"),
+                    call("Horde: Processing (50%)"),
+                    call("Horde: Refining (10%)"),
+                    call("Horde: Finishing (100%)"),
+                ]
+                self.assertEqual(status_callback.call_args_list, expected_calls)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds three new tests to `plugin/tests/test_image_status_callback.py` to cover edge cases and functionality for the AI Horde Image Provider's status callbacks:
- **Provider failure-shape**: Verifies that exceptions during provider generation are correctly caught, returning `([], error_message)` rather than crashing the calling service.
- **Callback optionality**: Validates that setting `status_callback=None` suppresses errors without crashing the internal informer bridge.
- **Ordering and formatting**: Asserts that sequential, non-monotonic progress updates trigger the `status_callback` in the exact expected order with the correct `Horde:` prefix formatting.

---
*PR created automatically by Jules for task [18025326862938318132](https://jules.google.com/task/18025326862938318132) started by @KeithCu*