### PR TITLE
Fix silent exception handlers in sidebar logic

### DIFF
--- a/plugin/modules/chatbot/panel_factory.py
+++ b/plugin/modules/chatbot/panel_factory.py
@@ -403,16 +403,22 @@ class ChatPanelElement(unohelper.Base, XUIElement):
             class ModelSyncListener(BaseItemListener):
                 def __init__(self, ctx): self.ctx = ctx
                 def on_item_state_changed(self, ev):
-                    txt = model_selector.getText()
-                    if txt: set_config(self.ctx, "text_model", txt)
+                    try:
+                        txt = model_selector.getText()
+                        if txt: set_config(self.ctx, "text_model", txt)
+                    except Exception as e:
+                        log.exception("ModelSyncListener error: %s", e)
             model_selector.addItemListener(ModelSyncListener(self.ctx))
 
         if image_model_selector and hasattr(image_model_selector, "addItemListener"):
             class ImageModelSyncListener(BaseItemListener):
                 def __init__(self, ctx): self.ctx = ctx
                 def on_item_state_changed(self, ev):
-                    txt = image_model_selector.getText()
-                    if txt: set_image_model(self.ctx, txt, update_lru=False)
+                    try:
+                        txt = image_model_selector.getText()
+                        if txt: set_image_model(self.ctx, txt, update_lru=False)
+                    except Exception as e:
+                        log.exception("ImageModelSyncListener error: %s", e)
             image_model_selector.addItemListener(ImageModelSyncListener(self.ctx))
 
     def _wire_image_ui(self, aspect_ratio_selector, base_size_input, base_size_label, 
@@ -443,9 +449,12 @@ class ChatPanelElement(unohelper.Base, XUIElement):
             if hasattr(aspect_ratio_selector, "addItemListener"):
                 class AspectListener(BaseItemListener):
                     def on_item_state_changed(self, ev):
-                        idx = getattr(ev, "Selected", -1)
-                        if idx >= 0:
-                            update_base_size_label(aspect_ratio_selector.getItem(idx))
+                        try:
+                            idx = getattr(ev, "Selected", -1)
+                            if idx >= 0:
+                                update_base_size_label(aspect_ratio_selector.getItem(idx))
+                        except Exception as e:
+                            log.exception("AspectListener error: %s", e)
                 aspect_ratio_selector.addItemListener(AspectListener())
 
         def set_control_enabled(ctrl, enabled):
@@ -562,7 +571,8 @@ class ChatPanelElement(unohelper.Base, XUIElement):
             try:
                 clear_listener = ClearButtonListener(self.session, controls["response"], controls["status"], greeting=active_greeting)
                 controls["clear"].addActionListener(clear_listener)
-            except Exception: pass
+            except Exception as e:
+                log.exception("Clear button wiring error: %s", e)
 
         if controls["web_research_check"] and hasattr(controls["web_research_check"], "addItemListener"):
             from plugin.framework.constants import get_greeting_for_document, DEFAULT_RESEARCH_GREETING

--- a/plugin/modules/chatbot/panel_factory.py
+++ b/plugin/modules/chatbot/panel_factory.py
@@ -403,22 +403,16 @@ class ChatPanelElement(unohelper.Base, XUIElement):
             class ModelSyncListener(BaseItemListener):
                 def __init__(self, ctx): self.ctx = ctx
                 def on_item_state_changed(self, ev):
-                    try:
-                        txt = model_selector.getText()
-                        if txt: set_config(self.ctx, "text_model", txt)
-                    except Exception as e:
-                        log.exception("ModelSyncListener error: %s", e)
+                    txt = model_selector.getText()
+                    if txt: set_config(self.ctx, "text_model", txt)
             model_selector.addItemListener(ModelSyncListener(self.ctx))
 
         if image_model_selector and hasattr(image_model_selector, "addItemListener"):
             class ImageModelSyncListener(BaseItemListener):
                 def __init__(self, ctx): self.ctx = ctx
                 def on_item_state_changed(self, ev):
-                    try:
-                        txt = image_model_selector.getText()
-                        if txt: set_image_model(self.ctx, txt, update_lru=False)
-                    except Exception as e:
-                        log.exception("ImageModelSyncListener error: %s", e)
+                    txt = image_model_selector.getText()
+                    if txt: set_image_model(self.ctx, txt, update_lru=False)
             image_model_selector.addItemListener(ImageModelSyncListener(self.ctx))
 
     def _wire_image_ui(self, aspect_ratio_selector, base_size_input, base_size_label, 
@@ -449,12 +443,9 @@ class ChatPanelElement(unohelper.Base, XUIElement):
             if hasattr(aspect_ratio_selector, "addItemListener"):
                 class AspectListener(BaseItemListener):
                     def on_item_state_changed(self, ev):
-                        try:
-                            idx = getattr(ev, "Selected", -1)
-                            if idx >= 0:
-                                update_base_size_label(aspect_ratio_selector.getItem(idx))
-                        except Exception as e:
-                            log.exception("AspectListener error: %s", e)
+                        idx = getattr(ev, "Selected", -1)
+                        if idx >= 0:
+                            update_base_size_label(aspect_ratio_selector.getItem(idx))
                 aspect_ratio_selector.addItemListener(AspectListener())
 
         def set_control_enabled(ctrl, enabled):

--- a/plugin/modules/chatbot/panel_wiring.py
+++ b/plugin/modules/chatbot/panel_wiring.py
@@ -99,7 +99,7 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
     web_checked = False
     if controls["web_research_check"]:
         try: web_checked = (get_checkbox_state(controls["web_research_check"]) == 1)
-        except Exception: pass
+        except Exception as e: log.exception("Error reading web_research_check state: %s", e)
         
     if web_checked:
         self.session = self.web_session
@@ -129,7 +129,7 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
 
     if controls["status"] and hasattr(controls["status"], "setText"):
         try: controls["status"].setText("Ready")
-        except Exception: pass
+        except Exception as e: log.exception("Error setting status text: %s", e)
 
     # 5. Timer and Resize
     try:


### PR DESCRIPTION
Replaces silent `except Exception: pass` blocks in `panel_factory.py` and `panel_wiring.py` with `log.exception` to ensure proper error visibility and debugging, specifically targeting the lines identified in the issue description.

---
*PR created automatically by Jules for task [1049897960379307786](https://jules.google.com/task/1049897960379307786) started by @KeithCu*