### PR TITLE
Refactor Calc tools to use standardized _tool_error

### DIFF
--- a/plugin/modules/calc/cells.py
+++ b/plugin/modules/calc/cells.py
@@ -97,7 +97,7 @@ class ReadCellRange(ToolBase):
 
         try:
             if len(rn) == 0:
-                return {"status": "error", "error": "range_name is required"}
+                return self._tool_error("range_name is required")
             if len(rn) == 1:
                 result = inspector.read_range(rn[0])
                 return {"status": "ok", "result": [result]}
@@ -105,7 +105,7 @@ class ReadCellRange(ToolBase):
             return {"status": "ok", "result": results}
         except Exception as e:
             logger.exception("read_cell_range failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class WriteCellRange(ToolBase):
@@ -157,7 +157,7 @@ class WriteCellRange(ToolBase):
 
         try:
             if len(rn) == 0:
-                return {"status": "error", "error": "range_name is required"}
+                return self._tool_error("range_name is required")
             if len(rn) == 1:
                 result = manipulator.write_formula_range(rn[0], fov)
                 return {"status": "ok", "message": result}
@@ -166,7 +166,7 @@ class WriteCellRange(ToolBase):
             return {"status": "ok", "message": f"Wrote to {len(rn)} ranges"}
         except Exception as e:
             logger.exception("write_formula_range failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class SetCellStyle(ToolBase):
@@ -252,15 +252,15 @@ class SetCellStyle(ToolBase):
 
         bg_color = _parse_or_error("bg_color")
         if isinstance(bg_color, dict) and "__error__" in bg_color:
-            return {"status": "error", "error": bg_color["__error__"]}
+            return self._tool_error(bg_color["__error__"])
 
         font_color = _parse_or_error("font_color")
         if isinstance(font_color, dict) and "__error__" in font_color:
-            return {"status": "error", "error": font_color["__error__"]}
+            return self._tool_error(font_color["__error__"])
 
         border_color = _parse_or_error("border_color")
         if isinstance(border_color, dict) and "__error__" in border_color:
-            return {"status": "error", "error": border_color["__error__"]}
+            return self._tool_error(border_color["__error__"])
 
         style_kwargs = {
             "bold": kwargs.get("bold"),
@@ -277,7 +277,7 @@ class SetCellStyle(ToolBase):
 
         try:
             if len(rn) == 0:
-                return {"status": "error", "error": "range_name is required"}
+                return self._tool_error("range_name is required")
             if len(rn) == 1:
                 manipulator.set_cell_style(rn[0], **style_kwargs)
                 return {"status": "ok", "message": f"Style applied to {rn[0]}"}
@@ -289,7 +289,7 @@ class SetCellStyle(ToolBase):
             }
         except Exception as e:
             logger.exception("set_cell_style failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class MergeCells(ToolBase):
@@ -332,7 +332,7 @@ class MergeCells(ToolBase):
 
         try:
             if len(rn) == 0:
-                return {"status": "error", "error": "range_name is required"}
+                return self._tool_error("range_name is required")
             if len(rn) == 1:
                 manipulator.merge_cells(rn[0], center=center)
                 return {"status": "ok", "message": f"Merged cells {rn[0]}"}
@@ -344,7 +344,7 @@ class MergeCells(ToolBase):
             }
         except Exception as e:
             logger.exception("merge_cells failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class ClearRange(ToolBase):
@@ -380,7 +380,7 @@ class ClearRange(ToolBase):
 
         try:
             if len(rn) == 0:
-                return {"status": "error", "error": "range_name is required"}
+                return self._tool_error("range_name is required")
             if len(rn) == 1:
                 manipulator.clear_range(rn[0])
                 return {"status": "ok", "message": f"Cleared range {rn[0]}"}
@@ -392,7 +392,7 @@ class ClearRange(ToolBase):
             }
         except Exception as e:
             logger.exception("clear_range failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class SortRange(ToolBase):
@@ -452,7 +452,7 @@ class SortRange(ToolBase):
 
         try:
             if len(rn) == 0:
-                return {"status": "error", "error": "range_name is required"}
+                return self._tool_error("range_name is required")
             if len(rn) == 1:
                 result = manipulator.sort_range(
                     rn[0], sort_column=sort_column,
@@ -470,7 +470,7 @@ class SortRange(ToolBase):
             }
         except Exception as e:
             logger.exception("sort_range failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class ImportCsv(ToolBase):
@@ -510,7 +510,7 @@ class ImportCsv(ToolBase):
             return {"status": "ok", "message": result}
         except Exception as e:
             logger.exception("import_csv_from_string failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class DeleteStructure(ToolBase):
@@ -561,4 +561,4 @@ class DeleteStructure(ToolBase):
             return {"status": "ok", "message": result}
         except Exception as e:
             logger.exception("delete_structure failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/calc/charts.py
+++ b/plugin/modules/calc/charts.py
@@ -53,7 +53,7 @@ class ListCharts(ToolBase):
             }
         except Exception as e:
             logger.exception("list_charts failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetChartInfo(ToolBase):
@@ -84,12 +84,12 @@ class GetChartInfo(ToolBase):
         try:
             info = manipulator.get_chart_info(chart_name)
             if info is None:
-                return {"status": "error", "message": f"Chart '{chart_name}' not found."}
+                return self._tool_error(f"Chart '{chart_name}' not found.")
             info["status"] = "ok"
             return info
         except Exception as e:
             logger.exception("get_chart_info failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class CreateChart(ToolBase):
@@ -144,7 +144,7 @@ class CreateChart(ToolBase):
             return {"status": "ok", "message": result}
         except Exception as e:
             logger.exception("create_chart failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class EditChart(ToolBase):
@@ -194,7 +194,7 @@ class EditChart(ToolBase):
             return {"status": "ok", "chart_name": chart_name, "updated": updated}
         except Exception as e:
             logger.exception("edit_chart failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class DeleteChart(ToolBase):
@@ -224,7 +224,7 @@ class DeleteChart(ToolBase):
             if manipulator.delete_chart(chart_name):
                 return {"status": "ok", "deleted": chart_name}
             else:
-                return {"status": "error", "message": f"Chart '{chart_name}' not found."}
+                return self._tool_error(f"Chart '{chart_name}' not found.")
         except Exception as e:
             logger.exception("delete_chart failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/calc/comments.py
+++ b/plugin/modules/calc/comments.py
@@ -83,7 +83,7 @@ class ListCellComments(ToolBase):
                 "sheet": sheet.getName(),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class AddCellComment(ToolBase):
@@ -119,7 +119,7 @@ class AddCellComment(ToolBase):
         cell_ref = kwargs.get("cell", "")
         text = kwargs.get("text", "")
         if not cell_ref or not text:
-            return {"status": "error", "message": "cell and text are required."}
+            return self._tool_error("cell and text are required.")
 
         doc = ctx.doc
         try:
@@ -149,7 +149,7 @@ class AddCellComment(ToolBase):
                 "sheet": sheet.getName(),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class DeleteCellComment(ToolBase):
@@ -178,7 +178,7 @@ class DeleteCellComment(ToolBase):
     def execute(self, ctx, **kwargs):
         cell_ref = kwargs.get("cell", "")
         if not cell_ref:
-            return {"status": "error", "message": "cell is required."}
+            return self._tool_error("cell is required.")
 
         doc = ctx.doc
         try:
@@ -198,9 +198,6 @@ class DeleteCellComment(ToolBase):
                         "message": "Comment deleted.",
                     }
 
-            return {
-                "status": "error",
-                "message": "No comment found at %s." % cell_ref,
-            }
+            return self._tool_error("No comment found at %s." % cell_ref)
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/calc/conditional.py
+++ b/plugin/modules/calc/conditional.py
@@ -61,7 +61,7 @@ class ListConditionalFormats(ToolBase):
             }
         except Exception as e:
             logger.exception("list_conditional_formats failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class AddConditionalFormat(ToolBase):
@@ -133,7 +133,7 @@ class AddConditionalFormat(ToolBase):
             }
         except Exception as e:
             logger.exception("add_conditional_format failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class RemoveConditionalFormat(ToolBase):
@@ -169,10 +169,10 @@ class RemoveConditionalFormat(ToolBase):
             if manipulator.remove_conditional_format(kwargs["range_name"], kwargs["rule_index"]):
                 return {"status": "ok", "range_name": kwargs["range_name"], "removed_index": kwargs["rule_index"]}
             else:
-                return {"status": "error", "message": f"Rule index {kwargs['rule_index']} not found on {kwargs['range_name']}."}
+                return self._tool_error(f"Rule index {kwargs['rule_index']} not found on {kwargs['range_name']}.")
         except Exception as e:
             logger.exception("remove_conditional_format failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class ClearConditionalFormats(ToolBase):
@@ -202,4 +202,4 @@ class ClearConditionalFormats(ToolBase):
             return {"status": "ok", "range_name": kwargs["range_name"], "cleared": True}
         except Exception as e:
             logger.exception("clear_conditional_formats failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/calc/formulas.py
+++ b/plugin/modules/calc/formulas.py
@@ -86,4 +86,4 @@ class DetectErrors(ToolBase):
                 return {"status": "ok", "result": result}
         except Exception as e:
             logger.exception("detect_and_explain_errors failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/calc/navigation.py
+++ b/plugin/modules/calc/navigation.py
@@ -61,7 +61,7 @@ class ListNamedRanges(ToolBase):
                 "count": len(result),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetSheetOverview(ToolBase):
@@ -92,8 +92,7 @@ class GetSheetOverview(ToolBase):
             if sheet_name:
                 sheets = doc.getSheets()
                 if not sheets.hasByName(sheet_name):
-                    return {"status": "error",
-                            "message": "Sheet not found: %s" % sheet_name}
+                    return self._tool_error("Sheet not found: %s" % sheet_name)
                 sheet = sheets.getByName(sheet_name)
             else:
                 controller = doc.getCurrentController()
@@ -150,4 +149,4 @@ class GetSheetOverview(ToolBase):
 
             return result
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/calc/search.py
+++ b/plugin/modules/calc/search.py
@@ -77,7 +77,7 @@ class SearchInSpreadsheet(ToolBase):
     def execute(self, ctx, **kwargs):
         pattern = kwargs.get("pattern", "")
         if not pattern:
-            return {"status": "error", "message": "pattern is required."}
+            return self._tool_error("pattern is required.")
 
         use_regex = kwargs.get("regex", False)
         case_sensitive = kwargs.get("case_sensitive", False)
@@ -126,7 +126,7 @@ class SearchInSpreadsheet(ToolBase):
                 "count": len(matches),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class ReplaceInSpreadsheet(ToolBase):
@@ -175,7 +175,7 @@ class ReplaceInSpreadsheet(ToolBase):
         search = kwargs.get("search", "")
         replace = kwargs.get("replace", "")
         if not search:
-            return {"status": "error", "message": "search is required."}
+            return self._tool_error("search is required.")
 
         use_regex = kwargs.get("regex", False)
         case_sensitive = kwargs.get("case_sensitive", False)
@@ -213,4 +213,4 @@ class ReplaceInSpreadsheet(ToolBase):
                 "replace": replace,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/calc/sheets.py
+++ b/plugin/modules/calc/sheets.py
@@ -53,7 +53,7 @@ class ListSheets(ToolBase):
             return {"status": "ok", "result": result}
         except Exception as e:
             logger.exception("list_sheets failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class SwitchSheet(ToolBase):
@@ -85,7 +85,7 @@ class SwitchSheet(ToolBase):
             return {"status": "ok", "message": result}
         except Exception as e:
             logger.exception("switch_sheet failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class CreateSheet(ToolBase):
@@ -125,7 +125,7 @@ class CreateSheet(ToolBase):
             return {"status": "ok", "message": result}
         except Exception as e:
             logger.exception("create_sheet failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetSheetSummary(ToolBase):
@@ -160,4 +160,4 @@ class GetSheetSummary(ToolBase):
             return {"status": "ok", "result": result}
         except Exception as e:
             logger.exception("get_sheet_summary failed")
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))


### PR DESCRIPTION
Refactored error payload returns in all `plugin/modules/calc/` files (`cells.py`, `formulas.py`, `charts.py`, `conditional.py`, `comments.py`, `search.py`, `sheets.py`, `navigation.py`) to use `self._tool_error(message)` instead of hardcoded `{"status": "error", "error": ...}` dictionaries. This ensures consistent error formats across the codebase.

---
*PR created automatically by Jules for task [4537700818857977387](https://jules.google.com/task/4537700818857977387) started by @KeithCu*