### PR TITLE
Refactor UNO listeners to use base classes to reduce boilerplate

### DIFF
--- a/plugin/framework/dialogs.py
+++ b/plugin/framework/dialogs.py
@@ -40,6 +40,7 @@ XDL dialog loading (used by ModuleBase helpers)::
 import logging
 import threading
 import unohelper
+from plugin.framework.listeners import BaseActionListener
 from com.sun.star.awt import XActionListener
 from plugin.framework.uno_context import get_desktop, get_extension_url
 
@@ -233,22 +234,19 @@ def msgbox_with_copy(ctx, title, message, copy_text):
             "com.sun.star.awt.Toolkit", ctx)
         dlg.createPeer(toolkit, None)
 
-        class _CopyListener(unohelper.Base, XActionListener):
+        class _CopyListener(BaseActionListener):
             def __init__(self, dialog, context, text):
                 self._dlg = dialog
                 self._ctx = context
                 self._text = text
 
-            def actionPerformed(self, ev):
+            def on_action_performed(self, ev):
                 if copy_to_clipboard(self._ctx, self._text):
                     try:
                         self._dlg.getModel().getByName("CopyBtn").Label = \
                             "Copied!"
                     except Exception as e:
                         log.debug("Failed to set CopyBtn Label: %s", e)
-
-            def disposing(self, ev):
-                pass
 
         dlg.getControl("CopyBtn").addActionListener(
             _CopyListener(dlg, ctx, copy_text))
@@ -310,13 +308,13 @@ def status_dialog(ctx, title, build_status_fn, copy_url_fn=None):
 
         # Wire copy button
         if has_copy:
-            class _CopyListener(unohelper.Base, XActionListener):
+            class _CopyListener(BaseActionListener):
                 def __init__(self, dialog, context, url_fn):
                     self._dlg = dialog
                     self._ctx = context
                     self._url_fn = url_fn
 
-                def actionPerformed(self, ev):
+                def on_action_performed(self, ev):
                     url = self._url_fn()
                     if url and copy_to_clipboard(self._ctx, url):
                         try:
@@ -324,9 +322,6 @@ def status_dialog(ctx, title, build_status_fn, copy_url_fn=None):
                                 "Copied!"
                         except Exception as e:
                             log.debug("Failed to set CopyBtn Label: %s", e)
-
-                def disposing(self, ev):
-                    pass
 
             dlg.getControl("CopyBtn").addActionListener(
                 _CopyListener(dlg, ctx, copy_url_fn))
@@ -505,7 +500,7 @@ def set_checkbox_state(ctrl, value):
         log.debug("set_checkbox_state error: %s", e)
 
 
-class TabListener(unohelper.Base, XActionListener):
+class TabListener(BaseActionListener):
     """Listener for tab buttons in multi-page XDL dialogs.
 
     Usage: dlg.getControl("btn_tab_name").addActionListener(TabListener(dlg, page_number))
@@ -517,10 +512,6 @@ class TabListener(unohelper.Base, XActionListener):
         self._dlg = dialog
         self._page = page
 
-    def actionPerformed(self, ev):
+    def on_action_performed(self, ev):
         """Switch to the specified page when button is clicked."""
         self._dlg.getModel().Step = self._page
-
-    def disposing(self, ev):
-        """Required by XActionListener interface."""
-        pass

--- a/plugin/framework/legacy_ui.py
+++ b/plugin/framework/legacy_ui.py
@@ -90,7 +90,7 @@ def settings_box(ctx, title="Settings", x=None, y=None):
     from plugin.framework.config import populate_combobox_with_lru, populate_image_model_selector, endpoint_from_selector_text, get_api_key_for_endpoint, populate_endpoint_selector, as_bool
 
     log.debug("settings_box entry")
-    import unohelper
+    from plugin.framework.listeners import BaseListener
     from com.sun.star.awt import XItemListener, XTextListener
 
     smgr = ctx.getServiceManager()
@@ -174,7 +174,7 @@ def settings_box(ctx, title="Settings", x=None, y=None):
                 elif field["name"] == "endpoint":
                     populate_endpoint_selector(ctx, ctrl, field["value"])
                     if hasattr(ctrl, "addItemListener"):
-                        class EndpointCombinedListener(unohelper.Base, XItemListener, XTextListener):
+                        class EndpointCombinedListener(BaseListener, XItemListener, XTextListener):
                             def __init__(self, dialog, context, combo_ctrl):
                                 self._dlg = dialog
                                 self._ctx = context
@@ -199,8 +199,8 @@ def settings_box(ctx, title="Settings", x=None, y=None):
                                     api_key_ctrl = self._dlg.getControl("api_key")
                                     if api_key_ctrl:
                                         api_key_ctrl.getModel().Text = get_api_key_for_endpoint(self._ctx, resolved)
-                                except Exception:
-                                    pass
+                                except Exception as e:
+                                    log.error("EndpointCombinedListener error updating dropdowns: %s", e, exc_info=True)
 
                             def itemStateChanged(self, ev):
                                 try:
@@ -211,15 +211,15 @@ def settings_box(ctx, title="Settings", x=None, y=None):
                                         url = endpoint_from_selector_text(item_text)
                                         if url: self._ctrl.setText(url)
                                         self.update_dropdowns()
-                                except Exception:
-                                    pass
+                                except Exception as e:
+                                    log.error("EndpointCombinedListener error in itemStateChanged: %s", e, exc_info=True)
 
                             def textChanged(self, ev):
-                                self.update_dropdowns()
+                                try:
+                                    self.update_dropdowns()
+                                except Exception as e:
+                                    log.error("EndpointCombinedListener error in textChanged: %s", e, exc_info=True)
 
-                            def disposing(self, ev):
-                                pass
-                        
                         listener = EndpointCombinedListener(dlg, ctx, ctrl)
                         ctrl.addItemListener(listener)
                         if hasattr(ctrl, "addTextListener"):
@@ -316,8 +316,7 @@ def settings_box(ctx, title="Settings", x=None, y=None):
         dlg.dispose()
 
 def show_eval_dashboard(ctx):
-    import unohelper
-    from com.sun.star.awt import XActionListener
+    from plugin.framework.listeners import BaseActionListener
     from plugin.tests.eval_runner import run_benchmark_suite
 
     smgr = ctx.getServiceManager()
@@ -334,14 +333,14 @@ def show_eval_dashboard(ctx):
         current_endpoint = str(get_config(ctx, "endpoint") or "").strip()
         populate_combobox_with_lru(ctx, model_ctrl, current_model, "model_lru", current_endpoint)
 
-        class EvalRunListener(unohelper.Base, XActionListener):
+        class EvalRunListener(BaseActionListener):
             def __init__(self, ctx, dialog, toolkit):
                 self.ctx = ctx
                 self.dialog = dialog
                 self.toolkit = toolkit
                 self.is_running = False
 
-            def actionPerformed(self, ev):
+            def on_action_performed(self, ev):
                 if self.is_running: return
                 self.is_running = True
                 try:
@@ -375,15 +374,12 @@ def show_eval_dashboard(ctx):
                 self.dialog.getControl("log_area").setText(log_text)
                 self.dialog.getControl("status").setText("Finished")
 
-            def disposing(self, ev): pass
-
         toolkit = smgr.createInstanceWithContext("com.sun.star.awt.Toolkit", ctx)
         dlg.getControl("btn_run").addActionListener(EvalRunListener(ctx, dlg, toolkit))
         
-        class CloseListener(unohelper.Base, XActionListener):
+        class CloseListener(BaseActionListener):
             def __init__(self, dialog): self.dialog = dialog
-            def actionPerformed(self, ev): self.dialog.endDialog(0)
-            def disposing(self, ev): pass
+            def on_action_performed(self, ev): self.dialog.endDialog(0)
         dlg.getControl("btn_close").addActionListener(CloseListener(dlg))
 
         dlg.execute()

--- a/plugin/framework/listeners.py
+++ b/plugin/framework/listeners.py
@@ -1,0 +1,116 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2024 John Balis
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Base classes for UNO listeners to reduce boilerplate.
+
+These base classes provide empty `disposing` implementations and standard
+try/except logging blocks around the main event callbacks.
+"""
+
+import logging
+import functools
+import unohelper
+from com.sun.star.awt import XActionListener, XItemListener, XTextListener, XWindowListener
+from com.sun.star.lang import XEventListener
+
+log = logging.getLogger(__name__)
+
+
+def _catch_and_log(func):
+    """Decorator to catch and log exceptions in UNO listener callbacks."""
+    @functools.wraps(func)
+    def wrapper(self, ev, *args, **kwargs):
+        try:
+            return func(self, ev, *args, **kwargs)
+        except Exception as e:
+            log.error(f"{self.__class__.__name__} exception in {func.__name__}: %s", e, exc_info=True)
+    return wrapper
+
+
+class BaseListener(unohelper.Base, XEventListener):
+    """Base UNO listener providing empty disposing()."""
+
+    def disposing(self, ev):
+        """Required by XEventListener interface."""
+        pass
+
+
+class BaseActionListener(BaseListener, XActionListener):
+    """Base class for XActionListener that catches and logs exceptions."""
+
+    @_catch_and_log
+    def actionPerformed(self, ev):
+        self.on_action_performed(ev)
+
+    def on_action_performed(self, ev):
+        """Override this method to handle the action event."""
+        pass
+
+
+class BaseItemListener(BaseListener, XItemListener):
+    """Base class for XItemListener that catches and logs exceptions."""
+
+    @_catch_and_log
+    def itemStateChanged(self, ev):
+        self.on_item_state_changed(ev)
+
+    def on_item_state_changed(self, ev):
+        """Override this method to handle the item state change event."""
+        pass
+
+
+class BaseTextListener(BaseListener, XTextListener):
+    """Base class for XTextListener that catches and logs exceptions."""
+
+    @_catch_and_log
+    def textChanged(self, ev):
+        self.on_text_changed(ev)
+
+    def on_text_changed(self, ev):
+        """Override this method to handle the text changed event."""
+        pass
+
+
+class BaseWindowListener(BaseListener, XWindowListener):
+    """Base class for XWindowListener providing empty defaults and catching exceptions."""
+
+    @_catch_and_log
+    def windowResized(self, ev):
+        self.on_window_resized(ev)
+
+    @_catch_and_log
+    def windowMoved(self, ev):
+        self.on_window_moved(ev)
+
+    @_catch_and_log
+    def windowShown(self, ev):
+        self.on_window_shown(ev)
+
+    @_catch_and_log
+    def windowHidden(self, ev):
+        self.on_window_hidden(ev)
+
+    def on_window_resized(self, ev):
+        pass
+
+    def on_window_moved(self, ev):
+        pass
+
+    def on_window_shown(self, ev):
+        pass
+
+    def on_window_hidden(self, ev):
+        pass

--- a/plugin/modules/chatbot/panel.py
+++ b/plugin/modules/chatbot/panel.py
@@ -132,11 +132,11 @@ class ChatSession:
 # QueryTextListener - dynamic button toggling
 # ---------------------------------------------------------------------------
 
-from com.sun.star.awt import XTextListener
+from plugin.framework.listeners import BaseTextListener, BaseActionListener
 
 log = logging.getLogger(__name__)
 
-class QueryTextListener(unohelper.Base, XTextListener):
+class QueryTextListener(BaseTextListener):
     def __init__(self, send_button):
         self.send_button = send_button
         # Pixel width measured for Record/Send/Stop Rec; stops sidebar width creep on GTK.
@@ -145,46 +145,41 @@ class QueryTextListener(unohelper.Base, XTextListener):
     def set_fixed_send_width(self, width_px):
         self._fixed_send_width = width_px
 
-    def textChanged(self, ev):
-        try:
-            model = getattr(ev.Source, "Model", None)
-            if not model:
-                model = ev.Source.getModel()
-            text = model.Text.strip()
+    def on_text_changed(self, ev):
+        model = getattr(ev.Source, "Model", None)
+        if not model:
+            model = ev.Source.getModel()
+        text = model.Text.strip()
 
-            btn_model = self.send_button.getModel()
-            # If currently recording, do not toggle back to Record
-            if btn_model.Label == "Stop Rec":
-                return
+        btn_model = self.send_button.getModel()
+        # If currently recording, do not toggle back to Record
+        if btn_model.Label == "Stop Rec":
+            return
 
-            if text:
-                new_label = "Send"
-            else:
-                new_label = "Record" if HAS_RECORDING else "Send"
+        if text:
+            new_label = "Send"
+        else:
+            new_label = "Record" if HAS_RECORDING else "Send"
 
-            if btn_model.Label != new_label:
-                log.debug("QueryTextListener: toggle label '%s' -> '%s'" % (btn_model.Label, new_label))
-                btn_model.Label = new_label
-            if self._fixed_send_width:
-                try:
-                    r = self.send_button.getPosSize()
-                    if r.Width != self._fixed_send_width:
-                        self.send_button.setPosSize(
-                            r.X, r.Y, self._fixed_send_width, r.Height, 15
-                        )
-                except Exception:
-                    pass
-        except Exception as e:
-            log.error("QueryTextListener error: %s" % e)
+        if btn_model.Label != new_label:
+            log.debug("QueryTextListener: toggle label '%s' -> '%s'" % (btn_model.Label, new_label))
+            btn_model.Label = new_label
+        if self._fixed_send_width:
+            try:
+                r = self.send_button.getPosSize()
+                if r.Width != self._fixed_send_width:
+                    self.send_button.setPosSize(
+                        r.X, r.Y, self._fixed_send_width, r.Height, 15
+                    )
+            except Exception:
+                pass
 
-    def disposing(self, ev):
-        pass
 
 # ---------------------------------------------------------------------------
 # SendButtonListener - handles Send button click with tool-calling loop
 # ---------------------------------------------------------------------------
 
-class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XActionListener):
+class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener):
     """Listener for the Send button - runs chat with document, supports tool-calling."""
 
     def __init__(self, ctx, frame, send_control, stop_control, query_control, response_control, image_model_selector, model_selector, status_control, session, direct_image_checkbox=None, aspect_ratio_selector=None, base_size_input=None, web_research_checkbox=None, ensure_path_fn=None):
@@ -306,7 +301,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
         set_control_enabled(self.send_control, send_enabled)
         set_control_enabled(self.stop_control, stop_enabled)
 
-    def actionPerformed(self, evt):
+    def on_action_performed(self, evt):
         try:
             btn_model = self.send_control.getModel()
             if HAS_RECORDING and btn_model.Label == "Record":
@@ -344,6 +339,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
             log.error("SendButton unhandled exception [doc: %s]: %s\n%s", doc_type_for_log, e, tb)
 
             self._append_response("\n\n[Error: %s]\n" % str(e))
+            raise
         finally:
             self._send_busy = False
             log.debug("actionPerformed finally: resetting UI")
@@ -509,46 +505,40 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, unohelper.Base, XA
 # StopButtonListener - allows user to cancel the AI request
 # ---------------------------------------------------------------------------
 
-class StopButtonListener(unohelper.Base, XActionListener):
+class StopButtonListener(BaseActionListener):
     """Listener for the Stop button - sets a flag in SendButtonListener to halt loops."""
 
     def __init__(self, send_listener):
         self.send_listener = send_listener
 
-    def actionPerformed(self, evt):
-        try:
-            if self.send_listener:
-                self.send_listener.stop_requested = True
+    def on_action_performed(self, evt):
+        if self.send_listener:
+            self.send_listener.stop_requested = True
 
-                # 1. Stop the HTTP client immediately (breaks hanging reads)
-                client = getattr(self.send_listener, "client", None)
-                if client and hasattr(client, "stop"):
-                    try:
-                        client.stop()
-                    except Exception as e:
-                        log.error("StopButton error stopping client: %s", e)
+            # 1. Stop the HTTP client immediately (breaks hanging reads)
+            client = getattr(self.send_listener, "client", None)
+            if client and hasattr(client, "stop"):
+                try:
+                    client.stop()
+                except Exception as e:
+                    log.error("StopButton error stopping client: %s", e)
 
-                # 2. If an external agent backend is running, tell it to stop
-                adapter = getattr(self.send_listener, "_current_agent_backend", None)
-                if adapter and hasattr(adapter, "stop"):
-                    try:
-                        adapter.stop()
-                    except Exception as e:
-                        log.error("StopButton error stopping agent backend: %s", e)
-                # Update status immediately
-                self.send_listener._set_status("Stopping...")
-        except Exception as e:
-            log.error("StopButton unhandled exception: %s", e)
-
-    def disposing(self, evt):
-        pass
+            # 2. If an external agent backend is running, tell it to stop
+            adapter = getattr(self.send_listener, "_current_agent_backend", None)
+            if adapter and hasattr(adapter, "stop"):
+                try:
+                    adapter.stop()
+                except Exception as e:
+                    log.error("StopButton error stopping agent backend: %s", e)
+            # Update status immediately
+            self.send_listener._set_status("Stopping...")
 
 
 # ---------------------------------------------------------------------------
 # ClearButtonListener - resets the conversation
 # ---------------------------------------------------------------------------
 
-class ClearButtonListener(unohelper.Base, XActionListener):
+class ClearButtonListener(BaseActionListener):
     """Listener for the Clear button - resets conversation history."""
 
     def __init__(self, session, response_control, status_control, greeting=""):
@@ -569,16 +559,10 @@ class ClearButtonListener(unohelper.Base, XActionListener):
         if greeting is not None:
             self.greeting = greeting
 
-    def actionPerformed(self, evt):
-        try:
-            self.session.clear()
-            if self.response_control and self.response_control.getModel():
-                text = self.greeting + "\n" if self.greeting else ""
-                self.response_control.getModel().Text = text
-            if self.status_control:
-                self.status_control.setText("")
-        except Exception as e:
-            log.error("ClearButton error: %s", e)
-
-    def disposing(self, evt):
-        pass
+    def on_action_performed(self, evt):
+        self.session.clear()
+        if self.response_control and self.response_control.getModel():
+            text = self.greeting + "\n" if self.greeting else ""
+            self.response_control.getModel().Text = text
+        if self.status_control:
+            self.status_control.setText("")

--- a/plugin/modules/chatbot/panel_factory.py
+++ b/plugin/modules/chatbot/panel_factory.py
@@ -61,6 +61,7 @@ from plugin.modules.chatbot.panel_wiring import _wireControls as wire_chatpanel_
 
 from com.sun.star.ui import XUIElementFactory, XUIElement, XToolPanel, XSidebarPanel
 from com.sun.star.ui.UIElementType import TOOLPANEL
+from plugin.framework.listeners import BaseItemListener
 from com.sun.star.awt import XItemListener
 
 log = logging.getLogger(__name__)
@@ -399,25 +400,19 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                 set_image_model(self.ctx, set_image_val, update_lru=False)
 
         if model_selector and hasattr(model_selector, "addItemListener"):
-            class ModelSyncListener(unohelper.Base, XItemListener):
+            class ModelSyncListener(BaseItemListener):
                 def __init__(self, ctx): self.ctx = ctx
-                def itemStateChanged(self, ev):
-                    try:
-                        txt = model_selector.getText()
-                        if txt: set_config(self.ctx, "text_model", txt)
-                    except Exception: pass
-                def disposing(self, ev): pass
+                def on_item_state_changed(self, ev):
+                    txt = model_selector.getText()
+                    if txt: set_config(self.ctx, "text_model", txt)
             model_selector.addItemListener(ModelSyncListener(self.ctx))
 
         if image_model_selector and hasattr(image_model_selector, "addItemListener"):
-            class ImageModelSyncListener(unohelper.Base, XItemListener):
+            class ImageModelSyncListener(BaseItemListener):
                 def __init__(self, ctx): self.ctx = ctx
-                def itemStateChanged(self, ev):
-                    try:
-                        txt = image_model_selector.getText()
-                        if txt: set_image_model(self.ctx, txt, update_lru=False)
-                    except Exception: pass
-                def disposing(self, ev): pass
+                def on_item_state_changed(self, ev):
+                    txt = image_model_selector.getText()
+                    if txt: set_image_model(self.ctx, txt, update_lru=False)
             image_model_selector.addItemListener(ImageModelSyncListener(self.ctx))
 
     def _wire_image_ui(self, aspect_ratio_selector, base_size_input, base_size_label, 
@@ -446,14 +441,11 @@ class ChatPanelElement(unohelper.Base, XUIElement):
         if aspect_ratio_selector:
             update_base_size_label(aspect_ratio_selector.getText())
             if hasattr(aspect_ratio_selector, "addItemListener"):
-                class AspectListener(unohelper.Base, XItemListener):
-                    def itemStateChanged(self, ev):
-                        try:
-                            idx = getattr(ev, "Selected", -1)
-                            if idx >= 0:
-                                update_base_size_label(aspect_ratio_selector.getItem(idx))
-                        except Exception: pass
-                    def disposing(self, ev): pass
+                class AspectListener(BaseItemListener):
+                    def on_item_state_changed(self, ev):
+                        idx = getattr(ev, "Selected", -1)
+                        if idx >= 0:
+                            update_base_size_label(aspect_ratio_selector.getItem(idx))
                 aspect_ratio_selector.addItemListener(AspectListener())
 
         def set_control_enabled(ctrl, enabled):
@@ -488,20 +480,16 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                     set_control_enabled(web_research_check, False)
                     
                 if hasattr(direct_image_check, "addItemListener"):
-                    class DirectImageCheckListener(unohelper.Base, XItemListener):
+                    class DirectImageCheckListener(BaseItemListener):
                         def __init__(self, ctx, toggle_cb, web_check):
                             self.ctx = ctx
                             self.toggle_cb = toggle_cb
                             self.web_check = web_check
-                        def itemStateChanged(self, ev):
-                            try:
-                                is_checked = (getattr(ev, "Selected", 0) == 1)
-                                set_config(self.ctx, "chat_direct_image", is_checked)
-                                self.toggle_cb(is_checked)
-                                set_control_enabled(self.web_check, not is_checked)
-                            except Exception as e:
-                                log.error("Image checkbox listener error: %s" % e)
-                        def disposing(self, ev): pass
+                        def on_item_state_changed(self, ev):
+                            is_checked = (getattr(ev, "Selected", 0) == 1)
+                            set_config(self.ctx, "chat_direct_image", is_checked)
+                            self.toggle_cb(is_checked)
+                            set_control_enabled(self.web_check, not is_checked)
                     direct_image_check.addItemListener(DirectImageCheckListener(self.ctx, toggle_image_ui, web_research_check))
             except Exception as e:
                 log.error("direct_image_check wire error: %s" % e)
@@ -578,7 +566,7 @@ class ChatPanelElement(unohelper.Base, XUIElement):
 
         if controls["web_research_check"] and hasattr(controls["web_research_check"], "addItemListener"):
             from plugin.framework.constants import get_greeting_for_document, DEFAULT_RESEARCH_GREETING
-            class ResearchChatToggledListener(unohelper.Base, XItemListener):
+            class ResearchChatToggledListener(BaseItemListener):
                 def __init__(self, panel, response_ctrl, model, send_listener, clear_listener, img_check, set_control_enabled):
                     self.panel = panel
                     self.response_ctrl = response_ctrl
@@ -588,26 +576,23 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                     self.img_check = img_check
                     self.set_control_enabled = set_control_enabled
 
-                def itemStateChanged(self, ev):
-                    try:
-                        is_research = (getattr(ev, "Selected", 0) == 1)
-                        self.set_control_enabled(self.img_check, not is_research)
-                        
-                        if is_research:
-                            self.panel.session = self.panel.web_session
-                            greeting = DEFAULT_RESEARCH_GREETING
-                        else:
-                            self.panel.session = self.panel.doc_session
-                            greeting = get_greeting_for_document(self.model)
-                        
-                        if self.send_listener:
-                            self.send_listener.set_session(self.panel.session)
-                        if self.clear_listener:
-                            self.clear_listener.set_session(self.panel.session, greeting=greeting)
-                        self.panel._render_session_history(self.panel.session, self.response_ctrl, self.model, greeting)
-                    except Exception as e:
-                        log.error("Research Chat listener error: %s" % e)
-                def disposing(self, ev): pass
+                def on_item_state_changed(self, ev):
+                    is_research = (getattr(ev, "Selected", 0) == 1)
+                    self.set_control_enabled(self.img_check, not is_research)
+
+                    if is_research:
+                        self.panel.session = self.panel.web_session
+                        greeting = DEFAULT_RESEARCH_GREETING
+                    else:
+                        self.panel.session = self.panel.doc_session
+                        greeting = get_greeting_for_document(self.model)
+
+                    if self.send_listener:
+                        self.send_listener.set_session(self.panel.session)
+                    if self.clear_listener:
+                        self.clear_listener.set_session(self.panel.session, greeting=greeting)
+                    self.panel._render_session_history(self.panel.session, self.response_ctrl, self.model, greeting)
+
             controls["web_research_check"].addItemListener(ResearchChatToggledListener(
                 self, controls["response"], model, send_listener, clear_listener, controls["direct_image_check"], set_control_enabled))
 

--- a/plugin/modules/chatbot/panel_resize.py
+++ b/plugin/modules/chatbot/panel_resize.py
@@ -1,7 +1,6 @@
-import unohelper
 import logging
 
-from com.sun.star.awt import XWindowListener
+from plugin.framework.listeners import BaseWindowListener
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ _MIN_WIDTHS = {
 }
 
 
-class _PanelResizeListener(unohelper.Base, XWindowListener):
+class _PanelResizeListener(BaseWindowListener):
     """Adjusts panel layout on resize. Reads control sizes/gaps from the XDL;
     only the response area height changes to fill available space."""
 
@@ -62,29 +61,13 @@ class _PanelResizeListener(unohelper.Base, XWindowListener):
         finally:
             self._in_relayout = False
 
-    def windowResized(self, evt):
+    def on_window_resized(self, evt):
         r = evt.Source.getPosSize()
         log.debug("windowResized: W=%d H=%d" % (r.Width, r.Height))
         if self._in_relayout:
             log.debug("windowResized: skipped (in_relayout)")
             return
         self.relayout_now(evt.Source)
-
-    def windowMoved(self, evt):  # noqa: D401, D416
-        """No-op for sidebar resize listener."""
-        pass
-
-    def windowShown(self, evt):  # noqa: D401, D416
-        """No-op for sidebar resize listener."""
-        pass
-
-    def windowHidden(self, evt):  # noqa: D401, D416
-        """No-op for sidebar resize listener."""
-        pass
-
-    def disposing(self, evt):  # noqa: D401, D416
-        """No-op for sidebar resize listener."""
-        pass
 
     def _capture_initial(self, win):
         """Snapshot XDL-loaded pixel positions/sizes of every control."""


### PR DESCRIPTION
The codebase contained numerous UNO listener implementations that followed repetitive patterns such as inheriting from both `unohelper.Base` and a UNO interface, implementing empty `disposing()` methods, and manually wrapping execution in `try/except` blocks to log errors.

This PR introduces `plugin/framework/listeners.py`, providing a cohesive set of base listener classes (`BaseActionListener`, `BaseItemListener`, `BaseTextListener`, `BaseWindowListener`) to abstract these responsibilities away. By centralizing error handling with a `@_catch_and_log` decorator, boilerplate code across the extension is drastically reduced, ensuring a consistent and safer approach to handling UNO events.

---
*PR created automatically by Jules for task [1199443563954527912](https://jules.google.com/task/1199443563954527912) started by @KeithCu*