### PR TITLE
Update debug_log calls to use explicit logging levels

### DIFF
--- a/plugin/main.py
+++ b/plugin/main.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys
 import os
+import logging
 
 # Ensure the extension's install directory is on sys.path
 # so that "plugin.xxx" imports work correctly.
@@ -232,14 +233,14 @@ def _run_test_suite(test_func, doc_checker, test_name):
     ctx = get_ctx()
     try:
         from plugin.framework.logging import debug_log
-        debug_log(f"_run_test_suite start: {test_name}", context="Tests")
+        debug_log(f"_run_test_suite start: {test_name}", context="Tests", level=logging.INFO)
         from plugin.framework.async_stream import run_blocking_in_thread
         from plugin.testing_runner import run_module_suite
         model = get_active_document(ctx)
         doc_model = model if (model and doc_checker(model)) else None
         debug_log(f"Calling run_blocking_in_thread for {test_name}", context="Tests")
         p, f, log = run_blocking_in_thread(ctx, run_module_suite, ctx, test_func, test_name, doc_model)
-        debug_log(f"_run_test_suite finished: {test_name}, p={p}, f={f}", context="Tests")
+        debug_log(f"_run_test_suite finished: {test_name}, p={p}, f={f}", context="Tests", level=logging.INFO)
         msgbox(ctx, test_name, f"{test_name}: {p} passed, {f} failed.\n\n" + "\n".join(log))
     except Exception as e:
         msgbox(ctx, test_name, f"Tests failed to run: {e}")
@@ -647,7 +648,7 @@ class DispatchHandler(unohelper.Base, XDispatch, XDispatchProvider,
         from plugin.framework.logging import debug_log, init_logging, log_exception
         try:
             init_logging(self.ctx)
-            debug_log(f"Dispatch entered: {command}", context="Dispatch")
+            debug_log(f"Dispatch entered: {command}", context="Dispatch", level=logging.INFO)
             # msgbox(self.ctx, "Dispatch", f"Command: {command}") # Temporary probe
             bootstrap(self.ctx)
             _dispatch_command(command)

--- a/plugin/modules/agent_backend/hermes_proxy.py
+++ b/plugin/modules/agent_backend/hermes_proxy.py
@@ -29,6 +29,7 @@ ACP spec: https://agentcommunicationprotocol.dev
 Hermes docs: https://github.com/NousResearch/hermes-agent
 """
 
+import logging
 import json
 import os
 import shutil
@@ -170,7 +171,7 @@ class HermesBackend(AgentBackend):
             }, timeout=15)
             debug_log(f"ACP initialized: {result}", context=_LOG)
         except Exception as e:
-            debug_log(f"ACP initialize failed: {e}", context=_LOG)
+            debug_log(f"ACP initialize failed: {e}", context=_LOG, level=logging.ERROR)
             self._conn.stop()
             self._conn = None
             raise
@@ -200,7 +201,7 @@ class HermesBackend(AgentBackend):
             self._session_id = result.get("sessionId", "") if result else ""
             debug_log(f"ACP session created: {self._session_id}", context=_LOG)
         except Exception as e:
-            debug_log(f"ACP session creation failed: {e}", context=_LOG)
+            debug_log(f"ACP session creation failed: {e}", context=_LOG, level=logging.ERROR)
             raise
 
     def send(
@@ -310,7 +311,7 @@ class HermesBackend(AgentBackend):
             if self._stop_requested:
                 queue.put(("stopped",))
             else:
-                debug_log(f"Prompt error: {e}", context=_LOG)
+                debug_log(f"Prompt error: {e}", context=_LOG, level=logging.ERROR)
                 queue.put(("error", e))
         finally:
             self._conn.set_notification_callback(None)
@@ -401,7 +402,7 @@ class HermesBackend(AgentBackend):
                 })
                 debug_log("Cancel notification sent", context=_LOG)
             except Exception as e:
-                debug_log(f"Cancel failed: {e}", context=_LOG)
+                debug_log(f"Cancel failed: {e}", context=_LOG, level=logging.ERROR)
 
     def submit_approval(self, request_id, approved):
         """Submit approval for a permission request."""
@@ -420,7 +421,7 @@ class HermesBackend(AgentBackend):
             self._conn._proc.stdin.flush()
             debug_log(f"Approval responded (id={request_id}): approved={approved}", context=_LOG)
         except Exception as e:
-            debug_log(f"Approval response failed: {e}", context=_LOG)
+            debug_log(f"Approval response failed: {e}", context=_LOG, level=logging.ERROR)
 
     def cleanup(self):
         """Shutdown the ACP subprocess."""

--- a/plugin/modules/chatbot/panel.py
+++ b/plugin/modules/chatbot/panel.py
@@ -24,6 +24,7 @@ remain in panel_factory.py.
 
 import uno
 import unohelper
+import logging
 from plugin.framework.uno_context import get_active_document
 from plugin.framework.dialogs import get_checkbox_state
 from com.sun.star.awt import XActionListener
@@ -61,7 +62,7 @@ class ChatSession:
                 self.db = get_chat_history(session_id)
                 self.messages = self.db.get_messages()
             except Exception as e:
-                debug_log("ChatSession history load error: %s" % e, context="Chat")
+                debug_log("ChatSession history load error: %s" % e, context="Chat", level=logging.ERROR)
 
         # If no history, or system prompt forced
         if not self.messages and system_prompt:
@@ -160,7 +161,7 @@ class QueryTextListener(unohelper.Base, XTextListener):
             else:
                 debug_log("QueryTextListener: label already '%s'" % new_label, context="Chat")
         except Exception as e:
-            debug_log("QueryTextListener error: %s" % e, context="Chat")
+            debug_log("QueryTextListener error: %s" % e, context="Chat", level=logging.ERROR)
 
     def disposing(self, ev):
         pass
@@ -206,7 +207,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
                 debug_log(f"*** SendButtonListener subscribed to MCP events on services.events (id={id(event_bus)}) ***", context="Chat")
         except Exception as e:
             from plugin.framework.logging import debug_log
-            debug_log("MCP subscribe error: %s" % e, context="Chat")
+            debug_log("MCP subscribe error: %s" % e, context="Chat", level=logging.ERROR)
 
     def set_session(self, session):
         """Update the active session (e.g. when switching between Document and Research chat)."""
@@ -257,7 +258,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
             debug_log(f"MCP Request (hidden from UI): {fmt_str}", context="Chat")
         except Exception as e:
             from plugin.framework.logging import debug_log
-            debug_log("_on_mcp_request error: %s" % e, context="Chat")
+            debug_log("_on_mcp_request error: %s" % e, context="Chat", level=logging.ERROR)
 
     def _on_mcp_result(self, tool="", result_snippet="", **kwargs):
         """Handle MCP result events from the bus (background thread)."""
@@ -270,13 +271,13 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
                 self._append_response(f"[MCP Result] {fmt_str}\n")
             except Exception as e:
                 from plugin.framework.logging import debug_log
-                debug_log("_on_mcp_result UI update error: %s" % e, context="Chat")
+                debug_log("_on_mcp_result UI update error: %s" % e, context="Chat", level=logging.ERROR)
 
         try:
             execute_on_main_thread(_update_ui)
         except Exception as e:
             from plugin.framework.logging import debug_log
-            debug_log("_on_mcp_result post error: %s" % e, context="Chat")
+            debug_log("_on_mcp_result post error: %s" % e, context="Chat", level=logging.ERROR)
 
     def _get_document_model(self):
         """Get the Writer document model."""
@@ -329,7 +330,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
             import traceback
             tb = traceback.format_exc()
             self._append_response("\n\n[Error: %s]\n%s\n" % (str(e), tb))
-            debug_log("SendButton error: %s\n%s" % (e, tb), context="Chat")
+            debug_log("SendButton error: %s\n%s" % (e, tb), context="Chat", level=logging.ERROR)
         finally:
             self._send_busy = False
             debug_log("actionPerformed finally: resetting UI", context="Chat")
@@ -376,14 +377,14 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
         
         if self.initial_doc_type and doc_type_str != self.initial_doc_type:
             err_msg = "[Internal Error: Document type changed from %s to %s! Please file an error.]" % (self.initial_doc_type, doc_type_str)
-            debug_log("_do_send ERROR: %s" % err_msg, context="Chat")
+            debug_log("_do_send ERROR: %s" % err_msg, context="Chat", level=logging.ERROR)
             self._append_response("\n%s\n" % err_msg)
             self._terminal_status = "Error"
             return
 
         if doc_type_str == "Unknown":
             err_msg = "[Internal Error: Could not identify document type for %s. Please report this!]" % (model.getImplementationName() if hasattr(model, "getImplementationName") else "Unknown")
-            debug_log("_do_send ERROR: %s" % err_msg, context="Chat")
+            debug_log("_do_send ERROR: %s" % err_msg, context="Chat", level=logging.ERROR)
             self._append_response("\n%s\n" % err_msg)
             self._terminal_status = "Error"
             return
@@ -440,7 +441,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
             try:
                 direct_image_checked = (get_checkbox_state(self.direct_image_checkbox) == 1)
             except Exception as e:
-                debug_log("_do_send: Use Image model checkbox read error: %s" % e, context="Chat")
+                debug_log("_do_send: Use Image model checkbox read error: %s" % e, context="Chat", level=logging.ERROR)
         if direct_image_checked:
             debug_log("_do_send: using image model (direct) — skip chat model", context="Chat")
             self._do_send_direct_image(query_text, model)
@@ -455,7 +456,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
                 self._do_send_via_agent_backend(query_text, model, doc_type_str.lower())
                 return
         except Exception as e:
-            debug_log("_do_send: agent backend check failed: %s" % e, context="Chat")
+            debug_log("_do_send: agent backend check failed: %s" % e, context="Chat", level=logging.ERROR)
 
         # Regular Chat with Tools or Streams
         self._do_send_chat_with_tools(query_text, model, doc_type_str.lower())

--- a/plugin/modules/chatbot/panel_factory.py
+++ b/plugin/modules/chatbot/panel_factory.py
@@ -24,6 +24,7 @@ import hashlib
 import uuid
 import uno
 import unohelper
+import logging
 
 # Ensure the extension's install directory is on sys.path
 # so that "plugin.xxx" imports work correctly. This file lives at
@@ -100,7 +101,7 @@ def _ensure_extension_on_path(ctx):
             debug_log("Extension path already on sys.path: %s" % ext_path, context="Chat")
     except Exception as e:
         init_logging(ctx)
-        debug_log("_ensure_extension_on_path ERROR: %s" % e, context="Chat")
+        debug_log("_ensure_extension_on_path ERROR: %s" % e, context="Chat", level=logging.ERROR)
 
 
 
@@ -167,9 +168,9 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                 wire_chatpanel_controls(self, root_window, HAS_RECORDING, _ensure_extension_on_path)
                 debug_log("getRealInterface completed successfully", context="Chat")
             except Exception as e:
-                debug_log("getRealInterface ERROR: %s" % e, context="Chat")
+                debug_log("getRealInterface ERROR: %s" % e, context="Chat", level=logging.ERROR)
                 import traceback
-                debug_log(traceback.format_exc(), context="Chat")
+                debug_log(traceback.format_exc(), context="Chat", level=logging.ERROR)
                 raise
         return self.toolpanel
 
@@ -222,7 +223,7 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                     import uno
                     response_ctrl.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", length, length))
         except Exception as e:
-            debug_log("_render_session_history error: %s" % e, context="Chat")
+            debug_log("_render_session_history error: %s" % e, context="Chat", level=logging.ERROR)
 
     def _refresh_controls_from_config(self):
         """Reload model and prompt selectors from config (e.g. after user changes Settings)."""
@@ -310,7 +311,7 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                 web_research_check.getModel().Enabled = not is_external
                 
         except Exception as e:
-            debug_log("_update_backend_indicator error: %s" % e, context="Chat")
+            debug_log("_update_backend_indicator error: %s" % e, context="Chat", level=logging.ERROR)
 
     def _get_document_model(self):
         """Helper to get the current document model."""
@@ -435,18 +436,18 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                                 self.toggle_cb(is_checked)
                                 set_control_enabled(self.web_check, not is_checked)
                             except Exception as e:
-                                debug_log("Image checkbox listener error: %s" % e, context="Chat")
+                                debug_log("Image checkbox listener error: %s" % e, context="Chat", level=logging.ERROR)
                         def disposing(self, ev): pass
                     direct_image_check.addItemListener(DirectImageCheckListener(self.ctx, toggle_image_ui, web_research_check))
             except Exception as e:
-                debug_log("direct_image_check wire error: %s" % e, context="Chat")
+                debug_log("direct_image_check wire error: %s" % e, context="Chat", level=logging.ERROR)
 
         if web_research_check:
             try:
                 if get_checkbox_state(web_research_check) == 1:
                     set_control_enabled(direct_image_check, False)
             except Exception as e:
-                debug_log("web_research_check initial wire error: %s" % e, context="Chat")
+                debug_log("web_research_check initial wire error: %s" % e, context="Chat", level=logging.ERROR)
                 
         return set_control_enabled
 
@@ -502,7 +503,7 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                 controls["stop"].addActionListener(StopButtonListener(send_listener))
             send_listener._set_button_states(send_enabled=True, stop_enabled=False)
         except Exception as e:
-            debug_log("Send/Stop button error: %s" % e, context="Chat")
+            debug_log("Send/Stop button error: %s" % e, context="Chat", level=logging.ERROR)
 
         clear_listener = None
         if controls["clear"]:
@@ -541,7 +542,7 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                             self.clear_listener.set_session(self.panel.session, greeting=greeting)
                         self.panel._render_session_history(self.panel.session, self.response_ctrl, self.model, greeting)
                     except Exception as e:
-                        debug_log("Research Chat listener error: %s" % e, context="Chat")
+                        debug_log("Research Chat listener error: %s" % e, context="Chat", level=logging.ERROR)
                 def disposing(self, ev): pass
             controls["web_research_check"].addItemListener(ResearchChatToggledListener(
                 self, controls["response"], model, send_listener, clear_listener, controls["direct_image_check"], set_control_enabled))

--- a/plugin/modules/chatbot/panel_resize.py
+++ b/plugin/modules/chatbot/panel_resize.py
@@ -1,4 +1,5 @@
 import unohelper
+import logging
 
 from com.sun.star.awt import XWindowListener
 
@@ -48,7 +49,7 @@ class _PanelResizeListener(unohelper.Base, XWindowListener):
             self._in_relayout = True
             self._relayout(evt.Source)
         except Exception as e:
-            debug_log("windowResized error: %s" % e, context="Chat")
+            debug_log("windowResized error: %s" % e, context="Chat", level=logging.ERROR)
         finally:
             self._in_relayout = False
 

--- a/plugin/modules/chatbot/panel_wiring.py
+++ b/plugin/modules/chatbot/panel_wiring.py
@@ -1,4 +1,5 @@
 import weakref
+import logging
 
 from plugin.framework.logging import debug_log
 from plugin.framework.dialogs import (
@@ -41,7 +42,7 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
 
     # Helper to show errors visibly in the response area
     def _show_init_error(msg):
-        debug_log("_wireControls ERROR: %s" % msg, context="Chat")
+        debug_log("_wireControls ERROR: %s" % msg, context="Chat", level=logging.ERROR)
         try:
             if controls["response"] and controls["response"].getModel():
                 current = controls["response"].getModel().Text or ""
@@ -66,7 +67,7 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
     except Exception as e:
         import traceback
         _show_init_error("Config: %s" % e)
-        debug_log(traceback.format_exc(), context="Chat")
+        debug_log(traceback.format_exc(), context="Chat", level=logging.ERROR)
         extra_instructions = ""
         set_control_enabled = lambda ctrl, en: None
 
@@ -103,7 +104,7 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
             else:
                 controls["send"].getModel().Label = "Record" if has_recording else "Send"
         except Exception as e:
-            debug_log("QueryTextListener setup error: %s" % e, context="Chat")
+            debug_log("QueryTextListener setup error: %s" % e, context="Chat", level=logging.ERROR)
 
     if controls["status"] and hasattr(controls["status"], "setText"):
         try: controls["status"].setText("Ready")
@@ -126,7 +127,7 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
         root_window.addWindowListener(_resize)
         _resize._relayout(root_window)
     except Exception as e:
-        debug_log("Resize listener error: %s" % e, context="Chat")
+        debug_log("Resize listener error: %s" % e, context="Chat", level=logging.ERROR)
 
     # Backend indicator (Aider / Hermes when external agent enabled)
     self._update_backend_indicator(root_window)

--- a/plugin/modules/chatbot/send_handlers.py
+++ b/plugin/modules/chatbot/send_handlers.py
@@ -10,7 +10,7 @@ alternate send flows that would otherwise bloat that class:
 """
 
 import queue
-
+import logging
 
 class SendHandlersMixin:
     def _transcribe_audio_async(self, wav_path, stt_model, model, query_text=""):
@@ -130,7 +130,7 @@ class SendHandlersMixin:
                         self.ctx, base_size_val, "image_base_size_lru", ""
                     )
                 except Exception as elru:
-                    debug_log("LRU update error: %s" % elru, context="Chat")
+                    debug_log("LRU update error: %s" % elru, context="Chat", level=logging.ERROR)
 
                 import json
 
@@ -153,7 +153,7 @@ class SendHandlersMixin:
                 q.put(("chunk", "[generate_image: %s]\n" % note))
                 q.put(("stream_done", {}))
             except Exception as e:
-                debug_log("Direct image path ERROR: %s" % e, context="Chat")
+                debug_log("Direct image path ERROR: %s" % e, context="Chat", level=logging.ERROR)
                 q.put(("error", e))
 
         from plugin.framework.worker_pool import run_in_background

--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -7,6 +7,7 @@ multi-round tool-calling loop plus simple streaming fallback.
 import inspect
 import json
 import queue
+import logging
 
 from plugin.framework.async_stream import (
     run_stream_completion_async,
@@ -45,7 +46,7 @@ class ToolCallingMixin:
 
             debug_log("_do_send: core modules imported OK", context="Chat")
         except Exception as e:
-            debug_log("_do_send: core import FAILED: %s" % e, context="Chat")
+            debug_log("_do_send: core import FAILED: %s" % e, context="Chat", level=logging.ERROR)
             self._append_response("\n[Import error - core: %s]\n" % e)
             self._terminal_status = "Error"
             return
@@ -99,7 +100,7 @@ class ToolCallingMixin:
                     return json.dumps({"status": "error", "message": str(e)})
 
         except Exception as e:
-            debug_log("_do_send: tool import FAILED: %s" % e, context="Chat")
+            debug_log("_do_send: tool import FAILED: %s" % e, context="Chat", level=logging.ERROR)
             self._append_response("\n[Import error - tools: %s]\n" % e)
             self._terminal_status = "Error"
             return
@@ -182,7 +183,7 @@ class ToolCallingMixin:
             self.session.update_document_context(doc_text)
         except Exception as e:
             debug_log(
-                "_do_send: document context FAILED: %s" % e, context="Chat"
+                "_do_send: document context FAILED: %s" % e, context="Chat", level=logging.ERROR
             )
             self._append_response("\n[Document unavailable or closed.]\n")
             self._terminal_status = "Error"
@@ -217,7 +218,7 @@ class ToolCallingMixin:
                 self._append_response("\nYou: %s\n" % display_text)
                 # Note: We do NOT delete the audio file yet, in case native call fails and we need STT fallback
             except Exception as e:
-                debug_log("_do_send: Error reading audio: %s" % e, context="Chat")
+                debug_log("_do_send: Error reading audio: %s" % e, context="Chat", level=logging.ERROR)
                 self.session.add_user_message(query_text)
                 self._append_response("\nYou: %s\n" % query_text)
                 self.audio_wav_path = None
@@ -282,6 +283,7 @@ class ToolCallingMixin:
                 debug_log(
                     "Tool loop round %d: API ERROR: %s" % (round_num, e),
                     context="Chat",
+                    level=logging.ERROR
                 )
                 q.put(("error", e))
 
@@ -713,6 +715,7 @@ class ToolCallingMixin:
                     "Model %s failed native audio, caching and falling back to STT"
                     % current_model,
                     context="Chat",
+                    level=logging.WARNING
                 )
                 set_native_audio_support(
                     self.ctx, current_model, current_endpoint, supported=False

--- a/plugin/modules/http/client.py
+++ b/plugin/modules/http/client.py
@@ -19,6 +19,7 @@ LLM API client for WriterAgent.
 Takes a config dict (from plugin.framework.config.get_api_config) and UNO ctx.
 """
 import collections
+import logging
 import json
 import ssl
 import urllib.request
@@ -234,7 +235,7 @@ def sync_request(url, data=None, headers=None, timeout=10, parse_json=True):
             err_body = ""
         
         msg = _format_http_error_response(status, reason, err_body)
-        debug_log(f"HTTP Error: {msg}", context="API")
+        debug_log(f"HTTP Error: {msg}", context="API", level=logging.ERROR)
         raise Exception(msg) from e
     except Exception as e:
         if is_local_https and _is_certificate_verify_error(e):
@@ -252,12 +253,12 @@ def sync_request(url, data=None, headers=None, timeout=10, parse_json=True):
                 except Exception:
                     err_body = ""
                 msg = _format_http_error_response(status, reason, err_body)
-                debug_log(f"HTTP Error: {msg}", context="API")
+                debug_log(f"HTTP Error: {msg}", context="API", level=logging.ERROR)
                 raise Exception(msg) from retry_http_e
             except Exception as retry_e:
-                debug_log(f"Request failed: {format_error_message(retry_e)}", context="API")
+                debug_log(f"Request failed: {format_error_message(retry_e)}", context="API", level=logging.ERROR)
                 raise
-        debug_log(f"Request failed: {format_error_message(e)}", context="API")
+        debug_log(f"Request failed: {format_error_message(e)}", context="API", level=logging.ERROR)
         raise
 
 
@@ -447,7 +448,7 @@ class LlmClient:
             h.update(auth_headers)
         except AuthError as e:
             # Fall back to the previous behavior: simple Bearer header from config.
-            debug_log(f"Auth resolution error ({e.provider or 'unknown'}): {e}", context="API")
+            debug_log(f"Auth resolution error ({e.provider or 'unknown'}): {e}", context="API", level=logging.ERROR)
             api_key = self.config.get("api_key", "")
             if api_key:
                 h["Authorization"] = "Bearer %s" % api_key
@@ -692,7 +693,7 @@ class LlmClient:
                 # Using synchronous chat completion with model override
                 return self.chat_completion_sync(messages, max_tokens=16384, model=model_name)
             except Exception as e:
-                debug_log("Multimodal transcription failed: %s. Falling back to stt endpoint." % e, context="API")
+                debug_log("Multimodal transcription failed: %s. Falling back to stt endpoint." % e, context="API", level=logging.WARNING)
 
         # 2. Standard multipart fallback (Whisper, etc.)
         boundary = "Boundary-%s" % uuid.uuid4().hex
@@ -783,7 +784,7 @@ class LlmClient:
             
             if response.status != 200:
                 err_body = response.read().decode("utf-8", errors="replace")
-                debug_log("API Error %d: %s" % (response.status, err_body), context="API")
+                debug_log("API Error %d: %s" % (response.status, err_body), context="API", level=logging.ERROR)
                 # Close on error to be safe
                 self._close_connection()
                 raise Exception(_format_http_error_response(response.status, response.reason, err_body))
@@ -803,7 +804,7 @@ class LlmClient:
                     try:
                         chunk = json.loads(payload)
                     except json.JSONDecodeError:
-                        debug_log("streaming_loop: JSON decode error in payload: %s" % payload, context="API")
+                        debug_log("streaming_loop: JSON decode error in payload: %s" % payload, context="API", level=logging.ERROR)
                         continue
                     if chunk is None:
                         continue
@@ -872,12 +873,12 @@ class LlmClient:
                     self._close_connection()
 
         except (http.client.HTTPException, socket.error, OSError) as e:
-            debug_log("Connection error, closing: %s" % e, context="API")
+            debug_log("Connection error, closing: %s" % e, context="API", level=logging.ERROR)
             self._close_connection()
             # If the user requested a stop, don't retry. The connection error
             # might be a side-effect of us closing the connection in stop().
             if stop_checker and stop_checker():
-                debug_log("Connection error during stop; exiting streaming loop", context="API")
+                debug_log("Connection error during stop; exiting streaming loop", context="API", level=logging.ERROR)
                 return "stop"
             if self._enable_local_ssl_fallback(e):
                 return self._run_streaming_loop(
@@ -900,12 +901,12 @@ class LlmClient:
                     stop_checker=stop_checker,
                     _retry=False,
                 )
-            debug_log("Connection retry failed: %s" % err_msg, context="API")
+            debug_log("Connection retry failed: %s" % err_msg, context="API", level=logging.ERROR)
             raise Exception(err_msg)
         except Exception as e:
             self._close_connection() # Reset on any other error too
             err_msg = format_error_message(e)
-            debug_log("ERROR in _run_streaming_loop: %s -> %s" % (e, err_msg), context="API")
+            debug_log("ERROR in _run_streaming_loop: %s -> %s" % (e, err_msg), context="API", level=logging.ERROR)
             raise Exception(err_msg)
 
         return last_finish_reason
@@ -966,24 +967,24 @@ class LlmClient:
                 response = conn.getresponse()
                 if response.status != 200:
                     err_body = response.read().decode("utf-8", errors="replace")
-                    debug_log("API Error %d: %s" % (response.status, err_body), context="API")
+                    debug_log("API Error %d: %s" % (response.status, err_body), context="API", level=logging.ERROR)
                     self._close_connection()
                     raise Exception(_format_http_error_response(response.status, response.reason, err_body))
                 result = json.loads(response.read().decode("utf-8"))
                 break
             except (http.client.HTTPException, socket.error, OSError) as e:
-                debug_log("Connection error, closing: %s" % e, context="API")
+                debug_log("Connection error, closing: %s" % e, context="API", level=logging.ERROR)
                 self._close_connection()
                 if self._enable_local_ssl_fallback(e):
                     continue
                 if attempt == 0:
                     debug_log("Retrying request_with_tools once on fresh connection", context="API")
                     continue
-                debug_log("Connection retry failed: %s" % format_error_message(e), context="API")
+                debug_log("Connection retry failed: %s" % format_error_message(e), context="API", level=logging.ERROR)
                 raise Exception(format_error_message(e))
             except Exception as e:
                 err_msg = format_error_message(e)
-                debug_log("request_with_tools ERROR: %s -> %s" % (e, err_msg), context="API")
+                debug_log("request_with_tools ERROR: %s -> %s" % (e, err_msg), context="API", level=logging.ERROR)
                 raise Exception(err_msg)
 
         debug_log("=== Tool response: %s" % json.dumps(result, indent=2), context="API")
@@ -1052,7 +1053,7 @@ class LlmClient:
             )
         except Exception as e:
             err_msg = format_error_message(e)
-            debug_log("stream_request_with_tools ERROR: %s -> %s" % (e, err_msg), context="API")
+            debug_log("stream_request_with_tools ERROR: %s -> %s" % (e, err_msg), context="API", level=logging.ERROR)
             raise Exception(err_msg)
 
         # LiteLLM: streaming_handler.py ~L970 finish_reason_handler() "## if tool use"

--- a/plugin/modules/http/mcp_protocol.py
+++ b/plugin/modules/http/mcp_protocol.py
@@ -27,6 +27,7 @@ import time
 import uuid
 
 from plugin.framework.main_thread import execute_on_main_thread
+from plugin.framework.logging import debug_log
 
 log = logging.getLogger("writeragent.mcp.protocol")
 
@@ -343,11 +344,10 @@ class MCPProtocolHandler:
         if not tool_name:
             raise ValueError("Missing 'name' in tools/call params")
 
-        from plugin.framework.logging import debug_log
-        debug_log(f"*** tools/call: {tool_name}, event_bus={self.event_bus} ***", context="MCP Protocol")
+        debug_log(f"*** tools/call: {tool_name}, event_bus={self.event_bus} ***", context="MCP Protocol", level=logging.DEBUG)
 
         if self.event_bus:
-            from plugin.framework.logging import debug_log
+            pass
         # Fire event for MCP request
         if getattr(self, "event_bus", None) is not None:
             self.event_bus.emit(
@@ -411,8 +411,7 @@ class MCPProtocolHandler:
             "prompts/list":    self._mcp_prompts_list,
         }.get(method)
 
-        from plugin.framework.logging import debug_log
-        debug_log(f"*** MCP INCOMING METHOD: {method} (id={req_id}) ***", context="MCP Protocol")
+        debug_log(f"*** MCP INCOMING METHOD: {method} (id={req_id}) ***", context="MCP Protocol", level=logging.DEBUG)
 
         if handler is None:
             return (400, _jsonrpc_error(
@@ -424,7 +423,7 @@ class MCPProtocolHandler:
                 result = handler(params, document_url=document_url)
             else:
                 result = handler(params)
-            debug_log(f"*** MCP RESULT: {str(result)[:100]} ***", context="MCP Protocol")
+            debug_log(f"*** MCP RESULT: {str(result)[:100]} ***", context="MCP Protocol", level=logging.DEBUG)
             return (200, _jsonrpc_ok(req_id, result))
         except BusyError as e:
             log.warning("MCP %s: busy (%s)", method, e)


### PR DESCRIPTION
Addresses the issue where all logs were defaulting to debug level. This initial pass updates 10 files to properly use `logging.ERROR`, `logging.WARNING`, `logging.INFO`, and `logging.DEBUG` levels in `debug_log` calls, mostly based on heuristic rules (e.g. logs mentioning 'error' or 'fail' set to ERROR). Also standardizes `import logging` to be at the top level of the files.

---
*PR created automatically by Jules for task [10609854972345562177](https://jules.google.com/task/10609854972345562177) started by @KeithCu*