### PR TITLE
Combine path_utils and url_utils into utils.py

### DIFF
--- a/plugin/contrib/smolagents/default_tools.py
+++ b/plugin/contrib/smolagents/default_tools.py
@@ -9,7 +9,7 @@ from typing import Any
 
 
 from plugin.framework.constants import BROWSER_USER_AGENT, USER_AGENT
-from plugin.framework.url_utils import get_url_hostname, is_pdf_url
+from plugin.framework.utils import get_url_hostname, is_pdf_url
 try:
     from plugin.modules.chatbot.history_db import HAS_SQLITE, sqlite3
 except Exception:

--- a/plugin/framework/auth.py
+++ b/plugin/framework/auth.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
 from plugin.framework.config import get_provider_from_endpoint
-from plugin.framework.url_utils import normalize_endpoint_url
+from plugin.framework.utils import normalize_endpoint_url
 from plugin.framework.errors import ConfigError
 
 class AuthError(ConfigError):

--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -1,4 +1,4 @@
-from plugin.framework.url_utils import normalize_endpoint_url
+from plugin.framework.utils import normalize_endpoint_url
 # WriterAgent - AI Writing Assistant for LibreOffice
 # Copyright (c) 2024 John Balis
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
@@ -20,7 +20,7 @@ Configuration logic for WriterAgent.
 Reads/writes writeragent.json in LibreOffice's user config directory.
 """
 import os
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import json
 import logging
 import dataclasses

--- a/plugin/framework/path_utils.py
+++ b/plugin/framework/path_utils.py
@@ -1,5 +1,0 @@
-import os
-
-def get_plugin_dir():
-    """Returns the absolute path to the plugin/ directory."""
-    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/plugin/framework/utils.py
+++ b/plugin/framework/utils.py
@@ -1,4 +1,9 @@
+import os
 import urllib.parse
+
+def get_plugin_dir():
+    """Returns the absolute path to the plugin/ directory."""
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 def normalize_endpoint_url(url):
     """Strip and rstrip slash for consistent storage."""

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys
 import os
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import logging
 
 # Ensure the extension's install directory is on sys.path

--- a/plugin/modules/chatbot/web_research.py
+++ b/plugin/modules/chatbot/web_research.py
@@ -41,7 +41,7 @@ class WebResearchTool(ToolBase):
     def execute(self, ctx, query, history_text=None):
         from plugin.framework.errors import format_error_payload, ToolExecutionError
         import os
-        from plugin.framework.url_utils import get_url_domain
+        from plugin.framework.utils import get_url_domain
 
         try:
             from plugin.framework.config import get_api_config, get_config_int, user_config_dir

--- a/plugin/modules/http/client.py
+++ b/plugin/modules/http/client.py
@@ -36,7 +36,7 @@ from plugin.framework.constants import APP_REFERER, APP_TITLE
 from plugin.framework.logging import init_logging
 from plugin.framework.auth import resolve_auth_for_config, build_auth_headers, AuthError
 from plugin.framework.errors import NetworkError, safe_json_loads
-from plugin.framework.url_utils import get_url_hostname, get_url_path_and_query
+from plugin.framework.utils import get_url_hostname, get_url_path_and_query
 
 from plugin.modules.http.errors import format_error_message, _format_http_error_response
 from plugin.modules.http.ssl_helpers import (

--- a/plugin/modules/http/requests.py
+++ b/plugin/modules/http/requests.py
@@ -4,7 +4,7 @@ import urllib.request
 import urllib.parse
 from plugin.framework.constants import APP_REFERER, APP_TITLE, USER_AGENT
 from plugin.framework.errors import NetworkError
-from plugin.framework.url_utils import get_url_hostname
+from plugin.framework.utils import get_url_hostname
 from plugin.modules.http.ssl_helpers import get_verified_ssl_context, get_unverified_ssl_context, _is_local_host, _is_certificate_verify_error
 from plugin.modules.http.errors import _format_http_error_response, format_error_message
 

--- a/plugin/modules/http/server.py
+++ b/plugin/modules/http/server.py
@@ -26,7 +26,7 @@ import logging
 import socketserver
 import threading
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from plugin.framework.url_utils import get_url_path, get_url_query_dict
+from plugin.framework.utils import get_url_path, get_url_query_dict
 
 from plugin.framework.errors import safe_json_loads
 from plugin.framework.worker_pool import run_in_background

--- a/plugin/modules/writer/index.py
+++ b/plugin/modules/writer/index.py
@@ -23,7 +23,7 @@ Language detected from UNO CharLocale. Stemming via bundled snowballstemmer.
 import logging
 import re
 import sys
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import os
 import time
 import unicodedata

--- a/plugin/prompt_function.py
+++ b/plugin/prompt_function.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import sys
 
 # Ensure the extension's install directory is on sys.path

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -223,7 +223,7 @@ def run_all_tests(ctx: Any) -> str:
     draw_doc = model if (model is not None and is_draw(model)) else None
 
     import os
-    from plugin.framework.path_utils import get_plugin_dir
+    from plugin.framework.utils import get_plugin_dir
     import importlib.util
 
     tests_dir = os.path.join(get_plugin_dir(), "tests", "uno")

--- a/plugin/tests/run_format_tests.py
+++ b/plugin/tests/run_format_tests.py
@@ -5,7 +5,7 @@ it for local/source runs (e.g. python -m plugin.tests.run_format_tests).
 """
 
 import sys
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import os
 
 if __name__ == "__main__":

--- a/plugin/tests/test_config_sync.py
+++ b/plugin/tests/test_config_sync.py
@@ -1,5 +1,5 @@
 import sys
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import os
 import json
 import tempfile

--- a/plugin/tests/test_image_service_refactor.py
+++ b/plugin/tests/test_image_service_refactor.py
@@ -1,5 +1,5 @@
 import sys
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import os
 import unittest
 import json

--- a/plugin/tests/test_image_status_callback.py
+++ b/plugin/tests/test_image_status_callback.py
@@ -1,6 +1,6 @@
 
 import sys
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import os
 import unittest
 from unittest.mock import MagicMock, patch

--- a/plugin/tests/test_search_web.py
+++ b/plugin/tests/test_search_web.py
@@ -20,7 +20,7 @@ You can pass a custom --max-tokens if desired, and override the model with --mod
 import argparse
 import json
 import os
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import sys
 import time
 from typing import Any

--- a/plugin/tests/test_streaming.py
+++ b/plugin/tests/test_streaming.py
@@ -3,7 +3,7 @@
 # see inline comments and core/api.py LiteLLM references for source locations.
 import json
 import os
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import sys
 import unittest
 from unittest.mock import MagicMock, patch

--- a/plugin/tests/uno/test_chat_model_logic.py
+++ b/plugin/tests/uno/test_chat_model_logic.py
@@ -1,5 +1,5 @@
 import sys
-from plugin.framework.path_utils import get_plugin_dir
+from plugin.framework.utils import get_plugin_dir
 import os
 import unittest
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
Combine `path_utils.py` and `url_utils.py` into a single `utils.py` file to simplify standard operations and reduce the number of small utility files, fixing all import references.

---
*PR created automatically by Jules for task [15051466249181306018](https://jules.google.com/task/15051466249181306018) started by @KeithCu*