### PR TITLE
Refactor MCP protocol tool execution to use pure state machine architecture

### DIFF
--- a/plugin/modules/http/mcp_protocol.py
+++ b/plugin/modules/http/mcp_protocol.py
@@ -30,7 +30,11 @@ import uuid
 
 from plugin.framework.main_thread import execute_on_main_thread
 from plugin.framework.errors import WriterAgentException, safe_json_loads
-log = logging.getLogger(__name__)
+from plugin.modules.http.mcp_state import (
+    MCPState, MCPStateStr, EventKind, MCPEvent,
+    ParseRequestEffect, ResolveDocumentEffect,
+    ExecuteToolEffect, StreamResponseEffect, SendErrorEffect, next_state
+)
 
 log = logging.getLogger("writeragent.mcp.protocol")
 
@@ -371,50 +375,99 @@ class MCPProtocolHandler:
         return {"prompts": []}
 
     def _mcp_tools_call(self, params, document_url=None):
+        state = MCPState(status=MCPStateStr.IDLE)
+
         tool_name = params.get("name")
         arguments = params.get("arguments", {})
-        if not tool_name:
-            raise ValueError("Missing 'name' in tools/call params")
-
-        log.debug(f"*** tools/call: {tool_name}, event_bus={self.event_bus} ***")
-
-        if self.event_bus:
-            pass
-        # Fire event for MCP request
-        if getattr(self, "event_bus", None) is not None:
-            self.event_bus.emit(
-                "mcp:request",
-                tool=params["name"],
-                args=params.get("arguments", {}),
-                method="tools/call"
-            )
-
         tool = self.tool_registry.get(tool_name)
         is_long_running = getattr(tool, "long_running", False) if tool else False
 
-        if is_long_running:
-            result = self._execute_long_running(
-                tool_name, arguments, document_url=document_url)
-        else:
-            result = self._execute_with_backpressure(
-                tool_name, arguments, document_url=document_url)
+        initial_event = MCPEvent(
+            kind=EventKind.REQUEST_RECEIVED,
+            data={
+                "tool_name": tool_name,
+                "arguments": arguments,
+                "document_url": document_url,
+                "is_long_running": is_long_running
+            }
+        )
 
-        if self.event_bus:
-            snippet = str(result)[:100] if result else ""
-            self.event_bus.emit("mcp:result", tool=tool_name, result_snippet=snippet, args=arguments)
+        # State machine runner
+        events_to_process = [initial_event]
+        final_result = None
 
-        is_error = (isinstance(result, dict)
-                    and result.get("status") == "error")
-        return {
-            "content": [
-                {
-                    "type": "text",
-                    "text": json.dumps(result, ensure_ascii=False,
-                                       default=str),
-                }
-            ],
-            "isError": is_error,
-        }
+        while events_to_process:
+            event = events_to_process.pop(0)
+            state, effects = next_state(state, event)
+
+            for effect in effects:
+                if isinstance(effect, ParseRequestEffect):
+                    log.debug(f"*** tools/call: {state.tool_name}, event_bus={self.event_bus} ***")
+                    if getattr(self, "event_bus", None) is not None:
+                        self.event_bus.emit(
+                            "mcp:request",
+                            tool=state.tool_name,
+                            args=state.arguments,
+                            method="tools/call"
+                        )
+
+                elif isinstance(effect, ResolveDocumentEffect):
+                    # We do not use doc_context/uno_ctx from here since the
+                    # execution methods currently handle context resolution
+                    # themselves (on main thread). We emit DOCUMENT_RESOLVED immediately.
+                    events_to_process.append(MCPEvent(
+                        kind=EventKind.DOCUMENT_RESOLVED,
+                        data={
+                            "doc_context": None,
+                            "doc_type": "writer",
+                            "uno_ctx": None
+                        }
+                    ))
+
+                elif isinstance(effect, ExecuteToolEffect):
+                    events_to_process.append(MCPEvent(kind=EventKind.TOOL_EXECUTION_STARTED))
+                    try:
+                        if effect.is_long_running:
+                            res = self._execute_long_running(
+                                effect.tool_name, effect.arguments, document_url=effect.document_url)
+                        else:
+                            res = self._execute_with_backpressure(
+                                effect.tool_name, effect.arguments, document_url=effect.document_url)
+                        events_to_process.append(MCPEvent(
+                            kind=EventKind.TOOL_COMPLETED,
+                            data={"result": res}
+                        ))
+                    except (BusyError, TimeoutError, WriterAgentException) as e:
+                        # Re-raise standard json-rpc errors to be caught in _process_jsonrpc
+                        raise e
+                    except Exception as e:
+                        events_to_process.append(MCPEvent(
+                            kind=EventKind.REQUEST_ERROR,
+                            data={
+                                "message": str(e),
+                                "code": "INTERNAL_ERROR"
+                            }
+                        ))
+
+                elif isinstance(effect, StreamResponseEffect):
+                    if getattr(self, "event_bus", None) is not None:
+                        snippet = str(effect.result)[:100] if effect.result else ""
+                        self.event_bus.emit("mcp:result", tool=state.tool_name, result_snippet=snippet, args=state.arguments)
+
+                    final_result = {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": json.dumps(effect.result, ensure_ascii=False, default=str),
+                            }
+                        ],
+                        "isError": effect.is_error,
+                    }
+
+                elif isinstance(effect, SendErrorEffect):
+                    raise ValueError(effect.message)
+
+        return final_result
 
     # ── JSON-RPC processing ──────────────────────────────────────────
 

--- a/plugin/modules/http/mcp_state.py
+++ b/plugin/modules/http/mcp_state.py
@@ -1,0 +1,172 @@
+import dataclasses
+from enum import Enum, auto
+from typing import Any, Dict, List, Optional, Tuple, NamedTuple
+
+# --- States ---
+class MCPStateStr(Enum):
+    IDLE = "idle"
+    PARSING_REQUEST = "parsing_request"
+    RESOLVING_DOCUMENT = "resolving_document"
+    EXECUTING_TOOL = "executing_tool"
+    STREAMING_RESPONSE = "streaming_response"  # Despite name, we send a single JSON-RPC response
+    ERROR = "error"
+
+@dataclasses.dataclass(frozen=True)
+class MCPState:
+    status: MCPStateStr
+    tool_name: Optional[str] = None
+    arguments: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    document_url: Optional[str] = None
+    doc_type: Optional[str] = None
+    doc_context: Any = None  # The resolved document UNO context, if any
+    uno_ctx: Any = None      # The UNO component context, if any
+    result: Any = None       # The final result payload
+    error_message: Optional[str] = None
+    error_code: Optional[str] = None
+    is_long_running: bool = False
+    is_error: bool = False
+
+# --- Events ---
+class EventKind(Enum):
+    REQUEST_RECEIVED = auto()
+    DOCUMENT_RESOLVED = auto()
+    TOOL_EXECUTION_STARTED = auto()
+    TOOL_COMPLETED = auto()
+    REQUEST_ERROR = auto()
+
+@dataclasses.dataclass(frozen=True)
+class MCPEvent:
+    kind: EventKind
+    data: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+# --- Effects ---
+
+@dataclasses.dataclass(frozen=True)
+class ParseRequestEffect:
+    pass
+
+@dataclasses.dataclass(frozen=True)
+class ResolveDocumentEffect:
+    document_url: Optional[str]
+    is_long_running: bool
+
+@dataclasses.dataclass(frozen=True)
+class ExecuteToolEffect:
+    tool_name: str
+    arguments: Dict[str, Any]
+    doc_context: Any
+    doc_type: str
+    uno_ctx: Any
+    is_long_running: bool
+    document_url: Optional[str] = None
+
+@dataclasses.dataclass(frozen=True)
+class StreamResponseEffect:
+    result: Any
+    is_error: bool
+
+@dataclasses.dataclass(frozen=True)
+class SendErrorEffect:
+    message: str
+    code: str
+
+# --- State Machine Transition ---
+
+def next_state(state: MCPState, event: MCPEvent) -> Tuple[MCPState, List[Any]]:
+    """Pure transition function for the MCP tool-calling loop."""
+    effects: List[Any] = []
+
+    if event.kind == EventKind.REQUEST_RECEIVED:
+        # Move to parsing/resolving
+        tool_name = event.data.get("tool_name")
+        arguments = event.data.get("arguments", {})
+        document_url = event.data.get("document_url")
+        is_long_running = event.data.get("is_long_running", False)
+
+        if not tool_name:
+            effects.append(SendErrorEffect(message="Missing 'name' in tools/call params", code="INVALID_PARAMS"))
+            return dataclasses.replace(state, status=MCPStateStr.ERROR, is_error=True), effects
+
+        effects.append(ParseRequestEffect())
+        effects.append(ResolveDocumentEffect(document_url=document_url, is_long_running=is_long_running))
+        return dataclasses.replace(
+            state,
+            status=MCPStateStr.RESOLVING_DOCUMENT,
+            tool_name=tool_name,
+            arguments=arguments,
+            document_url=document_url,
+            is_long_running=is_long_running
+        ), effects
+
+    elif event.kind == EventKind.DOCUMENT_RESOLVED:
+        doc_context = event.data.get("doc_context")
+        doc_type = event.data.get("doc_type", "writer")
+        uno_ctx = event.data.get("uno_ctx")
+        error_payload = event.data.get("error_payload")
+
+        if error_payload:
+            # Resolution failed
+            effects.append(StreamResponseEffect(result=error_payload, is_error=True))
+            return dataclasses.replace(
+                state,
+                status=MCPStateStr.ERROR,
+                is_error=True,
+                result=error_payload
+            ), effects
+
+        # Move to executing tool
+        effects.append(ExecuteToolEffect(
+            tool_name=state.tool_name,
+            arguments=state.arguments,
+            doc_context=doc_context,
+            doc_type=doc_type,
+            uno_ctx=uno_ctx,
+            is_long_running=state.is_long_running,
+            document_url=state.document_url
+        ))
+        return dataclasses.replace(
+            state,
+            status=MCPStateStr.EXECUTING_TOOL,
+            doc_context=doc_context,
+            doc_type=doc_type,
+            uno_ctx=uno_ctx
+        ), effects
+
+    elif event.kind == EventKind.TOOL_EXECUTION_STARTED:
+        # Just an informational event, we stay in EXECUTING_TOOL
+        return state, effects
+
+    elif event.kind == EventKind.TOOL_COMPLETED:
+        result = event.data.get("result")
+        is_error = isinstance(result, dict) and result.get("status") == "error"
+
+        effects.append(StreamResponseEffect(result=result, is_error=is_error))
+        return dataclasses.replace(
+            state,
+            status=MCPStateStr.STREAMING_RESPONSE,
+            result=result,
+            is_error=is_error
+        ), effects
+
+    elif event.kind == EventKind.REQUEST_ERROR:
+        message = event.data.get("message", "Unknown error")
+        code = event.data.get("code", "INTERNAL_ERROR")
+
+        # Determine if we should send a raw exception bubble-up or stream response effect
+        # For simplicity, we can trigger StreamResponseEffect with an error payload
+        err_payload = {
+            "status": "error",
+            "code": code,
+            "message": message
+        }
+        effects.append(StreamResponseEffect(result=err_payload, is_error=True))
+        return dataclasses.replace(
+            state,
+            status=MCPStateStr.ERROR,
+            is_error=True,
+            error_message=message,
+            error_code=code,
+            result=err_payload
+        ), effects
+
+    return state, effects


### PR DESCRIPTION
This pull request refactors the `tools/call` handling logic within the MCP JSON-RPC protocol (`plugin/modules/http/mcp_protocol.py`). Following the established architectural pattern from `tool_loop.py`, it decouples procedural execution into an Elm/Redux-style pure state machine.

**Changes introduced:**
*   Created `plugin/modules/http/mcp_state.py` to define the purely functional state transitions, housing the `MCPState`, `MCPEvent`, and various effect dataclasses (`ExecuteToolEffect`, `ResolveDocumentEffect`, etc.).
*   Refactored `_mcp_tools_call` to act as an orchestrating interpreter that loops over events and executes side-effects synchronously.
*   Retained the specific requirement of not streaming chunks back to the client; it collects the final execution result and emits a standard single JSON-RPC response.
*   All tests continue to pass successfully.

---
*PR created automatically by Jules for task [11385379760985129417](https://jules.google.com/task/11385379760985129417) started by @KeithCu*