### PR TITLE
Implement service auto-discovery in writer module

### DIFF
--- a/plugin/framework/service_registry.py
+++ b/plugin/framework/service_registry.py
@@ -44,6 +44,28 @@ class ServiceRegistry:
             raise ValueError(f"Service already registered: {name}")
         self._services[name] = instance
 
+    def auto_discover(self, module):
+        """Automatically discover and register ServiceBase subclasses in a module."""
+        import inspect
+        import logging
+        from plugin.framework.service_base import ServiceBase
+
+        log = logging.getLogger("writeragent.services")
+
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if (issubclass(obj, ServiceBase) and
+                obj is not ServiceBase and
+                obj.__module__ == module.__name__ and
+                not inspect.isabstract(obj) and
+                getattr(obj, "name", None)):
+
+                try:
+                    # Instantiate by passing the registry itself as 'services'
+                    svc_instance = obj(self)
+                    self.register(obj.name, svc_instance)
+                except Exception as e:
+                    log.error("Failed to instantiate service %s: %s", obj.__name__, e)
+
     def get(self, name):
         """Get a service by name, or None if not registered."""
         return self._services.get(name)

--- a/plugin/modules/writer/__init__.py
+++ b/plugin/modules/writer/__init__.py
@@ -25,24 +25,12 @@ class WriterModule(ModuleBase):
     def initialize(self, services):
         self.services = services
 
-        # Initialize core Writer services (merged from writer_nav and writer_index)
-        from .bookmarks import BookmarkService
-        from .tree import TreeService
-        from .proximity import ProximityService
-        from .index import IndexService
+        # Initialize core Writer services via auto-discovery
+        from . import bookmarks, tree, proximity, index
 
-        doc_svc = services.document
-        events = services.events
-
-        bm = BookmarkService(doc_svc)
-        tree = TreeService(doc_svc, bm, events)
-        prox = ProximityService(doc_svc, tree, bm, events)
-        idx = IndexService(doc_svc, tree, bm, events)
-
-        services.register("writer_bookmarks", bm)
-        services.register("writer_tree", tree)
-        services.register("writer_proximity", prox)
-        services.register("writer_index", idx)
+        # Order matters: tree needs bookmarks, proximity/index need tree
+        for module in (bookmarks, tree, proximity, index):
+            services.auto_discover(module)
 
         # Register tools
         from . import outline, styles, images, content, search, comments, tracking, frames

--- a/plugin/modules/writer/bookmarks.py
+++ b/plugin/modules/writer/bookmarks.py
@@ -22,14 +22,18 @@ Ported from mcp-libre services/writer/tree.py (bookmark methods).
 import logging
 import uuid
 
+from plugin.framework.service_base import ServiceBase
+
 log = logging.getLogger("writeragent.writer.nav.bookmarks")
 
 
-class BookmarkService:
+class BookmarkService(ServiceBase):
     """Manage _mcp_ bookmarks on headings for stable addressing."""
 
-    def __init__(self, doc_svc):
-        self._doc_svc = doc_svc
+    name = "writer_bookmarks"
+
+    def __init__(self, services):
+        self._doc_svc = services.document
 
     def get_mcp_bookmark_map(self, doc):
         """Return {para_index: bookmark_name} for all _mcp_ bookmarks."""

--- a/plugin/modules/writer/index.py
+++ b/plugin/modules/writer/index.py
@@ -29,6 +29,7 @@ import time
 import unicodedata
 
 from plugin.framework.errors import ToolExecutionError
+from plugin.framework.service_base import ServiceBase
 
 log = logging.getLogger("writeragent.writer.index")
 
@@ -184,13 +185,16 @@ class _DocIndex:
 
 # ── Service ───────────────────────────────────────────────────────────
 
-class IndexService:
+class IndexService(ServiceBase):
     """Per-document inverted index with Snowball stemming."""
 
-    def __init__(self, doc_svc, tree_svc, bookmark_svc, events):
-        self._doc_svc = doc_svc
-        self._tree_svc = tree_svc
-        self._bm_svc = bookmark_svc
+    name = "writer_index"
+
+    def __init__(self, services):
+        self._doc_svc = services.document
+        self._tree_svc = services.writer_tree
+        self._bm_svc = services.writer_bookmarks
+        events = services.events
         self._cache = {}       # doc_key -> _DocIndex
         self._stemmers = {}    # lang -> StemmerInstance
         events.subscribe("document:cache_invalidated",

--- a/plugin/modules/writer/proximity.py
+++ b/plugin/modules/writer/proximity.py
@@ -24,17 +24,21 @@ import bisect
 import logging
 
 from plugin.framework.errors import ToolExecutionError
+from plugin.framework.service_base import ServiceBase
 
 log = logging.getLogger("writeragent.writer.nav.proximity")
 
 
-class ProximityService:
+class ProximityService(ServiceBase):
     """Local proximity navigation on Writer documents."""
 
-    def __init__(self, doc_svc, tree_svc, bookmark_svc, events):
-        self._doc_svc = doc_svc
-        self._tree_svc = tree_svc
-        self._bm_svc = bookmark_svc
+    name = "writer_proximity"
+
+    def __init__(self, services):
+        self._doc_svc = services.document
+        self._tree_svc = services.writer_tree
+        self._bm_svc = services.writer_bookmarks
+        events = services.events
         self._flat_cache = {}  # doc_key -> [flat entries]
         events.subscribe("document:cache_invalidated",
                          self._on_cache_invalidated)

--- a/plugin/modules/writer/tree.py
+++ b/plugin/modules/writer/tree.py
@@ -22,16 +22,20 @@ Ported from mcp-libre services/writer/tree.py.
 import logging
 
 from plugin.framework.errors import ToolExecutionError
+from plugin.framework.service_base import ServiceBase
 
 log = logging.getLogger("writeragent.writer.nav.tree")
 
 
-class TreeService:
+class TreeService(ServiceBase):
     """Heading tree navigation with per-document caching."""
 
-    def __init__(self, doc_svc, bm_svc, events):
-        self._doc_svc = doc_svc
-        self._bm_svc = bm_svc
+    name = "writer_tree"
+
+    def __init__(self, services):
+        self._doc_svc = services.document
+        self._bm_svc = services.writer_bookmarks
+        events = services.events
         self._tree_cache = {}  # doc_key -> root node
         self._ai_summary_cache = {}  # doc_key -> {para_index: summary}
         events.subscribe("document:cache_invalidated",

--- a/plugin/tests/test_tree_search_logic.py
+++ b/plugin/tests/test_tree_search_logic.py
@@ -31,7 +31,14 @@ class TestTreeServiceSearch(unittest.TestCase):
         }
 
         self.events = MagicMock()
-        self.tree_svc = TreeService(self.doc_svc, self.bm_svc, self.events)
+
+        # We need a mock services object
+        services = MagicMock()
+        services.document = self.doc_svc
+        services.writer_bookmarks = self.bm_svc
+        services.events = self.events
+
+        self.tree_svc = TreeService(services)
 
     def test_exact_match(self):
         # Should match "Introduction" exactly


### PR DESCRIPTION
Implemented auto-discovery for services to remove repetitive boilerplate registration code. `ServiceRegistry` now has an `auto_discover` method that scans modules for `ServiceBase` subclasses. The `writer` module was updated to use this pattern, and its core services were modified to inherit from `ServiceBase` and retrieve their own dependencies from the registry. Corresponding tests were updated.

---
*PR created automatically by Jules for task [6971396974473988211](https://jules.google.com/task/6971396974473988211) started by @KeithCu*