### PR TITLE
Standardize Error Schemas in Writer Tools

### DIFF
--- a/plugin/modules/writer/comments.py
+++ b/plugin/modules/writer/comments.py
@@ -159,11 +159,9 @@ class AddComment(ToolBaseDummy):
                 if 0 <= para_index < len(para_ranges):
                     anchor_range = para_ranges[para_index].getStart()
                 else:
-                    return {"status": "error",
-                            "message": "Paragraph %d out of range." % para_index}
+                    return self._tool_error("Paragraph %d out of range." % para_index)
         else:
-            return {"status": "error",
-                    "message": "Provide search_text, locator, or paragraph_index."}
+            return self._tool_error("Provide search_text, locator, or paragraph_index.")
 
         annotation = doc.createInstance(
             "com.sun.star.text.textfield.Annotation"
@@ -212,8 +210,7 @@ class DeleteComment(ToolBaseDummy):
         author = kwargs.get("author")
 
         if not comment_name and not author:
-            return {"status": "error",
-                    "message": "Provide comment_name or author."}
+            return self._tool_error("Provide comment_name or author.")
 
         doc = ctx.doc
         text_obj = doc.getText()
@@ -373,7 +370,7 @@ class Workflow(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         action = kwargs.get("action")
         if action not in ("scan_tasks", "get_status", "set_status", "check_stop"):
-            return {"status": "error", "message": "Invalid action: %s" % action}
+            return self._tool_error("Invalid action: %s" % action)
 
         if action == "scan_tasks":
             return self._scan_tasks(ctx, kwargs)
@@ -593,14 +590,14 @@ class AddAiSummary(ToolBaseDummy):
                 resolved = ctx.services.document.resolve_locator(ctx.doc, locator)
                 para_index = resolved.get("para_index")
             except ValueError as e:
-                return {"status": "error", "error": str(e)}
+                return self._tool_error(str(e))
         if para_index is None:
-            return {"status": "error", "error": "Provide locator or para_index"}
+            return self._tool_error("Provide locator or para_index")
         try:
             result = tree_svc.add_ai_summary(ctx.doc, para_index, kwargs["summary"])
             return {"status": "ok", **result}
         except ValueError as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetAiSummaries(ToolBaseDummy):
@@ -646,8 +643,8 @@ class RemoveAiSummary(ToolBaseDummy):
                 resolved = ctx.services.document.resolve_locator(ctx.doc, locator)
                 para_index = resolved.get("para_index")
             except ValueError as e:
-                return {"status": "error", "error": str(e)}
+                return self._tool_error(str(e))
         if para_index is None:
-            return {"status": "error", "error": "Provide locator or para_index"}
+            return self._tool_error("Provide locator or para_index")
         removed = tree_svc.remove_ai_summary(ctx.doc, para_index)
         return {"status": "ok", "removed": removed, "para_index": para_index}

--- a/plugin/modules/writer/content.py
+++ b/plugin/modules/writer/content.py
@@ -112,7 +112,7 @@ class GetDocumentContent(ToolBase):
         range_end = kwargs.get("end") if scope == "range" else None
 
         if scope == "range" and (range_start is None or range_end is None):
-            return {"status": "error", "message": "scope 'range' requires start and end."}
+            return self._tool_error("scope 'range' requires start and end.")
 
         content = format_support.document_to_content(
             ctx.doc, ctx.ctx, ctx.services,
@@ -226,10 +226,10 @@ class ApplyDocumentContent(ToolBase):
         if not target and old_content is not None:
             target = "search"
         if not target:
-            return {"status": "error", "message": "Provide a target ('beginning', 'end', 'selection', 'full_document', 'search') or old_content for find-and-replace."}
+            return self._tool_error("Provide a target ('beginning', 'end', 'selection', 'full_document', 'search') or old_content for find-and-replace.")
         
         if target == "search" and old_content is None:
-            return {"status": "error", "message": "target='search' requires old_content."}
+            return self._tool_error("target='search' requires old_content.")
 
         # Normalize content:
         # - If the model (or caller) serialized a list as a JSON string,
@@ -304,7 +304,7 @@ class ApplyDocumentContent(ToolBase):
         # Normalize for literal find: single \n (e.g. from HTML wraps) -> space; \n\n -> \n. LO regex does not work across paragraphs.
         search_string = _normalize_search_string_for_find(search_string)
         if not search_string:
-            return {"status": "error", "message": "old_content is empty after normalization."}
+            return self._tool_error("old_content is empty after normalization.")
         doc = ctx.doc
         all_matches = kwargs.get("all_matches", False)
         if all_matches:
@@ -477,7 +477,7 @@ class InsertAtParagraph(ToolBase):
         position = kwargs.get("position", "before")
 
         if para_index is None:
-            return {"status": "error", "message": "Provide locator or paragraph_index."}
+            return self._tool_error("Provide locator or paragraph_index.")
 
         doc_svc = ctx.services.document
         para_ranges = doc_svc.get_paragraph_ranges(ctx.doc)
@@ -563,19 +563,16 @@ class ModifyParagraph(ToolBase):
         text = kwargs.get("text")
         style = kwargs.get("style")
         if text is None and style is None:
-            return {"status": "error",
-                    "message": "Provide at least one of text or style."}
+            return self._tool_error("Provide at least one of text or style.")
 
         para_index = _resolve_para_index(ctx, kwargs)
         if para_index is None:
-            return {"status": "error",
-                    "message": "Provide locator or paragraph_index."}
+            return self._tool_error("Provide locator or paragraph_index.")
 
         doc_svc = ctx.services.document
         target, _ = doc_svc.find_paragraph_element(ctx.doc, para_index)
         if target is None:
-            return {"status": "error",
-                    "message": "Paragraph %d not found." % para_index}
+            return self._tool_error("Paragraph %d not found." % para_index)
 
         result = {"status": "ok", "paragraph_index": para_index}
 
@@ -633,8 +630,7 @@ class DeleteParagraph(ToolBase):
     def execute(self, ctx, **kwargs):
         para_index = _resolve_para_index(ctx, kwargs)
         if para_index is None:
-            return {"status": "error",
-                    "message": "Provide locator or paragraph_index."}
+            return self._tool_error("Provide locator or paragraph_index.")
 
         doc_text = ctx.doc.getText()
         enum = doc_text.createEnumeration()
@@ -648,8 +644,7 @@ class DeleteParagraph(ToolBase):
             idx += 1
 
         if target is None:
-            return {"status": "error",
-                    "message": "Paragraph %d not found." % para_index}
+            return self._tool_error("Paragraph %d not found." % para_index)
 
         cursor = doc_text.createTextCursorByRange(target)
         cursor.gotoStartOfParagraph(False)
@@ -709,12 +704,11 @@ class DuplicateParagraph(ToolBase):
 
         para_index = _resolve_para_index(ctx, kwargs)
         if para_index is None:
-            return {"status": "error",
-                    "message": "Provide locator or paragraph_index."}
+            return self._tool_error("Provide locator or paragraph_index.")
 
         count = kwargs.get("count", 1)
         if count < 1:
-            return {"status": "error", "message": "count must be >= 1."}
+            return self._tool_error("count must be >= 1.")
 
         doc_text = ctx.doc.getText()
         enum = doc_text.createEnumeration()
@@ -729,8 +723,7 @@ class DuplicateParagraph(ToolBase):
             idx += 1
 
         if not elements:
-            return {"status": "error",
-                    "message": "Paragraph %d not found." % para_index}
+            return self._tool_error("Paragraph %d not found." % para_index)
 
         last = elements[-1]
         cursor = doc_text.createTextCursorByRange(last)
@@ -792,22 +785,19 @@ class CloneHeadingBlock(ToolBase):
 
         para_index = _resolve_para_index(ctx, kwargs)
         if para_index is None:
-            return {"status": "error",
-                    "message": "Provide locator or paragraph_index."}
+            return self._tool_error("Provide locator or paragraph_index.")
 
         # Use writer_tree service to find the heading node and block size
         tree_svc = ctx.services.get("writer_tree")
         if tree_svc is None:
-            return {"status": "error",
-                    "message": "writer_nav module not loaded; "
-                               "cannot resolve heading block."}
+            return self._tool_error("writer_nav module not loaded; "
+                               "cannot resolve heading block.")
 
         tree = tree_svc.build_heading_tree(ctx.doc)
         node = tree_svc._find_node_by_para_index(tree, para_index)
         if node is None:
-            return {"status": "error",
-                    "message": "No heading found at paragraph %d."
-                               % para_index}
+            return self._tool_error("No heading found at paragraph %d."
+                               % para_index)
 
         # Total paragraphs in the block: heading + body + all children
         total = 1 + tree_svc._count_all_children(node)
@@ -826,8 +816,7 @@ class CloneHeadingBlock(ToolBase):
             idx += 1
 
         if not elements:
-            return {"status": "error",
-                    "message": "Could not collect heading block paragraphs."}
+            return self._tool_error("Could not collect heading block paragraphs.")
 
         # Insert duplicates after the last element of the block
         last = elements[-1]
@@ -909,19 +898,17 @@ class InsertParagraphsBatch(ToolBase):
 
         paragraphs = kwargs.get("paragraphs")
         if not paragraphs:
-            return {"status": "error", "message": "Empty paragraphs list."}
+            return self._tool_error("Empty paragraphs list.")
 
         position = kwargs.get("position", "after")
         para_index = _resolve_para_index(ctx, kwargs)
         if para_index is None:
-            return {"status": "error",
-                    "message": "Provide locator or paragraph_index."}
+            return self._tool_error("Provide locator or paragraph_index.")
 
         doc_svc = ctx.services.document
         target, _ = doc_svc.find_paragraph_element(ctx.doc, para_index)
         if target is None:
-            return {"status": "error",
-                    "message": "Paragraph %d not found." % para_index}
+            return self._tool_error("Paragraph %d not found." % para_index)
 
         doc_text = ctx.doc.getText()
         cursor = doc_text.createTextCursorByRange(target)
@@ -958,8 +945,7 @@ class InsertParagraphsBatch(ToolBase):
                     cursor.setPropertyValue("ParaStyleName", sty)
                     cursor.gotoEndOfParagraph(False)
         else:
-            return {"status": "error",
-                    "message": "Invalid position: %s" % position}
+            return self._tool_error("Invalid position: %s" % position)
 
         n = len(paragraphs)
         return {

--- a/plugin/modules/writer/frames.py
+++ b/plugin/modules/writer/frames.py
@@ -106,7 +106,7 @@ class GetTextFrameInfo(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         frame_name = kwargs.get("frame_name", "")
         if not frame_name:
-            return {"status": "error", "message": "frame_name is required."}
+            return self._tool_error("frame_name is required.")
 
         frame = self.get_item(
             ctx.doc, "getTextFrames", frame_name,
@@ -228,7 +228,7 @@ class SetTextFrameProperties(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         frame_name = kwargs.get("frame_name", "")
         if not frame_name:
-            return {"status": "error", "message": "frame_name is required."}
+            return self._tool_error("frame_name is required.")
 
         frame = self.get_item(
             ctx.doc, "getTextFrames", frame_name,

--- a/plugin/modules/writer/search.py
+++ b/plugin/modules/writer/search.py
@@ -75,7 +75,7 @@ class SearchInDocument(ToolBase):
 
         pattern = kwargs.get("pattern", "")
         if not pattern:
-            return {"status": "error", "message": "pattern is required."}
+            return self._tool_error("pattern is required.")
 
         use_regex = kwargs.get("regex", False)
         case_sensitive = kwargs.get("case_sensitive", False)
@@ -168,7 +168,7 @@ class SearchInDocument(ToolBase):
                 "count": total_count,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 def _build_match(text, para_idx, ctx_paras, para_count, para_texts):
@@ -259,7 +259,7 @@ class AdvancedSearch(ToolBaseDummy):
                 context_paragraphs=kwargs.get("context_paragraphs", 1),
             )
         except ValueError as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
         # Post-process: add page numbers and filter by page proximity
         if include_pages and result.get("matches"):

--- a/plugin/modules/writer/structural.py
+++ b/plugin/modules/writer/structural.py
@@ -44,7 +44,7 @@ class ListSections(ToolBaseDummy):
                 })
             return {"status": "ok", "sections": sections, "count": len(sections)}
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GotoPage(ToolBaseDummy):
@@ -67,7 +67,7 @@ class GotoPage(ToolBaseDummy):
             vc.jumpToPage(kwargs["page"])
             return {"status": "ok", "page": vc.getPage()}
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetPageObjects(ToolBaseDummy):
@@ -101,7 +101,7 @@ class GetPageObjects(ToolBaseDummy):
                     resolved = doc_svc.resolve_locator(doc, locator)
                     para_idx = resolved.get("para_index", 0)
                 except ValueError as e:
-                    return {"status": "error", "error": str(e)}
+                    return self._tool_error(str(e))
             if para_idx is not None:
                 page = doc_svc.get_page_for_paragraph(doc, para_idx)
             else:
@@ -122,7 +122,7 @@ class GetPageObjects(ToolBaseDummy):
                 doc.unlockControllers()
             return {"status": "ok", "page": page, **objects}
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
     def _scan_page(self, doc, vc, page):
         images = []
@@ -187,7 +187,7 @@ class RefreshIndexes(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
         if not hasattr(doc, "getDocumentIndexes"):
-            return {"status": "error", "error": "Document does not support indexes"}
+            return self._tool_error("Document does not support indexes")
         try:
             indexes = doc.getDocumentIndexes()
             count = indexes.getCount()
@@ -199,7 +199,7 @@ class RefreshIndexes(ToolBaseDummy):
                 refreshed.append(name)
             return {"status": "ok", "refreshed": refreshed, "count": count}
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class ReadSection(ToolBaseDummy):
@@ -226,21 +226,18 @@ class ReadSection(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         section_name = kwargs.get("section_name", "")
         if not section_name:
-            return {"status": "error", "message": "section_name is required."}
+            return self._tool_error("section_name is required.")
 
         doc = ctx.doc
         if not hasattr(doc, "getTextSections"):
-            return {"status": "error", "message": "Document does not support sections."}
+            return self._tool_error("Document does not support sections.")
 
         try:
             sections = doc.getTextSections()
             if not sections.hasByName(section_name):
                 available = list(sections.getElementNames())
-                return {
-                    "status": "error",
-                    "message": "Section '%s' not found." % section_name,
-                    "available": available,
-                }
+                return self._tool_error("Section '%s' not found." % section_name,
+                    available=available)
 
             section = sections.getByName(section_name)
             anchor = section.getAnchor()
@@ -264,7 +261,7 @@ class ReadSection(ToolBaseDummy):
                 "length": len(content),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class ResolveBookmark(ToolBaseDummy):
@@ -292,11 +289,11 @@ class ResolveBookmark(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         bookmark_name = kwargs.get("bookmark_name", "")
         if not bookmark_name:
-            return {"status": "error", "message": "bookmark_name is required."}
+            return self._tool_error("bookmark_name is required.")
 
         doc = ctx.doc
         if not hasattr(doc, "getBookmarks"):
-            return {"status": "error", "message": "Document does not support bookmarks."}
+            return self._tool_error("Document does not support bookmarks.")
 
         try:
             bookmarks = doc.getBookmarks()
@@ -315,7 +312,7 @@ class ResolveBookmark(ToolBaseDummy):
                     ]
                     if existing:
                         hint += " Existing bookmarks: %s" % ", ".join(existing[:10])
-                return {"status": "error", "message": hint}
+                return self._tool_error(hint)
 
             bm = bookmarks.getByName(bookmark_name)
             anchor = bm.getAnchor()
@@ -348,7 +345,7 @@ class ResolveBookmark(ToolBaseDummy):
 
             return result
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class UpdateFields(ToolBaseDummy):
@@ -367,10 +364,7 @@ class UpdateFields(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
         if not hasattr(doc, "getTextFields"):
-            return {
-                "status": "error",
-                "message": "Document does not support text fields.",
-            }
+            return self._tool_error("Document does not support text fields.")
         try:
             fields = doc.getTextFields()
             fields.refresh()
@@ -384,7 +378,7 @@ class UpdateFields(ToolBaseDummy):
 
             return {"status": "ok", "fields_refreshed": count}
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 class ListBookmarks(ToolBaseDummy):
     name = "list_bookmarks"
@@ -413,7 +407,7 @@ class ListBookmarks(ToolBaseDummy):
                 })
             return {"status": "ok", "bookmarks": result, "count": len(result)}
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class CleanupBookmarks(ToolBaseDummy):

--- a/plugin/modules/writer/styles.py
+++ b/plugin/modules/writer/styles.py
@@ -143,10 +143,7 @@ class GetStyleInfo(ToolBase):
             return style_family
 
         if not style_family.hasByName(style_name):
-            return {
-                "status": "error",
-                "message": "Style '%s' not found in %s." % (style_name, family),
-            }
+            return self._tool_error("Style '%s' not found in %s." % (style_name, family))
 
         style = style_family.getByName(style_name)
         info = {

--- a/plugin/modules/writer/tables.py
+++ b/plugin/modules/writer/tables.py
@@ -163,13 +163,13 @@ log = logging.getLogger("writeragent.writer")
 #         start_cell = (kwargs.get("start_cell") or "A1").strip().upper()
 
 #         if not data or not isinstance(data, list):
-#             return {"status": "error", "message": "data must be a non-empty array of rows."}
+#             return self._tool_error("data must be a non-empty array of rows.")
 #         if not any(isinstance(row, list) and len(row) > 0 for row in data):
-#             return {"status": "error", "message": "data must contain at least one row with at least one value."}
+#             return self._tool_error("data must contain at least one row with at least one value.")
 
 #         parsed = _parse_cell(start_cell)
 #         if parsed is None:
-#             return {"status": "error", "message": "Invalid start_cell: %s (use Excel-style e.g. A1, B3)." % start_cell}
+#             return self._tool_error("Invalid start_cell: %s (use Excel-style e.g. A1, B3)." % start_cell)
 #         start_row, start_col = parsed
 
 #         table = self.get_item(
@@ -277,7 +277,7 @@ log = logging.getLogger("writeragent.writer")
 #         rows = kwargs.get("rows")
 #         cols = kwargs.get("cols")
 #         if rows < 1 or cols < 1:
-#             return {"status": "error", "message": "rows and cols must be >= 1."}
+#             return self._tool_error("rows and cols must be >= 1.")
 
 #         paragraph_index = kwargs.get("paragraph_index")
 #         locator = kwargs.get("locator")
@@ -389,7 +389,7 @@ def _col_letter(c):
 #         doc = ctx.doc
 #         tables_sup = doc.getTextTables()
 #         if not tables_sup.hasByName(table_name):
-#             return {"status": "error", "message": "Table '%s' not found." % table_name}
+#             return self._tool_error("Table '%s' not found." % table_name)
 
 #         table = tables_sup.getByName(table_name)
 #         try:
@@ -398,7 +398,7 @@ def _col_letter(c):
 #             text.removeTextContent(table)
 #             return {"status": "ok", "deleted": table_name}
 #         except Exception as e:
-#             return {"status": "error", "error": str(e)}
+#             return self._tool_error(str(e))
 
 
 # # ------------------------------------------------------------------
@@ -466,7 +466,7 @@ def _col_letter(c):
 #         doc = ctx.doc
 #         tables_sup = doc.getTextTables()
 #         if not tables_sup.hasByName(table_name):
-#             return {"status": "error", "message": "Table '%s' not found." % table_name}
+#             return self._tool_error("Table '%s' not found." % table_name)
 
 #         table = tables_sup.getByName(table_name)
 #         updated = []
@@ -584,7 +584,7 @@ def _col_letter(c):
 #         doc = ctx.doc
 #         tables_sup = doc.getTextTables()
 #         if not tables_sup.hasByName(table_name):
-#             return {"status": "error", "message": "Table '%s' not found." % table_name}
+#             return self._tool_error("Table '%s' not found." % table_name)
 
 #         table = tables_sup.getByName(table_name)
 #         rows = table.getRows()
@@ -603,7 +603,7 @@ def _col_letter(c):
 #                 "total_rows": rows.getCount(),
 #             }
 #         except Exception as e:
-#             return {"status": "error", "error": str(e)}
+#             return self._tool_error(str(e))
 
 
 # class AddTableColumns(ToolBase):
@@ -638,7 +638,7 @@ def _col_letter(c):
 #         doc = ctx.doc
 #         tables_sup = doc.getTextTables()
 #         if not tables_sup.hasByName(table_name):
-#             return {"status": "error", "message": "Table '%s' not found." % table_name}
+#             return self._tool_error("Table '%s' not found." % table_name)
 
 #         table = tables_sup.getByName(table_name)
 #         cols = table.getColumns()
@@ -657,7 +657,7 @@ def _col_letter(c):
 #                 "total_columns": cols.getCount(),
 #             }
 #         except Exception as e:
-#             return {"status": "error", "error": str(e)}
+#             return self._tool_error(str(e))
 
 
 # # ------------------------------------------------------------------
@@ -696,7 +696,7 @@ def _col_letter(c):
 #         doc = ctx.doc
 #         tables_sup = doc.getTextTables()
 #         if not tables_sup.hasByName(table_name):
-#             return {"status": "error", "message": "Table '%s' not found." % table_name}
+#             return self._tool_error("Table '%s' not found." % table_name)
 
 #         table = tables_sup.getByName(table_name)
 #         rows = table.getRows()
@@ -712,7 +712,7 @@ def _col_letter(c):
 #                 "total_rows": rows.getCount(),
 #             }
 #         except Exception as e:
-#             return {"status": "error", "error": str(e)}
+#             return self._tool_error(str(e))
 
 
 # class DeleteTableColumns(ToolBase):
@@ -747,7 +747,7 @@ def _col_letter(c):
 #         doc = ctx.doc
 #         tables_sup = doc.getTextTables()
 #         if not tables_sup.hasByName(table_name):
-#             return {"status": "error", "message": "Table '%s' not found." % table_name}
+#             return self._tool_error("Table '%s' not found." % table_name)
 
 #         table = tables_sup.getByName(table_name)
 #         cols = table.getColumns()
@@ -763,7 +763,7 @@ def _col_letter(c):
 #                 "total_columns": cols.getCount(),
 #             }
 #         except Exception as e:
-#             return {"status": "error", "error": str(e)}
+#             return self._tool_error(str(e))
 
 
 # # ------------------------------------------------------------------
@@ -809,7 +809,7 @@ def _col_letter(c):
 #         doc = ctx.doc
 #         tables_sup = doc.getTextTables()
 #         if not tables_sup.hasByName(table_name):
-#             return {"status": "error", "message": "Table '%s' not found." % table_name}
+#             return self._tool_error("Table '%s' not found." % table_name)
 
 #         table = tables_sup.getByName(table_name)
 #         cols = table.getColumns().getCount()

--- a/plugin/modules/writer/tracking.py
+++ b/plugin/modules/writer/tracking.py
@@ -137,7 +137,7 @@ class ManageTrackedChanges(ToolBaseDummy):
     def execute(self, ctx, **kwargs):
         action = kwargs.get("action")
         if action not in ("accept_all", "reject_all"):
-            return {"status": "error", "message": "Invalid action: %s" % action}
+            return self._tool_error("Invalid action: %s" % action)
 
         smgr = ctx.ctx.ServiceManager
         dispatcher = smgr.createInstanceWithContext(


### PR DESCRIPTION
Standardized tool error returns using `self._tool_error` across 8 Writer module python files to maintain consistent application error formatting. Checked all changes by running `pytest`. Replaced dictionary keys returning `"status": "error"` values appropriately. Deleted artifacts generated during modifications.

---
*PR created automatically by Jules for task [3642185738879114603](https://jules.google.com/task/3642185738879114603) started by @KeithCu*