### PR TITLE
test: expand tool registry coverage

### DIFF
--- a/plugin/tests/test_tool_registry.py
+++ b/plugin/tests/test_tool_registry.py
@@ -124,6 +124,25 @@ class TestExecute:
         assert result["status"] == "error"
         assert "intentional failure" in result.get("error", result.get("message", ""))
 
+    def test_execution_wrong_type_returns_error(self):
+        class TypeCheckingTool(ToolBase):
+            name = "type_checker"
+            description = "Checks type"
+            parameters = {"type": "object", "properties": {"text": {"type": "string"}}}
+            def execute(self, ctx, **kwargs):
+                text = kwargs.get("text")
+                if not isinstance(text, str):
+                    raise TypeError("text must be a string")
+                return {"status": "ok", "text": text}
+
+        reg = _make_registry(TypeCheckingTool())
+        ctx = _make_ctx("writer")
+
+        # Pass a list instead of string
+        result = reg.execute("type_checker", ctx, text=["not", "a", "string"])
+        assert result["status"] == "error"
+        assert "text must be a string" in result.get("message", "")
+
 
 class TestSchemas:
     def test_openai_schemas(self):
@@ -189,6 +208,53 @@ class TestExecuteEventsAndInvalidation:
         assert len(doc_svc.invalidated) == 1
         assert doc_svc.invalidated[0] is ctx.doc
 
+    def test_execute_failure_emits_events_and_invalidates_cache(self):
+        class MockEventBus:
+            def __init__(self):
+                self.events = []
+
+            def emit(self, event, **kwargs):
+                self.events.append((event, kwargs))
+
+        class MockDocumentService:
+            def __init__(self):
+                self.invalidated = []
+
+            def invalidate_cache(self, doc):
+                self.invalidated.append(doc)
+
+        class FailingToolWithParams(ToolBase):
+            name = "failing_tool_with_params"
+            description = "Tool with params that fails"
+            parameters = {"type": "object", "properties": {"arg1": {"type": "string"}}}
+            doc_types = ["writer"]
+
+            def execute(self, ctx, **kwargs):
+                raise RuntimeError("something went wrong")
+
+        services = ServiceRegistry()
+        events = MockEventBus()
+        doc_svc = MockDocumentService()
+        services.register_instance("events", events)
+        services.register_instance("document", doc_svc)
+
+        reg = ToolRegistry(services)
+        reg.register(FailingToolWithParams())
+
+        ctx = ToolContext(doc=object(), ctx=None, doc_type="writer", services=services, caller="test")
+        result = reg.execute("failing_tool_with_params", ctx, arg1="val1")
+
+        assert result["status"] == "error"
+        assert "something went wrong" in result["message"]
+
+        assert len(events.events) == 2
+        assert events.events[0][0] == "tool:executing"
+        assert events.events[1][0] == "tool:failed"
+        assert events.events[1][1]["error"] == "something went wrong"
+
+        assert len(doc_svc.invalidated) == 1
+        assert doc_svc.invalidated[0] is ctx.doc
+
 
 def test_tool_registry_discover(tmpdir):
     """Discovery from a directory (from test_registry)."""
@@ -210,5 +276,56 @@ class MyFakeTool(ToolBase):
     try:
         registry.discover(str(pkg_dir), "fake_tools")
         assert "my_fake" in registry.tool_names
+    finally:
+        sys.path.pop(0)
+
+def test_tool_registry_discovery_hygiene(tmpdir):
+    """Discovery hygiene: ensures duplicate names resolve deterministically and non-ToolBase classes are ignored."""
+    import sys
+
+    services = ServiceRegistry()
+    registry = ToolRegistry(services)
+
+    pkg_dir = tmpdir.mkdir("fake_tools_hygiene")
+    pkg_dir.join("__init__.py").write("")
+
+    # Tool 1 defines 'my_fake' tool
+    pkg_dir.join("my_tool_1.py").write("""
+from plugin.framework.tool_base import ToolBase
+class MyFakeTool(ToolBase):
+    name = "my_fake"
+    description = "First version"
+    def execute(self, ctx, **kwargs): pass
+""")
+
+    # Tool 2 defines same 'my_fake' tool (should overwrite Tool 1 based on alphabetical import or discovery order)
+    # Plus defines a NonToolClass that should be ignored
+    pkg_dir.join("my_tool_2.py").write("""
+from plugin.framework.tool_base import ToolBase
+
+class MyFakeToolOverwrite(ToolBase):
+    name = "my_fake"
+    description = "Second version"
+    def execute(self, ctx, **kwargs): pass
+
+class NonToolClass:
+    name = "not_a_tool"
+    description = "This should be ignored"
+    def execute(self, ctx, **kwargs): pass
+""")
+
+    sys.path.insert(0, str(tmpdir))
+    try:
+        registry.discover(str(pkg_dir), "fake_tools_hygiene")
+        assert "my_fake" in registry.tool_names
+
+        # Verify non-ToolBase class is ignored
+        assert "not_a_tool" not in registry.tool_names
+
+        # Verify deterministic replacement: my_tool_2.py should be processed after my_tool_1.py
+        # because iter_modules iterates over module names alphabetically.
+        tool = registry.get("my_fake")
+        assert tool is not None
+        assert tool.description == "Second version"
     finally:
         sys.path.pop(0)


### PR DESCRIPTION
This commit adds test coverage to `plugin/tests/test_tool_registry.py` covering failure-path events (asserting correct emission and cache invalidation on tool exception), parameter validation edge cases (wrapping exceptions from wrongly typed arguments into `{"status": "error"}` payload), and discovery hygiene (checking deterministic conflict resolution and non-ToolBase ignoring during tool discovery).

---
*PR created automatically by Jules for task [16848603628327628552](https://jules.google.com/task/16848603628327628552) started by @KeithCu*