### PR TITLE
Refactor draw tools to use unified _tool_error method

### DIFF
--- a/plugin/modules/draw/masters.py
+++ b/plugin/modules/draw/masters.py
@@ -52,7 +52,7 @@ class ListMasterSlides(ToolBase):
                 result.append(entry)
             return {"status": "ok", "master_slides": result, "count": len(result)}
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetSlideMaster(ToolBase):
@@ -86,7 +86,7 @@ class GetSlideMaster(ToolBase):
                 "master_name": master.Name if hasattr(master, "Name") else "",
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class SetSlideMaster(ToolBase):
@@ -134,11 +134,10 @@ class SetSlideMaster(ToolBase):
                 for i in range(masters.getCount()):
                     m = masters.getByIndex(i)
                     available.append(m.Name if hasattr(m, "Name") else "")
-                return {
-                    "status": "error",
-                    "message": "Master '%s' not found." % master_name,
-                    "available": available,
-                }
+                return self._tool_error(
+                    "Master '%s' not found." % master_name,
+                    available=available,
+                )
 
             page.MasterPage = target
             return {
@@ -147,4 +146,4 @@ class SetSlideMaster(ToolBase):
                 "master_name": master_name,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/draw/notes.py
+++ b/plugin/modules/draw/notes.py
@@ -56,7 +56,7 @@ class GetSpeakerNotes(ToolBase):
                 "notes": notes_text,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class SetSpeakerNotes(ToolBase):
@@ -96,7 +96,7 @@ class SetSpeakerNotes(ToolBase):
             page = _get_slide(ctx.doc, kwargs.get("page_index"))
             notes_page = page.getNotesPage()
             if notes_page is None or notes_page.getCount() < 2:
-                return {"status": "error", "message": "No notes page available."}
+                return self._tool_error("No notes page available.")
 
             notes_shape = notes_page.getByIndex(1)
             if append:
@@ -111,4 +111,4 @@ class SetSpeakerNotes(ToolBase):
                 "message": "Speaker notes updated.",
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/draw/pages.py
+++ b/plugin/modules/draw/pages.py
@@ -96,13 +96,12 @@ class ReadSlideText(ToolBase):
         if page_index is not None:
             pages = bridge.get_pages()
             if page_index < 0 or page_index >= pages.getCount():
-                return {"status": "error",
-                        "message": "Page index %d out of range." % page_index}
+                return self._tool_error("Page index %d out of range." % page_index)
             page = pages.getByIndex(page_index)
         else:
             page = bridge.get_active_page()
             if page is None:
-                return {"status": "error", "message": "No active page."}
+                return self._tool_error("No active page.")
 
         texts = []
         for i in range(page.getCount()):

--- a/plugin/modules/draw/placeholders.py
+++ b/plugin/modules/draw/placeholders.py
@@ -172,7 +172,7 @@ class ListPlaceholders(ToolBase):
                 "count": len(placeholders),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetPlaceholderText(ToolBase):
@@ -213,21 +213,20 @@ class GetPlaceholderText(ToolBase):
 
             if shape_index is not None:
                 if shape_index < 0 or shape_index >= page.getCount():
-                    return {"status": "error", "message": "Shape index out of range."}
+                    return self._tool_error("Shape index out of range.")
                 shape = page.getByIndex(shape_index)
             elif role:
                 shape, _ = _find_placeholder(page, role)
                 if shape is None:
-                    return {
-                        "status": "error",
-                        "message": "Placeholder '%s' not found." % role,
-                        "available": _list_placeholders(page),
-                    }
+                    return self._tool_error(
+                        "Placeholder '%s' not found." % role,
+                        available=_list_placeholders(page),
+                    )
             else:
-                return {"status": "error", "message": "Specify role or shape_index."}
+                return self._tool_error("Specify role or shape_index.")
 
             if not hasattr(shape, "getString"):
-                return {"status": "error", "message": "Shape has no text."}
+                return self._tool_error("Shape has no text.")
 
             return {
                 "status": "ok",
@@ -236,7 +235,7 @@ class GetPlaceholderText(ToolBase):
                 "shape_index": shape_index,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class SetPlaceholderText(ToolBase):
@@ -283,21 +282,20 @@ class SetPlaceholderText(ToolBase):
 
             if shape_index is not None:
                 if shape_index < 0 or shape_index >= page.getCount():
-                    return {"status": "error", "message": "Shape index out of range."}
+                    return self._tool_error("Shape index out of range.")
                 shape = page.getByIndex(shape_index)
             elif role:
                 shape, shape_index = _find_placeholder(page, role)
                 if shape is None:
-                    return {
-                        "status": "error",
-                        "message": "Placeholder '%s' not found." % role,
-                        "available": _list_placeholders(page),
-                    }
+                    return self._tool_error(
+                        "Placeholder '%s' not found." % role,
+                        available=_list_placeholders(page),
+                    )
             else:
-                return {"status": "error", "message": "Specify role or shape_index."}
+                return self._tool_error("Specify role or shape_index.")
 
             if not hasattr(shape, "setString"):
-                return {"status": "error", "message": "Shape does not support text."}
+                return self._tool_error("Shape does not support text.")
 
             shape.setString(text)
             return {
@@ -307,4 +305,4 @@ class SetPlaceholderText(ToolBase):
                 "shape_index": shape_index,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/draw/shapes.py
+++ b/plugin/modules/draw/shapes.py
@@ -142,10 +142,7 @@ class CreateShape(ToolBase):
         }
         uno_type = type_map.get(kwargs["shape_type"])
         if not uno_type:
-            return {
-                "status": "error",
-                "message": f"Unsupported shape type: {kwargs['shape_type']}",
-            }
+            return self._tool_error(f"Unsupported shape type: {kwargs['shape_type']}")
         shape = bridge.create_shape(
             uno_type, kwargs["x"], kwargs["y"], kwargs["width"], kwargs["height"]
         )

--- a/plugin/modules/draw/transitions.py
+++ b/plugin/modules/draw/transitions.py
@@ -164,7 +164,7 @@ class GetSlideTransition(ToolBase):
                 "advance": {0: "on_click", 1: "auto", 2: "semi_auto"}.get(change, "on_click"),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class SetSlideTransition(ToolBase):
@@ -272,13 +272,12 @@ class SetSlideTransition(ToolBase):
                         page.setPropertyValue("Effect", effects_map[uno_name])
                         updated.append("effect")
                     else:
-                        return {
-                            "status": "error",
-                            "message": "Unknown effect: %s" % effect_name,
-                            "available": sorted(_FADE_EFFECTS.keys()),
-                        }
+                        return self._tool_error(
+                            "Unknown effect: %s" % effect_name,
+                            available=sorted(_FADE_EFFECTS.keys()),
+                        )
                 except ImportError:
-                    return {"status": "error", "message": "FadeEffect enum not available."}
+                    return self._tool_error("FadeEffect enum not available.")
 
             # Speed
             speed = kwargs.get("speed")
@@ -319,7 +318,7 @@ class SetSlideTransition(ToolBase):
                 "updated": updated,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetSlideLayout(ToolBase):
@@ -356,7 +355,7 @@ class GetSlideLayout(ToolBase):
                 "available_layouts": sorted(_LAYOUTS.keys()),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class SetSlideLayout(ToolBase):
@@ -392,11 +391,10 @@ class SetSlideLayout(ToolBase):
     def execute(self, ctx, **kwargs):
         layout_name = kwargs.get("layout", "").strip().lower()
         if layout_name not in _LAYOUTS:
-            return {
-                "status": "error",
-                "message": "Unknown layout: %s" % layout_name,
-                "available": sorted(_LAYOUTS.keys()),
-            }
+            return self._tool_error(
+                "Unknown layout: %s" % layout_name,
+                available=sorted(_LAYOUTS.keys()),
+            )
         try:
             page = _get_slide(ctx.doc, kwargs.get("page_index"))
             page.Layout = _LAYOUTS[layout_name]
@@ -406,4 +404,4 @@ class SetSlideLayout(ToolBase):
                 "layout": layout_name,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))


### PR DESCRIPTION
Updates draw/impress tools to utilize the `self._tool_error()` method for error payloads, matching the standard error schema for tool returns.

---
*PR created automatically by Jules for task [10857296956546514610](https://jules.google.com/task/10857296956546514610) started by @KeithCu*