### PR TITLE
feat: web research confirmation prompt and enhanced logging

### DIFF
--- a/plugin/framework/tool_context.py
+++ b/plugin/framework/tool_context.py
@@ -29,11 +29,12 @@ class ToolContext:
         status_callback: Optional callback for status updates (Writer tools).
         append_thinking_callback: Optional callback for thinking text (Writer tools).
         stop_checker: Optional callable () -> bool; if present and returns True, tool should stop.
+        approval_callback: Optional callable for human-in-the-loop approval.
     """
 
-    __slots__ = ("doc", "ctx", "doc_type", "services", "caller", "status_callback", "append_thinking_callback", "stop_checker")
+    __slots__ = ("doc", "ctx", "doc_type", "services", "caller", "status_callback", "append_thinking_callback", "stop_checker", "approval_callback")
 
-    def __init__(self, doc, ctx, doc_type, services, caller="", status_callback=None, append_thinking_callback=None, stop_checker=None):
+    def __init__(self, doc, ctx, doc_type, services, caller="", status_callback=None, append_thinking_callback=None, stop_checker=None, approval_callback=None):
         self.doc = doc
         self.ctx = ctx
         self.doc_type = doc_type
@@ -42,3 +43,4 @@ class ToolContext:
         self.status_callback = status_callback
         self.append_thinking_callback = append_thinking_callback
         self.stop_checker = stop_checker
+        self.approval_callback = approval_callback

--- a/plugin/modules/chatbot/module.yaml
+++ b/plugin/modules/chatbot/module.yaml
@@ -67,6 +67,13 @@ config:
     widget: checkbox
     label: Show Web Search Thinking
 
+  prompt_for_web_research:
+    type: boolean
+    default: false
+    widget: checkbox
+    label: Prompt for Web Research
+    helper: "Ask for confirmation before sending a web search query"
+
   web_cache_max_mb:
     type: int
     default: 50

--- a/plugin/modules/chatbot/send_handlers.py
+++ b/plugin/modules/chatbot/send_handlers.py
@@ -449,6 +449,20 @@ class SendHandlersMixin:
                 def thinking_cb(msg):
                     q.put(("thinking", msg))
 
+                def approval_cb(description, tool_name, args):
+                    import threading
+                    event = threading.Event()
+                    event.approved = False
+                    q.put(("approval_required", description, tool_name, event))
+                    event.wait()
+                    if not event.approved:
+                        # If the user rejects the search query, do not let the LLM
+                        # keep going without the data it requested. Instead, immediately
+                        # halt the entire tool call loop, acting exactly as if the
+                        # user clicked the explicit 'Stop' button in the UI.
+                        q.put(("stopped",))
+                    return event.approved
+
                 from plugin.framework.tool_context import ToolContext
 
                 tctx = ToolContext(
@@ -460,6 +474,7 @@ class SendHandlersMixin:
                     caller="chat",
                     status_callback=status_cb,
                     append_thinking_callback=thinking_cb,
+                    approval_callback=approval_cb,
                 )
 
                 import json
@@ -541,6 +556,18 @@ class SendHandlersMixin:
         def on_error(e):
             dispatch_event(ErrorEvent(e))
 
+        def on_approval_required(item):
+            # item = ("approval_required", description, tool_name, event_obj)
+            from plugin.framework.dialogs import show_approval_dialog
+            description = item[1] if len(item) > 1 else ""
+            tool_name = item[2] if len(item) > 2 else ""
+            event_obj = item[3] if len(item) > 3 else None
+
+            approved = show_approval_dialog(self.ctx, description, tool_name)
+            if event_obj is not None:
+                event_obj.approved = approved
+                event_obj.set()
+
         from plugin.framework.async_stream import run_stream_drain_loop
 
         run_stream_drain_loop(
@@ -554,6 +581,7 @@ class SendHandlersMixin:
             on_status_fn=self._set_status,
             ctx=self.ctx,
             stop_checker=lambda: self.stop_requested,
+            on_approval_required=on_approval_required,
         )
 
     def _get_mcp_url(self):

--- a/plugin/modules/chatbot/web_research.py
+++ b/plugin/modules/chatbot/web_research.py
@@ -56,6 +56,7 @@ class WebResearchTool(ToolBase):
         status_callback = getattr(ctx, "status_callback", None)
         append_thinking_callback = getattr(ctx, "append_thinking_callback", None)
         stop_checker = getattr(ctx, "stop_checker", None)
+        approval_callback = getattr(ctx, "approval_callback", None)
 
         if history_text:
             # Truncate if extremely long, though the agent will handle it
@@ -95,6 +96,14 @@ class WebResearchTool(ToolBase):
             task = f"### CONVERSATION HISTORY:\n{history_text or 'None'}\n\n### CURRENT QUERY:\n{query}"
             
             final_ans = None
+
+            prompt_for_web_research = False
+            try:
+                from plugin.framework.config import get_config, as_bool
+                prompt_for_web_research = as_bool(get_config(ctx.ctx, "chatbot.prompt_for_web_research"))
+            except Exception:
+                pass
+
             for step in agent.run(task, stream=True):
                 if stop_checker and stop_checker():
                     return format_error_payload(ToolExecutionError("Web search stopped by user.", code="USER_STOPPED"))
@@ -102,14 +111,29 @@ class WebResearchTool(ToolBase):
                     status_msg = ""
                     if step.name == "web_search":
                         q = str(step.arguments.get("query", "")) if isinstance(step.arguments, dict) else ""
+
+                        if append_thinking_callback:
+                            append_thinking_callback(f"Running tool: {step.name} with {{'query': '{q}'}}\n")
+
+                        if prompt_for_web_research and approval_callback:
+                            approved = approval_callback(f"This search query '{q}' will be sent to the search engine.", "web_search", step.arguments)
+                            if not approved:
+                                return format_error_payload(ToolExecutionError("Web search stopped by user.", code="USER_STOPPED"))
+
                         if len(q) > 25:
                             q = q[:22] + "..."
                         status_msg = f"Search: {q}"
                     elif step.name == "visit_webpage":
                         url = str(step.arguments.get("url", "")) if isinstance(step.arguments, dict) else ""
+
+                        if append_thinking_callback:
+                            append_thinking_callback(f"Running tool: {step.name} with {{'url': '{url}'}}\n")
+
                         domain = get_url_domain(url)
                         status_msg = f"Read: {domain}"
                     else:
+                        if append_thinking_callback:
+                            append_thinking_callback(f"Running tool: {step.name} with {step.arguments}\n")
                         status_msg = str(step.name)
 
                     if status_callback and status_msg:
@@ -122,10 +146,6 @@ class WebResearchTool(ToolBase):
                             msg += f"{step.model_output.strip()}\n"
                         elif getattr(step, "model_output_message", None) and step.model_output_message.content:
                             msg += f"{str(step.model_output_message.content).strip()}\n"
-
-                        if step.tool_calls:
-                            for tc in step.tool_calls:
-                                msg += f"Running tool: {tc.name} with {tc.arguments}\n"
 
                         if step.observations:
                             msg += f"Observation: {str(step.observations).strip()}\n"


### PR DESCRIPTION
Addresses the issues requested:

1. **Show thinking before execution:** The web research sub-agent now intercepts `ToolCall` events specifically and prints out the arguments containing the search query *before* executing the tool, preventing the log from appearing afterwards.
2. **Confirmation prompt:** Reuses the existing HITL `show_approval_dialog` (Accept / Deny buttons) when the user enables the setting. It safely blocks the tool-execution background thread via a `threading.Event` and waits for the user's action on the main UI thread. 
3. **Toggle setting:** Added a `prompt_for_web_research` setting in `plugin/modules/chatbot/module.yaml` under the sidebar UI to configure this optional feature.
4. **LLM Halt:** As requested, if the user rejects the search query, it explicitly pushes `("stopped",)` to the stream drain loop, immediately ending the tool iteration and preventing the chat LLM from continuing without the requested data.

---
*PR created automatically by Jules for task [6892311416050700511](https://jules.google.com/task/6892311416050700511) started by @KeithCu*