### PR TITLE
Refactor Tool Registration with Auto-Discovery

### DIFF
--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -52,6 +52,28 @@ class ToolRegistry:
         for t in tools:
             self.register(t)
 
+    def auto_discover(self, module):
+        """Automatically discover and register ToolBase subclasses in a module."""
+        import inspect
+        from plugin.framework.tool_base import ToolBase, ToolBaseDummy
+
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            # Must inherit from ToolBase, but not be ToolBase itself or ToolBaseDummy
+            # Must be defined in this module to avoid double registration from imports
+            # Also exclude abstract classes or classes without a defined 'name'
+            if (issubclass(obj, ToolBase) and
+                obj is not ToolBase and
+                not issubclass(obj, ToolBaseDummy) and
+                obj.__module__ == module.__name__ and
+                not inspect.isabstract(obj) and
+                getattr(obj, "name", None)):
+
+                try:
+                    tool_instance = obj()
+                    self.register(tool_instance)
+                except Exception as e:
+                    log.error("Failed to instantiate tool %s: %s", obj.__name__, e)
+
     # ── Lookup & Schema Generation ────────────────────────────────────
 
     def get_tools(self, doc_type=None, tier=None, intent=None, names=None, filter_doc_type=True):

--- a/plugin/modules/calc/__init__.py
+++ b/plugin/modules/calc/__init__.py
@@ -26,44 +26,7 @@ class CalcModule(ModuleBase):
     def initialize(self, services):
         self.services = services
 
-        from .conditional import ListConditionalFormats, AddConditionalFormat, RemoveConditionalFormat, ClearConditionalFormats
-        from .charts import ListCharts, GetChartInfo, CreateChart, EditChart, DeleteChart
-        from .navigation import ListNamedRanges, GetSheetOverview
-        from .cells import ReadCellRange, WriteCellRange, SetCellStyle, MergeCells, ClearRange, SortRange, ImportCsv, DeleteStructure
-        from .formulas import DetectErrors
-        from .sheets import ListSheets, SwitchSheet, CreateSheet, GetSheetSummary
-        from .search import SearchInSpreadsheet, ReplaceInSpreadsheet
-        from .comments import ListCellComments, AddCellComment, DeleteCellComment
+        from . import conditional, charts, navigation, cells, formulas, sheets, search, comments
 
-        tools = [
-            ListConditionalFormats(),
-            AddConditionalFormat(),
-            RemoveConditionalFormat(),
-            ClearConditionalFormats(),
-            ListCharts(),
-            GetChartInfo(),
-            CreateChart(),
-            EditChart(),
-            DeleteChart(),
-            ListNamedRanges(),
-            GetSheetOverview(),
-            ReadCellRange(),
-            WriteCellRange(),
-            SetCellStyle(),
-            MergeCells(),
-            ClearRange(),
-            SortRange(),
-            ImportCsv(),
-            DeleteStructure(),
-            DetectErrors(),
-            ListSheets(),
-            SwitchSheet(),
-            CreateSheet(),
-            GetSheetSummary(),
-            SearchInSpreadsheet(),
-            ReplaceInSpreadsheet(),
-            ListCellComments(),
-            AddCellComment(),
-            DeleteCellComment(),
-        ]
-        services.tools.register_many(tools)
+        for module in (conditional, charts, navigation, cells, formulas, sheets, search, comments):
+            services.tools.auto_discover(module)

--- a/plugin/modules/chatbot/__init__.py
+++ b/plugin/modules/chatbot/__init__.py
@@ -31,8 +31,8 @@ class ChatbotModule(ModuleBase):
         self._routes_registered = False
         self._api_handler = None
 
-        from .web_research import WebResearchTool
-        services.tools.register_many([WebResearchTool()])
+        from . import web_research
+        services.tools.auto_discover(web_research)
 
         # Chat tool routing is now handled natively by main.py's get_tools() instead of ChatToolAdapter
         self._adapter = None

--- a/plugin/modules/draw/__init__.py
+++ b/plugin/modules/draw/__init__.py
@@ -25,34 +25,7 @@ class DrawModule(ModuleBase):
     def initialize(self, services):
         self.services = services
 
-        from .pages import AddSlide, DeleteSlide, ReadSlideText, GetPresentationInfo
-        from .transitions import GetSlideTransition, SetSlideTransition, GetSlideLayout, SetSlideLayout
-        from .masters import ListMasterSlides, GetSlideMaster, SetSlideMaster
-        from .notes import GetSpeakerNotes, SetSpeakerNotes
-        from .shapes import ListPages, GetDrawSummary, CreateShape, EditShape, DeleteShape
-        from .placeholders import ListPlaceholders, GetPlaceholderText, SetPlaceholderText
+        from . import pages, transitions, masters, notes, shapes, placeholders
 
-        tools = [
-            AddSlide(),
-            DeleteSlide(),
-            ReadSlideText(),
-            GetPresentationInfo(),
-            GetSlideTransition(),
-            SetSlideTransition(),
-            GetSlideLayout(),
-            SetSlideLayout(),
-            ListMasterSlides(),
-            GetSlideMaster(),
-            SetSlideMaster(),
-            GetSpeakerNotes(),
-            SetSpeakerNotes(),
-            ListPages(),
-            GetDrawSummary(),
-            CreateShape(),
-            EditShape(),
-            DeleteShape(),
-            ListPlaceholders(),
-            GetPlaceholderText(),
-            SetPlaceholderText(),
-        ]
-        services.tools.register_many(tools)
+        for module in (pages, transitions, masters, notes, shapes, placeholders):
+            services.tools.auto_discover(module)

--- a/plugin/modules/writer/__init__.py
+++ b/plugin/modules/writer/__init__.py
@@ -45,42 +45,7 @@ class WriterModule(ModuleBase):
         services.register("writer_index", idx)
 
         # Register tools
-        from .outline import GetDocumentTree
-        from .styles import ListStyles, GetStyleInfo
-        from .images import GenerateImage
-        from .content import GetDocumentContent, ApplyDocumentContent, ReadParagraphs, InsertAtParagraph, ModifyParagraph, DeleteParagraph, DuplicateParagraph, CloneHeadingBlock, InsertParagraphsBatch, GetDocumentStats
-        from .search import SearchInDocument, GetIndexStats
-        from .comments import ListComments, AddComment, DeleteComment
-        from .tracking import SetTrackChanges, GetTrackedChanges, ManageTrackedChanges
-        from .frames import ListTextFrames, GetTextFrameInfo, SetTextFrameProperties
+        from . import outline, styles, images, content, search, comments, tracking, frames
 
-        tools = [
-            GetDocumentTree(),
-            ListStyles(),
-            GetStyleInfo(),
-            GenerateImage(),
-            GetDocumentContent(),
-            ApplyDocumentContent(),
-            ReadParagraphs(),
-            InsertAtParagraph(),
-            ModifyParagraph(),
-            DeleteParagraph(),
-            DuplicateParagraph(),
-            CloneHeadingBlock(),
-            InsertParagraphsBatch(),
-            GetDocumentStats(),
-            SearchInDocument(),
-            GetIndexStats(),
-            ListComments(),
-            AddComment(),
-            DeleteComment(),
-            # Table tools: uncomment classes in tables.py, then import/register here.
-            # ReplaceSection / FindParagraphForRange / FindTableForRange: add to structural.py when needed.
-            SetTrackChanges(),
-            GetTrackedChanges(),
-            ManageTrackedChanges(),
-            ListTextFrames(),
-            GetTextFrameInfo(),
-            SetTextFrameProperties(),
-        ]
-        services.tools.register_many(tools)
+        for module in (outline, styles, images, content, search, comments, tracking, frames):
+            services.tools.auto_discover(module)


### PR DESCRIPTION
This PR introduces an auto-discovery mechanism for `ToolBase` subclasses across the various feature modules (`writer`, `calc`, `draw`, and `chatbot`). By using Python's `inspect` module, the `ToolRegistry` can now dynamically discover, instantiate, and register tools defined within a specific submodule. This eliminates the need for long, manually curated lists of imports and tool instantiations in the `__init__.py` files, significantly reducing boilerplate and making the process of adding new tools more straightforward.

Code review feedback has been implemented to verify `obj.__module__ == module.__name__`, preventing accidental double-registration from imports. Tested against existing pytest suites to ensure functional parity.

---
*PR created automatically by Jules for task [11190789860379595951](https://jules.google.com/task/11190789860379595951) started by @KeithCu*