### PR TITLE
Finish Tool Registry Refactoring with auto_discover

### DIFF
--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -58,7 +58,9 @@ class ToolRegistry:
         from plugin.framework.tool_base import ToolBase, ToolBaseDummy
 
         for name, obj in inspect.getmembers(module, inspect.isclass):
-            # Must inherit from ToolBase, but not be ToolBase itself or ToolBaseDummy
+            # Must inherit from ToolBase, but not be ToolBase itself or ToolBaseDummy.
+            # ToolBaseDummy is our way of easily disabling a tool if we don't think it's
+            # worth having exposed to the AI, so we explicitly skip registering them.
             # Must be defined in this module to avoid double registration from imports
             # Also exclude abstract classes or classes without a defined 'name'
             if (issubclass(obj, ToolBase) and

--- a/plugin/modules/doc/__init__.py
+++ b/plugin/modules/doc/__init__.py
@@ -10,4 +10,11 @@ from plugin.framework.module_base import ModuleBase
 
 class CommonModule(ModuleBase):
     """Provides generic document tools (info, save, export)."""
-    pass
+
+    def initialize(self, services):
+        self.services = services
+
+        from . import diagnostics, print_doc, undo
+
+        for module in (diagnostics, print_doc, undo):
+            services.tools.auto_discover(module)

--- a/plugin/tests/test_tool_registry.py
+++ b/plugin/tests/test_tool_registry.py
@@ -57,6 +57,55 @@ def _make_ctx(doc_type="writer"):
 
 
 class TestRegister:
+    def test_auto_discover(self):
+        # Create a fake module to test auto_discover
+        from plugin.framework.tool_base import ToolBaseDummy
+        import types
+
+        mock_module = types.ModuleType("mock_module")
+
+        class GoodTool(ToolBase):
+            name = "good_tool"
+            def execute(self, ctx, **kwargs): pass
+        GoodTool.__module__ = "mock_module"
+
+        class AnotherTool(ToolBase):
+            name = "another_tool"
+            def execute(self, ctx, **kwargs): pass
+        AnotherTool.__module__ = "mock_module"
+
+        class AbstractTool(ToolBase):
+            pass # No name defined
+        AbstractTool.__module__ = "mock_module"
+
+        class DummyTool(ToolBaseDummy):
+            name = "dummy_tool"
+            def execute(self, ctx, **kwargs): pass
+        DummyTool.__module__ = "mock_module"
+
+        class ImportedTool(ToolBase):
+            name = "imported_tool"
+            def execute(self, ctx, **kwargs): pass
+        ImportedTool.__module__ = "other_module" # Simulate an imported class
+
+        # Add classes to module
+        mock_module.GoodTool = GoodTool
+        mock_module.AnotherTool = AnotherTool
+        mock_module.AbstractTool = AbstractTool
+        mock_module.DummyTool = DummyTool
+        mock_module.ImportedTool = ImportedTool
+        mock_module.NotATool = object()
+
+        reg = _make_registry()
+        reg.auto_discover(mock_module)
+
+        # Should only register GoodTool and AnotherTool
+        assert reg.get("good_tool") is not None
+        assert reg.get("another_tool") is not None
+        assert reg.get("dummy_tool") is None
+        assert reg.get("imported_tool") is None
+        assert len(reg) == 2
+
     def test_register_and_get(self):
         reg = _make_registry(FakeTool())
         assert reg.get("fake_tool") is not None


### PR DESCRIPTION
Finish Tool Registry Refactoring with auto_discover

This commit completes the Tool Registry Refactoring:
1. Applies `auto_discover` to the remaining module (`doc`).
2. Documents in `ToolRegistry.auto_discover` that `ToolBaseDummy` is used intentionally to disable tools that aren't worth having.
3. Adds comprehensive unit tests for `auto_discover` in `test_tool_registry.py` to ensure it correctly identifies tools and skips dummy, abstract, or imported tools.

---
*PR created automatically by Jules for task [15235462320473127731](https://jules.google.com/task/15235462320473127731) started by @KeithCu*