### PR TITLE
Refactor AudioRecorder to use a pure state machine

### DIFF
--- a/plugin/modules/chatbot/audio_recorder.py
+++ b/plugin/modules/chatbot/audio_recorder.py
@@ -19,18 +19,33 @@ import sys
 import wave
 import tempfile
 
+from plugin.modules.chatbot.audio_recorder_state import (
+    AudioRecorderState,
+    StartRequestedEvent,
+    DeviceReadyEvent,
+    StopRequestedEvent,
+    ErrorOccurredEvent,
+    InitializeDeviceEffect,
+    StartRecordingEffect,
+    StopRecordingEffect,
+    ReportErrorEffect,
+    next_state,
+)
+
+
 class AudioRecorder:
     def __init__(self):
         self.fs = 16000  # Sample rate
         self.channels = 1
-        self.recording = False
         self.stream = None
         self.wav_file = None
         self.temp_filename = None
 
+        # Initialize pure state
+        self.state = AudioRecorderState(status='idle')
+
     def _cleanup_failed_start(self):
         """Clean up resources if stream creation/start fails."""
-        self.recording = False
         # Close and remove the temporary WAV file if we created one
         if self.wav_file is not None:
             try:
@@ -56,63 +71,110 @@ class AudioRecorder:
                 pass
             self.stream = None
 
+    def _execute_effect(self, effect):
+        if isinstance(effect, InitializeDeviceEffect):
+            try:
+                import sounddevice as sd
+            except OSError as e:
+                self._apply_event(ErrorOccurredEvent(
+                    "Audio recording requires PortAudio. On Linux, please run: sudo apt-get install libportaudio2"
+                ))
+                return
+
+            try:
+                fd, self.temp_filename = tempfile.mkstemp(suffix=".wav")
+                os.close(fd)
+                self.wav_file = wave.open(self.temp_filename, 'wb')
+                self.wav_file.setnchannels(self.channels)
+                self.wav_file.setsampwidth(2) # 16-bit
+                self.wav_file.setframerate(self.fs)
+
+                def callback(indata, frames, time_info, status):
+                    if status:
+                        print(status, file=sys.stderr)
+                    # Use state directly to decide if we should write
+                    if self.state.status == 'recording' and self.wav_file:
+                        # sounddevice returns bytes if we pass dtype='int16' when opening as RawInputStream
+                        self.wav_file.writeframes(indata)
+
+                self.stream = sd.RawInputStream(
+                    samplerate=self.fs,
+                    channels=self.channels,
+                    dtype="int16",
+                    callback=callback,
+                )
+
+                # Signal readiness
+                self._apply_event(DeviceReadyEvent())
+
+            except AssertionError as e:
+                # Some PortAudio backends raise AssertionError (e.g. structVersion mismatch)
+                self._apply_event(ErrorOccurredEvent(
+                    "Audio recording is not available on this system (PortAudio backend error)."
+                ))
+            except OSError as e:
+                # Preserve the existing PortAudio missing-library hint
+                self._apply_event(ErrorOccurredEvent(
+                    "Audio recording requires PortAudio. On Linux, please run: sudo apt-get install libportaudio2"
+                ))
+            except Exception as e:
+                # Generic fallback for other backend errors
+                self._apply_event(ErrorOccurredEvent(
+                    f"Audio recording failed to start: {e}"
+                ))
+
+        elif isinstance(effect, StartRecordingEffect):
+            try:
+                if self.stream:
+                    self.stream.start()
+            except Exception as e:
+                self._apply_event(ErrorOccurredEvent(
+                    f"Audio recording failed to start stream: {e}"
+                ))
+
+        elif isinstance(effect, StopRecordingEffect):
+            if self.stream:
+                try:
+                    self.stream.stop()
+                except Exception:
+                    pass
+                try:
+                    self.stream.close()
+                except Exception:
+                    pass
+                self.stream = None
+
+            if self.wav_file:
+                try:
+                    self.wav_file.close()
+                except Exception:
+                    pass
+                self.wav_file = None
+
+            # If we error'd before creating a file, temp_filename could be empty/removed
+            if self.state.status == 'error':
+                self._cleanup_failed_start()
+
+        elif isinstance(effect, ReportErrorEffect):
+            # Let the exception bubble up to the caller just like the old version
+            raise RuntimeError(effect.error_message)
+
+
+    def _apply_event(self, event):
+        """Advances the state machine and executes effects synchronously."""
+        step = next_state(self.state, event)
+        self.state = step.state
+        for effect in step.effects:
+            self._execute_effect(effect)
+
+
     def start_recording(self):
-        try:
-            import sounddevice as sd
-        except OSError as e:
-            raise RuntimeError("Audio recording requires PortAudio. On Linux, please run: sudo apt-get install libportaudio2") from e
-
-        self.recording = True
-        fd, self.temp_filename = tempfile.mkstemp(suffix=".wav")
-        os.close(fd)
-        self.wav_file = wave.open(self.temp_filename, 'wb')
-        self.wav_file.setnchannels(self.channels)
-        self.wav_file.setsampwidth(2) # 16-bit
-        self.wav_file.setframerate(self.fs)
-
-        def callback(indata, frames, time_info, status):
-            if status:
-                print(status, file=sys.stderr)
-            if self.recording:
-                # indata is numpy array, but we don't have numpy.
-                # sounddevice returns bytes if we pass dtype='int16' when opening as RawInputStream
-                self.wav_file.writeframes(indata)
-
-        try:
-            self.stream = sd.RawInputStream(
-                samplerate=self.fs,
-                channels=self.channels,
-                dtype="int16",
-                callback=callback,
-            )
-            self.stream.start()
-        except AssertionError as e:
-            # Some PortAudio backends raise AssertionError (e.g. structVersion mismatch)
-            self._cleanup_failed_start()
-            raise RuntimeError(
-                "Audio recording is not available on this system (PortAudio backend error)."
-            ) from e
-        except OSError as e:
-            # Preserve the existing PortAudio missing-library hint
-            self._cleanup_failed_start()
-            raise RuntimeError(
-                "Audio recording requires PortAudio. On Linux, please run: sudo apt-get install libportaudio2"
-            ) from e
-        except Exception as e:
-            # Generic fallback for other backend errors
-            self._cleanup_failed_start()
-            raise RuntimeError(f"Audio recording failed to start: {e}") from e
+        self._apply_event(StartRequestedEvent())
 
     def stop_recording(self):
-        self.recording = False
-        if self.stream:
-            self.stream.stop()
-            self.stream.close()
-            self.stream = None
-        if self.wav_file:
-            self.wav_file.close()
-            self.wav_file = None
+        self._apply_event(StopRequestedEvent())
 
+        # After stopping, return the temp filename (which may be None if error occurred)
         return self.temp_filename
 
 _recorder = AudioRecorder()

--- a/plugin/modules/chatbot/audio_recorder_state.py
+++ b/plugin/modules/chatbot/audio_recorder_state.py
@@ -1,0 +1,98 @@
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+try:
+    import deal
+except ImportError:
+    class _DummyDeal:
+        @staticmethod
+        def pre(func): return lambda f: f
+        @staticmethod
+        def post(func): return lambda f: f
+        @staticmethod
+        def ensure(func): return lambda f: f
+    deal = _DummyDeal()
+
+# --- State ---
+
+@dataclass(frozen=True)
+class AudioRecorderState:
+    status: str  # 'idle', 'initializing', 'recording', 'stopping', 'error'
+    error_message: Optional[str] = None
+
+# --- Events ---
+
+class StartRequestedEvent:
+    pass
+
+class DeviceReadyEvent:
+    pass
+
+class StopRequestedEvent:
+    pass
+
+@dataclass(frozen=True)
+class ErrorOccurredEvent:
+    error_message: str
+
+AudioRecorderEvent = StartRequestedEvent | DeviceReadyEvent | StopRequestedEvent | ErrorOccurredEvent
+
+# --- Effects ---
+
+class InitializeDeviceEffect:
+    pass
+
+class StartRecordingEffect:
+    pass
+
+class StopRecordingEffect:
+    pass
+
+@dataclass(frozen=True)
+class ReportErrorEffect:
+    error_message: str
+
+AudioRecorderEffect = InitializeDeviceEffect | StartRecordingEffect | StopRecordingEffect | ReportErrorEffect
+
+@dataclass(frozen=True)
+class AudioRecorderStep:
+    state: AudioRecorderState
+    effects: List[AudioRecorderEffect]
+
+# --- Pure Transition Function ---
+
+@deal.post(lambda result: result.state.status in ('idle', 'initializing', 'recording', 'stopping', 'error'))
+def next_state(
+    state: AudioRecorderState,
+    event: AudioRecorderEvent
+) -> AudioRecorderStep:
+    """Pure state transition for the audio recorder - NO SIDE EFFECTS"""
+
+    effects: List[AudioRecorderEffect] = []
+
+    match event:
+        case ErrorOccurredEvent(error_message=msg):
+            effects.append(StopRecordingEffect())
+            effects.append(ReportErrorEffect(msg))
+            new_state = AudioRecorderState(status='error', error_message=msg)
+            return AudioRecorderStep(new_state, effects)
+
+        case StartRequestedEvent():
+            if state.status in ('idle', 'error'):
+                effects.append(InitializeDeviceEffect())
+                return AudioRecorderStep(AudioRecorderState(status='initializing'), effects)
+            return AudioRecorderStep(state, effects)
+
+        case DeviceReadyEvent():
+            if state.status == 'initializing':
+                effects.append(StartRecordingEffect())
+                return AudioRecorderStep(AudioRecorderState(status='recording'), effects)
+            return AudioRecorderStep(state, effects)
+
+        case StopRequestedEvent():
+            if state.status in ('initializing', 'recording'):
+                effects.append(StopRecordingEffect())
+                return AudioRecorderStep(AudioRecorderState(status='idle'), effects)
+            return AudioRecorderStep(state, effects)
+
+    return AudioRecorderStep(state, effects)

--- a/plugin/modules/chatbot/tests/test_audio_recorder_state.py
+++ b/plugin/modules/chatbot/tests/test_audio_recorder_state.py
@@ -1,0 +1,103 @@
+import pytest
+
+from plugin.modules.chatbot.audio_recorder_state import (
+    AudioRecorderState,
+    StartRequestedEvent,
+    DeviceReadyEvent,
+    StopRequestedEvent,
+    ErrorOccurredEvent,
+    InitializeDeviceEffect,
+    StartRecordingEffect,
+    StopRecordingEffect,
+    ReportErrorEffect,
+    next_state,
+)
+
+def test_happy_path_transitions():
+    """Test the normal idle -> initializing -> recording -> stopping sequence."""
+
+    # 1. idle -> initializing
+    state = AudioRecorderState(status='idle')
+    event = StartRequestedEvent()
+    step = next_state(state, event)
+
+    assert step.state.status == 'initializing'
+    assert len(step.effects) == 1
+    assert isinstance(step.effects[0], InitializeDeviceEffect)
+
+    # 2. initializing -> recording
+    state = step.state
+    event = DeviceReadyEvent()
+    step = next_state(state, event)
+
+    assert step.state.status == 'recording'
+    assert len(step.effects) == 1
+    assert isinstance(step.effects[0], StartRecordingEffect)
+
+    # 3. recording -> stopping -> idle
+    state = step.state
+    event = StopRequestedEvent()
+    step = next_state(state, event)
+
+    assert step.state.status == 'idle'
+    assert len(step.effects) == 1
+    assert isinstance(step.effects[0], StopRecordingEffect)
+
+
+def test_start_while_initializing_or_recording_ignored():
+    """Test that start requests are ignored when not in idle/error."""
+
+    # In initializing
+    state = AudioRecorderState(status='initializing')
+    step = next_state(state, StartRequestedEvent())
+    assert step.state.status == 'initializing'
+    assert len(step.effects) == 0
+
+    # In recording
+    state = AudioRecorderState(status='recording')
+    step = next_state(state, StartRequestedEvent())
+    assert step.state.status == 'recording'
+    assert len(step.effects) == 0
+
+
+def test_stop_while_idle_ignored():
+    """Test that stop requests are ignored when already idle."""
+    state = AudioRecorderState(status='idle')
+    step = next_state(state, StopRequestedEvent())
+    assert step.state.status == 'idle'
+    assert len(step.effects) == 0
+
+
+def test_error_transition_from_any_state():
+    """Test that an error event from any state transitions to error and emits cleanup."""
+
+    states_to_test = [
+        AudioRecorderState(status='idle'),
+        AudioRecorderState(status='initializing'),
+        AudioRecorderState(status='recording'),
+    ]
+
+    error_msg = "test error"
+
+    for initial_state in states_to_test:
+        step = next_state(initial_state, ErrorOccurredEvent(error_msg))
+
+        assert step.state.status == 'error'
+        assert step.state.error_message == error_msg
+
+        assert len(step.effects) == 2
+        assert isinstance(step.effects[0], StopRecordingEffect)
+        assert isinstance(step.effects[1], ReportErrorEffect)
+        assert step.effects[1].error_message == error_msg
+
+
+def test_recovery_from_error():
+    """Test starting a new recording from an error state clears the error."""
+
+    state = AudioRecorderState(status='error', error_message='previous error')
+    step = next_state(state, StartRequestedEvent())
+
+    assert step.state.status == 'initializing'
+    assert step.state.error_message is None
+    assert len(step.effects) == 1
+    assert isinstance(step.effects[0], InitializeDeviceEffect)

--- a/plugin/tests/test_audio_recorder.py
+++ b/plugin/tests/test_audio_recorder.py
@@ -16,13 +16,13 @@ def test_audio_recorder_creates_file_mocked():
 
             assert temp_file is not None
             assert os.path.exists(temp_file)
-            assert recorder.recording is True
+            assert recorder.state.status == 'recording'
             assert recorder.wav_file is not None
 
             returned_file = recorder.stop_recording()
 
             assert returned_file == temp_file
-            assert recorder.recording is False
+            assert recorder.state.status == 'idle'
             assert recorder.wav_file is None
             assert recorder.stream is None
 
@@ -95,7 +95,7 @@ def test_audio_recorder_real_hardware():
             assert wf.getframerate() == recorder.fs
     finally:
         # Stop recording if we crashed mid-flight
-        if recorder.recording:
+        if getattr(recorder, 'state', None) and recorder.state.status in ('recording', 'initializing'):
             try:
                 recorder.stop_recording()
             except Exception:


### PR DESCRIPTION
Extracted the device lifecycle logic of `AudioRecorder` into a pure, testable state machine (`audio_recorder_state.py`). The existing class was updated to intercept requests and dispatch them via the pure `next_state` function, subsequently executing output effects synchronously. Tests were updated and supplemented to enforce the new strict transitions.

---
*PR created automatically by Jules for task [8365194097512343565](https://jules.google.com/task/8365194097512343565) started by @KeithCu*