### PR TITLE
Extract module discovery logic to ModuleLoader

### DIFF
--- a/plugin/framework/module_loader.py
+++ b/plugin/framework/module_loader.py
@@ -1,0 +1,109 @@
+import os
+import logging
+from typing import List
+
+from plugin.framework.utils import get_plugin_dir
+
+log = logging.getLogger(__name__)
+
+
+class ModuleLoader:
+    """
+    Handles discovery, topological sorting, and initialization of plugin modules.
+    """
+
+    @staticmethod
+    def load_manifest() -> List[dict]:
+        """Loads the module manifest."""
+        try:
+            from plugin._manifest import MODULES
+            return MODULES
+        except ImportError:
+            return []
+
+    @staticmethod
+    def topo_sort(modules: List[dict]) -> List[dict]:
+        """
+        Sorts modules based on their required services.
+        Ensures dependencies are initialized before the modules that require them.
+        """
+        by_name = {m["name"]: m for m in modules}
+        provides = {}
+        for m in modules:
+            for svc in m.get("provides_services", []):
+                provides[svc] = m["name"]
+
+        visited = set()
+        order = []
+
+        def visit(name):
+            if name in visited:
+                return
+            visited.add(name)
+            m = by_name.get(name)
+            if m is None:
+                return
+            for req in m.get("requires", []):
+                provider = provides.get(req, req)
+                if provider in by_name:
+                    visit(provider)
+            order.append(m)
+
+        if "core" in by_name:
+            visit("core")
+        for name in by_name:
+            visit(name)
+        return order
+
+    @classmethod
+    def load_modules(cls, services_registry) -> List[object]:
+        """
+        Discovers, imports, and initializes modules based on the manifest.
+        Returns a list of initialized module instances.
+        """
+        initialized_modules = []
+        manifests = cls.topo_sort(cls.load_manifest())
+
+        for manifest in manifests:
+            name = manifest["name"]
+            if name == "core":
+                continue
+
+            # Try nested path first (e.g. "launcher/providers/claude")
+            rel_path = name.replace(".", os.sep)
+            module_dir = os.path.join(get_plugin_dir(), "modules", rel_path)
+            import_path = "plugin.modules." + name
+
+            if not os.path.isdir(module_dir):
+                # Legacy fallback for flat paths (e.g. "launcher_claude")
+                dir_name = name.replace(".", "_")
+                module_dir = os.path.join(get_plugin_dir(), "modules", dir_name)
+                import_path = "plugin.modules." + dir_name
+                if not os.path.isdir(module_dir):
+                    continue
+
+            # Dynamic ModuleBase initialization
+            try:
+                import importlib
+                import inspect
+
+                mod_pkg = importlib.import_module(import_path)
+                module_class = None
+
+                # Look for a class subclassing ModuleBase by checking MRO names (avoids LO sys.path duplicate issues)
+                for attr_name in dir(mod_pkg):
+                    attr = getattr(mod_pkg, attr_name)
+                    if inspect.isclass(attr) and getattr(attr, "__name__", "") != "ModuleBase":
+                        if any(getattr(b, "__name__", "") == "ModuleBase" for b in getattr(attr, "__mro__", [])):
+                            module_class = attr
+                            break
+
+                if module_class:
+                    mod = module_class()
+                    mod.name = name
+                    mod.initialize(services_registry)
+                    initialized_modules.append(mod)
+            except Exception as e:
+                logging.getLogger("writeragent").warning("Failed to load module %s: %s", name, e)
+
+        return initialized_modules

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -76,42 +76,6 @@ def get_tools():
         bootstrap()
     return _tools
 
-def _load_manifest():
-    try:
-        from plugin._manifest import MODULES
-        return MODULES
-    except ImportError:
-        return []
-
-def _topo_sort(modules):
-    by_name = {m["name"]: m for m in modules}
-    provides = {}
-    for m in modules:
-        for svc in m.get("provides_services", []):
-            provides[svc] = m["name"]
-
-    visited = set()
-    order = []
-
-    def visit(name):
-        if name in visited:
-            return
-        visited.add(name)
-        m = by_name.get(name)
-        if m is None:
-            return
-        for req in m.get("requires", []):
-            provider = provides.get(req, req)
-            if provider in by_name:
-                visit(provider)
-        order.append(m)
-
-    if "core" in by_name:
-        visit("core")
-    for name in by_name:
-        visit(name)
-    return order
-
 def bootstrap(ctx=None):
     global _services, _tools, _modules, _initialized
     
@@ -157,49 +121,8 @@ def bootstrap(ctx=None):
         _initialized = True
 
         # 5. Load manifest and initialize modules
-        manifests = _topo_sort(_load_manifest())
-        
-        for manifest in manifests:
-            name = manifest["name"]
-            if name == "core":
-                continue
-            
-            # Try nested path first (e.g. "launcher/providers/claude")
-            rel_path = name.replace(".", os.sep)
-            module_dir = os.path.join(get_plugin_dir(), "modules", rel_path)
-            import_path = "plugin.modules." + name
-            
-            if not os.path.isdir(module_dir):
-                # Legacy fallback for flat paths (e.g. "launcher_claude")
-                dir_name = name.replace(".", "_")
-                module_dir = os.path.join(get_plugin_dir(), "modules", dir_name)
-                import_path = "plugin.modules." + dir_name
-                if not os.path.isdir(module_dir):
-                    continue
-
-            # Dynamic ModuleBase initialization
-            try:
-                import importlib
-                import inspect
-                
-                mod_pkg = importlib.import_module(import_path)
-                module_class = None
-                
-                # Look for a class subclassing ModuleBase by checking MRO names (avoids LO sys.path duplicate issues)
-                for attr_name in dir(mod_pkg):
-                    attr = getattr(mod_pkg, attr_name)
-                    if inspect.isclass(attr) and attr.__name__ != "ModuleBase":
-                        if any(b.__name__ == "ModuleBase" for b in attr.__mro__):
-                            module_class = attr
-                            break
-                        
-                if module_class:
-                    mod = module_class()
-                    mod.name = name
-                    mod.initialize(_services)
-                    _modules.append(mod)
-            except Exception as e:
-                logging.getLogger("writeragent").warning("Failed to load module %s: %s", name, e)
+        from plugin.framework.module_loader import ModuleLoader
+        _modules.extend(ModuleLoader.load_modules(_services))
 
         # Wire event bus into config service
         events_svc = _services.get("events")

--- a/plugin/tests/test_module_loader.py
+++ b/plugin/tests/test_module_loader.py
@@ -1,0 +1,79 @@
+import pytest
+from unittest.mock import patch
+from plugin.framework.module_loader import ModuleLoader
+
+def test_topo_sort():
+    modules = [
+        {"name": "a", "requires": ["b", "c"]},
+        {"name": "b", "requires": ["c"]},
+        {"name": "c", "requires": []},
+        {"name": "core", "requires": []},
+    ]
+
+    order = ModuleLoader.topo_sort(modules)
+    names = [m["name"] for m in order]
+
+    # "core" should always be first
+    assert names[0] == "core"
+
+    # Dependency sorting checks
+    assert names.index("c") < names.index("b")
+    assert names.index("b") < names.index("a")
+    assert names.index("c") < names.index("a")
+
+def test_topo_sort_with_provides_services():
+    modules = [
+        {"name": "consumer", "requires": ["service_a"]},
+        {"name": "provider", "provides_services": ["service_a"]},
+    ]
+
+    order = ModuleLoader.topo_sort(modules)
+    names = [m["name"] for m in order]
+
+    assert names.index("provider") < names.index("consumer")
+
+@patch("plugin.framework.module_loader.ModuleLoader.load_manifest")
+def test_load_modules(mock_load_manifest):
+    mock_load_manifest.return_value = [
+        {"name": "core"},
+        {"name": "test_module"},
+    ]
+
+    import types
+    mock_module = types.ModuleType("plugin.modules.test_module")
+
+    class ModuleBase:
+        pass
+
+    class TestModule(ModuleBase):
+        def __init__(self):
+            self.name = ""
+        def initialize(self, registry):
+            pass
+
+    TestModule.__name__ = "TestModule"
+    ModuleBase.__name__ = "ModuleBase"
+
+    mock_module.TestModule = TestModule
+
+    # Actually `os` is imported at the top of the module, so we must patch `plugin.framework.module_loader.os.path.isdir`
+    # However we also need to avoid mock trying to patch a missing property.
+    import os
+    with patch("importlib.import_module", return_value=mock_module), \
+         patch.object(os.path, "isdir", return_value=True):
+
+        # We need to ensure inspect.isclass returns True for TestModule inside load_modules
+        import sys
+        import inspect
+        original_isclass = inspect.isclass
+
+        def fake_isclass(obj):
+            if getattr(obj, "__name__", "") == "TestModule":
+                return True
+            return original_isclass(obj)
+
+        with patch.object(inspect, "isclass", side_effect=fake_isclass):
+            modules = ModuleLoader.load_modules({})
+
+        assert len(modules) == 1
+        assert modules[0].name == "test_module"


### PR DESCRIPTION
Extracted the module discovery, topological sorting, and initialization logic from `plugin/main.py` into a new `ModuleLoader` class located in `plugin/framework/module_loader.py`. Added comprehensive unit tests for this logic in `plugin/tests/test_module_loader.py` to ensure dependencies resolve in the correct topological order and dynamic class loading operates correctly without duplicating system-path modules.

---
*PR created automatically by Jules for task [6405532202436054993](https://jules.google.com/task/6405532202436054993) started by @KeithCu*