### PR TITLE
Remove DocumentCache layer from Writer integration

### DIFF
--- a/plugin/framework/document.py
+++ b/plugin/framework/document.py
@@ -146,28 +146,28 @@ def normalize_linebreaks(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\n\r", "\n").replace("\r", "\n")
 
 
-class DocumentCache:
-    """Cache for expensive UNO calls, tied to a document model."""
-    _instances = {}  # {id(model): cache}
-
-    def __init__(self):
-        self.length = None
-        self.para_ranges = None
-        self.page_cache = {}  # (search_key) -> page_number
-        self.last_invalidated = time.time()
-
-    @classmethod
-    def get(cls, model):
-        mid = id(model)
-        if mid not in cls._instances:
-            cls._instances[mid] = DocumentCache()
-        return cls._instances[mid]
-
-    @classmethod
-    def invalidate(cls, model):
-        mid = id(model)
-        if mid in cls._instances:
-            del cls._instances[mid]
+# class DocumentCache:
+#     """Cache for expensive UNO calls, tied to a document model."""
+#     _instances = {}  # {id(model): cache}
+#
+#     def __init__(self):
+#         self.length = None
+#         self.para_ranges = None
+#         self.page_cache = {}  # (search_key) -> page_number
+#         self.last_invalidated = time.time()
+#
+#     @classmethod
+#     def get(cls, model):
+#         mid = id(model)
+#         if mid not in cls._instances:
+#             cls._instances[mid] = DocumentCache()
+#         return cls._instances[mid]
+#
+#     @classmethod
+#     def invalidate(cls, model):
+#         mid = id(model)
+#         if mid in cls._instances:
+#             del cls._instances[mid]
 
 
 
@@ -285,16 +285,12 @@ _GO_RIGHT_CHUNK = 8192
 
 def get_document_length(model):
     """Return total character length of the document. Returns 0 on error."""
-    cache = DocumentCache.get(model)
-    if cache.length is not None:
-        return cache.length
     try:
         text = model.getText()
         cursor = text.createTextCursor()
         cursor.gotoStart(False)
         cursor.gotoEnd(True)
         length = len(normalize_linebreaks(cursor.getString()))
-        cache.length = length
         return length
     except Exception as e:
         logging.getLogger(__name__).warning("get_document_length exception: %s", type(e).__name__)
@@ -552,17 +548,12 @@ def _inject_markers_into_excerpt(excerpt_text, excerpt_start, excerpt_end, sel_s
 import uuid
 
 def get_paragraph_ranges(model):
-    """Return list of top-level paragraph elements. Uses DocumentCache."""
-    cache = DocumentCache.get(model)
-    if cache.para_ranges is not None:
-        return cache.para_ranges
-    
+    """Return list of top-level paragraph elements."""
     text = model.getText()
     enum = text.createEnumeration()
     ranges = []
     while enum.hasMoreElements():
         ranges.append(enum.nextElement())
-    cache.para_ranges = ranges
     return ranges
 
 
@@ -626,8 +617,6 @@ def build_heading_tree(model):
 
 def ensure_heading_bookmarks(model):
     """Ensure every heading has an _mcp_ bookmark. Returns {para_index: bookmark_name}."""
-    cache = DocumentCache.get(model)
-    
     text = model.getText()
     para_ranges = get_paragraph_ranges(model)
     
@@ -730,9 +719,6 @@ class DocumentService(ServiceBase):
         if is_calc(doc): return "calc"
         if is_draw(doc): return "draw"
         return "writer"
-
-    def invalidate_cache(self, doc):
-        DocumentCache.invalidate(doc)
 
     def is_writer(self, doc): return is_writer(doc)
     def is_calc(self, doc): return is_calc(doc)

--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -182,12 +182,6 @@ class ToolRegistry:
         if bus:
             bus.emit("tool:executing", name=tool_name, caller=ctx.caller)
 
-        # Invalidate document cache on mutations (skipped in batch mode)
-        if tool.detects_mutation() and not self.batch_mode:
-            doc_svc = self._services.get("document")
-            if doc_svc:
-                doc_svc.invalidate_cache(ctx.doc)
-
         try:
             result = tool.execute(ctx, **kwargs)
             # Ensure any returned dict with status='error' includes full context details

--- a/plugin/modules/calc/search.py
+++ b/plugin/modules/calc/search.py
@@ -202,10 +202,6 @@ class ReplaceInSpreadsheet(ToolBase):
                 rd.SearchCaseSensitive = bool(case_sensitive)
                 total += sheet.replaceAll(rd)
 
-            if total > 0:
-                doc_svc = ctx.services.document
-                doc_svc.invalidate_cache(doc)
-
             return {
                 "status": "ok",
                 "replacements": total,

--- a/plugin/tests/test_tool_registry.py
+++ b/plugin/tests/test_tool_registry.py
@@ -163,22 +163,15 @@ class TestSchemas:
 
 
 class TestExecuteEventsAndInvalidation:
-    """Tests that execute() emits events and invalidates document cache (from test_registry)."""
+    """Tests that execute() emits events."""
 
-    def test_execute_emits_events_and_invalidates_cache(self):
+    def test_execute_emits_events(self):
         class MockEventBus:
             def __init__(self):
                 self.events = []
 
             def emit(self, event, **kwargs):
                 self.events.append((event, kwargs))
-
-        class MockDocumentService:
-            def __init__(self):
-                self.invalidated = []
-
-            def invalidate_cache(self, doc):
-                self.invalidated.append(doc)
 
         class ToolWithParams(ToolBase):
             name = "tool_with_params"
@@ -191,9 +184,7 @@ class TestExecuteEventsAndInvalidation:
 
         services = ServiceRegistry()
         events = MockEventBus()
-        doc_svc = MockDocumentService()
         services.register("events", events)
-        services.register("document", doc_svc)
 
         reg = ToolRegistry(services)
         reg.register(ToolWithParams())
@@ -205,23 +196,14 @@ class TestExecuteEventsAndInvalidation:
         assert len(events.events) == 2
         assert events.events[0][0] == "tool:executing"
         assert events.events[1][0] == "tool:completed"
-        assert len(doc_svc.invalidated) == 1
-        assert doc_svc.invalidated[0] is ctx.doc
 
-    def test_execute_failure_emits_events_and_invalidates_cache(self):
+    def test_execute_failure_emits_events(self):
         class MockEventBus:
             def __init__(self):
                 self.events = []
 
             def emit(self, event, **kwargs):
                 self.events.append((event, kwargs))
-
-        class MockDocumentService:
-            def __init__(self):
-                self.invalidated = []
-
-            def invalidate_cache(self, doc):
-                self.invalidated.append(doc)
 
         class FailingToolWithParams(ToolBase):
             name = "failing_tool_with_params"
@@ -234,9 +216,7 @@ class TestExecuteEventsAndInvalidation:
 
         services = ServiceRegistry()
         events = MockEventBus()
-        doc_svc = MockDocumentService()
         services.register("events", events)
-        services.register("document", doc_svc)
 
         reg = ToolRegistry(services)
         reg.register(FailingToolWithParams())
@@ -251,7 +231,4 @@ class TestExecuteEventsAndInvalidation:
         assert events.events[0][0] == "tool:executing"
         assert events.events[1][0] == "tool:failed"
         assert events.events[1][1]["error"] == "something went wrong"
-
-        assert len(doc_svc.invalidated) == 1
-        assert doc_svc.invalidated[0] is ctx.doc
 

--- a/plugin/tests/uno/core_tests.py
+++ b/plugin/tests/uno/core_tests.py
@@ -1,4 +1,3 @@
-from plugin.framework.document import DocumentCache
 from plugin.framework.uno_context import get_desktop
 from plugin.testing_runner import setup, teardown, native_test
 

--- a/plugin/tests/uno/core_tests.py
+++ b/plugin/tests/uno/core_tests.py
@@ -37,21 +37,6 @@ def teardown_framework_tests(ctx):
 
 
 @native_test
-def test_document_cache():
-    cache1 = DocumentCache.get(_test_doc1)
-    cache1_again = DocumentCache.get(_test_doc1)
-    assert cache1 is cache1_again, "DocumentCache returned different instances for same model"
-
-    cache2 = DocumentCache.get(_test_doc2)
-    assert cache1 is not cache2, "DocumentCache returned same instance for different model"
-
-    DocumentCache.invalidate(_test_doc1)
-    DocumentCache.invalidate(_test_doc2)
-    cache1_new = DocumentCache.get(_test_doc1)
-    assert cache1 is not cache1_new, "DocumentCache.invalidate failed"
-
-
-@native_test
 def test_event_bus():
     from plugin.framework.event_bus import EventBus
     events = EventBus()

--- a/plugin/tests/uno/test_writer.py
+++ b/plugin/tests/uno/test_writer.py
@@ -1,5 +1,4 @@
 from plugin.framework.document import (
-    DocumentCache,
     build_heading_tree,
     resolve_locator,
     get_paragraph_ranges,
@@ -88,13 +87,12 @@ def test_proximity_service():
     from plugin.modules.writer.ops import find_paragraph_for_range as ops_find_paragraph_for_range
 
     events = EventBus()
-    cache3 = DocumentCache.get(_test_doc)
 
     class DocSvcAdapter:
         def doc_key(self, doc):
             return id(doc)
         def get_document_length(self, model):
-            return cache3.length
+            return get_document_length(model)
         def resolve_locator(self, doc, locator):
             return resolve_locator(doc, locator)
         def get_paragraph_ranges(self, doc):

--- a/plugin/tests/uno/test_writer.py
+++ b/plugin/tests/uno/test_writer.py
@@ -256,30 +256,6 @@ def test_writer_structural_and_tree_service():
 
 
 @native_test
-def test_document_cache_length_tracking():
-    try:
-        import pytest
-        if _test_doc is None:
-            pytest.skip("Requires LibreOffice document from native runner")
-    except ImportError:
-        pass
-    cache3 = DocumentCache.get(_test_doc)
-    _ = get_document_length(_test_doc)
-    prev_len = cache3.length
-    assert prev_len is not None and prev_len > 0, "DocumentCache length not properly initialized"
-
-    text = _test_doc.getText()
-    cursor = text.createTextCursor()
-    text.insertControlCharacter(cursor, 0, False)
-    text.insertString(cursor, "More text", False)
-    DocumentCache.invalidate(_test_doc)
-    _ = get_document_length(_test_doc)
-    cache3_new = DocumentCache.get(_test_doc)
-    new_len = cache3_new.length
-    assert new_len is not None and new_len > prev_len, "DocumentCache length did not update"
-
-
-@native_test
 def test_get_text_cursor_at_range():
     try:
         import pytest

--- a/plugin/tests/uno/test_writer_navigation.py
+++ b/plugin/tests/uno/test_writer_navigation.py
@@ -28,23 +28,12 @@ except ImportError:
 
 from plugin.tests.testing_utils import ElementStub, WriterDocStub
 from plugin.framework.document import (
-    DocumentCache,
     build_heading_tree,
     resolve_locator,
     get_paragraph_ranges
 )
 
 class TestWriterNavigation(unittest.TestCase):
-    def test_document_cache(self):
-        model = WriterDocStub([])
-        cache1 = DocumentCache.get(model)
-        cache2 = DocumentCache.get(model)
-        self.assertIs(cache1, cache2)
-        
-        DocumentCache.invalidate(model)
-        cache3 = DocumentCache.get(model)
-        self.assertIsNot(cache1, cache3)
-
     def test_build_heading_tree(self):
         elements = [
             ElementStub("H1", outline_level=1),
@@ -66,21 +55,6 @@ class TestWriterNavigation(unittest.TestCase):
         h2 = tree["children"][1]
         self.assertEqual(h2["text"], "H2")
         self.assertEqual(h2["body_paragraphs"], 0) # H2 is at end
-
-    def test_get_paragraph_ranges_caching(self):
-        doc = WriterDocStub([ElementStub("P1"), ElementStub("P2")])
-        ranges1 = get_paragraph_ranges(doc)
-        self.assertEqual(len(ranges1), 2)
-        
-        # Change underlying elements, but cache should remain
-        doc.elements = [ElementStub("P3")]
-        ranges2 = get_paragraph_ranges(doc)
-        self.assertEqual(len(ranges2), 2)
-        self.assertEqual(ranges1, ranges2)
-        
-        DocumentCache.invalidate(doc)
-        ranges3 = get_paragraph_ranges(doc)
-        self.assertEqual(len(ranges3), 1)
 
     def test_resolve_locator(self):
         doc = WriterDocStub([


### PR DESCRIPTION
As requested, the `DocumentCache` layer has been removed to simplify the logic, as the cache added unneeded complexity given the average document length. 
- The `DocumentCache` class logic is commented out to retain visibility but is no longer executed anywhere.
- `get_document_length` and `get_paragraph_ranges` compute values directly from `getText()` now.
- `doc_svc.invalidate_cache` references in the `ToolRegistry` and Calc `search` module were removed.
- Tests directly asserting cache behavior in the `plugin/tests/` and `plugin/tests/uno/` directories have been cleaned up and commented out where appropriate. All tests pass successfully.

---
*PR created automatically by Jules for task [15835006353494930911](https://jules.google.com/task/15835006353494930911) started by @KeithCu*