### PR TITLE
perf: batch tool thinking tokens in async stream drain loop

### DIFF
--- a/plugin/framework/async_stream.py
+++ b/plugin/framework/async_stream.py
@@ -145,7 +145,9 @@ def run_stream_drain_loop(
                         break
                 elif kind == "tool_thinking":
                     if show_search_thinking:
-                        apply_chunk_fn(data, is_thinking=True)
+                        if current_content:
+                            flush_buffers()
+                        current_thinking.append(data)
                 elif kind == "approval_required":
                     flush_buffers()
                     close_thinking()


### PR DESCRIPTION
In `run_stream_drain_loop`, `tool_thinking` items were being forwarded immediately to the text document via `apply_chunk_fn`, bypassing the buffering system used for regular `thinking` items. Since LibreOffice UNO API string insertions are a known performance bottleneck, doing this per-token causes slowdowns.

This patch updates `tool_thinking` token handling to use `current_thinking.append()` so they are flushed in larger batches, providing a performance uplift. The `stop_checker` behavior remains unmodified, preserving correct interrupt semantics expected by the test suite.

---
*PR created automatically by Jules for task [9674915792734492696](https://jules.google.com/task/9674915792734492696) started by @KeithCu*