### PR TITLE
Fix logging levels for 10 files

### DIFF
--- a/plugin/contrib/smolagents/default_tools.py
+++ b/plugin/contrib/smolagents/default_tools.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 
+import logging
 import threading
 import time
 from dataclasses import dataclass
@@ -248,9 +249,9 @@ class DuckDuckGoSearchTool(Tool):
         if self._cache_path and self._cache_max_mb > 0 and key:
             cached = _web_cache_get(self._cache_path, "search", key, max_age_days=self._cache_max_age_days)
             if cached is not None:
-                debug_log("web_cache: search hit: %s" % (key[:60] + "..." if len(key) > 60 else key), context="Chat")
+                debug_log("web_cache: search hit: %s" % (key[:60] + "..." if len(key) > 60 else key), context="Chat", level=logging.DEBUG)
                 return cached
-            debug_log("web_cache: search miss: %s" % (key[:60] + "..." if len(key) > 60 else key), context="Chat")
+            debug_log("web_cache: search miss: %s" % (key[:60] + "..." if len(key) > 60 else key), context="Chat", level=logging.DEBUG)
 
         import urllib.request
         import urllib.parse
@@ -367,9 +368,9 @@ class VisitWebpageTool(Tool):
         if self._cache_path and self._cache_max_mb > 0 and key:
             cached = _web_cache_get(self._cache_path, "page", key, max_age_days=self._cache_max_age_days)
             if cached is not None:
-                debug_log("web_cache: page hit: %s" % (key[:60] + "..." if len(key) > 60 else key), context="Chat")
+                debug_log("web_cache: page hit: %s" % (key[:60] + "..." if len(key) > 60 else key), context="Chat", level=logging.DEBUG)
                 return cached
-            debug_log("web_cache: page miss: %s" % (key[:60] + "..." if len(key) > 60 else key), context="Chat")
+            debug_log("web_cache: page miss: %s" % (key[:60] + "..." if len(key) > 60 else key), context="Chat", level=logging.DEBUG)
 
         # Fail fast: URL path ends with .pdf
         parsed = urlparse(url)

--- a/plugin/framework/async_stream.py
+++ b/plugin/framework/async_stream.py
@@ -20,6 +20,7 @@ Handles both simple streaming and complex tool-calling loops with thinking/statu
 Runs blocking API calls on worker threads and drains logic via a main-thread loop
 to keep the LibreOffice UI responsive (processEventsToIdle).
 """
+import logging
 import queue
 import threading
 
@@ -66,7 +67,7 @@ def run_stream_drain_loop(
 
     while not job_done[0]:
         if stop_checker and stop_checker():
-            debug_log("run_stream_drain_loop: Stop requested via checker.", context="API")
+            debug_log("run_stream_drain_loop: Stop requested via checker.", context="API", level=logging.INFO)
             on_stopped()
             job_done[0] = True
             break
@@ -107,7 +108,7 @@ def run_stream_drain_loop(
 
             for item in items:
                 if stop_checker and stop_checker():
-                    debug_log("run_stream_drain_loop: Stop requested via checker.", context="API")
+                    debug_log("run_stream_drain_loop: Stop requested via checker.", context="API", level=logging.INFO)
                     flush_buffers()
                     close_thinking()
                     on_stopped()
@@ -155,7 +156,7 @@ def run_stream_drain_loop(
                         try:
                             on_approval_required(item)
                         except Exception as e:
-                            debug_log("approval_required handler: %s" % e, context="API")
+                            debug_log("approval_required handler: %s" % e, context="API", level=logging.ERROR)
                 elif kind == "final_done":
                     flush_buffers()
                     close_thinking()
@@ -186,7 +187,7 @@ def run_stream_drain_loop(
             flush_buffers()
 
         except Exception as e:
-            debug_log("run_stream_drain_loop EXCEPTION: %s" % e, context="API")
+            debug_log("run_stream_drain_loop EXCEPTION: %s" % e, context="API", level=logging.ERROR)
             job_done[0] = True
             try:
                 on_error(e)

--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -20,6 +20,7 @@ Reads/writes writeragent.json in LibreOffice's user config directory.
 """
 import os
 import json
+import logging
 try:
     import uno
     import unohelper
@@ -265,7 +266,7 @@ def set_config(ctx, key, value):
             json.dump(config_data, f, indent=4)
     except IOError as e:
         from plugin.framework.logging import debug_log
-        debug_log("Error writing to %s: %s" % (config_file_path, e), context="Config")
+        debug_log("Error writing to %s: %s" % (config_file_path, e), context="Config", level=logging.ERROR)
 
 
 def remove_config(ctx, key):
@@ -284,7 +285,7 @@ def remove_config(ctx, key):
             json.dump(config_data, f, indent=4)
     except IOError as e:
         from plugin.framework.logging import debug_log
-        debug_log("Error writing to %s: %s" % (config_file_path, e), context="Config")
+        debug_log("Error writing to %s: %s" % (config_file_path, e), context="Config", level=logging.ERROR)
 
 
 # Listeners are called when config is changed (e.g. after Settings dialog).
@@ -431,7 +432,7 @@ def fetch_available_models(endpoint):
             return models
     except Exception as e:
         from plugin.framework.logging import debug_log
-        debug_log(f"fetch_available_models failed for {url}: {e}", context="Config")
+        debug_log(f"fetch_available_models failed for {url}: {e}", context="Config", level=logging.WARNING)
     _model_fetch_cache[url] = None
     return None
 

--- a/plugin/framework/pricing.py
+++ b/plugin/framework/pricing.py
@@ -14,8 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import os
 import json
+import logging
+import os
 import time
 from plugin.modules.http.client import sync_request
 from plugin.framework.config import user_config_dir
@@ -37,19 +38,19 @@ def fetch_openrouter_pricing(ctx, force=False):
     if not force and cache_path and os.path.exists(cache_path):
         mtime = os.path.getmtime(cache_path)
         if time.time() - mtime < CACHE_TTL:
-            debug_log("Using cached OpenRouter pricing.", context="Pricing")
+            debug_log("Using cached OpenRouter pricing.", context="Pricing", level=logging.DEBUG)
             return
             
-    debug_log("Fetching fresh OpenRouter pricing...", context="Pricing")
+    debug_log("Fetching fresh OpenRouter pricing...", context="Pricing", level=logging.INFO)
     url = "https://openrouter.ai/api/v1/models"
     try:
         data = sync_request(url, parse_json=True)
         if data and "data" in data:
             with open(cache_path, "w", encoding="utf-8") as f:
                 json.dump(data["data"], f, indent=2)
-            debug_log(f"Cached {len(data['data'])} models.", context="Pricing")
+            debug_log(f"Cached {len(data['data'])} models.", context="Pricing", level=logging.INFO)
     except Exception as e:
-        debug_log(f"Failed to fetch OpenRouter pricing: {e}", context="Pricing")
+        debug_log(f"Failed to fetch OpenRouter pricing: {e}", context="Pricing", level=logging.ERROR)
 
 def get_model_pricing(ctx, model_id):
     """Return (prompt_rate, completion_rate) per token in USD."""

--- a/plugin/framework/settings_dialog.py
+++ b/plugin/framework/settings_dialog.py
@@ -16,10 +16,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from plugin.framework.config import get_config, set_config, get_current_endpoint, as_bool, endpoint_from_selector_text, get_image_model, set_image_model, get_api_key_for_endpoint, set_api_key_for_endpoint, notify_config_changed
 
+import logging
+
 def get_settings_field_specs(ctx):
     """Return field specs for Settings dialog (single source for dialog and apply keys)."""
     from plugin.framework.logging import debug_log
-    debug_log("get_settings_field_specs entry", context="Settings")
+    debug_log("get_settings_field_specs entry", context="Settings", level=logging.DEBUG)
     current_endpoint_for_specs = get_current_endpoint(ctx)
     field_specs = [
         {"name": "endpoint", "value": str(get_config(ctx, "endpoint") or "")},
@@ -77,9 +79,9 @@ def get_settings_field_specs(ctx):
                 if provider_path:
                     try:
                         field["options"] = _call_options_provider(ctx, provider_path)
-                    except Exception:
+                    except Exception as e:
                         from plugin.framework.logging import debug_log
-                        debug_log(f"Failed to resolve options_provider: {provider_path}", context="Settings")
+                        debug_log(f"Failed to resolve options_provider: {provider_path} {e}", context="Settings", level=logging.ERROR)
                 elif schema.get("options"):
                     field["options"] = schema["options"]
 
@@ -183,7 +185,7 @@ def _call_options_provider(ctx, provider_path):
     The function receives the ServiceRegistry as its argument.
     """
     from plugin.framework.logging import debug_log
-    debug_log(f"_call_options_provider: {provider_path}", context="Settings")
+    debug_log(f"_call_options_provider: {provider_path}", context="Settings", level=logging.DEBUG)
     try:
         module_path, func_name = provider_path.rsplit(":", 1)
         import importlib
@@ -193,10 +195,10 @@ def _call_options_provider(ctx, provider_path):
         from plugin.main import get_services
         services = get_services()
         options = func(services)
-        debug_log(f"_call_options_provider success: {len(options)} options returned", context="Settings")
+        debug_log(f"_call_options_provider success: {len(options)} options returned", context="Settings", level=logging.DEBUG)
         return options
     except Exception as e:
-        debug_log(f"_call_options_provider FAILED for {provider_path}: {e}", context="Settings")
+        debug_log(f"_call_options_provider FAILED for {provider_path}: {e}", context="Settings", level=logging.ERROR)
         import traceback
-        debug_log(traceback.format_exc(), context="Settings")
+        debug_log(traceback.format_exc(), context="Settings", level=logging.ERROR)
         raise

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -37,7 +37,6 @@ import officehelper
 
 from plugin.framework.logging import init_logging
 import uno
-import logging
 
 from com.sun.star.task import XJobExecutor, XJob
 from com.sun.star.frame import XDispatch, XDispatchProvider
@@ -238,7 +237,7 @@ def _run_test_suite(test_func, doc_checker, test_name):
         from plugin.testing_runner import run_module_suite
         model = get_active_document(ctx)
         doc_model = model if (model and doc_checker(model)) else None
-        debug_log(f"Calling run_blocking_in_thread for {test_name}", context="Tests")
+        debug_log(f"Calling run_blocking_in_thread for {test_name}", context="Tests", level=logging.DEBUG)
         p, f, log = run_blocking_in_thread(ctx, run_module_suite, ctx, test_func, test_name, doc_model)
         debug_log(f"_run_test_suite finished: {test_name}, p={p}, f={f}", context="Tests", level=logging.INFO)
         msgbox(ctx, test_name, f"{test_name}: {p} passed, {f} failed.\n\n" + "\n".join(log))

--- a/plugin/modules/agent_backend/acp_connection.py
+++ b/plugin/modules/agent_backend/acp_connection.py
@@ -21,6 +21,7 @@ acting as an ACP client connected to a supporting agent binary backend.
 """
 
 import json
+import logging
 import os
 import subprocess
 import threading
@@ -51,7 +52,7 @@ class ACPConnection:
 
     def start(self):
         """Spawn the ACP subprocess."""
-        debug_log(f"Spawning: {' '.join(self._cmd_line)}", context=_LOG)
+        debug_log(f"Spawning: {' '.join(self._cmd_line)}", context=_LOG, level=logging.INFO)
 
         env = dict(os.environ)
         if self._env:
@@ -116,7 +117,7 @@ class ACPConnection:
             self._pending[req_id] = {"event": event, "response": None}
 
         line = json.dumps(msg) + "\n"
-        debug_log(f"→ {method} (id={req_id})", context=_LOG)
+        debug_log(f"→ {method} (id={req_id})", context=_LOG, level=logging.DEBUG)
 
         try:
             self._proc.stdin.write(line.encode("utf-8"))
@@ -164,7 +165,7 @@ class ACPConnection:
 
     def _reader_loop(self):
         """Read JSON-RPC messages from stdout and dispatch them."""
-        debug_log("Reader loop started", context=_LOG)
+        debug_log("Reader loop started", context=_LOG, level=logging.INFO)
         while self._running and self._proc and self._proc.poll() is None:
             try:
                 line = self._proc.stdout.readline()
@@ -181,7 +182,7 @@ class ACPConnection:
                 try:
                     msg = json.loads(line)
                 except json.JSONDecodeError:
-                    debug_log(f"Non-JSON output: {line[:200]}", context=_LOG)
+                    debug_log(f"Non-JSON output: {line[:200]}", context=_LOG, level=logging.DEBUG)
                     continue
 
                 if "id" in msg and msg["id"] is not None and "method" not in msg:
@@ -193,7 +194,7 @@ class ACPConnection:
                         entry["response"] = msg
                         entry["event"].set()
                     else:
-                        debug_log(f"Response for unknown id={req_id}", context=_LOG)
+                        debug_log(f"Response for unknown id={req_id}", context=_LOG, level=logging.WARNING)
                 else:
                     # Notification or Request from the agent
                     method = msg.get("method", "")
@@ -203,11 +204,11 @@ class ACPConnection:
                         try:
                             self._notify_callback(method, params, msg_id)
                         except Exception as e:
-                            debug_log(f"Notification callback error: {e}", context=_LOG)
+                            debug_log(f"Notification callback error: {e}", context=_LOG, level=logging.ERROR)
 
             except Exception as e:
                 if self._running:
-                    debug_log(f"Reader error: {e}", context=_LOG)
+                    debug_log(f"Reader error: {e}", context=_LOG, level=logging.ERROR)
                 break
 
         # Read stderr for debugging
@@ -216,8 +217,8 @@ class ACPConnection:
                 stderr = self._proc.stderr.read()
                 if stderr:
                     stderr_text = stderr.decode("utf-8", errors="replace")[:500]
-                    debug_log(f"ACP stderr: {stderr_text}", context=_LOG)
+                    debug_log(f"ACP stderr: {stderr_text}", context=_LOG, level=logging.WARNING)
             except Exception:
                 pass
 
-        debug_log("Reader loop ended", context=_LOG)
+        debug_log("Reader loop ended", context=_LOG, level=logging.INFO)

--- a/plugin/modules/chatbot/panel_resize.py
+++ b/plugin/modules/chatbot/panel_resize.py
@@ -41,9 +41,9 @@ class _PanelResizeListener(unohelper.Base, XWindowListener):
 
     def windowResized(self, evt):
         r = evt.Source.getPosSize()
-        debug_log("windowResized: W=%d H=%d" % (r.Width, r.Height), context="Chat")
+        debug_log("windowResized: W=%d H=%d" % (r.Width, r.Height), context="Chat", level=logging.DEBUG)
         if self._in_relayout:
-            debug_log("windowResized: skipped (in_relayout)", context="Chat")
+            debug_log("windowResized: skipped (in_relayout)", context="Chat", level=logging.DEBUG)
             return
         try:
             self._in_relayout = True
@@ -77,6 +77,7 @@ class _PanelResizeListener(unohelper.Base, XWindowListener):
         debug_log(
             "_capture_initial: starting snapshot for win W=%d H=%d" % (r.Width, r.Height),
             context="Chat",
+            level=logging.DEBUG,
         )
         info = {"win_w": r.Width, "win_h": r.Height, "ctrls": {}}
         resp = self._c.get("response")
@@ -124,6 +125,7 @@ class _PanelResizeListener(unohelper.Base, XWindowListener):
                 str(info.get("gap_below_response")),
             ),
             context="Chat",
+            level=logging.DEBUG,
         )
         # Lightweight per-control width summary for debugging GTK issues.
         try:
@@ -136,6 +138,7 @@ class _PanelResizeListener(unohelper.Base, XWindowListener):
             debug_log(
                 "_capture_initial ctrl_widths=%s" % width_summary,
                 context="Chat",
+                level=logging.DEBUG,
             )
         except Exception:
             # Logging must never break layout; ignore any issues here.
@@ -152,13 +155,14 @@ class _PanelResizeListener(unohelper.Base, XWindowListener):
             "_relayout: win W=%d H=%d (have_initial=%s)"
             % (w, h, bool(self._initial)),
             context="Chat",
+            level=logging.DEBUG,
         )
 
         if self._initial is None:
             self._capture_initial(win)
 
         if self._initial is None:
-            debug_log("_relayout: no initial state, skip", context="Chat")
+            debug_log("_relayout: no initial state, skip", context="Chat", level=logging.WARNING)
             return
 
         iw = self._initial["win_w"]

--- a/plugin/modules/chatbot/panel_wiring.py
+++ b/plugin/modules/chatbot/panel_wiring.py
@@ -11,9 +11,9 @@ from plugin.modules.chatbot.panel_resize import _PanelResizeListener
 
 def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
     """Main entry point to wire all controls for the panel."""
-    debug_log("_wireControls entered", context="Chat")
+    debug_log("_wireControls entered", context="Chat", level=logging.DEBUG)
     if not hasattr(root_window, "getControl"):
-        debug_log("_wireControls: root_window has no getControl, aborting", context="Chat")
+        debug_log("_wireControls: root_window has no getControl, aborting", context="Chat", level=logging.ERROR)
         return
 
     def get_optional(name):
@@ -115,13 +115,14 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
         from main import try_ensure_mcp_timer
         try_ensure_mcp_timer(self.ctx)
     except Exception as e:
-        debug_log("try_ensure_mcp_timer: %s" % e, context="Chat")
+        debug_log("try_ensure_mcp_timer: %s" % e, context="Chat", level=logging.ERROR)
 
     try:
         debug_log(
             "Attaching _PanelResizeListener to root_window; controls=%s"
             % (sorted(k for k, v in controls.items() if v)),
             context="Chat",
+            level=logging.DEBUG,
         )
         _resize = _PanelResizeListener(controls)
         root_window.addWindowListener(_resize)

--- a/plugin/prompt_function.py
+++ b/plugin/prompt_function.py
@@ -36,36 +36,23 @@ from org.extension.writeragent.PromptFunction import XPromptFunction
 from plugin.framework.config import get_config, get_api_config
 from plugin.modules.http.client import LlmClient
 
-# Enable debug logging
-DEBUG = True
-
-def debug_log(message):
-    """Debug logging function"""
-    if DEBUG:
-        try:
-            # Try to write to a debug file
-            debug_file = os.path.expanduser("~/libreoffice_prompt_debug.log")
-            with open(debug_file, "a", encoding="utf-8") as f:
-                f.write(f"{message}\n")
-        except:
-            # Fallback to stdout
-            print(f"DEBUG: {message}")
-            sys.stdout.flush()
+import logging
+from plugin.framework.logging import debug_log
 
 class PromptFunction(unohelper.Base, XPromptFunction):
     def __init__(self, ctx):
-        debug_log("=== PromptFunction.__init__ called ===")
+        debug_log("=== PromptFunction.__init__ called ===", context="PROMPT", level=logging.DEBUG)
         self.ctx = ctx
         self.client = None
 
     def getProgrammaticFunctionName(self, aDisplayName):
-        debug_log(f"=== getProgrammaticFunctionName called with: '{aDisplayName}' ===")
+        debug_log(f"=== getProgrammaticFunctionName called with: '{aDisplayName}' ===", context="PROMPT", level=logging.DEBUG)
         if aDisplayName == "PROMPT":
             return "prompt"
         return ""
 
     def getDisplayFunctionName(self, aProgrammaticName):
-        debug_log(f"=== getDisplayFunctionName called with: '{aProgrammaticName}' ===")
+        debug_log(f"=== getDisplayFunctionName called with: '{aProgrammaticName}' ===", context="PROMPT", level=logging.DEBUG)
         if aProgrammaticName == "prompt":
             return "PROMPT"
         return ""
@@ -131,7 +118,7 @@ class PromptFunction(unohelper.Base, XPromptFunction):
         pass
 
     def prompt(self, message, systemPrompt, model, maxTokens):
-        debug_log(f"=== PromptFunction.PROMPT({message}) called ===")
+        debug_log(f"=== PromptFunction.PROMPT({message}) called ===", context="PROMPT", level=logging.DEBUG)
         aProgrammaticName = "PROMPT"
         if aProgrammaticName == "PROMPT":
             try:
@@ -161,7 +148,7 @@ class PromptFunction(unohelper.Base, XPromptFunction):
                 return run_blocking_in_thread(self.ctx, self.client.chat_completion_sync, messages, max_tokens=max_tokens)
             except Exception as e:
                 from plugin.modules.http.client import format_error_for_display
-                debug_log("PROMPT error: %s" % str(e))
+                debug_log("PROMPT error: %s" % str(e), context="PROMPT", level=logging.ERROR)
                 return format_error_for_display(e)
         return ""
 
@@ -185,12 +172,12 @@ g_ImplementationHelper.addImplementation(
 # Test function registration
 def test_registration():
     """Test if the function is properly registered"""
-    debug_log("=== Testing function registration ===")
+    debug_log("=== Testing function registration ===", context="PROMPT", level=logging.DEBUG)
     try:
         # This will be called when LibreOffice loads the extension
-        debug_log("Function registration test completed")
+        debug_log("Function registration test completed", context="PROMPT", level=logging.INFO)
     except Exception as e:
-        debug_log(f"Registration test failed: {e}")
+        debug_log(f"Registration test failed: {e}", context="PROMPT", level=logging.ERROR)
 
 # Call test on module load
 test_registration()


### PR DESCRIPTION
Addresses the issue where all logs were defaulting to debug level. This initial pass updates 10 files to properly use `logging.ERROR`, `logging.WARNING`, `logging.INFO`, and `logging.DEBUG` levels in `debug_log` calls, mostly based on heuristic rules. Also standardizes `import logging` to be at the top level of the files.

---
*PR created automatically by Jules for task [13478680649177991532](https://jules.google.com/task/13478680649177991532) started by @KeithCu*