### PR TITLE
Decouple HTTP client top-level helpers

### DIFF
--- a/plugin/contrib/aihordeclient/__init__.py
+++ b/plugin/contrib/aihordeclient/__init__.py
@@ -31,7 +31,8 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request
 from plugin.framework.translation_tool import opustm_hf_translate, OPUSTM_SOURCE_LANGUAGES  # noqa F401
 
-from plugin.modules.http.client import sync_request, format_error_message
+from plugin.modules.http.requests import sync_request
+from plugin.modules.http.errors import format_error_message
 from plugin.framework.logging import log_exception
 from plugin.framework.constants import USER_AGENT
 

--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -536,7 +536,7 @@ def fetch_available_models(endpoint):
     if url in _model_fetch_cache:
         return _model_fetch_cache[url]
 
-    from plugin.modules.http.client import sync_request
+    from plugin.modules.http.requests import sync_request
     try:
         data = sync_request(url, parse_json=True)
         if data and isinstance(data, dict) and "data" in data:

--- a/plugin/framework/image_utils.py
+++ b/plugin/framework/image_utils.py
@@ -20,7 +20,9 @@ import logging
 import tempfile
 import re
 import base64
-from plugin.modules.http.client import sync_request, LlmClient, _format_http_error_response
+from plugin.modules.http.client import LlmClient
+from plugin.modules.http.requests import sync_request
+from plugin.modules.http.errors import _format_http_error_response
 from plugin.contrib.aihordeclient import AiHordeClient
 
 log = logging.getLogger(__name__)

--- a/plugin/framework/pricing.py
+++ b/plugin/framework/pricing.py
@@ -18,7 +18,7 @@ import json
 import logging
 import os
 import time
-from plugin.modules.http.client import sync_request
+from plugin.modules.http.requests import sync_request
 from plugin.framework.config import user_config_dir
 log = logging.getLogger(__name__)
 

--- a/plugin/framework/translation_tool.py
+++ b/plugin/framework/translation_tool.py
@@ -25,7 +25,7 @@
 # https://github.com/ikks/aihorde-client/blob/main/LICENSE
 
 import json
-from plugin.modules.http.client import sync_request
+from plugin.modules.http.requests import sync_request
 
 API_TRANSLATE_GRADIO = "https://igortamara-opus-translate.hf.space/call/translate"
 

--- a/plugin/modules/calc/legacy.py
+++ b/plugin/modules/calc/legacy.py
@@ -17,7 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Legacy operations for Calc (Extend/Edit Selection)."""
 from plugin.framework.config import get_config, get_config_int, get_api_config, validate_api_config
-from plugin.modules.http.client import format_error_message, LlmClient
+from plugin.modules.http.errors import format_error_message
+from plugin.modules.http.client import LlmClient
 from plugin.framework.async_stream import run_stream_completion_async
 from plugin.framework.dialogs import msgbox
 

--- a/plugin/modules/chatbot/send_handlers.py
+++ b/plugin/modules/chatbot/send_handlers.py
@@ -18,7 +18,7 @@ class SendHandlersMixin:
     def _transcribe_audio_async(self, wav_path, stt_model, model, query_text=""):
         """Transcribe audio asynchronously and then proceed to chat."""
         from plugin.framework.async_stream import run_blocking_in_thread
-        from plugin.modules.http.client import format_error_message
+        from plugin.modules.http.errors import format_error_message
 
         self._set_status("Transcribing audio...")
         self._append_response("\n[Transcribing audio...]\n")
@@ -186,7 +186,7 @@ class SendHandlersMixin:
             self._set_status("Stopped")
 
         def on_error(e):
-            from plugin.modules.http.client import format_error_message
+            from plugin.modules.http.errors import format_error_message
 
             self._append_response("\n[%s]\n" % format_error_message(e))
             self._terminal_status = "Error"
@@ -344,7 +344,7 @@ class SendHandlersMixin:
             self._append_response("\n[Stopped by user]\n")
 
         def on_error(e):
-            from plugin.modules.http.client import format_error_message
+            from plugin.modules.http.errors import format_error_message
 
             self._append_response("\n[Error: %s]\n" % format_error_message(e))
             self._terminal_status = "Error"
@@ -385,7 +385,7 @@ class SendHandlersMixin:
 
     def _run_web_research(self, query_text, model):
         """Run the web_research tool via the sub-agent and stream its result into the response area."""
-        from plugin.modules.http.client import format_error_message
+        from plugin.modules.http.errors import format_error_message
         from plugin.main import get_tools
         from plugin.framework.document import is_calc, is_draw
 

--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -14,7 +14,7 @@ from plugin.framework.async_stream import (
     run_stream_drain_loop,
 )
 from plugin.framework.logging import agent_log, update_activity_state
-from plugin.modules.http.client import (
+from plugin.modules.http.errors import (
     format_error_message,
     is_audio_unsupported_error,
 )

--- a/plugin/modules/http/client.py
+++ b/plugin/modules/http/client.py
@@ -21,12 +21,9 @@ Takes a config dict (from plugin.framework.config.get_api_config) and UNO ctx.
 import logging
 import collections
 import json
-import ssl
-import urllib.request
 import urllib.parse
 import http.client
 import socket
-import ipaddress
 import datetime
 
 # LiteLLM: streaming_handler.py ~L198 safety_checker(), issue #5158
@@ -34,326 +31,33 @@ REPEATED_STREAMING_CHUNK_LIMIT = 20
 
 # accumulate_delta is required for tool-calling: it merges streaming deltas into message_snapshot so full tool_calls (with function.arguments) are available.
 from plugin.framework.streaming_deltas import accumulate_delta
-from plugin.framework.constants import APP_REFERER, APP_TITLE, USER_AGENT
+from plugin.framework.constants import APP_REFERER, APP_TITLE
 
 from plugin.framework.logging import init_logging
 from plugin.framework.auth import resolve_auth_for_config, build_auth_headers, AuthError
-from plugin.framework.errors import NetworkError, AgentParsingError
+from plugin.framework.errors import NetworkError
+
+from plugin.modules.http.errors import (
+    format_error_message,
+    _format_http_error_response,
+    format_error_for_display,
+    is_audio_unsupported_error,
+)
+from plugin.modules.http.ssl_helpers import (
+    get_unverified_ssl_context,
+    get_verified_ssl_context,
+    _is_certificate_verify_error,
+    _is_local_host,
+)
+from plugin.modules.http.stream_normalizer import (
+    iterate_sse,
+    _extract_thinking_from_delta,
+    _normalize_message_content,
+    _normalize_delta,
+)
+from plugin.modules.http.requests import sync_request
 
 log = logging.getLogger(__name__)
-
-
-def format_error_message(e):
-    """Map common exceptions to user-friendly advice."""
-    import urllib.error
-
-    msg = str(e)
-    if isinstance(e, ssl.SSLError):
-        return "TLS/SSL Error: %s" % msg
-    if isinstance(e, (urllib.error.HTTPError, http.client.HTTPResponse)):
-        code = e.code if hasattr(e, "code") else e.status
-        reason = e.reason if hasattr(e, "reason") else ""
-        if code == 401:
-            return "Invalid API Key. Please check your settings."
-        if code == 403:
-            return "API access Forbidden. Your key may lack permissions for this model."
-        if code == 404:
-            return "Endpoint not found (404). Check your URL and Model name."
-        if code >= 500:
-            return "Server error (%d). The AI provider is having issues." % code
-        return "HTTP Error %d: %s" % (code, reason)
-
-    if isinstance(e, socket.timeout) or "timed out" in msg.lower():
-        return "Request Timed Out. Try increasing 'Request Timeout' in Settings."
-
-    if isinstance(e, (urllib.error.URLError, socket.error)):
-        reason = str(e.reason) if hasattr(e, "reason") else str(e)
-        if "Connection refused" in reason or "111" in reason:
-            return "Connection Refused. Is your local AI server (Ollama/LM Studio) running?"
-        if "getaddrinfo failed" in reason:
-            return "DNS Error. Could not resolve the endpoint URL."
-        return "Connection Error: %s" % reason
-
-    if "finish_reason=error" in msg:
-        return "The AI provider reported an error. Try again."
-
-    return msg
-
-
-def _format_http_error_response(status, reason, err_body):
-    """Build error message including response body for display in chat/UI."""
-    base = "HTTP Error %d: %s" % (status, reason)
-    if not err_body or not err_body.strip():
-        return base
-    try:
-        data = json.loads(err_body)
-        err = data.get("error")
-        if isinstance(err, dict):
-            detail = err.get("message") or err.get("msg") or err.get("error") or ""
-        else:
-            detail = str(err) if err else ""
-        if detail:
-            return base + ". " + detail
-    except (json.JSONDecodeError, TypeError):
-        pass
-    snippet = err_body.strip().replace("\n", " ")[:400]
-    return base + ". " + snippet
-
-
-def format_error_for_display(e):
-    """Return user-friendly error string for display in cells or dialogs."""
-    from plugin.framework.errors import format_error_payload
-    payload = format_error_payload(e)
-    return "Error: %s" % payload.get("message", format_error_message(e))
-
-
-def is_audio_unsupported_error(e):
-    """Try to determine if the error indicates that audio/modality is unsupported by the model."""
-    msg = str(e).lower()
-    
-    # Common error strings across providers
-    if "unsupported content type" in msg: return True
-    if "unsupported modality" in msg: return True
-    if "audio" in msg and ("not supported" in msg or "unsupported" in msg): return True
-    if "modality" in msg and "not supported" in msg: return True
-    
-    # Specific API error bodies (passed via _format_http_error_response)
-    if "model" in msg and "cannot process" in msg and "audio" in msg: return True
-    if "no endpoints found that support input audio" in msg: return True
-    if "gpt-4" in msg and "audio" in msg: # Some legacy GPT-4 might not have it
-        if "not support" in msg: return True
-        
-    return False
-
-
-def get_unverified_ssl_context():
-    """Create an SSL context that doesn't verify certificates. Shared by API and aihordeclient."""
-    ssl_context = ssl.create_default_context()
-    ssl_context.check_hostname = False
-    ssl_context.verify_mode = ssl.CERT_NONE
-    return ssl_context
-
-
-def get_verified_ssl_context():
-    """Create a default verifying SSL context."""
-    return ssl.create_default_context()
-
-
-def _is_certificate_verify_error(e):
-    """Return True when an exception points to certificate validation failure."""
-    if isinstance(e, ssl.SSLCertVerificationError):
-        return True
-    reason = getattr(e, "reason", None)
-    if isinstance(reason, ssl.SSLCertVerificationError):
-        return True
-    msg = ("%s %s" % (e, reason or "")).lower()
-    for marker in (
-        "certificate_verify_failed",
-        "certificate verify failed",
-        "self-signed certificate",
-        "self signed certificate",
-        "unable to get local issuer certificate",
-        "hostname mismatch",
-    ):
-        if marker in msg:
-            return True
-    return False
-
-
-def _is_local_host(host):
-    """Heuristic for localhost / LAN hosts where self-signed TLS is common."""
-    host = (host or "").strip().lower()
-    if not host:
-        return False
-    if host in ("localhost", "ip6-localhost", "host.docker.internal"):
-        return True
-    if host.endswith(".local"):
-        return True
-    try:
-        ip = ipaddress.ip_address(host)
-        return ip.is_loopback or ip.is_private or ip.is_link_local
-    except ValueError:
-        pass
-    # Single-label hostnames are usually local network names.
-    return "." not in host
-
-
-def sync_request(url, data=None, headers=None, timeout=10, parse_json=True):
-    """
-    Blocking HTTP GET or POST. Shared by aihordeclient and other code.
-    url: str or urllib.request.Request. If Request, headers/data come from it.
-    data: optional bytes for POST. headers: optional dict (used only if url is str).
-    Returns response data: decoded JSON if parse_json else raw bytes. Raises on error.
-    """
-    import urllib.error
-    if headers is None:
-        headers = {}
-    
-    # Add default headers to avoid being blocked and provide application identity
-    has_ua = any(k.lower() == "user-agent" for k in headers.keys())
-    if not has_ua:
-        headers["User-Agent"] = USER_AGENT
-    
-    if "HTTP-Referer" not in headers:
-        headers["HTTP-Referer"] = APP_REFERER
-    if "X-Title" not in headers:
-        headers["X-Title"] = APP_TITLE
-
-    if isinstance(url, str):
-        req = urllib.request.Request(url, data=data, headers=headers)
-    else:
-        req = url
-    
-    # Debug: log which headers we are actually sending (keys only)
-    try:
-        header_keys = list(req.headers.keys()) if hasattr(req, "headers") else []
-        if not header_keys and hasattr(req, "get_full_url"):
-            # If it's a urllib Request object, headers might be in .headers
-            pass 
-        log.debug(f"Request to {getattr(req, 'full_url', url)} with header keys: {header_keys}")
-    except Exception:
-        pass
-
-    full_url = getattr(req, "full_url", url)
-    parsed = urllib.parse.urlparse(str(full_url))
-    host = parsed.hostname or ""
-    is_local_https = parsed.scheme.lower() == "https" and _is_local_host(host)
-    def _read_with_context(context):
-        log.debug(f"About to open URL: {getattr(req, 'full_url', url)}")
-        with urllib.request.urlopen(req, timeout=timeout, context=context) as resp:
-            log.debug(f"URL opened, status={resp.getcode()}. Heading to read...")
-            raw = resp.read()
-            log.debug(f"Read {len(raw)} bytes")
-            if parse_json:
-                return json.loads(raw.decode("utf-8"))
-            return raw
-
-    ctx = get_verified_ssl_context() if is_local_https else get_unverified_ssl_context()
-    try:
-        return _read_with_context(ctx)
-    except urllib.error.HTTPError as e:
-        status = e.code
-        reason = e.reason
-        try:
-            err_body = e.read().decode("utf-8", errors="replace")
-        except Exception:
-            err_body = ""
-        
-        msg = _format_http_error_response(status, reason, err_body)
-        log.error(f"HTTP Error: {msg}")
-        raise NetworkError(msg, code="HTTP_ERROR", context={"url": url, "status": status}) from e
-    except NetworkError:
-        raise
-    except Exception as e:
-        if is_local_https and _is_certificate_verify_error(e):
-            log.error("Local HTTPS certificate verification failed for %s; retrying unverified." % host)
-            try:
-                return _read_with_context(get_unverified_ssl_context())
-            except urllib.error.HTTPError as retry_http_e:
-                status = retry_http_e.code
-                reason = retry_http_e.reason
-                try:
-                    err_body = retry_http_e.read().decode("utf-8", errors="replace")
-                except Exception:
-                    err_body = ""
-                msg = _format_http_error_response(status, reason, err_body)
-                log.error(f"HTTP Error: {msg}")
-                raise NetworkError(msg, code="HTTP_ERROR", context={"url": url, "status": status}) from retry_http_e
-            except Exception as retry_e:
-                log.error(f"Request failed: {format_error_message(retry_e)}")
-                raise NetworkError(format_error_message(retry_e), context={"url": url}) from retry_e
-        log.error(f"Request failed: {format_error_message(e)}")
-        raise NetworkError(format_error_message(e), context={"url": url}) from e
-
-
-def iterate_sse(stream):
-    """
-    Iterate over SSE (Server-Sent Events) data payloads from a stream of lines (bytes).
-    Yields the payload string (everything after 'data:').
-    """
-    for line in stream:
-        line_str = line.strip()
-        if not line_str or line_str.startswith(b":"):
-            continue
-
-        if not line_str.startswith(b"data:"):
-            continue
-        
-        # Payload is everything after the first ":"
-        idx = line_str.find(b":") + 1
-        payload = line_str[idx:].decode("utf-8").strip()
-        yield payload
-
-
-def _extract_thinking_from_delta(chunk_delta):
-    """Extract reasoning/thinking text from a stream delta for display in UI."""
-    # Try direct fields first
-    for field in ["reasoning_content", "thought", "thinking"]:
-        thinking = chunk_delta.get(field)
-        if isinstance(thinking, str) and thinking:
-            return thinking
-    
-    # Try reasoning_details array
-    details = chunk_delta.get("reasoning_details")
-    if isinstance(details, list):
-        parts = []
-        for item in details:
-            if isinstance(item, dict):
-                item_type = item.get("type")
-                if item_type in ("reasoning.text", "thought", "reasoning"):
-                    parts.append(item.get("text") or "")
-                elif item_type == "reasoning.summary":
-                    parts.append(item.get("summary") or "")
-        if parts:
-            return "".join(parts)
-    
-    # Try choices[0].delta if not found at top level
-    choices = chunk_delta.get("choices")
-    if choices and isinstance(choices, list) and len(choices) > 0:
-        delta = choices[0].get("delta", {})
-        if delta:
-            return _extract_thinking_from_delta(delta)
-
-    return ""
-
-
-def _normalize_message_content(raw):
-    """Return a single string from API message content (string or list of parts)."""
-    if raw is None:
-        return None
-    if isinstance(raw, str):
-        return raw
-    if isinstance(raw, list):
-        parts = []
-        for item in raw:
-            if isinstance(item, dict):
-                if item.get("type") == "text":
-                    parts.append(item.get("text") or "")
-                elif "text" in item:
-                    parts.append(item.get("text") or "")
-        return "".join(parts) if parts else None
-    return str(raw)
-
-
-def _normalize_delta(delta):
-    """Normalize delta for Mistral/Azure compat before accumulate_delta.
-    LiteLLM: streaming_handler.py ~L847 (role), ~L853 (type), ~L820 (arguments).
-    """
-    if not isinstance(delta, dict):
-        return
-    # LiteLLM: streaming_handler.py ~L847 "mistral's api returns role as None"
-    if "role" in delta and delta["role"] is None:
-        delta["role"] = "assistant"
-    for tc in delta.get("tool_calls") or []:
-        if not isinstance(tc, dict):
-            continue
-        # LiteLLM: streaming_handler.py ~L853 "mistral's api returns type: None"
-        if tc.get("type") is None:
-            tc["type"] = "function"
-        fn = tc.get("function")
-        # LiteLLM: streaming_handler.py ~L820 "## AZURE - check if arguments is not None"
-        if isinstance(fn, dict) and fn.get("arguments") is None:
-            fn["arguments"] = ""
 
 
 class LlmClient:

--- a/plugin/modules/http/errors.py
+++ b/plugin/modules/http/errors.py
@@ -1,0 +1,87 @@
+import json
+import ssl
+import socket
+import http.client
+
+
+def format_error_message(e):
+    """Map common exceptions to user-friendly advice."""
+    import urllib.error
+
+    msg = str(e)
+    if isinstance(e, ssl.SSLError):
+        return "TLS/SSL Error: %s" % msg
+    if isinstance(e, (urllib.error.HTTPError, http.client.HTTPResponse)):
+        code = e.code if hasattr(e, "code") else e.status
+        reason = e.reason if hasattr(e, "reason") else ""
+        if code == 401:
+            return "Invalid API Key. Please check your settings."
+        if code == 403:
+            return "API access Forbidden. Your key may lack permissions for this model."
+        if code == 404:
+            return "Endpoint not found (404). Check your URL and Model name."
+        if code >= 500:
+            return "Server error (%d). The AI provider is having issues." % code
+        return "HTTP Error %d: %s" % (code, reason)
+
+    if isinstance(e, socket.timeout) or "timed out" in msg.lower():
+        return "Request Timed Out. Try increasing 'Request Timeout' in Settings."
+
+    if isinstance(e, (urllib.error.URLError, socket.error)):
+        reason = str(e.reason) if hasattr(e, "reason") else str(e)
+        if "Connection refused" in reason or "111" in reason:
+            return "Connection Refused. Is your local AI server (Ollama/LM Studio) running?"
+        if "getaddrinfo failed" in reason:
+            return "DNS Error. Could not resolve the endpoint URL."
+        return "Connection Error: %s" % reason
+
+    if "finish_reason=error" in msg:
+        return "The AI provider reported an error. Try again."
+
+    return msg
+
+
+def _format_http_error_response(status, reason, err_body):
+    """Build error message including response body for display in chat/UI."""
+    base = "HTTP Error %d: %s" % (status, reason)
+    if not err_body or not err_body.strip():
+        return base
+    try:
+        data = json.loads(err_body)
+        err = data.get("error")
+        if isinstance(err, dict):
+            detail = err.get("message") or err.get("msg") or err.get("error") or ""
+        else:
+            detail = str(err) if err else ""
+        if detail:
+            return base + ". " + detail
+    except (json.JSONDecodeError, TypeError):
+        pass
+    snippet = err_body.strip().replace("\n", " ")[:400]
+    return base + ". " + snippet
+
+
+def format_error_for_display(e):
+    """Return user-friendly error string for display in cells or dialogs."""
+    from plugin.framework.errors import format_error_payload
+    payload = format_error_payload(e)
+    return "Error: %s" % payload.get("message", format_error_message(e))
+
+
+def is_audio_unsupported_error(e):
+    """Try to determine if the error indicates that audio/modality is unsupported by the model."""
+    msg = str(e).lower()
+
+    # Common error strings across providers
+    if "unsupported content type" in msg: return True
+    if "unsupported modality" in msg: return True
+    if "audio" in msg and ("not supported" in msg or "unsupported" in msg): return True
+    if "modality" in msg and "not supported" in msg: return True
+
+    # Specific API error bodies (passed via _format_http_error_response)
+    if "model" in msg and "cannot process" in msg and "audio" in msg: return True
+    if "no endpoints found that support input audio" in msg: return True
+    if "gpt-4" in msg and "audio" in msg: # Some legacy GPT-4 might not have it
+        if "not support" in msg: return True
+
+    return False

--- a/plugin/modules/http/requests.py
+++ b/plugin/modules/http/requests.py
@@ -1,0 +1,97 @@
+import json
+import logging
+import urllib.request
+import urllib.parse
+from plugin.framework.constants import APP_REFERER, APP_TITLE, USER_AGENT
+from plugin.framework.errors import NetworkError
+from plugin.modules.http.ssl_helpers import get_verified_ssl_context, get_unverified_ssl_context, _is_local_host, _is_certificate_verify_error
+from plugin.modules.http.errors import _format_http_error_response, format_error_message
+
+log = logging.getLogger(__name__)
+
+def sync_request(url, data=None, headers=None, timeout=10, parse_json=True):
+    """
+    Blocking HTTP GET or POST. Shared by aihordeclient and other code.
+    url: str or urllib.request.Request. If Request, headers/data come from it.
+    data: optional bytes for POST. headers: optional dict (used only if url is str).
+    Returns response data: decoded JSON if parse_json else raw bytes. Raises on error.
+    """
+    import urllib.error
+    if headers is None:
+        headers = {}
+
+    # Add default headers to avoid being blocked and provide application identity
+    has_ua = any(k.lower() == "user-agent" for k in headers.keys())
+    if not has_ua:
+        headers["User-Agent"] = USER_AGENT
+
+    if "HTTP-Referer" not in headers:
+        headers["HTTP-Referer"] = APP_REFERER
+    if "X-Title" not in headers:
+        headers["X-Title"] = APP_TITLE
+
+    if isinstance(url, str):
+        req = urllib.request.Request(url, data=data, headers=headers)
+    else:
+        req = url
+
+    # Debug: log which headers we are actually sending (keys only)
+    try:
+        header_keys = list(req.headers.keys()) if hasattr(req, "headers") else []
+        if not header_keys and hasattr(req, "get_full_url"):
+            # If it's a urllib Request object, headers might be in .headers
+            pass
+        log.debug(f"Request to {getattr(req, 'full_url', url)} with header keys: {header_keys}")
+    except Exception:
+        pass
+
+    full_url = getattr(req, "full_url", url)
+    parsed = urllib.parse.urlparse(str(full_url))
+    host = parsed.hostname or ""
+    is_local_https = parsed.scheme.lower() == "https" and _is_local_host(host)
+    def _read_with_context(context):
+        log.debug(f"About to open URL: {getattr(req, 'full_url', url)}")
+        with urllib.request.urlopen(req, timeout=timeout, context=context) as resp:
+            log.debug(f"URL opened, status={resp.getcode()}. Heading to read...")
+            raw = resp.read()
+            log.debug(f"Read {len(raw)} bytes")
+            if parse_json:
+                return json.loads(raw.decode("utf-8"))
+            return raw
+
+    ctx = get_verified_ssl_context() if is_local_https else get_unverified_ssl_context()
+    try:
+        return _read_with_context(ctx)
+    except urllib.error.HTTPError as e:
+        status = e.code
+        reason = e.reason
+        try:
+            err_body = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_body = ""
+
+        msg = _format_http_error_response(status, reason, err_body)
+        log.error(f"HTTP Error: {msg}")
+        raise NetworkError(msg, code="HTTP_ERROR", context={"url": url, "status": status}) from e
+    except NetworkError:
+        raise
+    except Exception as e:
+        if is_local_https and _is_certificate_verify_error(e):
+            log.error("Local HTTPS certificate verification failed for %s; retrying unverified." % host)
+            try:
+                return _read_with_context(get_unverified_ssl_context())
+            except urllib.error.HTTPError as retry_http_e:
+                status = retry_http_e.code
+                reason = retry_http_e.reason
+                try:
+                    err_body = retry_http_e.read().decode("utf-8", errors="replace")
+                except Exception:
+                    err_body = ""
+                msg = _format_http_error_response(status, reason, err_body)
+                log.error(f"HTTP Error: {msg}")
+                raise NetworkError(msg, code="HTTP_ERROR", context={"url": url, "status": status}) from retry_http_e
+            except Exception as retry_e:
+                log.error(f"Request failed: {format_error_message(retry_e)}")
+                raise NetworkError(format_error_message(retry_e), context={"url": url}) from retry_e
+        log.error(f"Request failed: {format_error_message(e)}")
+        raise NetworkError(format_error_message(e), context={"url": url}) from e

--- a/plugin/modules/http/ssl_helpers.py
+++ b/plugin/modules/http/ssl_helpers.py
@@ -1,0 +1,54 @@
+import ssl
+import ipaddress
+
+
+def get_unverified_ssl_context():
+    """Create an SSL context that doesn't verify certificates. Shared by API and aihordeclient."""
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+    return ssl_context
+
+
+def get_verified_ssl_context():
+    """Create a default verifying SSL context."""
+    return ssl.create_default_context()
+
+
+def _is_certificate_verify_error(e):
+    """Return True when an exception points to certificate validation failure."""
+    if isinstance(e, ssl.SSLCertVerificationError):
+        return True
+    reason = getattr(e, "reason", None)
+    if isinstance(reason, ssl.SSLCertVerificationError):
+        return True
+    msg = ("%s %s" % (e, reason or "")).lower()
+    for marker in (
+        "certificate_verify_failed",
+        "certificate verify failed",
+        "self-signed certificate",
+        "self signed certificate",
+        "unable to get local issuer certificate",
+        "hostname mismatch",
+    ):
+        if marker in msg:
+            return True
+    return False
+
+
+def _is_local_host(host):
+    """Heuristic for localhost / LAN hosts where self-signed TLS is common."""
+    host = (host or "").strip().lower()
+    if not host:
+        return False
+    if host in ("localhost", "ip6-localhost", "host.docker.internal"):
+        return True
+    if host.endswith(".local"):
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+        return ip.is_loopback or ip.is_private or ip.is_link_local
+    except ValueError:
+        pass
+    # Single-label hostnames are usually local network names.
+    return "." not in host

--- a/plugin/modules/http/stream_normalizer.py
+++ b/plugin/modules/http/stream_normalizer.py
@@ -1,0 +1,88 @@
+def iterate_sse(stream):
+    """
+    Iterate over SSE (Server-Sent Events) data payloads from a stream of lines (bytes).
+    Yields the payload string (everything after 'data:').
+    """
+    for line in stream:
+        line_str = line.strip()
+        if not line_str or line_str.startswith(b":"):
+            continue
+
+        if not line_str.startswith(b"data:"):
+            continue
+
+        # Payload is everything after the first ":"
+        idx = line_str.find(b":") + 1
+        payload = line_str[idx:].decode("utf-8").strip()
+        yield payload
+
+
+def _extract_thinking_from_delta(chunk_delta):
+    """Extract reasoning/thinking text from a stream delta for display in UI."""
+    # Try direct fields first
+    for field in ["reasoning_content", "thought", "thinking"]:
+        thinking = chunk_delta.get(field)
+        if isinstance(thinking, str) and thinking:
+            return thinking
+
+    # Try reasoning_details array
+    details = chunk_delta.get("reasoning_details")
+    if isinstance(details, list):
+        parts = []
+        for item in details:
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                if item_type in ("reasoning.text", "thought", "reasoning"):
+                    parts.append(item.get("text") or "")
+                elif item_type == "reasoning.summary":
+                    parts.append(item.get("summary") or "")
+        if parts:
+            return "".join(parts)
+
+    # Try choices[0].delta if not found at top level
+    choices = chunk_delta.get("choices")
+    if choices and isinstance(choices, list) and len(choices) > 0:
+        delta = choices[0].get("delta", {})
+        if delta:
+            return _extract_thinking_from_delta(delta)
+
+    return ""
+
+
+def _normalize_message_content(raw):
+    """Return a single string from API message content (string or list of parts)."""
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, list):
+        parts = []
+        for item in raw:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    parts.append(item.get("text") or "")
+                elif "text" in item:
+                    parts.append(item.get("text") or "")
+        return "".join(parts) if parts else None
+    return str(raw)
+
+
+def _normalize_delta(delta):
+    """Normalize delta for Mistral/Azure compat before accumulate_delta.
+    LiteLLM: streaming_handler.py ~L847 (role), ~L853 (type), ~L820 (arguments).
+    """
+    if not isinstance(delta, dict):
+        return
+    # LiteLLM: streaming_handler.py ~L847 "mistral's api returns role as None"
+    if "role" in delta and delta["role"] is None:
+        delta["role"] = "assistant"
+    for tc in delta.get("tool_calls") or []:
+        if not isinstance(tc, dict):
+            continue
+        # LiteLLM: streaming_handler.py ~L853 "mistral's api returns type: None"
+        if tc.get("type") is None:
+            tc["type"] = "function"
+        fn = tc.get("function")
+        # LiteLLM: streaming_handler.py ~L820 "## AZURE - check if arguments is not None"
+        if isinstance(fn, dict) and fn.get("arguments") is None:
+            fn["arguments"] = ""

--- a/plugin/modules/writer/legacy.py
+++ b/plugin/modules/writer/legacy.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Legacy operations for Writer (Extend/Edit Selection)."""
 from plugin.framework.config import get_config, get_config_int, get_api_config, validate_api_config, get_current_endpoint, update_lru_history
-from plugin.modules.http.client import format_error_message
+from plugin.modules.http.errors import format_error_message
 from plugin.framework.async_stream import run_stream_completion_async
 from plugin.framework.dialogs import msgbox
 

--- a/plugin/prompt_function.py
+++ b/plugin/prompt_function.py
@@ -147,7 +147,7 @@ class PromptFunction(unohelper.Base, XPromptFunction):
                 from plugin.framework.async_stream import run_blocking_in_thread
                 return run_blocking_in_thread(self.ctx, self.client.chat_completion_sync, messages, max_tokens=max_tokens)
             except Exception as e:
-                from plugin.modules.http.client import format_error_for_display
+                from plugin.modules.http.errors import format_error_for_display
                 log.error("PROMPT error: %s" % str(e))
                 return format_error_for_display(e)
         return ""

--- a/plugin/tests/test_error_handling.py
+++ b/plugin/tests/test_error_handling.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 from plugin.framework.errors import WriterAgentException, format_error_payload
 from plugin.framework.tool_base import ToolBase
-from plugin.modules.http.client import format_error_for_display
+from plugin.modules.http.errors import format_error_for_display
 
 class DummyTool(ToolBase):
     name = "dummy_tool"

--- a/plugin/tests/test_llm_client_modality.py
+++ b/plugin/tests/test_llm_client_modality.py
@@ -3,8 +3,8 @@ import json
 import socket
 from unittest.mock import patch, MagicMock, mock_open
 import ssl
-from plugin.modules.http.client import (
-    LlmClient,
+from plugin.modules.http.client import LlmClient
+from plugin.modules.http.errors import (
     is_audio_unsupported_error,
     format_error_message,
     _format_http_error_response


### PR DESCRIPTION
Decouples the monolithic `plugin/modules/http/client.py` file by extracting loose top-level functions into specialized sub-modules (`errors.py`, `ssl_helpers.py`, `stream_normalizer.py`, and `requests.py`). This significantly declutters `client.py`, leaving it hyper-focused on `LlmClient` request formatting and streaming. All references and test cases have been updated to use the new imports and verify correctness.

---
*PR created automatically by Jules for task [16813018744756003035](https://jules.google.com/task/16813018744756003035) started by @KeithCu*