### PR TITLE
Refactor error handling in legacy and optional modules

### DIFF
--- a/plugin/framework/legacy_ui.py
+++ b/plugin/framework/legacy_ui.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
+from plugin.framework.errors import format_error_payload
 from plugin.framework.uno_context import get_desktop, get_active_document, get_extension_url
 from plugin.framework.dialogs import TabListener, is_checkbox_control, get_checkbox_state, set_checkbox_state, get_optional
 from plugin.framework.config import get_config, get_current_endpoint, get_text_model, populate_combobox_with_lru, set_config, update_lru_history
@@ -309,7 +310,7 @@ def settings_box(ctx, title="Settings", x=None, y=None):
         from plugin.framework.dialogs import msgbox
         import traceback
         msgbox(ctx, "Error", f"Failed to open Settings: {e}\n\n{traceback.format_exc()}")
-        return {}
+        return format_error_payload(e)
     finally:
         dlg.dispose()
 

--- a/plugin/modules/agent_backend/acp_connection.py
+++ b/plugin/modules/agent_backend/acp_connection.py
@@ -26,6 +26,8 @@ import os
 import subprocess
 import threading
 
+from plugin.framework.errors import ToolExecutionError
+
 log = logging.getLogger(__name__)
 
 _LOG = "ABP"
@@ -102,7 +104,7 @@ class ACPConnection:
     def send_request(self, method, params=None, timeout=120):
         """Send a JSON-RPC request and wait for the response."""
         if not self.is_alive:
-            raise RuntimeError("ACP process is not running")
+            raise ToolExecutionError("ACP process is not running")
 
         req_id = self._next_id()
         msg = {
@@ -125,7 +127,7 @@ class ACPConnection:
         except (BrokenPipeError, OSError) as e:
             with self._lock:
                 self._pending.pop(req_id, None)
-            raise RuntimeError(f"Failed to write to ACP: {e}") from e
+            raise ToolExecutionError(f"Failed to write to ACP: {e}") from e
 
         if not event.wait(timeout=timeout):
             with self._lock:
@@ -139,7 +141,7 @@ class ACPConnection:
         if resp and "error" in resp:
             err = resp["error"]
             msg_str = err.get("message", str(err)) if isinstance(err, dict) else str(err)
-            raise RuntimeError(f"ACP error: {msg_str}")
+            raise ToolExecutionError(f"ACP error: {msg_str}")
 
         return resp.get("result") if resp else None
 

--- a/plugin/modules/agent_backend/builtin.py
+++ b/plugin/modules/agent_backend/builtin.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Built-in backend: no-op. Sidebar uses the existing in-process LlmClient path."""
 
+from plugin.framework.errors import format_error_payload
 from plugin.modules.agent_backend.base import AgentBackend
 
 
@@ -25,4 +26,4 @@ class BuiltinBackend(AgentBackend):
 
     def send(self, queue, user_message, document_context, document_url, **kwargs):
         # Should not be called; sidebar branches away when backend is builtin.
-        queue.put(("error", RuntimeError("Built-in backend should not receive send()")))
+        queue.put(("error", format_error_payload(RuntimeError("Built-in backend should not receive send()"))))

--- a/plugin/modules/agent_backend/claude_proxy.py
+++ b/plugin/modules/agent_backend/claude_proxy.py
@@ -27,6 +27,7 @@ import shutil
 import threading
 import time
 
+from plugin.framework.errors import format_error_payload
 from plugin.modules.agent_backend.base import AgentBackend
 from plugin.modules.agent_backend.acp_connection import ACPConnection
 log = logging.getLogger(__name__)
@@ -205,7 +206,7 @@ class ClaudeBackend(AgentBackend):
         try:
             self._ensure_session(mcp_url=mcp_url, document_url=document_url)
         except Exception as e:
-            queue.put(("error", RuntimeError(f"Session creation failed: {e}")))
+            queue.put(("error", format_error_payload(RuntimeError(f"Session creation failed: {e}"))))
             return
 
         queue.put(("status", f"Sending to {self.display_name}..."))
@@ -247,13 +248,13 @@ class ClaudeBackend(AgentBackend):
             queue.put(("stream_done", None))
 
         except TimeoutError:
-            queue.put(("error", RuntimeError(f"{self.display_name} prompt timed out")))
+            queue.put(("error", format_error_payload(RuntimeError(f"{self.display_name} prompt timed out"))))
         except Exception as e:
             if self._stop_requested:
                 queue.put(("stopped",))
             else:
                 log.error(f"Claude prompt error: {e}")
-                queue.put(("error", e))
+                queue.put(("error", format_error_payload(e)))
         finally:
             self._conn.set_notification_callback(None)
             self._prompt_done.set()

--- a/plugin/modules/agent_backend/cli_backend.py
+++ b/plugin/modules/agent_backend/cli_backend.py
@@ -28,6 +28,8 @@ import subprocess
 import threading
 import time
 
+from plugin.framework.errors import format_error_payload
+
 try:
     import pty
     _PTY_AVAILABLE = True
@@ -235,15 +237,15 @@ class CLIProcessBackend(AgentBackend):
                         f"{self.display_name} subprocess ended unexpectedly (I/O error). "
                         "Check backend configuration."
                     )
-                    self._current_queue.put(("error", RuntimeError(msg)))
+                    self._current_queue.put(("error", format_error_payload(RuntimeError(msg))))
             else:
                 log.error(f"reader_loop: exception {e}")
                 if self._current_queue is not None:
-                    self._current_queue.put(("error", e))
+                    self._current_queue.put(("error", format_error_payload(e)))
         except Exception as e:
             log.error(f"reader_loop: exception {e}")
             if self._current_queue is not None:
-                self._current_queue.put(("error", e))
+                self._current_queue.put(("error", format_error_payload(e)))
         finally:
             log.debug(f"reader_loop: exiting (total lines read={line_count[0]}, level=logging.DEBUG), setting _response_done")
             self._response_done.set()
@@ -475,7 +477,7 @@ class CLIProcessBackend(AgentBackend):
                     ),
                 ))
             else:
-                queue.put(("error", RuntimeError(f"{self.display_name} did not start correctly within 30s.")))
+                queue.put(("error", format_error_payload(RuntimeError(f"{self.display_name} did not start correctly within 30s."))))
             return
 
         queue.put(("status", f"Waiting for {self.display_name}..."))
@@ -488,7 +490,7 @@ class CLIProcessBackend(AgentBackend):
                 log.debug(f"send(, level=logging.DEBUG): {self.display_name} died during wait, code={proc.returncode}")
                 # Fall through to the error handler logic at the end of send() or handle here
                 self._current_queue = None
-                queue.put(("error", RuntimeError(f"{self.display_name} exited with code {proc.returncode} before turn started.")))
+                queue.put(("error", format_error_payload(RuntimeError(f"{self.display_name} exited with code {proc.returncode} before turn started."))))
                 return
             # We'll try to proceed anyway, but it might fail
         else:
@@ -508,7 +510,7 @@ class CLIProcessBackend(AgentBackend):
         except Exception as e:
             self._current_queue = None
             log.debug(f"send(, level=logging.DEBUG): write failed {e}")
-            queue.put(("error", e))
+            queue.put(("error", format_error_payload(e)))
             return
 
         timeout_seconds = 300
@@ -541,7 +543,7 @@ class CLIProcessBackend(AgentBackend):
             if not err:
                 err = f"{self.display_name} exited with code {proc.returncode}."
             log.debug(f"send(, level=logging.DEBUG): process exited, returncode={proc.returncode}, stderr: {err[:300]}")
-            queue.put(("error", RuntimeError(err)))
+            queue.put(("error", format_error_payload(RuntimeError(err))))
         elif self._stop_requested or (stop_checker and stop_checker()):
             queue.put(("stopped",))
         else:

--- a/plugin/modules/agent_backend/hermes_proxy.py
+++ b/plugin/modules/agent_backend/hermes_proxy.py
@@ -36,6 +36,7 @@ import shutil
 import threading
 import time
 
+from plugin.framework.errors import format_error_payload
 from plugin.modules.agent_backend.base import AgentBackend
 from plugin.modules.agent_backend.acp_connection import ACPConnection
 log = logging.getLogger(__name__)
@@ -235,7 +236,7 @@ class HermesBackend(AgentBackend):
         try:
             self._ensure_session(mcp_url=mcp_url, document_url=document_url)
         except Exception as e:
-            queue.put(("error", RuntimeError(f"Session creation failed: {e}")))
+            queue.put(("error", format_error_payload(RuntimeError(f"Session creation failed: {e}"))))
             return
 
         queue.put(("status", f"Sending to {self.display_name}..."))
@@ -306,13 +307,13 @@ class HermesBackend(AgentBackend):
             queue.put(("stream_done", None))
 
         except TimeoutError:
-            queue.put(("error", RuntimeError(f"{self.display_name} prompt timed out")))
+            queue.put(("error", format_error_payload(RuntimeError(f"{self.display_name} prompt timed out"))))
         except Exception as e:
             if self._stop_requested:
                 queue.put(("stopped",))
             else:
                 log.error(f"Prompt error: {e}")
-                queue.put(("error", e))
+                queue.put(("error", format_error_payload(e)))
         finally:
             self._conn.set_notification_callback(None)
             self._prompt_done.set()

--- a/plugin/modules/tunnel/__init__.py
+++ b/plugin/modules/tunnel/__init__.py
@@ -36,14 +36,14 @@ _CREATION_FLAGS = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
 class TunnelError(WriterAgentException):
     """General tunnel error."""
-    def __init__(self, message, code="TUNNEL_ERROR", context=None):
-        super().__init__(message, code=code, context=context)
+    def __init__(self, message, code="TUNNEL_ERROR", details=None):
+        super().__init__(message, code=code, details=details)
 
 
 class TunnelAuthError(TunnelError):
     """Provider requires authentication credentials."""
-    def __init__(self, message, context=None):
-        super().__init__(message, code="TUNNEL_AUTH_ERROR", context=context)
+    def __init__(self, message, details=None):
+        super().__init__(message, code="TUNNEL_AUTH_ERROR", details=details)
 
 
 def get_provider_options(services):

--- a/plugin/modules/tunnel/providers/ngrok.py
+++ b/plugin/modules/tunnel/providers/ngrok.py
@@ -19,6 +19,8 @@
 import json
 import logging
 
+from plugin.modules.tunnel import TunnelAuthError
+
 log = logging.getLogger("writeragent.tunnel.ngrok")
 
 
@@ -61,7 +63,6 @@ class NgrokProvider:
             # This appears in 'err' or as a log message
             err = data.get("err") or data.get("error")
             if err and "ERR_NGROK_105" in str(err):
-                from .. import TunnelAuthError
                 raise TunnelAuthError("ngrok authtoken required")
 
         except Exception:


### PR DESCRIPTION
Standardizes error handling across several modules by leveraging the unified `format_error_payload` and base `WriterAgentException` schema.
- Updated `legacy_ui.py` to return formatted payloads.
- Realigned `TunnelError` and `TunnelAuthError` in `tunnel/__init__.py` to use `details` instead of `context`.
- Wrapped error queue pushes in all `agent_backend` proxies with `format_error_payload`.
- Replaced instances of raw `RuntimeError` with `ToolExecutionError` in `acp_connection.py`.

---
*PR created automatically by Jules for task [12230858410296963800](https://jules.google.com/task/12230858410296963800) started by @KeithCu*