### PR TITLE
Refactor threading to use run_in_background

### DIFF
--- a/plugin/framework/async_stream.py
+++ b/plugin/framework/async_stream.py
@@ -24,6 +24,8 @@ import logging
 import queue
 import threading
 
+from plugin.framework.worker_pool import run_in_background
+
 log = logging.getLogger(__name__)
 
 
@@ -242,8 +244,7 @@ def run_stream_completion_async(
         on_error_fn(e)
         return
 
-    t = threading.Thread(target=worker, daemon=True)
-    t.start()
+    run_in_background(worker, daemon=True, name="stream-completion")
 
     def on_stream_done_wrapper(_response):
         on_done_fn()
@@ -312,8 +313,7 @@ def run_stream_async(
             on_error_fn(e)
         return
 
-    t = threading.Thread(target=worker, daemon=True)
-    t.start()
+    run_in_background(worker, daemon=True, name="stream-async")
 
     def on_stream_done_wrapper(_response):
         if on_done_fn:
@@ -353,8 +353,7 @@ def run_blocking_in_thread(ctx, func, *args, **kwargs):
         # Fallback if toolkit isn't available (unlikely in UI context)
         return func(*args, **kwargs)
 
-    t = threading.Thread(target=worker, daemon=True)
-    t.start()
+    run_in_background(worker, daemon=True, name="blocking-thread")
 
     while True:
         try:

--- a/plugin/framework/dialogs.py
+++ b/plugin/framework/dialogs.py
@@ -41,6 +41,7 @@ import logging
 import threading
 import unohelper
 from plugin.framework.listeners import BaseActionListener
+from plugin.framework.worker_pool import run_in_background
 from com.sun.star.awt import XActionListener
 from plugin.framework.uno_context import get_desktop, get_extension_url
 
@@ -340,7 +341,7 @@ def status_dialog(ctx, title, build_status_fn, copy_url_fn=None):
             except Exception:
                 pass  # dialog already closed
 
-        threading.Thread(target=_probe_update, daemon=True).start()
+        run_in_background(_probe_update, daemon=True, name="status-dialog-probe")
 
         dlg.execute()
         dlg.dispose()

--- a/plugin/framework/logging.py
+++ b/plugin/framework/logging.py
@@ -23,6 +23,8 @@ import traceback
 import threading
 import logging
 
+from plugin.framework.worker_pool import run_in_background
+
 # Globals set by init_logging(ctx); used by debug_log and agent_log so ctx is not passed at write time.
 _debug_log_path = None
 _agent_log_path = None
@@ -343,5 +345,4 @@ def start_watchdog_thread(ctx, status_control=None):
         if _watchdog_started:
             return
         _watchdog_started = True
-    t = threading.Thread(target=_watchdog_loop, args=(status_control,), daemon=True)
-    t.start()
+    run_in_background(_watchdog_loop, status_control, name="watchdog", daemon=True)

--- a/plugin/modules/agent_backend/acp_connection.py
+++ b/plugin/modules/agent_backend/acp_connection.py
@@ -27,6 +27,7 @@ import subprocess
 import threading
 
 from plugin.framework.errors import ToolExecutionError
+from plugin.framework.worker_pool import run_in_background
 
 log = logging.getLogger(__name__)
 
@@ -69,10 +70,9 @@ class ACPConnection:
             cwd=self._cwd,
         )
         self._running = True
-        self._reader_thread = threading.Thread(
-            target=self._reader_loop, daemon=True, name="acp-reader"
+        self._reader_thread = run_in_background(
+            self._reader_loop, daemon=True, name="acp-reader"
         )
-        self._reader_thread.start()
 
     def stop(self):
         """Terminate the subprocess."""

--- a/plugin/modules/http/server.py
+++ b/plugin/modules/http/server.py
@@ -29,6 +29,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from plugin.framework.url_utils import get_url_path, get_url_query_dict
 
 from plugin.framework.errors import safe_json_loads
+from plugin.framework.worker_pool import run_in_background
 
 log = logging.getLogger("writeragent.framework.http_server")
 
@@ -168,9 +169,8 @@ class HttpServer:
                 self._server.socket, server_side=True)
 
         self._running = True
-        self._thread = threading.Thread(
-            target=self._run, daemon=True, name="http-server")
-        self._thread.start()
+        self._thread = run_in_background(
+            self._run, daemon=True, name="http-server")
 
         scheme = "https" if self.use_ssl else "http"
         url = "%s://%s:%s" % (scheme, self.host, self.port)

--- a/plugin/tests/test_async_stream.py
+++ b/plugin/tests/test_async_stream.py
@@ -2,6 +2,7 @@ import pytest
 import queue
 import time
 from plugin.framework.async_stream import run_stream_drain_loop
+from plugin.framework.worker_pool import run_in_background
 
 class DummyToolkit:
     def processEventsToIdle(self):
@@ -410,8 +411,6 @@ def test_run_stream_drain_loop_next_tool_and_approval():
 
 
 def test_run_stream_drain_loop_connection_drop():
-    import threading
-
     q = queue.Queue()
     job_done = [False]
     toolkit = DummyToolkit()
@@ -447,8 +446,7 @@ def test_run_stream_drain_loop_connection_drop():
         except Exception as e:
             q.put(("error", e))
 
-    t = threading.Thread(target=worker)
-    t.start()
+    t = run_in_background(worker, daemon=False)
 
     # Run the drain loop in the main thread (simulated)
     # The loop should terminate when job_done[0] becomes True, which happens on error

--- a/plugin/tests/test_hermes_acp.py
+++ b/plugin/tests/test_hermes_acp.py
@@ -13,6 +13,8 @@ import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
+from plugin.framework.worker_pool import run_in_background
+
 from plugin.modules.agent_backend.acp_connection import ACPConnection
 from plugin.modules.agent_backend.hermes_proxy import (
     HermesBackend,
@@ -97,8 +99,7 @@ class TestACPConnection(unittest.TestCase):
         conn._proc = mock_proc
 
         # Run reader in a thread briefly
-        reader = threading.Thread(target=conn._reader_loop, daemon=True)
-        reader.start()
+        reader = run_in_background(conn._reader_loop, daemon=True)
         event.wait(timeout=2)
         conn._running = False
         reader.join(timeout=2)
@@ -131,8 +132,7 @@ class TestACPConnection(unittest.TestCase):
         mock_proc.stderr.read.return_value = b""
         conn._proc = mock_proc
 
-        reader = threading.Thread(target=conn._reader_loop, daemon=True)
-        reader.start()
+        reader = run_in_background(conn._reader_loop, daemon=True)
         reader.join(timeout=2)
         conn._running = False
 

--- a/plugin/tests/test_main_thread.py
+++ b/plugin/tests/test_main_thread.py
@@ -3,6 +3,8 @@ import queue
 import pytest
 from unittest.mock import patch, MagicMock
 
+from plugin.framework.worker_pool import run_in_background
+
 from plugin.framework.main_thread import (
     _WorkItem,
     execute_on_main_thread,
@@ -77,11 +79,8 @@ def test_execute_on_main_thread_background(mock_poke, mock_get_async):
         except Exception as e:
             exceptions[val] = e
 
-    t1 = threading.Thread(target=bg_thread, args=(5,))
-    t2 = threading.Thread(target=bg_thread, args=(0,))
-
-    t1.start()
-    t2.start()
+    t1 = run_in_background(bg_thread, 5, daemon=False)
+    t2 = run_in_background(bg_thread, 0, daemon=False)
 
     t1.join(timeout=2.0)
     t2.join(timeout=2.0)
@@ -112,8 +111,7 @@ def test_execute_on_main_thread_timeout(mock_poke, mock_get_async):
         except Exception as e:
             exc_caught = e
 
-    t = threading.Thread(target=bg_thread)
-    t.start()
+    t = run_in_background(bg_thread, daemon=False)
     t.join(timeout=1.0)
 
     assert isinstance(exc_caught, TimeoutError)


### PR DESCRIPTION
This PR standardizes the usage of background threads across the WriterAgent codebase. Previously, various modules instantiated `threading.Thread(...)` directly, which could lead to inconsistent exception handling. 

By replacing these scattered usages with the centralized `run_in_background` function provided by `plugin.framework.worker_pool.py`, the code is now simpler and more robust, with all unhandled exceptions occurring in background threads being correctly caught and logged. 

Imports for `run_in_background` have also been placed at the top of the files where applicable. All relevant tests pass successfully.

---
*PR created automatically by Jules for task [2162815056251546514](https://jules.google.com/task/2162815056251546514) started by @KeithCu*