### PR TITLE
docs: Add formal verification tutorial and roadmap

### DIFF
--- a/docs/formal_verification.md
+++ b/docs/formal_verification.md
@@ -1,84 +1,74 @@
-# Formal Verification for WriterAgent
+# Formal Verification Strategy for WriterAgent
 
-This document provides a tutorial, overview, and roadmap for applying formal verification techniques to the WriterAgent Python codebase.
+This document explores the theoretical foundation and practical application of formal verification (FV) to the WriterAgent Python codebase.
 
-## 1. Introduction to Formal Verification
-
-Formal verification is the process of using mathematical proofs to verify that a system meets its specifications. Unlike traditional unit testing, which checks specific input/output pairs, formal verification aims to prove that a property holds for *all* possible inputs. If the property doesn't hold, the verifier provides a "counterexample"—a specific input that causes the failure.
-
-### The Challenge of Verifying Python
-Pure formal verification (like using Coq, TLA+, or Lean) is traditionally applied to statically-typed, compiled languages or specialized modeling languages. Python, being dynamically typed, heavily interpreted, and prone to "magic" (monkey-patching, metaclasses), is notoriously difficult to formally verify. Turning dynamic Python code into mathematical expressions (theorems) that an SMT solver (like Z3) can analyze is complex.
-
-### The Challenge of Verifying LibreOffice (UNO)
-WriterAgent's core functionality relies on LibreOffice's UNO API (Universal Network Objects). These objects are implemented in C++ and Java and are exposed to Python dynamically at runtime.
-**No current Python formal verification tool can model or verify the behavior of arbitrary C++/UNO objects.**
-Therefore, verification efforts must strictly isolate pure Python logic from UNO side-effects.
+**Critical Architectural Assumption:** WriterAgent relies heavily on LibreOffice's UNO API. For the scope of this document and any FV efforts, **we treat the UNO C++ bridge as an axiomatically sound, 100% reliable external environment.** We have no interest in verifying LibreOffice itself. If a UNO method is called with correct parameters, we assume it succeeds. Our FV scope is strictly constrained to proving the correctness of *our* Python code: our data transformations, parsing logic, state management, and algorithmic safety.
 
 ---
 
-## 2. Tools for Python Verification
+## 1. The Theoretical Landscape: Verifying Python
 
-While full formal verification of Python is limited, several tools bridge the gap between testing and proofs:
+Formal verification is the application of mathematical proofs to demonstrate that a program satisfies its formal specifications for all possible inputs. Traditional unit testing suffers from the *coverage problem*—it samples a finite subset of an infinite state space. FV, via techniques like Symbolic Execution and Bounded Model Checking (BMC), attempts to explore the state space exhaustively by treating inputs as symbolic variables.
 
-### A. Deal & Deal-Solver
-[`deal`](https://deal.readthedocs.io/) is a Python library for Design by Contract (DbC). It allows you to add decorators to functions specifying preconditions, postconditions, invariants, and expected exceptions.
+### The Dynamics of Python vs. SMT Solvers
+Most modern FV tools rely on Satisfiability Modulo Theories (SMT) solvers, such as Microsoft's Z3. An SMT solver decides the satisfiability of first-order logic formulas with respect to background theories (e.g., bit-vectors, arrays, real numbers).
+
+Applying this to Python introduces severe impedance mismatch:
+1.  **Dynamic Typing & Late Binding:** A symbolic Python variable lacks a fixed memory footprint or operational semantic bounds until runtime. A single `+` operator could mean integer addition, string concatenation, or a custom `__add__` metaclass resolution.
+2.  **State Space Explosion:** Python's highly mutable runtime (where dictionaries underpin classes, and functions are first-class objects) causes the state space to explode exponentially. Translating arbitrary Python bytecode into a finite set of logical constraints for an SMT solver is often undecidable.
+3.  **The Halting Problem:** Pure formal provers (like `deal-solver`) struggle with unbounded loops and recursive calls in Turing-complete languages. They often require manual loop invariants (mathematical properties that hold true before and after each loop iteration) to prove termination, which are exceedingly rare in standard Python codebases.
+
+Because of these constraints, *full* formal verification of Python is largely restricted to trivial, purely functional subsets. However, hybrid approaches—specifically **Concolic Execution**—offer a highly practical compromise.
+
+---
+
+## 2. Tooling: From Proofs to Concolic Execution
+
+We evaluate the current Python verification ecosystem strictly for its utility on our pure Python algorithmic modules.
+
+### A. Deal (Design by Contract) & Deal-Solver
+[`deal`](https://deal.readthedocs.io/) implements Design by Contract (DbC), heavily inspired by Hoare logic and the Eiffel language. It uses decorators (`@deal.pre`, `@deal.post`, `@deal.inv`) to define axioms and theorems about functions.
+
+*   **The Verifier (`deal-solver`):** `deal` includes an experimental static verifier that attempts to translate the Python AST and the contracts directly into Z3 theorems.
+*   **The CS Reality:** It is a fascinating academic exercise but practically unworkable for WriterAgent. It requires absolute referential transparency, does not support most of the Python standard library, cannot model sets or complex OOP structures, and fails on unbounded loops.
+
+### B. CrossHair: The Concolic Testing Engine
+[`CrossHair`](https://crosshair.readthedocs.io/) represents the most viable path forward. It is not a pure formal verifier; it is a **verifier-driven fuzzer** that utilizes **Concolic (Concrete + Symbolic) Execution**.
+
+*   **How it Works:** CrossHair hooks into the Python interpreter. As a function executes, CrossHair maintains two states: a concrete state (actual values) and a symbolic state (Z3 equations representing the path constraints). When it encounters a branch (e.g., `if len(url) > 10:`), it queries the Z3 SMT solver: *"Is there an input that satisfies the current path constraints AND makes `len(url) > 10` false?"* If so, it forks the execution and explores both paths.
+*   **Why it Fits Our Code:** Because it runs the actual CPython interpreter, it handles "magic", standard libraries, and complex types perfectly. It essentially exhaustively searches for a combination of inputs that will raise an unhandled exception or violate a `deal` contract. It trades mathematical certainty (it will time out on infinite state spaces) for immense practical utility in finding edge-case counterexamples.
+
+### C. Bounded Model Checking (ESBMC-Python)
+[ESBMC](https://github.com/esbmc/esbmc) uses Bounded Model Checking. It translates Python into a lower-level intermediate representation (IR) and "unrolls" loops up to a specific depth ($k$). It then converts the unrolled program into a single massive SMT formula to check for safety properties (e.g., buffer overflows, division by zero).
+*   **Utility:** Excellent for verifying highly complex, isolated algorithms (like our Calc cell range parsers) up to a bounded size, but overkill for standard API plumbing.
+
+---
+
+## 3. Execution Roadmap: Hardening WriterAgent's Pure Logic
+
+To implement FV, we must isolate our verifiable code from our axiomatic environment (UNO).
+
+### Phase 1: Segregation of Pure Logic (The "Hexagonal" Core)
+Verification requires deterministic boundaries. Our current architecture already has pockets of pure logic (e.g., `plugin/framework/url_utils.py`, `plugin/modules/calc/address_utils.py`, and `plugin/framework/pricing.py`).
+
+Moving forward, complex transformations (like AST parsing, text delta computation, or HTML sanitization) must be strictly decoupled from UNO calls. We extract data from UNO, pass it into pure, verifiable Python functions, and pass the output back to UNO.
+
+### Phase 2: Axiomatic Definition via Contracts
+We begin by establishing the formal properties of our pure functions using type hints and `deal` contracts. This shifts our development model from "writing tests that pass" to "defining invariants that must never fail."
+
+**Example: Verifying Calc Address Math**
+Consider `column_to_index` in `address_utils.py`. We know mathematically that:
+1. It must only accept uppercase alphabetical strings.
+2. The output must always be a non-negative integer.
+3. The inverse function (`index_to_column`) applied to the result must yield the original input.
 
 ```python
 import deal
 
-@deal.pre(lambda a, b: b != 0)
-@deal.post(lambda result: result > 0)
-def divide_positive(a: int, b: int) -> float:
-    return a / b
-```
-
-`deal` has an experimental built-in formal verifier called `deal-solver` that converts these contracts and pure Python code into Z3 theorems.
-*   **Pros:** Very strict, integrates directly with Python code via decorators.
-*   **Cons:** Extremely limited scope. It only works for a tiny subset of Python (no loops, limited standard library, no mutability modeling). It will fail on most real-world WriterAgent code.
-
-### B. CrossHair (Concolic Testing)
-[`CrossHair`](https://crosshair.readthedocs.io/) is a "verifier-driven fuzzer" or concolic (concrete + symbolic) execution engine. It analyzes Python type hints and contracts (it supports `deal` contracts natively) and uses the Z3 SMT solver to intelligently search for inputs that violate the contracts or cause unhandled exceptions (like `IndexError` or `TypeError`).
-
-*   **Pros:** Much more practical than pure verification. It executes the actual Python interpreter, so it supports most language features (loops, built-ins). It's excellent at finding edge cases you forgot to test.
-*   **Cons:** It's incomplete—it might not prove a property holds forever (it times out), but it excels at finding counterexamples. It still cannot model external state (like a database or LibreOffice UNO objects).
-
-### C. ESBMC-Python
-[ESBMC](https://github.com/esbmc/esbmc) (Efficient SMT-based Context-Bounded Model Checker) is a mature bounded model checker originally for C/C++ that recently added a Python frontend. It transforms a Python AST into an intermediate representation and checks it with SMT solvers to find runtime errors (bounds checks, division by zero, user assertions).
-
-*   **Pros:** Backed by a powerful, mature model checker. Great for verifying algorithmic correctness and low-level safety.
-*   **Cons:** Requires type annotations. It simulates program execution up to a certain bound (depth), so it's not a full proof for infinite loops.
-
-### D. PyVeritas
-[PyVeritas](https://arxiv.org/html/2508.08171) is a novel approach that uses Large Language Models (LLMs) to transpile Python code into C code. It then uses existing, highly-optimized C bounded model checkers (like CBMC) on the generated code to find bugs and localize faults.
-*   **Pros:** Leverages the maturity of C model checkers.
-*   **Cons:** Highly experimental. The transpilation step assumes the Python code maps cleanly to C (no dynamic typing, eval, or UNO objects).
-
----
-
-## 3. Roadmap for Incrementally Verifying WriterAgent
-
-Given the architecture of WriterAgent, formal verification must be applied incrementally and selectively. You cannot run `deal prove` on `plugin/main.py`.
-
-### Phase 1: Identify and Isolate Pure Logic
-The first step is identifying modules that have **zero UNO dependencies** and operate only on pure Python types (strings, ints, lists, dicts).
-
-Good candidates in WriterAgent:
-*   `plugin/framework/url_utils.py` (URL string manipulation)
-*   `plugin/modules/calc/address_utils.py` (Converting "A1" to column/row indices)
-*   `plugin/framework/pricing.py` (Token math and floating-point cost calculations)
-
-### Phase 2: Add Strict Type Hints and Contracts
-To use any of these tools, the pure functions must be fully type-hinted. Next, add logical contracts (preconditions and postconditions) describing the exact expected behavior.
-
-*Example for `plugin/modules/calc/address_utils.py`:*
-
-```python
-import deal
-
-# Precondition: input must be uppercase letters
 @deal.pre(lambda col_str: col_str.isalpha() and col_str.isupper())
-# Postcondition: result is always >= 0
 @deal.post(lambda result: result >= 0)
+# The ultimate invariant: f^-1(f(x)) == x
+@deal.ensure(lambda col_str, result: index_to_column(result) == col_str)
 def column_to_index(col_str: str) -> int:
     result = 0
     for char in col_str:
@@ -86,30 +76,19 @@ def column_to_index(col_str: str) -> int:
     return result - 1
 ```
 
-### Phase 3: Apply CrossHair (Concolic Testing)
-`CrossHair` is the most viable tool for immediate ROI on WriterAgent's pure logic.
-1.  Install it: `pip install crosshair-tool`
-2.  Run it on specific files: `crosshair check plugin/modules/calc/address_utils.py`
-3.  CrossHair will analyze the type hints (e.g., `col_str: str`) and try to generate weird strings (empty strings, numbers, unicode) that crash `column_to_index` or violate the `@deal.post` condition.
+### Phase 3: Concolic State Exploration with CrossHair
+With contracts in place, we unleash CrossHair.
+`crosshair check plugin/modules/calc/address_utils.py`
 
-You use CrossHair to *harden* your pure utility functions against edge cases.
+CrossHair's Z3 engine will not just throw random fuzzing data at the function; it will analytically dissect the bytecode. It will realize that `ord(char)` implies integer boundaries, and it will intentionally synthesize string inputs designed to trigger integer overflows, index out-of-bounds, or violate the `deal.ensure` inverse mapping contract.
 
-### Phase 4: Refactor UNO Code for Testability (Hexagonal Architecture)
-To verify code that currently touches LibreOffice, you must extract the decision-making logic away from the side-effects.
+When CrossHair finds a counterexample, it provides the exact symbolic input required to break our algorithm. We patch the code, and the state space is secured.
 
-Instead of a function that reads a document, analyzes it, and writes back to it (which is un-verifiable), refactor it into three steps:
-1.  **Read (UNO):** Extract text from LibreOffice.
-2.  **Analyze (Pure Python):** A pure function that takes a string and returns a modified string. **(This function can now be formally verified/concolically tested).**
-3.  **Write (UNO):** Push the modified string back to LibreOffice.
+### Phase 4: SMT-Driven Protocol Verification
+Beyond utility functions, we can apply FV to state machines. For example, our LLM streaming chunk normalizer (`plugin/modules/http/streaming_deltas.py`).
 
-### Phase 5: Explore Bounded Model Checking (ESBMC-Python)
-Once you have a robust suite of pure Python modules with assertions and contracts, you can experiment with `esbmc` to prove the absence of specific runtime errors (like division by zero or array out of bounds) up to a certain loop depth. This is particularly useful for complex algorithms, such as the `build_heading_tree` logic or the `error_detector` logic in Calc, assuming they can be fully isolated from UNO.
+By defining contracts that assert *"No matter how a JSON delta stream is arbitrarily chunked or fragmented over the network, the final assembled output string will exactly match the output of a synchronous, unfragmented payload,"* we can use CrossHair to mathematically prove our streaming parser's resilience against arbitrary network fragmentation.
 
----
+## Conclusion
 
-## 4. Summary
-
-1.  **Don't try to verify UNO code.** Focus on pure Python modules.
-2.  **Start with Type Hints and Contracts (`deal`).** Explicitly define what your utilities *should* do.
-3.  **Use `CrossHair`** as an advanced, Z3-backed fuzzer to find counterexamples to your contracts.
-4.  **Refactor** to push UNO side-effects to the edges of your architecture, leaving a verifiable, pure "core" of logic.
+By adopting concolic execution (CrossHair) and Design by Contract (`deal`), we can elevate the reliability of WriterAgent's pure algorithmic core from "empirically tested" to "mathematically robust." We acknowledge the intractability of verifying the entire application, and instead focus our SMT solvers exclusively on the pure data-transformation pipelines that feed our axiomatic UNO environment.

--- a/docs/formal_verification.md
+++ b/docs/formal_verification.md
@@ -1,0 +1,115 @@
+# Formal Verification for WriterAgent
+
+This document provides a tutorial, overview, and roadmap for applying formal verification techniques to the WriterAgent Python codebase.
+
+## 1. Introduction to Formal Verification
+
+Formal verification is the process of using mathematical proofs to verify that a system meets its specifications. Unlike traditional unit testing, which checks specific input/output pairs, formal verification aims to prove that a property holds for *all* possible inputs. If the property doesn't hold, the verifier provides a "counterexample"—a specific input that causes the failure.
+
+### The Challenge of Verifying Python
+Pure formal verification (like using Coq, TLA+, or Lean) is traditionally applied to statically-typed, compiled languages or specialized modeling languages. Python, being dynamically typed, heavily interpreted, and prone to "magic" (monkey-patching, metaclasses), is notoriously difficult to formally verify. Turning dynamic Python code into mathematical expressions (theorems) that an SMT solver (like Z3) can analyze is complex.
+
+### The Challenge of Verifying LibreOffice (UNO)
+WriterAgent's core functionality relies on LibreOffice's UNO API (Universal Network Objects). These objects are implemented in C++ and Java and are exposed to Python dynamically at runtime.
+**No current Python formal verification tool can model or verify the behavior of arbitrary C++/UNO objects.**
+Therefore, verification efforts must strictly isolate pure Python logic from UNO side-effects.
+
+---
+
+## 2. Tools for Python Verification
+
+While full formal verification of Python is limited, several tools bridge the gap between testing and proofs:
+
+### A. Deal & Deal-Solver
+[`deal`](https://deal.readthedocs.io/) is a Python library for Design by Contract (DbC). It allows you to add decorators to functions specifying preconditions, postconditions, invariants, and expected exceptions.
+
+```python
+import deal
+
+@deal.pre(lambda a, b: b != 0)
+@deal.post(lambda result: result > 0)
+def divide_positive(a: int, b: int) -> float:
+    return a / b
+```
+
+`deal` has an experimental built-in formal verifier called `deal-solver` that converts these contracts and pure Python code into Z3 theorems.
+*   **Pros:** Very strict, integrates directly with Python code via decorators.
+*   **Cons:** Extremely limited scope. It only works for a tiny subset of Python (no loops, limited standard library, no mutability modeling). It will fail on most real-world WriterAgent code.
+
+### B. CrossHair (Concolic Testing)
+[`CrossHair`](https://crosshair.readthedocs.io/) is a "verifier-driven fuzzer" or concolic (concrete + symbolic) execution engine. It analyzes Python type hints and contracts (it supports `deal` contracts natively) and uses the Z3 SMT solver to intelligently search for inputs that violate the contracts or cause unhandled exceptions (like `IndexError` or `TypeError`).
+
+*   **Pros:** Much more practical than pure verification. It executes the actual Python interpreter, so it supports most language features (loops, built-ins). It's excellent at finding edge cases you forgot to test.
+*   **Cons:** It's incomplete—it might not prove a property holds forever (it times out), but it excels at finding counterexamples. It still cannot model external state (like a database or LibreOffice UNO objects).
+
+### C. ESBMC-Python
+[ESBMC](https://github.com/esbmc/esbmc) (Efficient SMT-based Context-Bounded Model Checker) is a mature bounded model checker originally for C/C++ that recently added a Python frontend. It transforms a Python AST into an intermediate representation and checks it with SMT solvers to find runtime errors (bounds checks, division by zero, user assertions).
+
+*   **Pros:** Backed by a powerful, mature model checker. Great for verifying algorithmic correctness and low-level safety.
+*   **Cons:** Requires type annotations. It simulates program execution up to a certain bound (depth), so it's not a full proof for infinite loops.
+
+### D. PyVeritas
+[PyVeritas](https://arxiv.org/html/2508.08171) is a novel approach that uses Large Language Models (LLMs) to transpile Python code into C code. It then uses existing, highly-optimized C bounded model checkers (like CBMC) on the generated code to find bugs and localize faults.
+*   **Pros:** Leverages the maturity of C model checkers.
+*   **Cons:** Highly experimental. The transpilation step assumes the Python code maps cleanly to C (no dynamic typing, eval, or UNO objects).
+
+---
+
+## 3. Roadmap for Incrementally Verifying WriterAgent
+
+Given the architecture of WriterAgent, formal verification must be applied incrementally and selectively. You cannot run `deal prove` on `plugin/main.py`.
+
+### Phase 1: Identify and Isolate Pure Logic
+The first step is identifying modules that have **zero UNO dependencies** and operate only on pure Python types (strings, ints, lists, dicts).
+
+Good candidates in WriterAgent:
+*   `plugin/framework/url_utils.py` (URL string manipulation)
+*   `plugin/modules/calc/address_utils.py` (Converting "A1" to column/row indices)
+*   `plugin/framework/pricing.py` (Token math and floating-point cost calculations)
+
+### Phase 2: Add Strict Type Hints and Contracts
+To use any of these tools, the pure functions must be fully type-hinted. Next, add logical contracts (preconditions and postconditions) describing the exact expected behavior.
+
+*Example for `plugin/modules/calc/address_utils.py`:*
+
+```python
+import deal
+
+# Precondition: input must be uppercase letters
+@deal.pre(lambda col_str: col_str.isalpha() and col_str.isupper())
+# Postcondition: result is always >= 0
+@deal.post(lambda result: result >= 0)
+def column_to_index(col_str: str) -> int:
+    result = 0
+    for char in col_str:
+        result = result * 26 + (ord(char) - ord('A') + 1)
+    return result - 1
+```
+
+### Phase 3: Apply CrossHair (Concolic Testing)
+`CrossHair` is the most viable tool for immediate ROI on WriterAgent's pure logic.
+1.  Install it: `pip install crosshair-tool`
+2.  Run it on specific files: `crosshair check plugin/modules/calc/address_utils.py`
+3.  CrossHair will analyze the type hints (e.g., `col_str: str`) and try to generate weird strings (empty strings, numbers, unicode) that crash `column_to_index` or violate the `@deal.post` condition.
+
+You use CrossHair to *harden* your pure utility functions against edge cases.
+
+### Phase 4: Refactor UNO Code for Testability (Hexagonal Architecture)
+To verify code that currently touches LibreOffice, you must extract the decision-making logic away from the side-effects.
+
+Instead of a function that reads a document, analyzes it, and writes back to it (which is un-verifiable), refactor it into three steps:
+1.  **Read (UNO):** Extract text from LibreOffice.
+2.  **Analyze (Pure Python):** A pure function that takes a string and returns a modified string. **(This function can now be formally verified/concolically tested).**
+3.  **Write (UNO):** Push the modified string back to LibreOffice.
+
+### Phase 5: Explore Bounded Model Checking (ESBMC-Python)
+Once you have a robust suite of pure Python modules with assertions and contracts, you can experiment with `esbmc` to prove the absence of specific runtime errors (like division by zero or array out of bounds) up to a certain loop depth. This is particularly useful for complex algorithms, such as the `build_heading_tree` logic or the `error_detector` logic in Calc, assuming they can be fully isolated from UNO.
+
+---
+
+## 4. Summary
+
+1.  **Don't try to verify UNO code.** Focus on pure Python modules.
+2.  **Start with Type Hints and Contracts (`deal`).** Explicitly define what your utilities *should* do.
+3.  **Use `CrossHair`** as an advanced, Z3-backed fuzzer to find counterexamples to your contracts.
+4.  **Refactor** to push UNO side-effects to the edges of your architecture, leaving a verifiable, pure "core" of logic.


### PR DESCRIPTION
Added `docs/formal_verification.md` containing research on formal verification concepts in python, reviewing tools such as `deal` and `CrossHair`, and laying out a roadmap for incrementally applying FV to pure Python portions of the codebase, carefully ignoring UNO components.

---
*PR created automatically by Jules for task [8792905552088244310](https://jules.google.com/task/8792905552088244310) started by @KeithCu*