### PR TITLE
Improve error handling for Draw/Impress operations

### DIFF
--- a/plugin/modules/draw/shapes.py
+++ b/plugin/modules/draw/shapes.py
@@ -16,7 +16,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Shape tools for Draw/Impress documents."""
 
+from plugin.framework.errors import WriterAgentException
 from plugin.framework.tool_base import ToolBase
+
+
+class DrawError(WriterAgentException):
+    """Draw-specific errors."""
+
+    def __init__(self, message, code="DRAW_ERROR", context=None, details=None):
+        super().__init__(message, code=code, context=context, details=details)
 
 
 def _parse_color(color_str):
@@ -104,6 +112,80 @@ class GetDrawSummary(ToolBase):
         return {"status": "ok", "page_index": idx, "shapes": shapes}
 
 
+class DrawShapes:
+    def _is_valid_position(self, position):
+        if not hasattr(position, "X") or not hasattr(position, "Y"):
+            return False
+        return True
+
+    def _is_valid_size(self, size):
+        if not hasattr(size, "Width") or not hasattr(size, "Height"):
+            return False
+        if size.Width <= 0 or size.Height <= 0:
+            return False
+        return True
+
+    def safe_create_shape(self, page, shape_type, position, size):
+        """Safely create shape with error handling."""
+        try:
+            # Validate inputs
+            if not page:
+                raise DrawError(
+                    "Page is None",
+                    code="DRAW_PAGE_NULL",
+                    details={"operation": "create_shape", "shape_type": shape_type}
+                )
+
+            if not self._is_valid_position(position):
+                raise DrawError(
+                    f"Invalid position: {position}",
+                    code="DRAW_INVALID_POSITION",
+                    details={"position": position}
+                )
+
+            if not self._is_valid_size(size):
+                raise DrawError(
+                    f"Invalid size: {size}",
+                    code="DRAW_INVALID_SIZE",
+                    details={"size": size}
+                )
+
+            # Create shape
+            shape = page.createInstance(f"com.sun.star.drawing.{shape_type}")
+            if not shape:
+                raise DrawError(
+                    f"Failed to create shape of type: {shape_type}",
+                    code="DRAW_SHAPE_CREATION_FAILED",
+                    details={"shape_type": shape_type}
+                )
+
+            # Set properties
+            shape.setPosition(position)
+            shape.setSize(size)
+
+            # Add to page
+            page.add(shape)
+
+            return shape
+
+        except DrawError:
+            # Re-raise our draw errors
+            raise
+        except Exception as e:
+            # Wrap other exceptions
+            raise DrawError(
+                f"Failed to create shape: {str(e)}",
+                code="DRAW_SHAPE_CREATION_ERROR",
+                details={
+                    "shape_type": shape_type,
+                    "position": position,
+                    "size": size,
+                    "original_error": str(e),
+                    "error_type": type(e).__name__
+                }
+            ) from e
+
+
 class CreateShape(ToolBase):
     name = "create_shape"
     description = "Creates a new shape on the active page."
@@ -133,19 +215,32 @@ class CreateShape(ToolBase):
 
     def execute(self, ctx, **kwargs):
         from plugin.modules.draw.bridge import DrawBridge
+        from com.sun.star.awt import Point, Size
+
         bridge = DrawBridge(ctx.doc)
         type_map = {
-            "rectangle": "com.sun.star.drawing.RectangleShape",
-            "ellipse": "com.sun.star.drawing.EllipseShape",
-            "text": "com.sun.star.drawing.TextShape",
-            "line": "com.sun.star.drawing.LineShape",
+            "rectangle": "RectangleShape",
+            "ellipse": "EllipseShape",
+            "text": "TextShape",
+            "line": "LineShape",
         }
         uno_type = type_map.get(kwargs["shape_type"])
         if not uno_type:
             return self._tool_error(f"Unsupported shape type: {kwargs['shape_type']}")
-        shape = bridge.create_shape(
-            uno_type, kwargs["x"], kwargs["y"], kwargs["width"], kwargs["height"]
-        )
+
+        page = bridge.get_active_page()
+        position = Point(kwargs["x"], kwargs["y"])
+        size = Size(kwargs["width"], kwargs["height"])
+
+        draw_shapes = DrawShapes()
+
+        try:
+            shape = draw_shapes.safe_create_shape(
+                page, uno_type, position, size
+            )
+        except DrawError as e:
+            return self._tool_error(e.message)
+
         if kwargs.get("text") and hasattr(shape, "setString"):
             shape.setString(kwargs["text"])
         if kwargs.get("bg_color"):
@@ -160,7 +255,7 @@ class CreateShape(ToolBase):
                     shape.setPropertyValue(prop, color)
                 except Exception:
                     pass
-        page = bridge.get_active_page()
+
         return {
             "status": "ok",
             "message": f"Created {kwargs['shape_type']}",

--- a/plugin/tests/test_module_errors.py
+++ b/plugin/tests/test_module_errors.py
@@ -1,0 +1,127 @@
+import pytest
+from unittest.mock import MagicMock
+from plugin.modules.draw.shapes import DrawShapes, DrawError
+
+def test_draw_shapes_safe_create_shape_valid():
+    """Test safe_create_shape with valid inputs creates and adds the shape."""
+    draw_shapes = DrawShapes()
+
+    page = MagicMock()
+    shape = MagicMock()
+    page.createInstance.return_value = shape
+
+    position = MagicMock()
+    position.X = 100
+    position.Y = 200
+
+    size = MagicMock()
+    size.Width = 300
+    size.Height = 400
+
+    shape_type = "RectangleShape"
+
+    result = draw_shapes.safe_create_shape(page, shape_type, position, size)
+
+    page.createInstance.assert_called_once_with("com.sun.star.drawing.RectangleShape")
+    shape.setPosition.assert_called_once_with(position)
+    shape.setSize.assert_called_once_with(size)
+    page.add.assert_called_once_with(shape)
+
+    assert result == shape
+
+def test_draw_shapes_safe_create_shape_invalid_page():
+    """Test safe_create_shape raises DrawError when page is None."""
+    draw_shapes = DrawShapes()
+
+    position = MagicMock()
+    position.X = 100
+    position.Y = 200
+
+    size = MagicMock()
+    size.Width = 300
+    size.Height = 400
+
+    with pytest.raises(DrawError) as exc_info:
+        draw_shapes.safe_create_shape(None, "RectangleShape", position, size)
+
+    assert exc_info.value.code == "DRAW_PAGE_NULL"
+
+def test_draw_shapes_safe_create_shape_invalid_position():
+    """Test safe_create_shape raises DrawError when position is invalid."""
+    draw_shapes = DrawShapes()
+
+    page = MagicMock()
+
+    # Missing X/Y
+    position = MagicMock()
+    del position.X
+
+    size = MagicMock()
+    size.Width = 300
+    size.Height = 400
+
+    with pytest.raises(DrawError) as exc_info:
+        draw_shapes.safe_create_shape(page, "RectangleShape", position, size)
+
+    assert exc_info.value.code == "DRAW_INVALID_POSITION"
+
+def test_draw_shapes_safe_create_shape_invalid_size():
+    """Test safe_create_shape raises DrawError when size is invalid."""
+    draw_shapes = DrawShapes()
+
+    page = MagicMock()
+
+    position = MagicMock()
+    position.X = 100
+    position.Y = 200
+
+    # Missing Width/Height
+    size = MagicMock()
+    size.Width = 0 # Invalid
+    size.Height = 400
+
+    with pytest.raises(DrawError) as exc_info:
+        draw_shapes.safe_create_shape(page, "RectangleShape", position, size)
+
+    assert exc_info.value.code == "DRAW_INVALID_SIZE"
+
+def test_draw_shapes_safe_create_shape_creation_failed():
+    """Test safe_create_shape raises DrawError when shape creation fails."""
+    draw_shapes = DrawShapes()
+
+    page = MagicMock()
+    page.createInstance.return_value = None
+
+    position = MagicMock()
+    position.X = 100
+    position.Y = 200
+
+    size = MagicMock()
+    size.Width = 300
+    size.Height = 400
+
+    with pytest.raises(DrawError) as exc_info:
+        draw_shapes.safe_create_shape(page, "UnknownShape", position, size)
+
+    assert exc_info.value.code == "DRAW_SHAPE_CREATION_FAILED"
+
+def test_draw_shapes_safe_create_shape_exception_handling():
+    """Test safe_create_shape wraps generic exceptions in DrawError."""
+    draw_shapes = DrawShapes()
+
+    page = MagicMock()
+    page.createInstance.side_effect = Exception("Some UNO error")
+
+    position = MagicMock()
+    position.X = 100
+    position.Y = 200
+
+    size = MagicMock()
+    size.Width = 300
+    size.Height = 400
+
+    with pytest.raises(DrawError) as exc_info:
+        draw_shapes.safe_create_shape(page, "RectangleShape", position, size)
+
+    assert exc_info.value.code == "DRAW_SHAPE_CREATION_ERROR"
+    assert "Some UNO error" in exc_info.value.details["original_error"]


### PR DESCRIPTION
This PR addresses the issue of limited error handling in Draw/Impress operations by introducing a dedicated `DrawError` exception and a `DrawShapes.safe_create_shape` method. It ensures that inputs (like page, position, and size) are properly validated before making UNO calls, and any unexpected exceptions are caught and wrapped cleanly. Test coverage has been added specifically for these Draw operations to prevent future regressions.

---
*PR created automatically by Jules for task [4413684606006323786](https://jules.google.com/task/4413684606006323786) started by @KeithCu*