### PR TITLE
Add gettext infrastructure for Python-based localization

### DIFF
--- a/plugin/framework/dialogs.py
+++ b/plugin/framework/dialogs.py
@@ -44,6 +44,7 @@ from plugin.framework.listeners import BaseActionListener
 from plugin.framework.worker_pool import run_in_background
 from com.sun.star.awt import XActionListener
 from plugin.framework.uno_context import get_desktop, get_extension_url
+from plugin.framework.i18n import _
 
 log = logging.getLogger("writeragent.dialogs")
 
@@ -88,9 +89,9 @@ def show_approval_dialog(ctx, description, tool_name=""):
         window = frame.getContainerWindow()
         smgr = ctx.getServiceManager()
         toolkit = smgr.createInstanceWithContext("com.sun.star.awt.Toolkit", ctx)
-        title = "Agent requests approval"
-        message = (description or "Proceed with this action?") + (
-            "\n\nTool: %s" % tool_name if tool_name else ""
+        title = _("Agent requests approval")
+        message = (description or _("Proceed with this action?")) + (
+            "\n\n" + _("Tool: %s") % tool_name if tool_name else ""
         )
         # 1 = INFO, 3 = BUTTONS_YES_NO. Result 1 = Yes (Approve), 2 = No (Reject)
         box = toolkit.createMessageBox(window, 1, 3, title, message)
@@ -225,8 +226,8 @@ def msgbox_with_copy(ctx, title, message, copy_text):
         dlg_model.Height = 80
 
         add_dialog_label(dlg_model, "Msg", message, 10, 6, 230, 42)
-        add_dialog_button(dlg_model, "CopyBtn", "Copy URL", 10, 56, 75, 14)
-        add_dialog_button(dlg_model, "OKBtn", "OK", 190, 56, 50, 14, push_button_type=1)
+        add_dialog_button(dlg_model, "CopyBtn", _("Copy URL"), 10, 56, 75, 14)
+        add_dialog_button(dlg_model, "OKBtn", _("OK"), 190, 56, 50, 14, push_button_type=1)
 
         dlg = smgr.createInstanceWithContext(
             "com.sun.star.awt.UnoControlDialog", ctx)
@@ -245,7 +246,7 @@ def msgbox_with_copy(ctx, title, message, copy_text):
                 if copy_to_clipboard(self._ctx, self._text):
                     try:
                         self._dlg.getModel().getByName("CopyBtn").Label = \
-                            "Copied!"
+                                _("Copied!")
                     except Exception as e:
                         log.debug("Failed to set CopyBtn Label: %s", e)
 
@@ -295,10 +296,10 @@ def status_dialog(ctx, title, build_status_fn, copy_url_fn=None):
         # Copy button (disabled until copy_url_fn returns something)
         has_copy = copy_url_fn is not None
         if has_copy:
-            add_dialog_button(dlg_model, "CopyBtn", "Copy URL", 10, 88, 65, 14,
+            add_dialog_button(dlg_model, "CopyBtn", _("Copy URL"), 10, 88, 65, 14,
                               enabled=bool(copy_url_fn()))
 
-        add_dialog_button(dlg_model, "OKBtn", "OK", 170, 88, 50, 14, push_button_type=1)
+        add_dialog_button(dlg_model, "OKBtn", _("OK"), 170, 88, 50, 14, push_button_type=1)
 
         dlg = smgr.createInstanceWithContext(
             "com.sun.star.awt.UnoControlDialog", ctx)
@@ -320,7 +321,7 @@ def status_dialog(ctx, title, build_status_fn, copy_url_fn=None):
                     if url and copy_to_clipboard(self._ctx, url):
                         try:
                             self._dlg.getModel().getByName("CopyBtn").Label = \
-                                "Copied!"
+                                _("Copied!")
                         except Exception as e:
                             log.debug("Failed to set CopyBtn Label: %s", e)
 
@@ -369,23 +370,23 @@ def about_dialog(ctx):
 
         dlg_model = smgr.createInstanceWithContext(
             "com.sun.star.awt.UnoControlDialogModel", ctx)
-        dlg_model.Title = "About WriterAgent"
+        dlg_model.Title = _("About WriterAgent")
         dlg_model.Width = 220
         dlg_model.Height = 90
 
         # Info text
         info_text = (
             "WriterAgent\n"
-            "Version: %s\n"
-            "AI-powered extension for LibreOffice" % EXTENSION_VERSION
+            + _("Version: %s") % EXTENSION_VERSION + "\n"
+            + _("AI-powered extension for LibreOffice")
         )
         add_dialog_label(dlg_model, "Info", info_text, 10, 8, 200, 36)
 
         # Clickable hyperlink
-        add_dialog_hyperlink(dlg_model, "GitHubLink", "GitHub: quazardous/localwriter",
+        add_dialog_hyperlink(dlg_model, "GitHubLink", _("GitHub: quazardous/localwriter"),
                              "https://github.com/quazardous/localwriter", 10, 48, 200, 12)
 
-        add_dialog_button(dlg_model, "OKBtn", "OK", 160, 68, 50, 14, push_button_type=1)
+        add_dialog_button(dlg_model, "OKBtn", _("OK"), 160, 68, 50, 14, push_button_type=1)
 
         dlg = smgr.createInstanceWithContext(
             "com.sun.star.awt.UnoControlDialog", ctx)
@@ -397,7 +398,7 @@ def about_dialog(ctx):
         dlg.dispose()
     except Exception:
         log.exception("About dialog error")
-        msgbox(ctx, "About WriterAgent",
+        msgbox(ctx, _("About WriterAgent"),
                "WriterAgent %s\nhttps://github.com/quazardous/localwriter"
                % EXTENSION_VERSION)
 

--- a/plugin/framework/i18n.py
+++ b/plugin/framework/i18n.py
@@ -1,0 +1,98 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Internationalization (i18n) utility for WriterAgent.
+
+Uses standard Python gettext to localize strings dynamically.
+"""
+
+import os
+import sys
+import gettext
+import logging
+
+from plugin.framework.uno_context import get_plugin_dir
+
+log = logging.getLogger("writeragent.i18n")
+
+_translation = None
+
+
+def get_lo_locale(ctx=None):
+    """Attempt to determine the LibreOffice UI locale."""
+    try:
+        import uno
+        if ctx is None:
+            ctx = uno.getComponentContext()
+        smgr = ctx.getServiceManager()
+        # Fallback to a simple locale lookup if no advanced config is found
+        config_provider = smgr.createInstanceWithContext(
+            "com.sun.star.configuration.ConfigurationProvider", ctx)
+        ca = config_provider.createInstanceWithArguments(
+            "com.sun.star.configuration.ConfigurationAccess",
+            (uno.createUnoStruct("com.sun.star.beans.PropertyValue", Name="nodepath", Value="/org.openoffice.Setup/L10N"),)
+        )
+
+        locale = ca.getPropertyValue("ooLocale")
+        if locale:
+            # LibreOffice often returns "en-US", gettext prefers "en_US"
+            return locale.replace("-", "_")
+    except Exception as e:
+        log.debug("Failed to determine LibreOffice locale: %s", e)
+
+    # Fallback to system environment variable
+    return os.environ.get("LANG", "en_US").split(".")[0]
+
+
+def init_i18n(ctx=None):
+    """Initialize gettext translation based on LibreOffice locale."""
+    global _translation
+
+    if _translation is not None:
+        return  # Already initialized
+
+    try:
+        locale = get_lo_locale(ctx)
+        locales_dir = os.path.join(get_plugin_dir(), "locales")
+
+        log.debug("Initializing i18n for locale: %s, locales_dir: %s", locale, locales_dir)
+
+        _translation = gettext.translation(
+            domain="writeragent",
+            localedir=locales_dir,
+            languages=[locale],
+            fallback=True
+        )
+    except Exception as e:
+        log.debug("Failed to initialize i18n: %s. Falling back to default gettext.", e)
+        _translation = gettext.NullTranslations()
+
+
+def _(message):
+    """Translate a message string using the initialized gettext translation.
+
+    If i18n is not initialized or the translation is missing, the original
+    message is returned.
+    """
+    global _translation
+    if _translation is None:
+        init_i18n()
+
+    # Ensure message is a string before passing to gettext
+    if not isinstance(message, str):
+        return str(message)
+
+    return _translation.gettext(message)

--- a/plugin/locales/README.md
+++ b/plugin/locales/README.md
@@ -1,0 +1,34 @@
+# Localization (i18n)
+
+WriterAgent uses standard Python `gettext` for localizing its user interface, including dynamically translated LibreOffice menus and custom dialogs. This guide explains how to generate, update, and compile translations.
+
+## Adding or Updating Translations
+
+Translations are stored in the `plugin/locales/` directory.
+
+### 1. Extract Strings
+To generate a new `.pot` (Portable Object Template) file from the source code, run the standard `xgettext` tool from the repository root:
+
+```bash
+xgettext -d writeragent -o plugin/locales/writeragent.pot $(find plugin -name "*.py")
+```
+
+### 2. Create a New Language File
+To start translating a new language (e.g., German - `de`), create the directory structure and copy the `.pot` file to a `.po` file:
+
+```bash
+mkdir -p plugin/locales/de/LC_MESSAGES/
+cp plugin/locales/writeragent.pot plugin/locales/de/LC_MESSAGES/writeragent.po
+```
+
+### 3. Translate
+Open the `writeragent.po` file in a text editor or a tool like [Poedit](https://poedit.net/) and translate the `msgid` strings into `msgstr`.
+
+### 4. Compile Translations
+LibreOffice's Python runtime requires the compiled binary `.mo` files to load translations efficiently. Compile your `.po` file using `msgfmt`:
+
+```bash
+msgfmt -o plugin/locales/de/LC_MESSAGES/writeragent.mo plugin/locales/de/LC_MESSAGES/writeragent.po
+```
+
+The resulting `writeragent.mo` file will be packaged inside the LibreOffice extension (`.oxt`) during the build process and loaded automatically based on the user's LibreOffice UI locale setting.

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -148,6 +148,10 @@ def bootstrap(ctx=None):
         _tools = ToolRegistry(_services)
         _services.register("tools", _tools)
 
+        # Initialize i18n
+        from plugin.framework.i18n import init_i18n
+        init_i18n(ctx)
+
         # Set initialized early to prevent recursive calls from re-running bootstrap
         # but after _services and _tools are created.
         _initialized = True
@@ -315,9 +319,54 @@ def get_menu_text(command):
         return None
     mod_name = command[:dot]
     action = command[dot + 1:]
+
+    from plugin.framework.i18n import _
+
+    # Check if the module provides a dynamic text
     for mod in _modules:
         if mod.name == mod_name:
-            return mod.get_menu_text(action)
+            text = mod.get_menu_text(action)
+            if text is not None:
+                return _(text)
+
+    # Fallback to the title from the manifest
+    try:
+        from plugin._manifest import MODULES
+        for m in MODULES:
+            if m["name"] == mod_name:
+                # The manifest doesn't store action titles directly in a map,
+                # but it might have an action list. If we don't have a specific title,
+                # we can translate the action name by capitalizing it as a fallback,
+                # or better, let the module define it. But for static menus,
+                # we can translate the static titles from the manifest if we had them.
+                # Since Addons.xcu has the static names, and notify_menu_update sets them,
+                # if we return None, LO uses the Addons.xcu name.
+                # To override Addons.xcu with translated static names, we need a map.
+                # For now, let's map known static actions directly here if mod didn't provide it.
+                pass
+    except ImportError:
+        pass
+
+    # Hardcoded fallback for static Addons.xcu items so they get translated
+    # without needing dynamic state in their respective modules.
+    static_titles = {
+        "chatbot.extend_selection": "Extend Selection",
+        "chatbot.edit_selection": "Edit Selection",
+        "main.settings": "Settings",
+        "http.toggle_server": "Toggle MCP Server",
+        "http.server_status": "MCP Server Status",
+        "main.NoOp": "Debug",
+        "main.RunFormatTests": "Run format tests",
+        "main.RunCalcTests": "Run calc tests",
+        "main.RunCalcIntegrationTests": "Run Calc API integration tests",
+        "main.RunDrawTests": "Run draw tests",
+        "main.EvaluationDashboard": "Evaluation Dashboard",
+        "main.about": "About WriterAgent"
+    }
+
+    if command in static_titles:
+        return _(static_titles[command])
+
     return None
 
 


### PR DESCRIPTION
This submission introduces a robust, standard Python `gettext` infrastructure to localize the WriterAgent extension without polluting the LibreOffice `.xcu` XML files.

**Key Changes:**
1. **`i18n.py` utility**: Automatically detects the LibreOffice UI locale (`nodepath="/org.openoffice.Setup/L10N"`) and initializes the Python `gettext` module. It exposes a global `_()` function that falls back gracefully if translations are missing.
2. **Dynamic Menu Translation**: Rather than hardcoding `<value xml:lang="...">` into `Addons.xcu`, `plugin/main.py` intercepts menu requests (`get_menu_text()`) and translates the default static labels into the user's active language at runtime before rendering the UI.
3. **Python Dialog Localization**: Hardcoded strings in `dialogs.py` (like standard "OK" buttons, copy alerts, approval dialogs, and the "About WriterAgent" menu) are now properly wrapped using the `_()` macro.
4. **Locales directory setup**: Includes a newly created `plugin/locales/` folder with an instructions `README.md` for generating standard translation templates (`writeragent.pot`) using `xgettext` and compiling them to binary `.mo` objects required by the Python runtime.

This keeps changes clean, minimal, and fully embedded within the Python runtime.

---
*PR created automatically by Jules for task [14891674351132315638](https://jules.google.com/task/14891674351132315638) started by @KeithCu*