### PR TITLE
Refactor exception handling using centralized WriterAgentException hierarchy

### DIFF
--- a/plugin/modules/calc/address_utils.py
+++ b/plugin/modules/calc/address_utils.py
@@ -21,6 +21,7 @@ Pure utility functions with no UNO dependency. Ported from
 core/calc_address_utils.py for the plugin framework.
 """
 
+from plugin.framework.errors import UnoObjectError
 import re
 
 
@@ -71,7 +72,7 @@ def parse_address(address: str) -> tuple[int, int]:
     address = address.strip().upper()
     match = re.match(r'^([A-Z]+)(\d+)$', address)
     if not match:
-        raise ValueError(f"Invalid cell address: '{address}'")
+        raise UnoObjectError(f"Invalid cell address: '{address}'")
 
     col_str = match.group(1)
     row_num = int(match.group(2))
@@ -100,7 +101,7 @@ def parse_range_string(range_str: str) -> tuple[tuple[int, int], tuple[int, int]
     pattern = r'^([A-Z]+)(\d+)(?::([A-Z]+)(\d+))?$'
     match = re.match(pattern, range_str)
     if not match:
-        raise ValueError(f"Invalid cell range format: '{range_str}'")
+        raise UnoObjectError(f"Invalid cell range format: '{range_str}'")
 
     start_col = column_to_index(match.group(1))
     start_row = int(match.group(2)) - 1

--- a/plugin/modules/calc/analyzer.py
+++ b/plugin/modules/calc/analyzer.py
@@ -1,3 +1,4 @@
+from plugin.framework.errors import ToolExecutionError
 # WriterAgent - AI Writing Assistant for LibreOffice
 # Copyright (c) 2024 John Balis
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
@@ -96,4 +97,4 @@ class SheetAnalyzer:
             }
         except Exception as e:
             logger.error("Error creating sheet summary: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e

--- a/plugin/modules/calc/comments.py
+++ b/plugin/modules/calc/comments.py
@@ -5,6 +5,7 @@
 
 """Calc cell annotation (comment) tools."""
 
+from plugin.framework.errors import UnoObjectError
 import logging
 
 from plugin.framework.tool_base import ToolBase
@@ -21,7 +22,7 @@ def _resolve_sheet(doc, sheet_name=None):
     if sheet_name:
         sheets = doc.getSheets()
         if not sheets.hasByName(sheet_name):
-            raise ValueError("Sheet not found: %s" % sheet_name)
+            raise UnoObjectError("Sheet not found: %s" % sheet_name)
         return sheets.getByName(sheet_name)
     controller = doc.getCurrentController()
     if hasattr(controller, "getActiveSheet"):

--- a/plugin/modules/calc/error_detector.py
+++ b/plugin/modules/calc/error_detector.py
@@ -1,3 +1,4 @@
+from plugin.framework.errors import ToolExecutionError
 # WriterAgent - AI Writing Assistant for LibreOffice
 # Copyright (c) 2024 John Balis
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
@@ -239,7 +240,7 @@ class ErrorDetector:
             return errors
         except Exception as e:
             logger.error("Error detection failure: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def explain_error(self, address: str) -> dict:
         """Explain the error in the specified cell in detail.
@@ -295,7 +296,7 @@ class ErrorDetector:
             }
         except Exception as e:
             logger.error("Error explanation failure (%s): %s", address, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def detect_and_explain(self, range_str: str = None) -> dict:
         """Detect formula errors in a range and return them with explanations.

--- a/plugin/modules/calc/inspector.py
+++ b/plugin/modules/calc/inspector.py
@@ -1,3 +1,4 @@
+from plugin.framework.errors import ToolExecutionError
 # WriterAgent - AI Writing Assistant for LibreOffice
 # Copyright (c) 2024 John Balis
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
@@ -111,7 +112,7 @@ class CellInspector:
             }
         except Exception as e:
             logger.error("Cell reading error (%s): %s", address, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def get_cell_details(self, address: str) -> dict:
         """Return all detailed cell information.
@@ -157,7 +158,7 @@ class CellInspector:
             }
         except Exception as e:
             logger.error("Cell detailed reading error (%s): %s", address, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def read_range(self, range_name: str) -> list[list[dict]]:
         """Read values and formulas in a cell range.
@@ -219,7 +220,7 @@ class CellInspector:
             return result
         except Exception as e:
             logger.error("Range reading error (%s): %s", range_name, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def get_all_formulas(self, sheet_name: str = None) -> list[dict]:
         """List all formulas in a sheet.
@@ -279,4 +280,4 @@ class CellInspector:
             return formulas
         except Exception as e:
             logger.error("Formula listing error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e

--- a/plugin/modules/calc/manipulator.py
+++ b/plugin/modules/calc/manipulator.py
@@ -26,7 +26,7 @@ import io
 import json
 import logging
 
-from plugin.framework.errors import safe_json_loads
+from plugin.framework.errors import ToolExecutionError, UnoObjectError, safe_json_loads
 from plugin.modules.calc.address_utils import parse_address
 
 logger = logging.getLogger("writeragent.calc")
@@ -224,7 +224,7 @@ class CellManipulator:
                     return f"Text written to cell {address}: {formula}"
         except Exception as e:
             logger.error("Formula writing error (%s): %s", address, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     # ── Style operations ───────────────────────────────────────────────
 
@@ -282,7 +282,7 @@ class CellManipulator:
                 logger.info("Cell %s style updated.", address_or_range.upper())
         except Exception as e:
             logger.error("Style application error (%s): %s", address_or_range, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def _set_range_style(
         self, range_str, bold=None, italic=None, bg_color=None,
@@ -333,7 +333,7 @@ class CellManipulator:
             logger.info("Range %s cleared.", range_str.upper())
         except Exception as e:
             logger.error("Range clear error (%s): %s", range_str, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def merge_cells(self, range_str: str, center: bool = True):
         """Merge a cell range.
@@ -355,7 +355,7 @@ class CellManipulator:
                 cell_range.setPropertyValue("VertJustify", V_CENTER)
         except Exception as e:
             logger.error("Cell merge error (%s): %s", range_str, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def sort_range(
         self,
@@ -405,7 +405,7 @@ class CellManipulator:
             return f"Range {range_str} sorted {direction} by column {sort_column}."
         except Exception as e:
             logger.error("Sort error (%s): %s", range_str, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def write_formula_range(self, range_str: str, formula_or_values):
         """Write formula(s) or value(s) to a cell range.
@@ -434,7 +434,7 @@ class CellManipulator:
 
             if isinstance(formula_or_values, (list, tuple)):
                 if len(formula_or_values) != total_cells:
-                    raise ValueError(
+                    raise UnoObjectError(
                         f"Array has {len(formula_or_values)} values but range has "
                         f"{total_cells} cells. Use a single string to fill the whole "
                         "range, or an array with exactly that many values for "
@@ -504,7 +504,7 @@ class CellManipulator:
             return f"Range {range_str} filled with {len(values)} values."
         except Exception as e:
             logger.error("Range formula write error (%s): %s", range_str, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def import_csv_from_string(self, csv_data: str, target_cell: str = "A1"):
         """Import CSV data into the sheet starting at *target_cell*.
@@ -569,7 +569,7 @@ class CellManipulator:
             return f"Imported {total_rows} rows, {total_cols} cols to {range_imported}."
         except Exception as e:
             logger.error("CSV import error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     # ── Chart ──────────────────────────────────────────────────────────
 
@@ -638,7 +638,7 @@ class CellManipulator:
             return f"{chart_type} type chart created as '{chart_name}'."
         except Exception as e:
             logger.error("Chart creation error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def list_charts(self):
         """List all charts on the active sheet."""
@@ -668,7 +668,7 @@ class CellManipulator:
             return result
         except Exception as e:
             logger.error("List charts error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def get_chart_info(self, chart_name: str):
         """Get detailed info about a chart."""
@@ -715,7 +715,7 @@ class CellManipulator:
             return info
         except Exception as e:
             logger.error("Get chart info error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def edit_chart(
         self,
@@ -729,7 +729,7 @@ class CellManipulator:
             sheet = self.bridge.get_active_sheet()
             charts = sheet.getCharts()
             if not charts.hasByName(chart_name):
-                raise ValueError(f"Chart '{chart_name}' not found.")
+                raise UnoObjectError(f"Chart '{chart_name}' not found.")
 
             chart_obj = charts.getByName(chart_name)
             chart_doc = chart_obj.getEmbeddedObject()
@@ -756,7 +756,7 @@ class CellManipulator:
             return updated
         except Exception as e:
             logger.error("Edit chart error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def delete_chart(self, chart_name: str):
         """Delete a chart."""
@@ -769,7 +769,7 @@ class CellManipulator:
             return True
         except Exception as e:
             logger.error("Delete chart error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     # ── Conditional Formatting ─────────────────────────────────────────
 
@@ -803,7 +803,7 @@ class CellManipulator:
             return rules
         except Exception as e:
             logger.error("List conditional formats error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def add_conditional_format(
         self,
@@ -839,7 +839,7 @@ class CellManipulator:
 
             op_val = op_map.get(operator.upper())
             if op_val is None:
-                raise ValueError(f"Unknown condition operator: {operator}")
+                raise UnoObjectError(f"Unknown condition operator: {operator}")
 
             sheet = self.bridge.get_active_sheet()
             cell_range = self.bridge.get_cell_range(sheet, range_str)
@@ -874,7 +874,7 @@ class CellManipulator:
             return formats.getCount()
         except Exception as e:
             logger.error("Add conditional format error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def remove_conditional_format(self, range_str: str, index: int):
         """Remove a conditional formatting rule by index."""
@@ -889,7 +889,7 @@ class CellManipulator:
             return False
         except Exception as e:
             logger.error("Remove conditional format error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def clear_conditional_formats(self, range_str: str):
         """Clear all conditional formatting from a range."""
@@ -902,7 +902,7 @@ class CellManipulator:
             return True
         except Exception as e:
             logger.error("Clear conditional formats error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def _entry_to_dict(self, entry, idx):
         """Convert a conditional entry to a readable dict."""
@@ -944,7 +944,7 @@ class CellManipulator:
             return f"{count} row(s) deleted starting from row {row_num}."
         except Exception as e:
             logger.error("Row deletion error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def delete_columns(self, col_letter: str, count: int = 1):
         """Delete columns starting at *col_letter*."""
@@ -960,7 +960,7 @@ class CellManipulator:
             return f"{count} column(s) deleted starting from column {col_letter.upper()}."
         except Exception as e:
             logger.error("Column deletion error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def delete_structure(self, structure_type: str, start, count: int = 1):
         """Delete rows or columns.
@@ -975,7 +975,7 @@ class CellManipulator:
         elif structure_type == "columns":
             return self.delete_columns(start, count)
         else:
-            raise ValueError(
+            raise UnoObjectError(
                 f"Invalid structure_type: {structure_type}. "
                 f"Must be 'rows' or 'columns'."
             )
@@ -999,7 +999,7 @@ class CellManipulator:
             return sheet_names
         except Exception as e:
             logger.error("Sheet listing error: %s", str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def switch_sheet(self, sheet_name: str):
         """Switch to the specified sheet.
@@ -1014,7 +1014,7 @@ class CellManipulator:
             doc = self.bridge.get_active_document()
             sheets = doc.getSheets()
             if not sheets.hasByName(sheet_name):
-                raise ValueError(f"No sheet found named '{sheet_name}'.")
+                raise UnoObjectError(f"No sheet found named '{sheet_name}'.")
             sheet = sheets.getByName(sheet_name)
             controller = doc.getCurrentController()
             controller.setActiveSheet(sheet)
@@ -1022,7 +1022,7 @@ class CellManipulator:
             return f"Switched to sheet '{sheet_name}'."
         except Exception as e:
             logger.error("Sheet switch error (%s): %s", sheet_name, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e
 
     def create_sheet(self, sheet_name: str, position: int = None):
         """Create a new sheet.
@@ -1044,4 +1044,4 @@ class CellManipulator:
             return f"New sheet named '{sheet_name}' created."
         except Exception as e:
             logger.error("Sheet creation error (%s): %s", sheet_name, str(e))
-            raise
+            raise ToolExecutionError(str(e)) from e

--- a/plugin/modules/calc/search.py
+++ b/plugin/modules/calc/search.py
@@ -5,6 +5,7 @@
 
 """Calc search tools: search_in_spreadsheet, replace_in_spreadsheet."""
 
+from plugin.framework.errors import UnoObjectError
 import logging
 
 from plugin.framework.tool_base import ToolBase
@@ -17,7 +18,7 @@ def _resolve_sheet(doc, sheet_name=None):
     if sheet_name:
         sheets = doc.getSheets()
         if not sheets.hasByName(sheet_name):
-            raise ValueError("Sheet not found: %s" % sheet_name)
+            raise UnoObjectError("Sheet not found: %s" % sheet_name)
         return sheets.getByName(sheet_name)
     controller = doc.getCurrentController()
     if hasattr(controller, "getActiveSheet"):

--- a/plugin/modules/doc/diagnostics.py
+++ b/plugin/modules/doc/diagnostics.py
@@ -253,7 +253,7 @@ class SetDocumentProtection(ToolBaseDummy):
         try:
             sections = doc.getTextSections()
         except Exception as exc:
-            return {"status": "error", "error": str(exc)}
+            return self._tool_error(str(exc))
 
         count = sections.getCount()
         if count == 0:

--- a/plugin/modules/doc/print_doc.py
+++ b/plugin/modules/doc/print_doc.py
@@ -75,4 +75,4 @@ class PrintDocument(ToolBaseDummy):
                 "copies": copies,
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/doc/undo.py
+++ b/plugin/modules/doc/undo.py
@@ -53,7 +53,7 @@ class Undo(ToolBaseDummy):
                 "can_redo": um.isRedoPossible(),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class Redo(ToolBaseDummy):
@@ -94,4 +94,4 @@ class Redo(ToolBaseDummy):
                 "can_redo": um.isRedoPossible(),
             }
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/draw/masters.py
+++ b/plugin/modules/draw/masters.py
@@ -5,6 +5,7 @@
 
 """Impress/Draw master slide tools."""
 
+from plugin.framework.errors import ToolExecutionError, UnoObjectError
 from plugin.framework.tool_base import ToolBase
 
 
@@ -13,7 +14,7 @@ def _get_slide(doc, page_index=None):
     pages = doc.getDrawPages()
     if page_index is not None:
         if page_index < 0 or page_index >= pages.getCount():
-            raise ValueError("Page index %d out of range." % page_index)
+            raise ToolExecutionError("Page index %d out of range." % page_index)
         return pages.getByIndex(page_index)
     controller = doc.getCurrentController()
     if hasattr(controller, "getCurrentPage"):

--- a/plugin/modules/draw/notes.py
+++ b/plugin/modules/draw/notes.py
@@ -5,6 +5,7 @@
 
 """Impress speaker notes tools."""
 
+from plugin.framework.errors import ToolExecutionError, UnoObjectError
 from plugin.framework.tool_base import ToolBase
 
 
@@ -13,7 +14,7 @@ def _get_slide(doc, page_index=None):
     pages = doc.getDrawPages()
     if page_index is not None:
         if page_index < 0 or page_index >= pages.getCount():
-            raise ValueError("Page index %d out of range." % page_index)
+            raise ToolExecutionError("Page index %d out of range." % page_index)
         return pages.getByIndex(page_index)
     controller = doc.getCurrentController()
     if hasattr(controller, "getCurrentPage"):

--- a/plugin/modules/draw/placeholders.py
+++ b/plugin/modules/draw/placeholders.py
@@ -10,6 +10,7 @@ slide with specific presentation types. These tools provide direct access
 to placeholders by role rather than shape index.
 """
 
+from plugin.framework.errors import ToolExecutionError, UnoObjectError
 import logging
 
 from plugin.framework.tool_base import ToolBase
@@ -35,7 +36,7 @@ def _get_slide(doc, page_index=None):
     pages = doc.getDrawPages()
     if page_index is not None:
         if page_index < 0 or page_index >= pages.getCount():
-            raise ValueError("Page index %d out of range." % page_index)
+            raise ToolExecutionError("Page index %d out of range." % page_index)
         return pages.getByIndex(page_index)
     controller = doc.getCurrentController()
     if hasattr(controller, "getCurrentPage"):

--- a/plugin/modules/draw/transitions.py
+++ b/plugin/modules/draw/transitions.py
@@ -5,6 +5,7 @@
 
 """Impress slide transition and layout tools."""
 
+from plugin.framework.errors import ToolExecutionError, UnoObjectError
 import logging
 
 from plugin.framework.tool_base import ToolBase
@@ -17,7 +18,7 @@ def _get_slide(doc, page_index=None):
     pages = doc.getDrawPages()
     if page_index is not None:
         if page_index < 0 or page_index >= pages.getCount():
-            raise ValueError("Page index %d out of range." % page_index)
+            raise ToolExecutionError("Page index %d out of range." % page_index)
         return pages.getByIndex(page_index)
     controller = doc.getCurrentController()
     if hasattr(controller, "getCurrentPage"):

--- a/plugin/modules/writer/format_support.py
+++ b/plugin/modules/writer/format_support.py
@@ -1,3 +1,4 @@
+from plugin.framework.errors import ToolExecutionError
 # WriterAgent - AI Writing Assistant for LibreOffice
 # Copyright (c) 2024 John Balis
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
@@ -419,7 +420,7 @@ def insert_content_at_position(model, ctx, content, position,
             except Exception:
                 cursor.gotoEnd(False)
         else:
-            raise ValueError("Unknown position: %s" % position)
+            raise ToolExecutionError("Unknown position: %s" % position)
 
         filter_name, _ = _get_format_props(config_svc)
         filter_props = (_create_property_value("FilterName", filter_name),)
@@ -451,7 +452,7 @@ def apply_content_at_range(model, ctx, content, start, end,
 
     cursor = get_text_cursor_at_range(model, start, end)
     if cursor is None:
-        raise ValueError(
+        raise ToolExecutionError(
             "Invalid range or could not create cursor for (%d, %d)" % (start, end)
         )
 

--- a/plugin/modules/writer/index.py
+++ b/plugin/modules/writer/index.py
@@ -1,3 +1,4 @@
+from plugin.framework.errors import ToolExecutionError
 # WriterAgent - AI Writing Assistant for LibreOffice
 # Copyright (c) 2024 John Balis
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
@@ -369,7 +370,7 @@ class IndexService:
         parsed = self._parse_query(query, stemmer, stop_words)
 
         if parsed["error"]:
-            raise ValueError(parsed["error"])
+            raise ToolExecutionError(parsed["error"])
 
         mode = parsed["mode"]
         and_stems = parsed["and_stems"]
@@ -394,7 +395,7 @@ class IndexService:
         elif and_stems:
             hits = idx.query_and(and_stems)
         else:
-            raise ValueError("No search terms after stop-word filtering")
+            raise ToolExecutionError("No search terms after stop-word filtering")
 
         if not_stems:
             hits = idx.query_not(hits, not_stems)

--- a/plugin/modules/writer/navigation.py
+++ b/plugin/modules/writer/navigation.py
@@ -55,10 +55,10 @@ class NavigateHeading(ToolBaseDummy):
             result = prox_svc.navigate_heading(
                 ctx.doc, kwargs["locator"], kwargs["direction"])
             if "error" in result:
-                return {"status": "error", **result}
+                return self._tool_error(result["error"])
             return {"status": "ok", **result}
         except ValueError as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 
 class GetSurroundings(ToolBaseDummy):
@@ -102,4 +102,4 @@ class GetSurroundings(ToolBaseDummy):
                 include=kwargs.get("include"))
             return {"status": "ok", **result}
         except ValueError as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))

--- a/plugin/modules/writer/outline.py
+++ b/plugin/modules/writer/outline.py
@@ -118,6 +118,6 @@ class GetHeadingChildren(ToolBaseDummy):
             )
             return {"status": "ok", **result}
         except ValueError as e:
-            return {"status": "error", "error": str(e)}
+            return self._tool_error(str(e))
 
 

--- a/plugin/modules/writer/proximity.py
+++ b/plugin/modules/writer/proximity.py
@@ -1,3 +1,4 @@
+from plugin.framework.errors import ToolExecutionError
 # WriterAgent - AI Writing Assistant for LibreOffice
 # Copyright (c) 2024 John Balis
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
@@ -123,7 +124,7 @@ class ProximityService:
         resolved = self._doc_svc.resolve_locator(doc, locator)
         para_index = resolved.get("para_index")
         if para_index is None:
-            raise ValueError("Cannot resolve locator: %s" % locator)
+            raise ToolExecutionError("Cannot resolve locator: %s" % locator)
 
         tree = self._tree_svc.build_heading_tree(doc)
         bookmark_map = self._bm_svc.ensure_heading_bookmarks(doc)
@@ -206,7 +207,7 @@ class ProximityService:
                     error_msg = "No previous sibling heading"
 
         else:
-            raise ValueError(
+            raise ToolExecutionError(
                 "Unknown direction: %s. Use: next, previous, parent, "
                 "first_child, next_sibling, previous_sibling" % direction)
 
@@ -255,7 +256,7 @@ class ProximityService:
         resolved = self._doc_svc.resolve_locator(doc, locator)
         center_idx = resolved.get("para_index")
         if center_idx is None:
-            raise ValueError("Cannot resolve locator: %s" % locator)
+            raise ToolExecutionError("Cannot resolve locator: %s" % locator)
 
         radius = max(1, min(50, radius))
         if include is None:
@@ -266,7 +267,7 @@ class ProximityService:
         total = len(para_ranges)
 
         if center_idx >= total:
-            raise ValueError(
+            raise ToolExecutionError(
                 "Paragraph %d out of range (document has %d paragraphs)"
                 % (center_idx, total))
 

--- a/plugin/modules/writer/tree.py
+++ b/plugin/modules/writer/tree.py
@@ -1,3 +1,4 @@
+from plugin.framework.errors import ToolExecutionError
 # WriterAgent - AI Writing Assistant for LibreOffice
 # Copyright (c) 2024 John Balis
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
@@ -310,13 +311,11 @@ class TreeService:
             heading_para_index = resolved.get("para_index")
         elif heading_bookmark is not None and heading_para_index is None:
             if not hasattr(doc, "getBookmarks"):
-                return {"status": "error",
-                        "error": "Document doesn't support bookmarks"}
+                raise ToolExecutionError("Document doesn't support bookmarks")
             bm_sup = doc.getBookmarks()
             if not bm_sup.hasByName(heading_bookmark):
-                return {"status": "error",
-                        "error": "Bookmark '%s' not found"
-                                 % heading_bookmark}
+                raise ToolExecutionError("Bookmark '%s' not found"
+                                 % heading_bookmark)
             bm = bm_sup.getByName(heading_bookmark)
             anchor = bm.getAnchor()
             para_ranges = self._doc_svc.get_paragraph_ranges(doc)
@@ -324,17 +323,15 @@ class TreeService:
                 anchor, para_ranges, doc.getText())
 
         if heading_para_index is None:
-            return {"status": "error",
-                    "error": "Provide locator, heading_para_index, "
-                             "or heading_bookmark"}
+            raise ToolExecutionError("Provide locator, heading_para_index, "
+                             "or heading_bookmark")
 
         tree = self.build_heading_tree(doc)
         bookmark_map = self._bm_svc.ensure_heading_bookmarks(doc)
         target = self._find_node_by_para_index(tree, heading_para_index)
         if target is None:
-            return {"status": "error",
-                    "error": "Heading at paragraph %d not found"
-                             % heading_para_index}
+            raise ToolExecutionError("Heading at paragraph %d not found"
+                             % heading_para_index)
 
         ai_summaries = (
             self.get_ai_summaries_map(doc)
@@ -411,16 +408,14 @@ class TreeService:
             resolved = self._doc_svc.resolve_locator(doc, locator)
             para_index = resolved.get("para_index")
         if para_index is None:
-            return {"status": "error",
-                    "error": "Provide locator or para_index"}
+            raise ToolExecutionError("Provide locator or para_index")
 
         doc_text = doc.getText()
         self._remove_ai_annotation_at(doc, para_index)
 
         target, _ = self._doc_svc.find_paragraph_element(doc, para_index)
         if target is None:
-            return {"status": "error",
-                    "error": "Paragraph %d not found" % para_index}
+            raise ToolExecutionError("Paragraph %d not found" % para_index)
 
         annotation = doc.createInstance(
             "com.sun.star.text.textfield.Annotation")
@@ -457,8 +452,7 @@ class TreeService:
             resolved = self._doc_svc.resolve_locator(doc, locator)
             para_index = resolved.get("para_index")
         if para_index is None:
-            return {"status": "error",
-                    "error": "Provide locator or para_index"}
+            raise ToolExecutionError("Provide locator or para_index")
         removed = self._remove_ai_annotation_at(doc, para_index)
         self._ai_summary_cache.pop(
             self._doc_svc.doc_key(doc), None)
@@ -526,15 +520,15 @@ class TreeService:
                     anchor, para_ranges, text_obj)
                 return {"para_index": para_idx}
             except Exception as e:
-                raise ValueError(
+                raise ToolExecutionError(
                     "Cannot resolve page:%s — %s" % (loc_value, e))
 
         if loc_type == "section":
             if not hasattr(doc, "getTextSections"):
-                raise ValueError("Document does not support sections")
+                raise ToolExecutionError("Document does not support sections")
             sections = doc.getTextSections()
             if not sections.hasByName(loc_value):
-                raise ValueError("Section '%s' not found" % loc_value)
+                raise ToolExecutionError("Section '%s' not found" % loc_value)
             section = sections.getByName(loc_value)
             anchor = section.getAnchor()
             para_ranges = self._doc_svc.get_paragraph_ranges(doc)
@@ -550,7 +544,7 @@ class TreeService:
             for part in parts:
                 children = node.get("children", [])
                 if part < 1 or part > len(children):
-                    raise ValueError(
+                    raise ToolExecutionError(
                         "Heading index %d out of range (1..%d) "
                         "in 'heading:%s'" % (part, len(children), loc_value))
                 node = children[part - 1]
@@ -559,15 +553,15 @@ class TreeService:
         if loc_type == "heading_text":
             result = self._find_heading_by_text(doc, loc_value)
             if result is None:
-                raise ValueError(
+                raise ToolExecutionError(
                     "No heading matching '%s' found" % loc_value)
             return {"para_index": result["para_index"]}
 
-        raise ValueError("Unknown Writer locator type: '%s'" % loc_type)
+        raise ToolExecutionError("Unknown Writer locator type: '%s'" % loc_type)
 
     def _resolve_bookmark_locator(self, doc, bookmark_name):
         if not hasattr(doc, "getBookmarks"):
-            raise ValueError("Document doesn't support bookmarks")
+            raise ToolExecutionError("Document doesn't support bookmarks")
         bookmarks = doc.getBookmarks()
         if not bookmarks.hasByName(bookmark_name):
             hint = "Bookmark '%s' not found." % bookmark_name
@@ -580,7 +574,7 @@ class TreeService:
                 if existing:
                     hint += (" Existing bookmarks: "
                              + ", ".join(existing[:10]))
-            raise ValueError(hint)
+            raise ToolExecutionError(hint)
         bm = bookmarks.getByName(bookmark_name)
         anchor = bm.getAnchor()
         para_ranges = self._doc_svc.get_paragraph_ranges(doc)


### PR DESCRIPTION
This PR addresses issue #10 by standardizing error handling across the extension.

- Replaces raw `Exception` catches and generic error dictionary returns with `self._tool_error(str(e))` inside `ToolBase` subclasses to enforce consistent JSON error payloads.
- Replaces raw `ValueError` raises with contextual `ToolExecutionError` or `UnoObjectError` where appropriate.
- Ensures all non-vendored `except Exception:` blocks properly wrap and raise standard custom exceptions.
- Leaves intentional empty `except Exception:` silences intact for graceful UNO property checks in Calc and Draw modules.
- Refactors `TreeService` and other non-Tool helper classes to `raise ToolExecutionError(...)` so `ToolRegistry.execute()` can catch and format them appropriately.

---
*PR created automatically by Jules for task [1233869045002534111](https://jules.google.com/task/1233869045002534111) started by @KeithCu*