### PR TITLE
Refactor tool registration to use package auto-discovery

### DIFF
--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -52,6 +52,23 @@ class ToolRegistry:
         for t in tools:
             self.register(t)
 
+    def auto_discover_package(self, package_name):
+        """Automatically discover and register ToolBase subclasses in all submodules of a package."""
+        import importlib
+        import pkgutil
+
+        # Import the package itself to get its path
+        package = importlib.import_module(package_name)
+
+        # Iterate over all submodules in the package directory
+        for _, module_name, is_pkg in pkgutil.iter_modules(package.__path__):
+            full_module_name = f"{package_name}.{module_name}"
+            try:
+                module = importlib.import_module(full_module_name)
+                self.auto_discover(module)
+            except Exception as e:
+                log.error("Failed to discover tools in module %s: %s", full_module_name, e)
+
     def auto_discover(self, module):
         """Automatically discover and register ToolBase subclasses in a module."""
         import inspect

--- a/plugin/modules/calc/__init__.py
+++ b/plugin/modules/calc/__init__.py
@@ -26,7 +26,4 @@ class CalcModule(ModuleBase):
     def initialize(self, services):
         self.services = services
 
-        from . import conditional, charts, navigation, cells, formulas, sheets, search, comments
-
-        for module in (conditional, charts, navigation, cells, formulas, sheets, search, comments):
-            services.tools.auto_discover(module)
+        services.tools.auto_discover_package(__name__)

--- a/plugin/modules/draw/__init__.py
+++ b/plugin/modules/draw/__init__.py
@@ -25,7 +25,4 @@ class DrawModule(ModuleBase):
     def initialize(self, services):
         self.services = services
 
-        from . import pages, transitions, masters, notes, shapes, placeholders
-
-        for module in (pages, transitions, masters, notes, shapes, placeholders):
-            services.tools.auto_discover(module)
+        services.tools.auto_discover_package(__name__)

--- a/plugin/modules/writer/__init__.py
+++ b/plugin/modules/writer/__init__.py
@@ -44,8 +44,5 @@ class WriterModule(ModuleBase):
         services.register("writer_proximity", prox)
         services.register("writer_index", idx)
 
-        # Register tools
-        from . import outline, styles, images, content, search, comments, tracking, frames
-
-        for module in (outline, styles, images, content, search, comments, tracking, frames):
-            services.tools.auto_discover(module)
+        # Register tools automatically for the entire package
+        services.tools.auto_discover_package(__name__)


### PR DESCRIPTION
Fixes an issue with repetitive tool registration by introducing `auto_discover_package()` to dynamically load tools from all submodules within a package.
* Added `auto_discover_package(package_name)` to `plugin/framework/tool_registry.py`.
* Simplified `plugin/modules/writer/__init__.py`.
* Simplified `plugin/modules/calc/__init__.py`.
* Simplified `plugin/modules/draw/__init__.py`.

---
*PR created automatically by Jules for task [2688499972585435312](https://jules.google.com/task/2688499972585435312) started by @KeithCu*