### PR TITLE
Refactor tool_loop event processing for pure state machine transitions

### DIFF
--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -358,6 +358,43 @@ class ToolCallingMixin:
         from plugin.framework.worker_pool import run_in_background
         run_in_background(run_final, name="llm-worker-final")
 
+    def _create_event_from_stream_item(self, item):
+        """Factory method to convert a raw stream item tuple into a ToolLoopEvent."""
+        kind = item[0] if isinstance(item, (tuple, list)) else item
+        data = item[1] if isinstance(item, (tuple, list)) and len(item) > 1 else None
+
+        if kind == "stream_done":
+            return ToolLoopEvent(kind=EventKind.STREAM_DONE, data={
+                "response": data,
+                "has_audio": bool(self.audio_wav_path)
+            })
+        elif kind == "next_tool":
+            return ToolLoopEvent(kind=EventKind.NEXT_TOOL)
+        elif kind == "tool_done":
+            mutates = False
+            try:
+                from plugin.main import get_tools as _get_tools_registry
+                tool = _get_tools_registry().get(item[2])
+                if tool and tool.detects_mutation():
+                    mutates = True
+            except Exception:
+                pass
+            return ToolLoopEvent(
+                kind=EventKind.TOOL_RESULT,
+                data={
+                    "call_id": item[1],
+                    "func_name": item[2],
+                    "func_args_str": item[3],
+                    "result": item[4],
+                    "mutates_document": mutates
+                }
+            )
+        elif kind == "final_done":
+            return ToolLoopEvent(kind=EventKind.FINAL_DONE, data={"content": data})
+        elif kind == "error":
+            return ToolLoopEvent(kind=EventKind.ERROR, data={"error": data})
+        return None
+
     def _execute_effect(self, effect):
         """Execute a single pure effect returned by the state machine."""
         if effect == "exit_loop":
@@ -418,6 +455,19 @@ class ToolCallingMixin:
                 update_activity_state("tool_execute", round_num=effect.round_num, tool_name=effect.tool_name)
             elif effect.action == "exhausted_rounds":
                 update_activity_state("exhausted_rounds")
+
+        elif effect.__class__.__name__ == "CleanupAudioEffect":
+            current_model = get_text_model(self.ctx)
+            current_endpoint = get_current_endpoint(self.ctx)
+            set_native_audio_support(
+                self.ctx, current_model, current_endpoint, supported=True
+            )
+            import os
+            try:
+                os.remove(self.audio_wav_path)
+            except Exception:
+                pass
+            self.audio_wav_path = None
 
         elif isinstance(effect, SpawnToolWorkerEffect):
             func_name = effect.func_name
@@ -490,57 +540,11 @@ class ToolCallingMixin:
 
     def _handle_stream_completion(self, item):
         kind = item[0] if isinstance(item, (tuple, list)) else item
-        data = item[1] if isinstance(item, (tuple, list)) and len(item) > 1 else None
+        if kind == "next_tool" and self.stop_requested and not self._sm_state.is_stopped:
+            # Synchronize stop state into the state machine
+            self._sm_state = dataclasses.replace(self._sm_state, is_stopped=True)
 
-        # Build the Event object
-        event = None
-        if kind == "stream_done":
-            event = ToolLoopEvent(kind=EventKind.STREAM_DONE, data={"response": data})
-
-            # If we were using audio and it reached here, cache success
-            if self.audio_wav_path:
-                current_model = get_text_model(self.ctx)
-                current_endpoint = get_current_endpoint(self.ctx)
-                set_native_audio_support(
-                    self.ctx, current_model, current_endpoint, supported=True
-                )
-                import os
-                try:
-                    os.remove(self.audio_wav_path)
-                except Exception:
-                    pass
-                self.audio_wav_path = None
-
-        elif kind == "next_tool":
-            if self.stop_requested and not self._sm_state.is_stopped:
-                # Synchronize stop state into the state machine
-                self._sm_state = dataclasses.replace(self._sm_state, is_stopped=True)
-            event = ToolLoopEvent(kind=EventKind.NEXT_TOOL)
-        elif kind == "tool_done":
-            mutates = False
-            try:
-                from plugin.main import get_tools as _get_tools_registry
-                tool = _get_tools_registry().get(item[2])
-                if tool and tool.detects_mutation():
-                    mutates = True
-            except Exception:
-                pass
-
-            event = ToolLoopEvent(
-                kind=EventKind.TOOL_RESULT,
-                data={
-                    "call_id": item[1],
-                    "func_name": item[2],
-                    "func_args_str": item[3],
-                    "result": item[4],
-                    "mutates_document": mutates
-                }
-            )
-        elif kind == "final_done":
-            event = ToolLoopEvent(kind=EventKind.FINAL_DONE, data={"content": data})
-        elif kind == "error":
-            event = ToolLoopEvent(kind=EventKind.ERROR, data={"error": data})
-
+        event = self._create_event_from_stream_item(item)
         if not event:
             return False
 

--- a/plugin/modules/chatbot/tool_loop_state.py
+++ b/plugin/modules/chatbot/tool_loop_state.py
@@ -66,6 +66,10 @@ class UpdateActivityStateEffect:
     round_num: Optional[int] = None
     tool_name: Optional[str] = None
 
+@dataclasses.dataclass(frozen=True)
+class CleanupAudioEffect:
+    pass
+
 
 # --- State Machine Transition ---
 def next_state(state: ToolLoopState, event: ToolLoopEvent) -> Tuple[ToolLoopState, List[Any]]:
@@ -97,6 +101,7 @@ def next_state(state: ToolLoopState, event: ToolLoopEvent) -> Tuple[ToolLoopStat
 
         case EventKind.STREAM_DONE:
             response = event.data.get("response", {})
+            has_audio = event.data.get("has_audio", False)
             tool_calls = response.get("tool_calls")
             if isinstance(tool_calls, list) and len(tool_calls) == 0:
                 tool_calls = None
@@ -105,6 +110,9 @@ def next_state(state: ToolLoopState, event: ToolLoopEvent) -> Tuple[ToolLoopStat
 
             if not isinstance(tool_calls, list):
                 tool_calls = None
+
+            if has_audio:
+                effects.append(CleanupAudioEffect())
 
             effects.append(LogAgentEffect(
                 location="chat_panel.py:tool_round",


### PR DESCRIPTION
This change tackles a refactor of `_handle_stream_completion` inside `plugin/modules/chatbot/tool_loop.py`. 
Previously, this method mixed stream item unpacking, context mutation, and side effects. Now it parses stream items into pure `ToolLoopEvent` objects using a new factory method, feeds them into `next_state()`, and subsequently iterates over the pure effect descriptions returned. Audio file caching and deletion, previously an inline side effect, has been modeled as a dedicated `CleanupAudioEffect` state transition so `tool_loop.py` cleanly separates domain logic from I/O boundaries. All tool loop tests pass.

---
*PR created automatically by Jules for task [15424527977738704659](https://jules.google.com/task/15424527977738704659) started by @KeithCu*