### PR TITLE
Standardize tool execution error payloads

### DIFF
--- a/plugin/framework/tool_base.py
+++ b/plugin/framework/tool_base.py
@@ -60,6 +60,26 @@ class ToolBase(ABC):
             return not self.name.startswith(_READ_PREFIXES)
         return True
 
+    def _tool_error(self, message, code="TOOL_EXECUTION_ERROR", **details):
+        """Standardized JSON payload for tool errors.
+
+        Args:
+            message: User-friendly error message.
+            code: Internal error code.
+            **details: Optional context like tool_name, doc_type, etc.
+
+        Returns:
+            dict matching the standardized error format.
+        """
+        payload = {
+            "status": "error",
+            "code": code,
+            "message": message,
+        }
+        if details:
+            payload["details"] = details
+        return payload
+
     def validate(self, **kwargs):
         """Validate arguments against ``parameters`` schema.
 
@@ -102,12 +122,7 @@ class ToolBase(ABC):
         """
         if not hasattr(doc, getter_name):
             msg = missing_msg or f"Document does not support {getter_name}."
-            return {
-                "status": "error",
-                "code": "UNO_OBJECT_ERROR",
-                "message": msg,
-                "details": {"getter_name": getter_name},
-            }
+            return self._tool_error(msg, code="UNO_OBJECT_ERROR", getter_name=getter_name)
         return getattr(doc, getter_name)()
 
     def get_item(self, doc, getter_name, item_name, missing_msg=None, not_found_msg=None):
@@ -130,13 +145,13 @@ class ToolBase(ABC):
         if not collection.hasByName(item_name):
             available = list(collection.getElementNames())
             msg = not_found_msg or f"Item '{item_name}' not found."
-            return {
-                "status": "error",
-                "code": "UNO_OBJECT_ERROR",
-                "message": msg,
-                "available": available,
-                "details": {"item_name": item_name, "getter_name": getter_name},
-            }
+            return self._tool_error(
+                msg,
+                code="UNO_OBJECT_ERROR",
+                item_name=item_name,
+                getter_name=getter_name,
+                available=available
+            )
 
         return collection.getByName(item_name)
 
@@ -151,16 +166,22 @@ class ToolBaseDummy:
 
     name: str | None = None
 
+    def _tool_error(self, message, code="TOOL_EXECUTION_ERROR", **details):
+        """Standardized JSON payload for tool errors."""
+        payload = {
+            "status": "error",
+            "code": code,
+            "message": message,
+        }
+        if details:
+            payload["details"] = details
+        return payload
+
     def get_collection(self, doc, getter_name, missing_msg=None):
         """Helper to safely fetch a named collection from a document."""
         if not hasattr(doc, getter_name):
             msg = missing_msg or f"Document does not support {getter_name}."
-            return {
-                "status": "error",
-                "code": "UNO_OBJECT_ERROR",
-                "message": msg,
-                "details": {"getter_name": getter_name},
-            }
+            return self._tool_error(msg, code="UNO_OBJECT_ERROR", getter_name=getter_name)
         return getattr(doc, getter_name)()
 
     def get_item(self, doc, getter_name, item_name, missing_msg=None, not_found_msg=None):
@@ -171,12 +192,12 @@ class ToolBaseDummy:
         if not collection.hasByName(item_name):
             available = list(collection.getElementNames())
             msg = not_found_msg or f"Item '{item_name}' not found."
-            return {
-                "status": "error",
-                "code": "UNO_OBJECT_ERROR",
-                "message": msg,
-                "available": available,
-                "details": {"item_name": item_name, "getter_name": getter_name},
-            }
+            return self._tool_error(
+                msg,
+                code="UNO_OBJECT_ERROR",
+                item_name=item_name,
+                getter_name=getter_name,
+                available=available
+            )
         return collection.getByName(item_name)
 

--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -185,6 +185,13 @@ class ToolRegistry:
 
         from plugin.framework.errors import format_error_payload, WriterAgentException
 
+        # Common context for all error details
+        common_details = {"tool_name": tool_name}
+        if ctx.caller:
+            common_details["caller"] = ctx.caller
+        if ctx.doc_type:
+            common_details["doc_type"] = ctx.doc_type
+
         # Validate parameters
         ok, err = tool.validate(**kwargs)
         if not ok:
@@ -192,7 +199,7 @@ class ToolRegistry:
                 "status": "error",
                 "code": "VALIDATION_ERROR",
                 "message": err,
-                "details": {"tool_name": tool_name}
+                "details": common_details
             }
 
         # Emit executing event
@@ -208,16 +215,36 @@ class ToolRegistry:
 
         try:
             result = tool.execute(ctx, **kwargs)
+            # Ensure any returned dict with status='error' includes full context details
+            if isinstance(result, dict) and result.get("status") == "error":
+                result_details = result.get("details", {})
+                if isinstance(result_details, dict):
+                    # merge common_details into result_details without overwriting existing keys
+                    for k, v in common_details.items():
+                        if k not in result_details:
+                            result_details[k] = v
+                    result["details"] = result_details
         except ToolExecutionError as exc:
             log.exception("Tool execution failed (ToolExecutionError): %s", tool_name)
             if bus:
                 bus.emit("tool:failed", name=tool_name, error=str(exc), caller=ctx.caller)
-            return {"status": "error", "code": exc.code, "message": exc.message, "details": exc.details}
+
+            error_details = exc.details or {}
+            for k, v in common_details.items():
+                if k not in error_details:
+                    error_details[k] = v
+            return {"status": "error", "code": exc.code, "message": exc.message, "details": error_details}
         except Exception as exc:
             log.exception("Tool execution failed: %s", tool_name)
             if bus:
                 bus.emit("tool:failed", name=tool_name, error=str(exc), caller=ctx.caller)
-            return format_error_payload(exc)
+            payload = format_error_payload(exc)
+            error_details = payload.get("details", {})
+            for k, v in common_details.items():
+                if k not in error_details:
+                    error_details[k] = v
+            payload["details"] = error_details
+            return payload
 
         if bus:
             bus.emit("tool:completed", name=tool_name, caller=ctx.caller)

--- a/plugin/modules/writer/images.py
+++ b/plugin/modules/writer/images.py
@@ -107,7 +107,11 @@ class GenerateImage(ToolBase):
         if is_edit:
             source_b64 = get_selected_image_base64(ctx.doc, ctx.ctx)
             if not source_b64:
-                return {"status": "error", "message": "No image selected. Please select an image in the document first."}
+                return self._tool_error(
+                    "No image selected. Please select an image in the document first.",
+                    code="NO_SELECTION",
+                    action="edit_image"
+                )
             edit_width, edit_height = get_selected_image_dimensions_px(ctx.doc)
             if edit_width is None:
                 edit_width, edit_height = 512, 512
@@ -157,7 +161,11 @@ class GenerateImage(ToolBase):
         )
 
         if not paths:
-            return {"status": "error", "message": error_msg or "No image returned."}
+            return self._tool_error(
+                error_msg or "No image returned.",
+                code="PROVIDER_ERROR",
+                provider=provider
+            )
 
         if is_edit:
             replaced = replace_image_in_place(
@@ -446,7 +454,7 @@ class SetImageProperties(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         image_name = kwargs.get("image_name", "")
         if not image_name:
-            return {"status": "error", "message": "image_name is required."}
+            return self._tool_error("image_name is required.", code="MISSING_PARAMETER", parameter="image_name")
 
         graphic = self.get_item(
             ctx.doc, "getGraphicObjects", image_name,
@@ -628,14 +636,19 @@ class InsertImage(ToolBaseDummy):
             try:
                 image_path = _download_image_to_cache(image_path)
             except Exception as e:
-                return {"status": "error", "message": "Download failed: %s" % e}
+                return self._tool_error(
+                    f"Download failed: {e}",
+                    code="DOWNLOAD_FAILED",
+                    url=image_path
+                )
 
         # Verify local file exists
         if not os.path.isfile(image_path):
-            return {
-                "status": "error",
-                "message": "File not found: %s" % image_path,
-            }
+            return self._tool_error(
+                f"File not found: {image_path}",
+                code="FILE_NOT_FOUND",
+                path=image_path
+            )
 
         # Convert to file:// URL
         file_url = uno.systemPathToFileUrl(os.path.abspath(image_path))
@@ -662,10 +675,11 @@ class InsertImage(ToolBaseDummy):
         if paragraph_index is not None:
             target, _ = doc_svc.find_paragraph_element(doc, paragraph_index)
             if target is None:
-                return {
-                    "status": "error",
-                    "message": "Paragraph %d not found." % paragraph_index,
-                }
+                return self._tool_error(
+                    f"Paragraph {paragraph_index} not found.",
+                    code="PARAGRAPH_NOT_FOUND",
+                    paragraph_index=paragraph_index
+                )
             cursor = doc_text.createTextCursorByRange(target.getEnd())
         else:
             # Insert at current cursor position (end of document)
@@ -783,13 +797,18 @@ class ReplaceImage(ToolBaseDummy):
             try:
                 new_image_path = _download_image_to_cache(new_image_path)
             except Exception as e:
-                return {"status": "error", "message": "Download failed: %s" % e}
+                return self._tool_error(
+                    f"Download failed: {e}",
+                    code="DOWNLOAD_FAILED",
+                    url=new_image_path
+                )
 
         if not os.path.isfile(new_image_path):
-            return {
-                "status": "error",
-                "message": "File not found: %s" % new_image_path,
-            }
+            return self._tool_error(
+                f"File not found: {new_image_path}",
+                code="FILE_NOT_FOUND",
+                path=new_image_path
+            )
 
         file_url = uno.systemPathToFileUrl(os.path.abspath(new_image_path))
 

--- a/plugin/tests/test_tool_base.py
+++ b/plugin/tests/test_tool_base.py
@@ -105,7 +105,8 @@ def test_get_item():
     assert isinstance(res, dict)
     assert res["status"] == "error"
     assert "missing" in res["message"]
-    assert "item1" in res["available"]
+    assert "available" in res["details"]
+    assert "item1" in res["details"]["available"]
 
     # Item found
     res = tool.get_item(doc, "getMyItems", "item1")


### PR DESCRIPTION
This PR addresses "Phase 3 — Image + Tool Surface Consistency". It standardizes tool error payloads across the application by introducing a centralized `_tool_error` helper in `ToolBase`. The `ToolRegistry` now automatically injects crucial context (like `tool_name`, `caller`, and `doc_type`) into the `details` field of all failure paths. Furthermore, tools in `images.py` have been refactored to use this new helper, supplying explicit error codes and relevant arguments instead of generic strings.

---
*PR created automatically by Jules for task [8636372359201138514](https://jules.google.com/task/8636372359201138514) started by @KeithCu*