### PR TITLE
Refactor: Replace JSON decoding try/except blocks with `safe_json_loads`

### DIFF
--- a/plugin/contrib/tool_call_parsers/glm45_parser.py
+++ b/plugin/contrib/tool_call_parsers/glm45_parser.py
@@ -18,6 +18,7 @@ import re
 import uuid
 from typing import Any, Dict, List
 
+from plugin.framework.errors import safe_json_loads
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 
 from plugin.contrib.tool_call_parsers import ParseResult, ToolCallParser, register_parser
@@ -28,10 +29,9 @@ def _deserialize_value(value: str) -> Any:
     Try to deserialize a string value to its native Python type.
     Attempts json.loads, then ast.literal_eval, then returns raw string.
     """
-    try:
-        return json.loads(value)
-    except (json.JSONDecodeError, TypeError):
-        pass
+    data = safe_json_loads(value, default=None)
+    if data is not None:
+        return data
 
     try:
         return ast.literal_eval(value)

--- a/plugin/contrib/tool_call_parsers/hermes_parser.py
+++ b/plugin/contrib/tool_call_parsers/hermes_parser.py
@@ -10,6 +10,7 @@ import re
 import uuid
 from typing import List
 
+from plugin.framework.errors import safe_json_loads
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 
 from plugin.contrib.tool_call_parsers import ParseResult, ToolCallParser, register_parser
@@ -45,19 +46,20 @@ class HermesToolCallParser(ToolCallParser):
                 if not raw_json.strip():
                     continue
 
-                tc_data = json.loads(raw_json)
-                tool_calls.append(
-                    ChatCompletionMessageToolCall(
-                        id=f"call_{uuid.uuid4().hex[:8]}",
-                        type="function",
-                        function=Function(
-                            name=tc_data["name"],
-                            arguments=json.dumps(
-                                tc_data.get("arguments", {}), ensure_ascii=False
+                tc_data = safe_json_loads(raw_json, default=None)
+                if tc_data is not None and isinstance(tc_data, dict) and "name" in tc_data:
+                    tool_calls.append(
+                        ChatCompletionMessageToolCall(
+                            id=f"call_{uuid.uuid4().hex[:8]}",
+                            type="function",
+                            function=Function(
+                                name=tc_data["name"],
+                                arguments=json.dumps(
+                                    tc_data.get("arguments", {}), ensure_ascii=False
+                                ),
                             ),
-                        ),
+                        )
                     )
-                )
 
             if not tool_calls:
                 return text, None

--- a/plugin/contrib/tool_call_parsers/longcat_parser.py
+++ b/plugin/contrib/tool_call_parsers/longcat_parser.py
@@ -10,6 +10,7 @@ import re
 import uuid
 from typing import List
 
+from plugin.framework.errors import safe_json_loads
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 
 from plugin.contrib.tool_call_parsers import ParseResult, ToolCallParser, register_parser
@@ -42,19 +43,20 @@ class LongcatToolCallParser(ToolCallParser):
                 if not raw_json.strip():
                     continue
 
-                tc_data = json.loads(raw_json)
-                tool_calls.append(
-                    ChatCompletionMessageToolCall(
-                        id=f"call_{uuid.uuid4().hex[:8]}",
-                        type="function",
-                        function=Function(
-                            name=tc_data["name"],
-                            arguments=json.dumps(
-                                tc_data.get("arguments", {}), ensure_ascii=False
+                tc_data = safe_json_loads(raw_json, default=None)
+                if tc_data is not None and isinstance(tc_data, dict) and "name" in tc_data:
+                    tool_calls.append(
+                        ChatCompletionMessageToolCall(
+                            id=f"call_{uuid.uuid4().hex[:8]}",
+                            type="function",
+                            function=Function(
+                                name=tc_data["name"],
+                                arguments=json.dumps(
+                                    tc_data.get("arguments", {}), ensure_ascii=False
+                                ),
                             ),
-                        ),
+                        )
                     )
-                )
 
             if not tool_calls:
                 return text, None

--- a/plugin/contrib/tool_call_parsers/mistral_parser.py
+++ b/plugin/contrib/tool_call_parsers/mistral_parser.py
@@ -13,6 +13,7 @@ import json
 import re
 from typing import List
 
+from plugin.framework.errors import safe_json_loads
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 
 from plugin.contrib.tool_call_parsers import ParseResult, ToolCallParser, register_parser
@@ -76,8 +77,8 @@ class MistralToolCallParser(ToolCallParser):
                     )
             else:
                 # Pre-v11 format: [TOOL_CALLS] [{"name": ..., "arguments": {...}}]
-                try:
-                    parsed = json.loads(first_raw)
+                parsed = safe_json_loads(first_raw, default=None)
+                if parsed is not None:
                     if isinstance(parsed, dict):
                         parsed = [parsed]
 
@@ -95,13 +96,13 @@ class MistralToolCallParser(ToolCallParser):
                                 ),
                             )
                         )
-                except json.JSONDecodeError:
+                else:
                     # Fallback regex extraction
                     match = self.TOOL_CALL_REGEX.findall(first_raw)
                     if match:
                         for raw_json in match:
-                            try:
-                                tc = json.loads(raw_json)
+                            tc = safe_json_loads(raw_json, default=None)
+                            if tc and isinstance(tc, dict):
                                 args = tc.get("arguments", {})
                                 if isinstance(args, dict):
                                     args = json.dumps(args, ensure_ascii=False)
@@ -114,8 +115,6 @@ class MistralToolCallParser(ToolCallParser):
                                         ),
                                     )
                                 )
-                            except (json.JSONDecodeError, KeyError):
-                                continue
 
             if not tool_calls:
                 return text, None

--- a/plugin/contrib/tool_call_parsers/qwen3_coder_parser.py
+++ b/plugin/contrib/tool_call_parsers/qwen3_coder_parser.py
@@ -21,6 +21,7 @@ import re
 import uuid
 from typing import Any, Dict, List, Optional
 
+from plugin.framework.errors import safe_json_loads
 from plugin.contrib.tool_call_parsers.openai_compat import ChatCompletionMessageToolCall, Function
 
 from plugin.contrib.tool_call_parsers import ParseResult, ToolCallParser, register_parser
@@ -38,10 +39,9 @@ def _try_convert_value(value: str) -> Any:
         return None
 
     # Try JSON first (handles objects, arrays, strings, numbers, booleans)
-    try:
-        return json.loads(stripped)
-    except (json.JSONDecodeError, TypeError):
-        pass
+    data = safe_json_loads(stripped, default=None)
+    if data is not None:
+        return data
 
     # Try Python literal eval (handles tuples, etc.)
     try:

--- a/plugin/framework/errors.py
+++ b/plugin/framework/errors.py
@@ -5,6 +5,9 @@ All custom exceptions should inherit from WriterAgentException.
 """
 
 
+import json
+
+
 class WriterAgentException(Exception):
     """Base exception for all WriterAgent errors.
 
@@ -74,3 +77,22 @@ def format_error_payload(e: Exception) -> dict:
         "message": str(e),
         "details": {"type": type(e).__name__},
     }
+
+
+def safe_json_loads(text, default=None):
+    """Safely parse a JSON string into a Python object.
+
+    Args:
+        text: The string to parse.
+        default: The value to return if parsing fails. Defaults to None.
+
+    Returns:
+        The parsed Python object or the default value if an error occurs.
+    """
+    if not isinstance(text, (str, bytes, bytearray)):
+        return default
+    try:
+        parsed = json.loads(text)
+        return parsed if parsed is not None else default
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return default

--- a/plugin/modules/calc/manipulator.py
+++ b/plugin/modules/calc/manipulator.py
@@ -26,6 +26,7 @@ import io
 import json
 import logging
 
+from plugin.framework.errors import safe_json_loads
 from plugin.modules.calc.address_utils import parse_address
 
 logger = logging.getLogger("writeragent.calc")
@@ -75,16 +76,17 @@ def _parse_formula_or_values_string(s: str):
                     escaped = False
 
             normalized = "".join(normalized_list)
-            data = json.loads(normalized)
-            if isinstance(data, list):
-                flat = []
-                for item in data:
-                    if isinstance(item, list):
-                        flat.extend(item)
-                    else:
-                        flat.append(item)
-                return flat
-        except (json.JSONDecodeError, TypeError):
+            data = safe_json_loads(normalized)
+            if data is not None:
+                if isinstance(data, list):
+                    flat = []
+                    for item in data:
+                        if isinstance(item, list):
+                            flat.extend(item)
+                        else:
+                            flat.append(item)
+                    return flat
+        except TypeError:
             pass
 
     # Case 2: Raw semicolon-separated string e.g. "Name;Age;Country"

--- a/plugin/modules/chatbot/send_handlers.py
+++ b/plugin/modules/chatbot/send_handlers.py
@@ -11,6 +11,9 @@ alternate send flows that would otherwise bloat that class:
 
 import queue
 import logging
+import json
+
+from plugin.framework.errors import safe_json_loads
 
 log = logging.getLogger(__name__)
 
@@ -147,11 +150,11 @@ class SendHandlersMixin:
                     }
                 )
                 result = json.dumps(res) if isinstance(res, dict) else str(res)
-                try:
-                    data = json.loads(result)
+                data = safe_json_loads(result, default={})
+                if isinstance(data, dict):
                     note = data.get("message", data.get("status", "done"))
-                except Exception as parse_e:
-                    log.error("Failed to parse generate_image result in _do_send_direct_image: %s", parse_e)
+                else:
+                    log.error("Failed to parse generate_image result in _do_send_direct_image")
                     note = "done"
                 q.put(("chunk", "[generate_image: %s]\n" % note))
                 q.put(("stream_done", {}))
@@ -451,11 +454,10 @@ class SendHandlersMixin:
                 )
                 result = json.dumps(res) if isinstance(res, dict) else str(res)
 
-                try:
-                    data = json.loads(result)
-                except Exception as parse_e:
+                data = safe_json_loads(result)
+                if not isinstance(data, dict):
                     from plugin.framework.errors import AgentParsingError, format_error_payload
-                    log.error("Failed to parse web_research result in _run_web_research [doc: %s]: %s", doc_type, parse_e)
+                    log.error("Failed to parse web_research result in _run_web_research [doc: %s]", doc_type)
                     parsed_err = AgentParsingError("Invalid JSON from web search tool.", details={"raw_result": result})
                     data = format_error_payload(parsed_err)
 

--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -31,7 +31,7 @@ from plugin.framework.config import (
 )
 from plugin.framework.constants import get_chat_system_prompt_for_document
 from plugin.framework.document import get_document_context_for_chat
-from plugin.framework.errors import format_error_payload
+from plugin.framework.errors import format_error_payload, safe_json_loads
 from plugin.modules.http.client import LlmClient
 from plugin.framework.config import as_bool
 
@@ -487,11 +487,8 @@ class ToolCallingMixin:
                     "tool_execute", round_num=round_num, tool_name=func_name
                 )
 
-                try:
-                    func_args = json.loads(func_args_str)
-                    if not isinstance(func_args, dict):
-                        func_args = {}
-                except (json.JSONDecodeError, TypeError):
+                func_args = safe_json_loads(func_args_str, default={})
+                if not isinstance(func_args, dict):
                     func_args = {}
 
                 agent_log(
@@ -606,11 +603,10 @@ class ToolCallingMixin:
                 )
 
                 log.debug("Tool result: %s" % result)
-                try:
-                    result_data = json.loads(result)
+                result_data = safe_json_loads(result, default={})
+                if isinstance(result_data, dict):
                     note = result_data.get("message", result_data.get("status", "done"))
-                except Exception:
-                    result_data = {}
+                else:
                     note = "done"
                 self._append_response("[%s: %s]\n" % (func_name, note))
                 if func_name == "apply_document_content" and (

--- a/plugin/modules/http/client.py
+++ b/plugin/modules/http/client.py
@@ -38,7 +38,7 @@ from plugin.framework.constants import APP_REFERER, APP_TITLE, USER_AGENT
 
 from plugin.framework.logging import init_logging
 from plugin.framework.auth import resolve_auth_for_config, build_auth_headers, AuthError
-from plugin.framework.errors import NetworkError, AgentParsingError
+from plugin.framework.errors import NetworkError, AgentParsingError, safe_json_loads
 
 log = logging.getLogger(__name__)
 
@@ -85,8 +85,9 @@ def _format_http_error_response(status, reason, err_body):
     base = "HTTP Error %d: %s" % (status, reason)
     if not err_body or not err_body.strip():
         return base
-    try:
-        data = json.loads(err_body)
+
+    data = safe_json_loads(err_body)
+    if data and isinstance(data, dict):
         err = data.get("error")
         if isinstance(err, dict):
             detail = err.get("message") or err.get("msg") or err.get("error") or ""
@@ -94,8 +95,7 @@ def _format_http_error_response(status, reason, err_body):
             detail = str(err) if err else ""
         if detail:
             return base + ". " + detail
-    except (json.JSONDecodeError, TypeError):
-        pass
+
     snippet = err_body.strip().replace("\n", " ")[:400]
     return base + ". " + snippet
 
@@ -805,12 +805,10 @@ class LlmClient:
                         content_finished = True
                         continue
                     
-                    try:
-                        chunk = json.loads(payload)
-                    except json.JSONDecodeError:
-                        log.error("streaming_loop: JSON decode error in payload: %s" % payload)
-                        continue
+                    chunk = safe_json_loads(payload, default=None)
                     if chunk is None:
+                        if payload and payload != "{}":
+                            log.error("streaming_loop: JSON decode error in payload: %s" % payload)
                         continue
 
                     # Log all chunks for debugging, even after content_finished

--- a/plugin/modules/http/mcp_protocol.py
+++ b/plugin/modules/http/mcp_protocol.py
@@ -27,7 +27,7 @@ import time
 import uuid
 
 from plugin.framework.main_thread import execute_on_main_thread
-from plugin.framework.errors import WriterAgentException
+from plugin.framework.errors import WriterAgentException, safe_json_loads
 log = logging.getLogger(__name__)
 
 log = logging.getLogger("writeragent.mcp.protocol")
@@ -631,14 +631,14 @@ class MCPProtocolHandler:
         if content_length == 0:
             return {}
         raw = handler.rfile.read(content_length).decode("utf-8")
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError as e:
+        data = safe_json_loads(raw, default=None)
+        if data is None and raw.strip():
             log.warning("Invalid JSON body: %s", raw[:200])
             from plugin.framework.errors import AgentParsingError, format_error_payload
             err = AgentParsingError("Invalid JSON body in HTTP request", details={"raw": raw[:200]})
             self._send_json(handler, 400, format_error_payload(err))
             return None
+        return data if data is not None else {}
 
     def _send_json(self, handler, status, data):
         """Send a JSON response via an HTTP handler."""

--- a/plugin/modules/http/server.py
+++ b/plugin/modules/http/server.py
@@ -28,6 +28,8 @@ import threading
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 
+from plugin.framework.errors import safe_json_loads
+
 log = logging.getLogger("writeragent.framework.http_server")
 
 
@@ -94,14 +96,14 @@ class GenericRequestHandler(BaseHTTPRequestHandler):
         if content_length == 0:
             return {}
         raw = self.rfile.read(content_length).decode("utf-8")
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError as e:
+        data = safe_json_loads(raw, default=None)
+        if data is None and raw.strip():
             from plugin.framework.errors import AgentParsingError, format_error_payload
             log.warning("Invalid JSON body: %s", raw[:200])
             err = AgentParsingError("Invalid JSON body in HTTP request", details={"raw": raw[:200]})
             self._send_json(400, format_error_payload(err))
             return None
+        return data if data is not None else {}
 
     def _send_json(self, status, data):
         self.send_response(status)


### PR DESCRIPTION
This pull request introduces the `safe_json_loads(text, default=None)` helper in `plugin/framework/errors.py` to standardize JSON parsing across the application. It refactors multiple modules (e.g., `tool_loop.py`, HTTP clients/servers, tool call parsers) that previously relied on explicit `try/except json.JSONDecodeError` blocks. This update condenses error handling and improves type safety when working with tool arguments, configuration, and API responses.

---
*PR created automatically by Jules for task [16941235763514974893](https://jules.google.com/task/16941235763514974893) started by @KeithCu*