### PR TITLE
feat(registry): add schema validation to tool registration

### DIFF
--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -41,11 +41,24 @@ class ToolRegistry:
 
     def register(self, tool):
         """Register a single ToolBase instance."""
+        # Validate tool schema
+        if not tool.name or not isinstance(tool.name, str):
+            log.error("Failed to register tool '%s': missing or invalid name.", type(tool).__name__)
+            return
+        if not tool.description or not isinstance(tool.description, str):
+            log.error("Failed to register tool '%s': missing or invalid description.", tool.name)
+            return
+        if tool.parameters is not None and not isinstance(tool.parameters, dict):
+            log.error("Failed to register tool '%s': parameters must be a dictionary or None.", tool.name)
+            return
+
         if tool.name in self._tools:
             # If it's the exact same class, skip silently.
-            if type(self._tools[tool.name]) is type(tool):
+            existing_tool = self._tools[tool.name]
+            if type(existing_tool) is type(tool):
                 return
-            log.warning("Tool already registered, replacing: %s", tool.name)
+            log.warning("Tool '%s' already registered (class %s), replacing with class %s",
+                        tool.name, type(existing_tool).__name__, type(tool).__name__)
         self._tools[tool.name] = tool
 
     def register_many(self, tools):

--- a/plugin/tests/test_tool_registry.py
+++ b/plugin/tests/test_tool_registry.py
@@ -66,11 +66,13 @@ class TestRegister:
 
         class GoodTool(ToolBase):
             name = "good_tool"
+            description = "A good tool"
             def execute(self, ctx, **kwargs): pass
         GoodTool.__module__ = "mock_module"
 
         class AnotherTool(ToolBase):
             name = "another_tool"
+            description = "Another tool"
             def execute(self, ctx, **kwargs): pass
         AnotherTool.__module__ = "mock_module"
 


### PR DESCRIPTION
Implements tool schema validation and improved duplicate warnings in `ToolRegistry.register` as requested. Adds basic checks to ensure tools have a name (string), a description (string), and valid parameters (dict or None). Rejects invalid tools and logs an error instead of crashing later. Updates `plugin/tests/test_tool_registry.py` to match the new strict requirements.

---
*PR created automatically by Jules for task [7060387197794708384](https://jules.google.com/task/7060387197794708384) started by @KeithCu*