### PR TITLE
test: Complete test coverage in test_chat_model_logic.py

### DIFF
--- a/plugin/tests/test_chat_model_logic.py
+++ b/plugin/tests/test_chat_model_logic.py
@@ -4,8 +4,12 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 # Mock uno and unohelper before importing chat_panel
-class MockUnoBase: pass
-class XActionListener: pass
+class BaseStub: pass
+class MockUnoBase(BaseStub): pass
+class XActionListener(BaseStub): pass
+class XTextListener(BaseStub): pass
+class XWindowListener(BaseStub): pass
+class XItemListener(BaseStub): pass
 class XUIElement: pass
 class XToolPanel: pass
 class XSidebarPanel: pass
@@ -20,6 +24,9 @@ sys.modules['unohelper'] = mock_unohelper
 # Mock com structure
 com = MagicMock()
 com.sun.star.awt.XActionListener = XActionListener
+com.sun.star.awt.XTextListener = XTextListener
+com.sun.star.awt.XWindowListener = XWindowListener
+com.sun.star.awt.XItemListener = XItemListener
 com.sun.star.ui.XUIElement = XUIElement
 com.sun.star.ui.XToolPanel = XToolPanel
 com.sun.star.ui.XSidebarPanel = XSidebarPanel
@@ -70,34 +77,86 @@ class TestChatModelLogic(unittest.TestCase):
             self.model_selector, self.status_control, self.session
         )
 
+
+    @patch('plugin.modules.chatbot.panel_factory._ensure_extension_on_path')
+    @patch('plugin.framework.config.get_config')
+    @patch('plugin.framework.config.set_config')
+    @patch('plugin.modules.chatbot.tool_loop.update_lru_history')
+    @patch('plugin.modules.chatbot.tool_loop.get_current_endpoint')
+    @patch('plugin.modules.http.client.LlmClient')
+    def test_do_send_updates_model(self, mock_llm_client, mock_get_current_endpoint, mock_update_lru, mock_set_config, mock_get_config, mock_ensure_path, *args, **kwargs):
+        self.query_control.getModel().Text = "Hello AI"
+        self.model_selector.getText.return_value = "new-model-xyz"
+        mock_get_config.side_effect = lambda ctx, key, default=None: default
+        mock_get_current_endpoint.return_value = "http://x"
+        
+        doc_mock = MagicMock(spec=["getText"])
+        with patch.object(self.listener, '_get_document_model', return_value=doc_mock),              patch('plugin.framework.config.get_api_config', MagicMock(return_value={"model": "test", "endpoint": "http://x"})):
+
+            with patch('sys.modules', dict(sys.modules)):
+                sys.modules['plugin.main'] = MagicMock()
+                self.listener._do_send_chat_with_tools("Hello AI", doc_mock, "writer")
+
+            mock_set_config.assert_any_call(self.ctx, "text_model", "new-model-xyz")
+            mock_update_lru.assert_any_call(self.ctx, "new-model-xyz", "model_lru", "http://x")
+
     @patch('plugin.modules.chatbot.panel_factory._ensure_extension_on_path')
     @patch('plugin.framework.config.get_config')
     @patch('plugin.framework.config.set_config')
     @patch('plugin.framework.config.update_lru_history')
+    @patch('plugin.framework.config.get_current_endpoint')
     @patch('plugin.modules.http.client.LlmClient')
-    def test_do_send_updates_model(self, mock_llm_client, mock_update_lru, mock_set_config, mock_get_config, mock_ensure_path):
-        # Setup mocks
+    def test_image_model_updates(self, mock_llm_client, mock_get_current_endpoint, mock_update_lru, mock_set_config, mock_get_config, mock_ensure_path, *args, **kwargs):
         self.query_control.getModel().Text = "Hello AI"
         self.model_selector.getText.return_value = "new-model-xyz"
-        mock_get_config.side_effect = lambda ctx, key, default: default
-        
-        # Mock _get_document_model (Writer doc: has getText, no getSheets) so we reach the model update
+        self.image_model_selector.getText.return_value = "new-image-model-xyz"
+        mock_get_config.side_effect = lambda ctx, key, default=None: default
+        mock_get_current_endpoint.return_value = "http://x"
+
         doc_mock = MagicMock(spec=["getText"])
-        with patch.object(self.listener, '_get_document_model', return_value=doc_mock), \
-             patch('plugin.framework.config.get_api_config', MagicMock(return_value={"model": "test", "endpoint": "http://x"})):
-            
-            # This will still fail because of other internal imports in _do_send
-            # but we can try to trigger the model update part at least.
-            try:
-                # Mocking minimal parts to get to model update
-                self.listener._do_send()
-            except Exception:
-                # Expected to fail later in _do_send due to missing document model etc.
-                pass
+        with patch.object(self.listener, '_get_document_model', return_value=doc_mock),              patch('plugin.framework.config.get_api_config', MagicMock(return_value={"model": "test", "endpoint": "http://x"})):
 
-            # Check if set_config was called with the new text model
-            mock_set_config.assert_any_call(self.ctx, "text_model", "new-model-xyz")
-            mock_update_lru.assert_any_call(self.ctx, "new-model-xyz", "model_lru")
+            with patch('sys.modules', dict(sys.modules)):
+                sys.modules['plugin.main'] = MagicMock()
+                self.listener._do_send_chat_with_tools("Hello AI", doc_mock, "writer")
 
+            mock_set_config.assert_any_call(self.ctx, "image_model", "new-image-model-xyz")
+            mock_update_lru.assert_any_call(self.ctx, "new-image-model-xyz", "image_model_lru", "http://x")
+
+    @patch('plugin.framework.logging.debug_log')
+    @patch('plugin.framework.logging.update_activity_state')
+    def test_doc_type_leakage(self, mock_update_activity, mock_debug_log):
+        self.listener.initial_doc_type = "Writer"
+
+        # Mock _get_document_model to return a Calc document (getSheets instead of getText)
+        doc_mock = MagicMock()
+        self.listener.response_control.getModel().Text = ""
+
+        # We need to correctly patch the checks used in _do_send to identify the document
+        with patch.object(self.listener, '_get_document_model', return_value=doc_mock),              patch('plugin.framework.document.is_calc', return_value=True),              patch('plugin.framework.document.is_writer', return_value=False),              patch('plugin.framework.document.is_draw', return_value=False):
+            self.listener._do_send()
+
+            # Since document changed from Writer to Calc, it should abort and show an error.
+            self.assertEqual(self.listener._terminal_status, "Error")
+            # Verify the response control text was updated with the error
+            self.assertTrue("[Internal Error: Document type changed from Writer to Calc! Please file an error.]" in self.listener.response_control.getModel().Text)
+
+    @patch('plugin.framework.logging.debug_log')
+    @patch('plugin.framework.logging.update_activity_state')
+    def test_button_lifecycle(self, mock_update_activity, mock_debug_log):
+        # We need to test the actionPerformed method where _set_button_states is called.
+        # Let's mock _do_send to raise an Exception to test the exception path.
+
+        self.listener._do_send = MagicMock(side_effect=Exception("Test Error"))
+
+        # Call actionPerformed
+        evt = MagicMock()
+        self.listener.actionPerformed(evt)
+
+        # It should enable send and disable stop in the finally block
+        self.assertEqual(self.listener.send_control.getModel().Enabled, True)
+        self.assertEqual(self.listener.stop_control.getModel().Enabled, False)
+        # And send_busy should be reset
+        self.assertFalse(self.listener._send_busy)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR addresses the gaps in integration-only testing identified in `AGENTS.md`.

**What**
- Added `test_image_model_updates` to assert that `image_model` and `image_model_lru` configuration updates occur when an image model is selected and the UI is exercised.
- Added `test_doc_type_leakage` to ensure that `_do_send` correctly prevents document-type mismatches across execution paths (e.g. Writer -> Calc) by asserting an error state.
- Added `test_button_lifecycle` to verify that Send/Stop controls do not get stuck in inconsistent enabled/disabled states across exception paths.
- Cleaned up duplicate module content in `plugin/tests/test_chat_model_logic.py`.
- Added required COM UNO interface mocks like `XItemListener`, `XTextListener`, and `XWindowListener` so that `SendButtonListener` and internal window classes can be imported outside LibreOffice.

**Why**
To increase test reliability and cover critical UI logic inside `test_chat_model_logic.py` without depending on real UNO document models or hitting real LLMs.

**Verification**
Ran `pytest plugin/tests/test_chat_model_logic.py` and the complete test suite. Both pass successfully locally in the isolation sandbox.

**Result**
The chat model logic tests are now more robust and capture previously unverified side-effects on model configurations and button states.

---
*PR created automatically by Jules for task [14445930907972352221](https://jules.google.com/task/14445930907972352221) started by @KeithCu*