### PR TITLE
🐛 [fix] Fix stream drain loop edge cases in queue orchestration

### DIFF
--- a/plugin/framework/async_stream.py
+++ b/plugin/framework/async_stream.py
@@ -106,6 +106,14 @@ def run_stream_drain_loop(
                     current_content.clear()
 
             for item in items:
+                if stop_checker and stop_checker():
+                    debug_log("run_stream_drain_loop: Stop requested via checker.", context="API")
+                    flush_buffers()
+                    close_thinking()
+                    on_stopped()
+                    job_done[0] = True
+                    break
+
                 kind = item[0] if isinstance(item, (tuple, list)) else item
                 data = item[1] if isinstance(item, (tuple, list)) and len(item) > 1 else None
 
@@ -125,7 +133,7 @@ def run_stream_drain_loop(
                     close_thinking()
                     if on_stream_done(item): # Pass whole item for consistency
                         job_done[0] = True
-                    break
+                        break
                 elif kind == "tool_done":
                     # For unified tool loop handling, we relay back to on_stream_done
                     # with a special structure or just let the caller handle it if they passed
@@ -134,7 +142,7 @@ def run_stream_drain_loop(
                     close_thinking()
                     if on_stream_done(item): # Pass whole item for tool_done
                         job_done[0] = True
-                    break
+                        break
                 elif kind == "tool_thinking":
                     if show_search_thinking:
                         apply_chunk_fn(data, is_thinking=True)
@@ -151,7 +159,7 @@ def run_stream_drain_loop(
                     close_thinking()
                     if on_stream_done(item): # Same as tool_done
                         job_done[0] = True
-                    break
+                        break
                 elif kind == "next_tool":
                     # Caller usually puts this back in to trigger next iteration
                     # if it's a multi-tool-round loop.
@@ -159,7 +167,7 @@ def run_stream_drain_loop(
                     close_thinking()
                     if on_stream_done(item):
                         job_done[0] = True
-                    break
+                        break
                 elif kind == "stopped":
                     flush_buffers()
                     close_thinking()

--- a/plugin/tests/test_async_stream.py
+++ b/plugin/tests/test_async_stream.py
@@ -76,6 +76,109 @@ def test_run_stream_drain_loop_error():
     assert isinstance(errors[0], ValueError)
 
 
+def test_run_stream_drain_loop_stop_checker_mid_batch():
+    q = queue.Queue()
+    q.put(("chunk", "first "))
+    q.put(("chunk", "second "))
+    q.put(("chunk", "third "))
+
+    toolkit = DummyToolkit()
+    job_done = [False]
+    stopped_called = [False]
+    applied = []
+
+    def apply_chunk(t, is_thinking):
+        applied.append(t)
+
+    items_seen = [0]
+    def stop_checker():
+        # Stop on the second call (first item in the for loop)
+        items_seen[0] += 1
+        return items_seen[0] > 2
+
+    def on_stopped():
+        stopped_called[0] = True
+
+    # To prevent the while loop in run_stream_drain_loop from hanging, we need to return True for stop_checker on the first run after setting `stop_flag` to True.
+    # But since there is no `stream_done` at the end of the batch, the loop would just block on `q.get()`.
+    # Actually `q.put(("stream_done", None))` might not be executed when `stop_checker` flips mid stream.
+    # We should add a `stream_done` to break the loop normally if `stop_checker` somehow didn't stop the loop.
+    q.put(("stream_done", None))
+
+    run_stream_drain_loop(
+        q, toolkit, job_done, apply_chunk,
+        on_stream_done=lambda i: True, on_stopped=on_stopped, on_error=lambda e: None, stop_checker=stop_checker
+    )
+
+    assert stopped_called[0] is True
+    assert job_done[0] is True
+    # The first chunk should be processed, which sets stop_flag to True.
+    # The stop_checker check happens at the start of the next iteration of the `for item in items:` loop.
+    # So the remaining chunks in the batch shouldn't be processed.
+    assert len(applied) == 1
+    assert applied[0] == "first "
+
+
+def test_run_stream_drain_loop_callback_raises():
+    q = queue.Queue()
+    q.put(("chunk", "hello"))
+
+    toolkit = DummyToolkit()
+    job_done = [False]
+
+    def apply_chunk(t, is_thinking):
+        raise RuntimeError("apply_chunk error")
+
+    def on_error(e):
+        raise RuntimeError("on_error error")
+
+    # It should not hang, but gracefully mark job_done as True
+    # and swallow the exception in the catch-all.
+    run_stream_drain_loop(
+        q, toolkit, job_done, apply_chunk,
+        on_stream_done=lambda i: True, on_stopped=lambda: None, on_error=on_error
+    )
+
+    assert job_done[0] is True
+
+
+def test_run_stream_drain_loop_tool_done_continue():
+    q = queue.Queue()
+    q.put(("tool_done", "call_123", "web_search", '{"q": "answer"}', '{"status": "ok"}'))
+    q.put(("chunk", "next chunk"))
+
+    toolkit = None
+    job_done = [False]
+    applied = []
+    tools_done = []
+
+    def apply_chunk(t, is_thinking):
+        applied.append((t, is_thinking))
+
+    def on_stream_done(item):
+        if item[0] == "tool_done":
+            tools_done.append(item)
+            return False # Continue the loop!
+        elif item[0] == "stream_done":
+            return True
+        return False
+
+    def noop(*args, **kwargs):
+        pass
+
+    q.put(("stream_done", None))
+
+    run_stream_drain_loop(
+        q, toolkit, job_done, apply_chunk,
+        on_stream_done=on_stream_done, on_stopped=noop, on_error=noop
+    )
+
+    assert job_done[0] is True
+    assert len(tools_done) == 1
+    assert tools_done[0][1] == "call_123"
+    assert ("next chunk", False) in applied
+
+
 def test_run_stream_drain_loop_stopped():
     q = queue.Queue()
     q.put(("stopped",))


### PR DESCRIPTION
What
- Fixed a bug where `run_stream_drain_loop` would unconditionally exit the batch on certain events (like `tool_done`) regardless of `on_stream_done`'s return value.
- Added checking for `stop_checker` inside the batch processing loop so that the loop can stop immediately.
- Added 3 new tests in `test_async_stream.py` to verify:
  - Mid-batch stopping using a `stop_checker` check during batch processing.
  - Safe failure handling and thread termination when callbacks throw exceptions.
  - Continued batch processing when a stream loop explicitly permits continuation after a `tool_done` event.

Why
- Proper processing of long streams and precise control over stream termination is essential for the AI worker queue. If tool executions requested streams to remain active, they were previously being unintentionally halted or blocking later items. Mid-batch cancellation saves processing time during stream disruptions.

Verification
- Executed `pytest plugin/tests/test_async_stream.py` which passes completely (all 14 tests).

Result
- The queue orchestration now properly adheres to loop control boundaries and accurately fulfills all requested scenarios according to the documentation without interacting with LibreOffice internals.

---
*PR created automatically by Jules for task [8422603371886079192](https://jules.google.com/task/8422603371886079192) started by @KeithCu*