### PR TITLE
Trim large image payloads in API debug logs to prevent log bloat

### DIFF
--- a/plugin/framework/image_utils.py
+++ b/plugin/framework/image_utils.py
@@ -26,6 +26,22 @@ from plugin.contrib.aihordeclient import AiHordeClient
 
 logger = logging.getLogger(__name__)
 
+TRIM_IMAGES_IN_LOG = True
+
+def _trim_images(d):
+    if isinstance(d, dict):
+        new_d = {}
+        for k, v in d.items():
+            if k in ("b64_json", "url") and isinstance(v, str):
+                if k == "b64_json" or (k == "url" and v.startswith("data:image")):
+                    new_d[k] = "<IMAGE bytes trimmed to not ruin the log file>"
+                    continue
+            new_d[k] = _trim_images(v)
+        return new_d
+    elif isinstance(d, list):
+        return [_trim_images(item) for item in d]
+    return d
+
 class ImageProvider:
     def generate(self, prompt, **kwargs):
         raise NotImplementedError()
@@ -120,7 +136,8 @@ class EndpointImageProvider(ImageProvider):
                     raise Exception(_format_http_error_response(http_resp.status, http_resp.reason, err_body))
 
                 result = json.loads(http_resp.read().decode("utf-8"))
-                debug_log("=== Image Response: %s" % json.dumps(result, indent=2), context="API")
+                log_result = _trim_images(result) if TRIM_IMAGES_IN_LOG else result
+                debug_log("=== Image Response: %s" % json.dumps(log_result, indent=2), context="API")
 
                 # Standard OpenAI format: {"data": [{"url": "...", "b64_json": "..."}]}
                 paths = []


### PR DESCRIPTION
Added a global `TRIM_IMAGES_IN_LOG` flag in `plugin/framework/image_utils.py` with an internal helper function that recursively trims large image payloads (`b64_json` and `data:image` URLs) before writing them to the debug log. This prevents the logs from filling up with massive base64 strings when using the image generation API, while allowing developers to easily toggle the full payload logging if needed.

---
*PR created automatically by Jules for task [2328196337122777317](https://jules.google.com/task/2328196337122777317) started by @KeithCu*