### PR TITLE
🐛 [Fix multi-image generation in EndpointImageProvider]

### DIFF
--- a/plugin/framework/image_utils.py
+++ b/plugin/framework/image_utils.py
@@ -80,6 +80,7 @@ class EndpointImageProvider(ImageProvider):
             fallback_content = chat_resp.get("content") or ""
 
             # Parse response: OpenRouter etc. may put image in message.images[].image_url.url
+            paths = []
             for img in (chat_resp.get("images") or []):
                 url = None
                 if isinstance(img, dict):
@@ -94,9 +95,12 @@ class EndpointImageProvider(ImageProvider):
                 if "data:image" in url:
                     match = re.search(r'base64,([A-Za-z0-9+/=]+)', url)
                     if match:
-                        return self._save_b64(match.group(1)), ""
+                        paths.extend(self._save_b64(match.group(1)))
                 elif url.startswith("http"):
-                    return self._save_url(url), ""
+                    paths.extend(self._save_url(url))
+
+            if paths:
+                return paths, ""
         else:
             # Use standard /images/generations endpoint (Together, OpenAI, etc.). Optional source_image for img2img.
             valid_steps = steps if (steps is not None and steps > 0) else None
@@ -119,15 +123,20 @@ class EndpointImageProvider(ImageProvider):
                 debug_log("=== Image Response: %s" % json.dumps(result, indent=2), context="API")
 
                 # Standard OpenAI format: {"data": [{"url": "...", "b64_json": "..."}]}
+                paths = []
                 for img in (result.get("data") or []):
                     if b64 := img.get("b64_json"):
-                        return self._save_b64(b64), ""
-                    if url := img.get("url"):
+                        paths.extend(self._save_b64(b64))
+                    elif url := img.get("url"):
                         if "data:image" in url:
                             match = re.search(r'base64,([A-Za-z0-9+/=]+)', url)
                             if match:
-                                return self._save_b64(match.group(1)), ""
-                        return self._save_url(url), ""
+                                paths.extend(self._save_b64(match.group(1)))
+                        else:
+                            paths.extend(self._save_url(url))
+
+                if paths:
+                    return paths, ""
             except Exception:
                 logger.exception("Image generation failed")
                 raise

--- a/plugin/tests/test_image_service_refactor.py
+++ b/plugin/tests/test_image_service_refactor.py
@@ -143,6 +143,72 @@ class TestEndpointImageProvider(unittest.TestCase):
         except AttributeError as e:
             self.fail(f"Scoping bug still present! AttributeError: {e}")
 
+    def test_generate_error_handling_missing_fields(self):
+        """When provider response lacks expected image fields, ensure we return ([], '')."""
+        self.mock_client.config.get.side_effect = lambda k, d=None: True if k == "is_openrouter" else d
+        self.mock_client.make_chat_request.return_value = ("POST", "/chat", "{}", {})
+
+        # Missing image_url key
+        mock_resp = {
+            "images": [{"wrong_key": "http://example.com/image.png"}]
+        }
+        self.mock_client.request_with_tools.return_value = mock_resp
+
+        paths, err = self.provider.generate("test prompt")
+        self.assertEqual(paths, [])
+        self.assertEqual(err, "")
+
+    @patch('plugin.framework.image_utils.sync_request')
+    def test_generate_multi_image(self, mock_sync):
+        """If provider returns multiple images, ensure paths preserves ordering and all paths are created/cleaned."""
+        self.mock_client.config.get.return_value = False # Not OpenRouter
+        self.mock_client.make_image_request.return_value = ("POST", "/images", "{}", {})
+
+        # Mock standard connection and response with multiple images
+        mock_conn = MagicMock()
+        self.mock_client._get_connection.return_value = mock_conn
+
+        b64_data = base64.b64encode(b"multi-image-b64-data").decode()
+        mock_sync.return_value = b"multi-image-url-data"
+
+        mock_http_resp = create_mock_http_response(200, {"data": [
+            {"b64_json": b64_data},
+            {"url": "http://example.com/multi_image.png"}
+        ]})
+        mock_conn.getresponse.return_value = mock_http_resp
+
+        paths, err = self.provider.generate("test prompt")
+
+        self.assertEqual(len(paths), 2)
+        self.assertEqual(err, "")
+
+        self.assertTrue(paths[0].endswith(".png"))
+        with open(paths[0], 'rb') as f:
+            self.assertEqual(f.read(), b"multi-image-b64-data")
+
+        self.assertTrue(paths[1].endswith(".webp"))
+        mock_sync.assert_called_once_with("http://example.com/multi_image.png", parse_json=False)
+
+        os.unlink(paths[0])
+        os.unlink(paths[1])
+
+    def test_fallback_logic_invalid_data_url(self):
+        """For OpenRouter fallback content path, verify behavior when content contains a partial/invalid data URL string."""
+        self.mock_client.config.get.side_effect = lambda k, d=None: True if k == "is_openrouter" else d
+        self.mock_client.make_chat_request.return_value = ("POST", "/chat", "{}", {})
+
+        # Invalid data URL
+        mock_resp = {
+            "content": "Check this out: data:image/png;invalid",
+            "images": []
+        }
+        self.mock_client.request_with_tools.return_value = mock_resp
+
+        paths, err = self.provider.generate("test prompt")
+
+        self.assertEqual(paths, [])
+        self.assertEqual(err, "")
+
     @patch('plugin.framework.image_utils.LlmClient')
     def test_edit_image_openrouter_sends_multimodal_message(self, mock_client_cls):
         """When OpenRouter and source_image are set, make_chat_request receives message content with text + image_url."""


### PR DESCRIPTION
What:
Fixed a bug in `EndpointImageProvider.generate` where it previously returned early after finding the first image from a provider response. Now it supports multi-image generation by accumulating the paths of all images returned (whether through OpenRouter `images` list or standard endpoint `data` list).

Why:
Providers that support returning multiple images in a single request would have their outputs truncated to just the first image. This refactor implements full support for generating and writing out all images returned by the AI provider, as specified in the testing contracts and feature requests.

Verification:
- Added `test_generate_multi_image` which asserts that both an inline base64 image and a standard URL image from a single response are correctly decoded/downloaded, saved to disk, and returned as a list.
- Added `test_generate_error_handling_missing_fields` to ensure safety when the response array lacks expected image structures.
- Added `test_fallback_logic_invalid_data_url` to assert proper failing behavior on malformed `data:` fallback strings.
- All tests in `test_image_service_refactor.py` pass.

---
*PR created automatically by Jules for task [12169335459232160652](https://jules.google.com/task/12169335459232160652) started by @KeithCu*