### PR TITLE
Apply localization to remaining user-visible strings

### DIFF
--- a/plugin/framework/dialogs.py
+++ b/plugin/framework/dialogs.py
@@ -404,8 +404,8 @@ def about_dialog(ctx):
     except Exception:
         log.exception("About dialog error")
         msgbox(ctx, _("About WriterAgent"),
-               "WriterAgent %s\nhttps://github.com/quazardous/localwriter"
-               % EXTENSION_VERSION)
+               _("WriterAgent {0}\nhttps://github.com/quazardous/localwriter")
+               .format(EXTENSION_VERSION))
 
 
 # ── XDL dialog loading ──────────────────────────────────────────────

--- a/plugin/framework/legacy_ui.py
+++ b/plugin/framework/legacy_ui.py
@@ -18,6 +18,7 @@ import logging
 from plugin.framework.errors import format_error_payload
 from plugin.framework.uno_context import get_desktop, get_active_document, get_extension_url
 from plugin.framework.dialogs import TabListener, is_checkbox_control, get_checkbox_state, set_checkbox_state, get_optional, set_control_enabled, set_control_text, get_control_text
+from plugin.framework.i18n import _
 from plugin.framework.config import get_config, get_current_endpoint, get_text_model, populate_combobox_with_lru, set_config, update_lru_history
 from plugin.framework.logging import init_logging, agent_log
 from plugin.modules.chatbot.history_db import HAS_SQLITE
@@ -310,7 +311,7 @@ def settings_box(ctx, title="Settings", x=None, y=None):
     except Exception as e:
         from plugin.framework.dialogs import msgbox
         import traceback
-        msgbox(ctx, "Error", f"Failed to open Settings: {e}\n\n{traceback.format_exc()}")
+        msgbox(ctx, _("Error"), _("Failed to open Settings: {0}\n\n{1}").format(e, traceback.format_exc()))
         return format_error_payload(e)
     finally:
         dlg.dispose()

--- a/plugin/framework/settings_dialog.py
+++ b/plugin/framework/settings_dialog.py
@@ -17,6 +17,7 @@
 from plugin.framework.config import get_config, set_config, get_current_endpoint, as_bool, endpoint_from_selector_text, get_image_model, set_image_model, get_api_key_for_endpoint, set_api_key_for_endpoint, notify_config_changed
 
 import logging
+from plugin.framework.i18n import _
 
 log = logging.getLogger(__name__)
 
@@ -142,7 +143,7 @@ def apply_settings_result(ctx, result):
                     f_val = float(val)
                     if f_val > 1.0:
                         from plugin.framework.dialogs import msgbox
-                        msgbox(ctx, "Invalid Setting", "Temperature must be <= 1.0")
+                        msgbox(ctx, _("Invalid Setting"), _("Temperature must be <= 1.0"))
                         continue
                     if f_val < 0:
                         val = -1.0

--- a/plugin/locales/writeragent.pot
+++ b/plugin/locales/writeragent.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-21 16:46-0400\n"
+"POT-Creation-Date: 2026-03-21 21:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,12 +35,10 @@ msgid "Register at "
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:617
-#, python-brace-format
 msgid "You have {} kudos"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:625
-#, python-brace-format
 msgid "«{}» is not a valid API KEY, double check it or create a new one"
 msgstr ""
 
@@ -68,7 +66,6 @@ msgid ""
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:662
-#, python-brace-format
 msgid ""
 "Seems that «{}» has problems, double check it, create a new one or join "
 "Discord to ask for help"
@@ -93,6 +90,13 @@ msgstr ""
 #: plugin/contrib/aihordeclient/__init__.py:821
 msgid ""
 "When trying to ask for the image, the Horde was too slow, try again later"
+msgstr ""
+
+#: plugin/contrib/aihordeclient/__init__.py:836
+#, python-brace-format
+msgid ""
+"Register at {REGISTER_AI_HORDE_URL} and use your key to improve your rate "
+"success. Detail:"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:843
@@ -136,7 +140,6 @@ msgid "Please try another model,"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:973
-#, python-brace-format
 msgid "{} would take more time than you configured,"
 msgstr ""
 
@@ -163,7 +166,6 @@ msgid "Please try again later."
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:1020
-#, python-brace-format
 msgid "Probably your image will take {} additional minutes."
 msgstr ""
 
@@ -196,319 +198,6 @@ msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:1128
 msgid " with "
-msgstr ""
-
-#: plugin/framework/dialogs.py:93
-msgid "Agent requests approval"
-msgstr ""
-
-#: plugin/framework/dialogs.py:94
-msgid "Proceed with this action?"
-msgstr ""
-
-#: plugin/framework/dialogs.py:95
-#, python-format
-msgid "Tool: %s"
-msgstr ""
-
-#: plugin/framework/dialogs.py:234
-msgid "Copy"
-msgstr ""
-
-#: plugin/framework/dialogs.py:235 plugin/framework/dialogs.py:307
-#: plugin/framework/dialogs.py:394 plugin/modules/http/__init__.py:247
-msgid "OK"
-msgstr ""
-
-#: plugin/framework/dialogs.py:254 plugin/framework/dialogs.py:329
-msgid "Copied!"
-msgstr ""
-
-#: plugin/framework/dialogs.py:304
-msgid "Copy URL"
-msgstr ""
-
-#: plugin/framework/dialogs.py:378 plugin/framework/dialogs.py:406
-#: plugin/main.py:367
-msgid "About WriterAgent"
-msgstr ""
-
-#: plugin/framework/dialogs.py:385
-#, python-format
-msgid "Version: %s"
-msgstr ""
-
-#: plugin/framework/dialogs.py:386
-msgid "AI-powered extension for LibreOffice"
-msgstr ""
-
-#: plugin/framework/dialogs.py:391
-msgid "GitHub: quazardous/localwriter"
-msgstr ""
-
-#: plugin/modules/http/errors.py:15
-#, python-brace-format
-msgid "TLS/SSL Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:20
-msgid "Invalid API Key. Please check your settings."
-msgstr ""
-
-#: plugin/modules/http/errors.py:22
-msgid "API access Forbidden. Your key may lack permissions for this model."
-msgstr ""
-
-#: plugin/modules/http/errors.py:24
-msgid "Endpoint not found (404). Check your URL and Model name."
-msgstr ""
-
-#: plugin/modules/http/errors.py:26
-#, python-brace-format
-msgid "Server error ({0}). The AI provider is having issues."
-msgstr ""
-
-#: plugin/modules/http/errors.py:27 plugin/modules/http/errors.py:48
-#, python-brace-format
-msgid "HTTP Error {0}: {1}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:30
-msgid "Request Timed Out. Try increasing 'Request Timeout' in Settings."
-msgstr ""
-
-#: plugin/modules/http/errors.py:35
-msgid "Connection Refused. Is your local AI server (Ollama/LM Studio) running?"
-msgstr ""
-
-#: plugin/modules/http/errors.py:37
-msgid "DNS Error. Could not resolve the endpoint URL."
-msgstr ""
-
-#: plugin/modules/http/errors.py:38
-#, python-brace-format
-msgid "Connection Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:41
-msgid "The AI provider reported an error. Try again."
-msgstr ""
-
-#: plugin/modules/http/errors.py:70
-#, python-brace-format
-msgid "Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/client.py:534
-msgid "Stream ended with finish_reason=error"
-msgstr ""
-
-#: plugin/modules/http/client.py:547
-msgid ""
-"The model is repeating the same chunk (infinite loop). Try again or use a "
-"different model."
-msgstr ""
-
-#: plugin/modules/http/__init__.py:179
-msgid "Stop HTTP Server"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:180
-msgid "Start HTTP Server"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:201
-msgid "HTTP server stopped"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:208
-#, python-brace-format
-msgid ""
-"HTTP server started\n"
-"{0}"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:211
-msgid ""
-"HTTP server failed to start\n"
-"Check ~/localwriter.log"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:220
-msgid "HTTP server is not running"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:226
-msgid "HTTP server not running"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:231
-#, python-brace-format
-msgid ""
-"HTTP server running\n"
-"Routes: {0}"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:238
-msgid "Server Status"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:259
-#, python-brace-format
-msgid ""
-"{0}\n"
-"URL: {1}"
-msgstr ""
-
-#: plugin/modules/launcher/__init__.py:406
-#, python-brace-format
-msgid "{0} Running"
-msgstr ""
-
-#: plugin/modules/launcher/__init__.py:407
-#, python-brace-format
-msgid "Launch {0}"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:32 plugin/modules/writer/legacy.py:70
-msgid "Please enter edit instructions!"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:32 plugin/modules/writer/legacy.py:70
-msgid "Input"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
-msgid "WriterAgent: Edit Selection (Calc)"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
-msgid "WriterAgent: Extend Selection (Calc)"
-msgstr ""
-
-#: plugin/modules/writer/legacy.py:43 plugin/modules/writer/legacy.py:54
-msgid "WriterAgent: Extend Selection"
-msgstr ""
-
-#: plugin/modules/writer/legacy.py:78 plugin/modules/writer/legacy.py:88
-#: plugin/modules/writer/legacy.py:102
-msgid "WriterAgent: Edit Selection"
-msgstr ""
-
-#: plugin/modules/chatbot/panel_wiring.py:142
-msgid "Ready"
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:394
-msgid "Record"
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:396
-msgid "Stop Rec"
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:398
-msgid "Send"
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:418
-msgid "Getting document..."
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:423
-msgid ""
-"\n"
-"[No compatible LibreOffice document (Writer, Calc, or Draw) found in the "
-"active window.]\n"
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:433
-#, python-brace-format
-msgid ""
-"[Internal Error: Document type changed from {0} to {1}! Please file an "
-"error.]"
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:440
-#, python-brace-format
-msgid ""
-"[Internal Error: Could not identify document type for {0}. Please report "
-"this!]"
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:474
-#, python-brace-format
-msgid ""
-"[Model {0} does not support native audio. Please select an STT Model in "
-"Settings.]"
-msgstr ""
-
-#: plugin/modules/chatbot/panel.py:477
-#: plugin/modules/chatbot/send_handlers.py:282
-#: plugin/modules/chatbot/send_handlers.py:293
-#: plugin/modules/chatbot/send_handlers.py:302
-#: plugin/modules/chatbot/send_handlers.py:543
-msgid "Error"
-msgstr ""
-
-#: plugin/modules/chatbot/send_handlers.py:197
-#: plugin/modules/chatbot/send_handlers.py:365
-#: plugin/modules/chatbot/send_handlers.py:541
-#, python-brace-format
-msgid ""
-"\n"
-"[Error: {0}]\n"
-msgstr ""
-
-#: plugin/modules/chatbot/send_handlers.py:280
-#, python-brace-format
-msgid ""
-"\n"
-"[Document context error: {0}]\n"
-msgstr ""
-
-#: plugin/modules/chatbot/send_handlers.py:291
-#, python-brace-format
-msgid ""
-"\n"
-"[Agent backend '{0}' not found.]\n"
-msgstr ""
-
-#: plugin/modules/chatbot/send_handlers.py:298
-#, python-brace-format
-msgid ""
-"\n"
-"[Agent backend '{0}' is not available. Check Settings (path, install).]\n"
-msgstr ""
-
-#: plugin/modules/chatbot/send_handlers.py:517
-#, python-brace-format
-msgid "AI (research): {0}\n"
-msgstr ""
-
-#: plugin/modules/chatbot/send_handlers.py:523
-msgid "Unknown research error."
-msgstr ""
-
-#: plugin/modules/chatbot/send_handlers.py:524
-#, python-brace-format
-msgid "[Research error: {0}]\n"
-msgstr ""
-
-#: plugin/modules/chatbot/panel_factory.py:445
-msgid "Size:"
-msgstr ""
-
-#: plugin/modules/chatbot/panel_factory.py:446
-msgid "Height:"
-msgstr ""
-
-#: plugin/modules/chatbot/panel_factory.py:447
-msgid "Width:"
-msgstr ""
-
-#: plugin/tests/test_i18n.py:15
-msgid "ThisIsAnUntranslatedString999"
 msgstr ""
 
 #: plugin/main.py:243
@@ -564,6 +253,355 @@ msgstr ""
 msgid "Evaluation Dashboard"
 msgstr ""
 
+#: plugin/main.py:367 plugin/framework/dialogs.py:378
+#: plugin/framework/dialogs.py:406
+msgid "About WriterAgent"
+msgstr ""
+
 #: plugin/main.py:715
 msgid "Dispatch Error"
+msgstr ""
+
+#: plugin/modules/writer/legacy.py:43 plugin/modules/writer/legacy.py:54
+#: plugin/modules/chatbot/selection.py:69
+#: plugin/modules/chatbot/selection.py:145
+msgid "WriterAgent: Extend Selection"
+msgstr ""
+
+#: plugin/modules/writer/legacy.py:70 plugin/modules/calc/legacy.py:32
+msgid "Please enter edit instructions!"
+msgstr ""
+
+#: plugin/modules/writer/legacy.py:70 plugin/modules/calc/legacy.py:32
+msgid "Input"
+msgstr ""
+
+#: plugin/modules/writer/legacy.py:78 plugin/modules/writer/legacy.py:88
+#: plugin/modules/writer/legacy.py:102 plugin/modules/chatbot/selection.py:256
+#: plugin/modules/chatbot/selection.py:358
+msgid "WriterAgent: Edit Selection"
+msgstr ""
+
+#: plugin/modules/chatbot/panel_factory.py:445
+msgid "Size:"
+msgstr ""
+
+#: plugin/modules/chatbot/panel_factory.py:446
+msgid "Height:"
+msgstr ""
+
+#: plugin/modules/chatbot/panel_factory.py:447
+msgid "Width:"
+msgstr ""
+
+#: plugin/modules/chatbot/panel_wiring.py:142
+msgid "Ready"
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:394
+msgid "Record"
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:396
+msgid "Stop Rec"
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:398
+msgid "Send"
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:418
+msgid "Getting document..."
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:423
+msgid ""
+"\n"
+"[No compatible LibreOffice document (Writer, Calc, or Draw) found in the "
+"active window.]\n"
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:433
+#, python-brace-format
+msgid ""
+"[Internal Error: Document type changed from {0} to {1}! Please file an "
+"error.]"
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:440
+#, python-brace-format
+msgid ""
+"[Internal Error: Could not identify document type for {0}. Please report "
+"this!]"
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:474
+#, python-brace-format
+msgid ""
+"[Model {0} does not support native audio. Please select an STT Model in "
+"Settings.]"
+msgstr ""
+
+#: plugin/modules/chatbot/panel.py:477
+#: plugin/modules/chatbot/send_handlers.py:282
+#: plugin/modules/chatbot/send_handlers.py:293
+#: plugin/modules/chatbot/send_handlers.py:302
+#: plugin/modules/chatbot/send_handlers.py:543
+#: plugin/framework/legacy_ui.py:314
+msgid "Error"
+msgstr ""
+
+#: plugin/modules/chatbot/send_handlers.py:197
+#: plugin/modules/chatbot/send_handlers.py:365
+#: plugin/modules/chatbot/send_handlers.py:541
+#, python-brace-format
+msgid ""
+"\n"
+"[Error: {0}]\n"
+msgstr ""
+
+#: plugin/modules/chatbot/send_handlers.py:280
+#, python-brace-format
+msgid ""
+"\n"
+"[Document context error: {0}]\n"
+msgstr ""
+
+#: plugin/modules/chatbot/send_handlers.py:291
+#, python-brace-format
+msgid ""
+"\n"
+"[Agent backend '{0}' not found.]\n"
+msgstr ""
+
+#: plugin/modules/chatbot/send_handlers.py:298
+#, python-brace-format
+msgid ""
+"\n"
+"[Agent backend '{0}' is not available. Check Settings (path, install).]\n"
+msgstr ""
+
+#: plugin/modules/chatbot/send_handlers.py:517
+#, python-brace-format
+msgid "AI (research): {0}\n"
+msgstr ""
+
+#: plugin/modules/chatbot/send_handlers.py:523
+msgid "Unknown research error."
+msgstr ""
+
+#: plugin/modules/chatbot/send_handlers.py:524
+#, python-brace-format
+msgid "[Research error: {0}]\n"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:179
+msgid "Stop HTTP Server"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:180
+msgid "Start HTTP Server"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:201
+msgid "HTTP server stopped"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:208
+#, python-brace-format
+msgid ""
+"HTTP server started\n"
+"{0}"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:211
+msgid ""
+"HTTP server failed to start\n"
+"Check ~/localwriter.log"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:220
+msgid "HTTP server is not running"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:226
+msgid "HTTP server not running"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:231
+#, python-brace-format
+msgid ""
+"HTTP server running\n"
+"Routes: {0}"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:238
+msgid "Server Status"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:247 plugin/framework/dialogs.py:235
+#: plugin/framework/dialogs.py:307 plugin/framework/dialogs.py:394
+msgid "OK"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:259
+#, python-brace-format
+msgid ""
+"{0}\n"
+"URL: {1}"
+msgstr ""
+
+#: plugin/modules/http/client.py:534
+msgid "Stream ended with finish_reason=error"
+msgstr ""
+
+#: plugin/modules/http/client.py:547
+msgid ""
+"The model is repeating the same chunk (infinite loop). Try again or use a "
+"different model."
+msgstr ""
+
+#: plugin/modules/http/errors.py:15
+#, python-brace-format
+msgid "TLS/SSL Error: {0}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:20
+msgid "Invalid API Key. Please check your settings."
+msgstr ""
+
+#: plugin/modules/http/errors.py:22
+msgid "API access Forbidden. Your key may lack permissions for this model."
+msgstr ""
+
+#: plugin/modules/http/errors.py:24
+msgid "Endpoint not found (404). Check your URL and Model name."
+msgstr ""
+
+#: plugin/modules/http/errors.py:26
+#, python-brace-format
+msgid "Server error ({0}). The AI provider is having issues."
+msgstr ""
+
+#: plugin/modules/http/errors.py:27 plugin/modules/http/errors.py:48
+#, python-brace-format
+msgid "HTTP Error {0}: {1}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:30
+msgid "Request Timed Out. Try increasing 'Request Timeout' in Settings."
+msgstr ""
+
+#: plugin/modules/http/errors.py:35
+msgid "Connection Refused. Is your local AI server (Ollama/LM Studio) running?"
+msgstr ""
+
+#: plugin/modules/http/errors.py:37
+msgid "DNS Error. Could not resolve the endpoint URL."
+msgstr ""
+
+#: plugin/modules/http/errors.py:38
+#, python-brace-format
+msgid "Connection Error: {0}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:41
+msgid "The AI provider reported an error. Try again."
+msgstr ""
+
+#: plugin/modules/http/errors.py:70
+#, python-brace-format
+msgid "Error: {0}"
+msgstr ""
+
+#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
+msgid "WriterAgent: Edit Selection (Calc)"
+msgstr ""
+
+#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
+msgid "WriterAgent: Extend Selection (Calc)"
+msgstr ""
+
+#: plugin/modules/launcher/__init__.py:407
+#, python-brace-format
+msgid "{0} Running"
+msgstr ""
+
+#: plugin/modules/launcher/__init__.py:408
+#, python-brace-format
+msgid "Launch {0}"
+msgstr ""
+
+#: plugin/modules/launcher/__init__.py:502
+#, python-brace-format
+msgid ""
+"Command '{0}' not found.\n"
+"Make sure it is installed and in your PATH.\n"
+"\n"
+"Use 'Install AI CLI' from the menu to get install instructions."
+msgstr ""
+
+#: plugin/framework/settings_dialog.py:146
+msgid "Invalid Setting"
+msgstr ""
+
+#: plugin/framework/settings_dialog.py:146
+msgid "Temperature must be <= 1.0"
+msgstr ""
+
+#: plugin/framework/legacy_ui.py:314
+#, python-brace-format
+msgid ""
+"Failed to open Settings: {0}\n"
+"\n"
+"{1}"
+msgstr ""
+
+#: plugin/framework/dialogs.py:93
+msgid "Agent requests approval"
+msgstr ""
+
+#: plugin/framework/dialogs.py:94
+msgid "Proceed with this action?"
+msgstr ""
+
+#: plugin/framework/dialogs.py:95
+#, python-format
+msgid "Tool: %s"
+msgstr ""
+
+#: plugin/framework/dialogs.py:234
+msgid "Copy"
+msgstr ""
+
+#: plugin/framework/dialogs.py:254 plugin/framework/dialogs.py:329
+msgid "Copied!"
+msgstr ""
+
+#: plugin/framework/dialogs.py:304
+msgid "Copy URL"
+msgstr ""
+
+#: plugin/framework/dialogs.py:385
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: plugin/framework/dialogs.py:386
+msgid "AI-powered extension for LibreOffice"
+msgstr ""
+
+#: plugin/framework/dialogs.py:391
+msgid "GitHub: quazardous/localwriter"
+msgstr ""
+
+#: plugin/framework/dialogs.py:407
+#, python-brace-format
+msgid ""
+"WriterAgent {0}\n"
+"https://github.com/quazardous/localwriter"
+msgstr ""
+
+#: plugin/tests/test_i18n.py:15
+msgid "ThisIsAnUntranslatedString999"
 msgstr ""

--- a/plugin/modules/chatbot/selection.py
+++ b/plugin/modules/chatbot/selection.py
@@ -1,6 +1,7 @@
 """Action handlers for extending and editing document selections."""
 
 import logging
+from plugin.framework.i18n import _
 
 log = logging.getLogger("writeragent.chatbot.selection")
 
@@ -65,7 +66,7 @@ def _extend_writer(services, ctx, doc):
 
     def on_error(e):
         log.error("Extend selection failed: %s", e)
-        msgbox(ctx, "WriterAgent: Extend Selection", str(e))
+        msgbox(ctx, _("WriterAgent: Extend Selection"), str(e))
 
     api_config = get_api_config(ctx)
     client = LlmClient(api_config, ctx)
@@ -141,7 +142,7 @@ def _extend_calc(services, ctx, doc):
 
         def on_error(e):
             log.error("Extend selection (calc) failed: %s", e)
-            msgbox(ctx, "WriterAgent: Extend Selection", str(e))
+            msgbox(ctx, _("WriterAgent: Extend Selection"), str(e))
 
         run_stream_async(
             ctx, client, msgs, tools=None,
@@ -252,7 +253,7 @@ def _edit_writer(services, ctx, doc):
         except Exception:
             pass
         log.error("Edit selection failed: %s", e)
-        msgbox(ctx, "WriterAgent: Edit Selection", str(e))
+        msgbox(ctx, _("WriterAgent: Edit Selection"), str(e))
 
     api_config = get_api_config(ctx)
     client = LlmClient(api_config, ctx)
@@ -354,7 +355,7 @@ def _edit_calc(services, ctx, doc):
             except Exception:
                 pass
             log.error("Edit selection (calc) failed: %s", e)
-            msgbox(ctx, "WriterAgent: Edit Selection", str(e))
+            msgbox(ctx, _("WriterAgent: Edit Selection"), str(e))
 
         run_stream_async(
             ctx, client, msgs, tools=None,

--- a/plugin/modules/launcher/__init__.py
+++ b/plugin/modules/launcher/__init__.py
@@ -31,6 +31,7 @@ import sys
 import threading
 
 from plugin.framework.module_base import ModuleBase
+from plugin.framework.i18n import _
 
 log = logging.getLogger("writeragent.launcher")
 
@@ -498,10 +499,10 @@ class LauncherModule(ModuleBase):
         # Check command exists
         if not shutil.which(provider.binary_name):
             msgbox(ctx, "WriterAgent",
-                   "Command '%s' not found.\n"
-                   "Make sure it is installed and in your PATH.\n\n"
-                   "Use 'Install AI CLI' from the menu to get install instructions."
-                   % provider.binary_name)
+                   _("Command '{0}' not found.\n"
+                     "Make sure it is installed and in your PATH.\n\n"
+                     "Use 'Install AI CLI' from the menu to get install instructions.")
+                   .format(provider.binary_name))
             return
 
         # Build CLI command


### PR DESCRIPTION
Wrapped remaining user-visible UI strings across various subsystems (chatbot selections, UI framework, launcher) in `_()` gettext calls and updated the `.pot` template for translators.

---
*PR created automatically by Jules for task [15588402029792014520](https://jules.google.com/task/15588402029792014520) started by @KeithCu*