### PR TITLE
Refactor ToolRegistry to use `uno_services` over `doc_types`

### DIFF
--- a/plugin/framework/tool_base.py
+++ b/plugin/framework/tool_base.py
@@ -34,8 +34,8 @@ class ToolBase(ABC):
         name:        Unique tool identifier (e.g. "get_document_tree").
         description: Human-readable description shown to LLMs.
         parameters:  JSON Schema dict (MCP ``inputSchema`` format).
-        doc_types:   List of supported doc types (["writer"], ["calc"],
-                     ["draw"], or None for all types).
+        uno_services: List of UNO services the tool supports (e.g.,
+                     ["com.sun.star.text.TextDocument"], or None for all).
         tier:        "core" = always sent to the LLM, "extended" = on demand
                      via the tool broker.  Default "extended".
         intent:      Broker group: "navigate", "edit", "review", or "media".
@@ -48,7 +48,7 @@ class ToolBase(ABC):
     name: str = None
     description: str = ""
     parameters: dict = None
-    doc_types: list = None
+    uno_services: list = None
     tier: str = "extended"
     intent: str = None
     is_mutation: bool = None

--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -112,19 +112,46 @@ class ToolRegistry:
 
     # ── Lookup & Schema Generation ────────────────────────────────────
 
-    def get_tools(self, doc_type=None, tier=None, intent=None, names=None, filter_doc_type=True):
+    def get_tools(self, doc=None, doc_type=None, tier=None, intent=None, names=None, filter_doc_type=True):
         """Return a list of ToolBase instances matching the given criteria.
 
         Args:
-            doc_type: Optional string indicating compatibility. If None, only universal tools are returned (unless filter_doc_type=False).
+            doc: Optional document model instance to check against uno_services.
+            doc_type: Optional string indicating compatibility (deprecated, use doc). If None, only universal tools are returned (unless filter_doc_type=False).
             tier: Optional string (e.g. "core", "extended").
             intent: Optional string filtering by tool intent.
             names: Optional list of specific tool names to include.
-            filter_doc_type: If True, filters by doc_type. Defaults to True.
+            filter_doc_type: If True, filters by doc model services or doc_type. Defaults to True.
         """
         tools = self._tools.values()
-        if filter_doc_type:
-            tools = [t for t in tools if t.doc_types is None or (doc_type is not None and doc_type in t.doc_types)]
+
+        # Helper to check if a tool supports the document
+        def supports_doc(t):
+            if not filter_doc_type:
+                return True
+
+            # Use uno_services if available and doc is provided
+            if hasattr(t, "uno_services") and t.uno_services is not None:
+                if doc is not None and hasattr(doc, "supportsService"):
+                    for svc in t.uno_services:
+                        try:
+                            if doc.supportsService(svc):
+                                return True
+                        except Exception:
+                            pass
+                return False
+
+            # Fallback to legacy doc_types
+            if hasattr(t, "doc_types") and t.doc_types is not None:
+                if doc_type is not None and doc_type in t.doc_types:
+                    return True
+                return False
+
+            # Universal tool (both uno_services and doc_types are None)
+            return True
+
+        tools = [t for t in tools if supports_doc(t)]
+
         if tier:
             tools = [t for t in tools if t.tier == tier]
         if intent:
@@ -214,10 +241,26 @@ class ToolRegistry:
             if tool is None:
                 raise KeyError(f"Unknown tool: {tool_name}")
 
-            # Check doc_type compatibility
-            if tool.doc_types and ctx.doc_type and ctx.doc_type not in tool.doc_types:
+            # Check document compatibility using uno_services or fallback doc_types
+            is_supported = False
+            if hasattr(tool, "uno_services") and tool.uno_services is not None:
+                if ctx.doc and hasattr(ctx.doc, "supportsService"):
+                    for svc in tool.uno_services:
+                        try:
+                            if ctx.doc.supportsService(svc):
+                                is_supported = True
+                                break
+                        except Exception:
+                            pass
+            elif hasattr(tool, "doc_types") and tool.doc_types is not None:
+                if ctx.doc_type and ctx.doc_type in tool.doc_types:
+                    is_supported = True
+            else:
+                is_supported = True # universal tool
+
+            if not is_supported:
                 raise ValueError(
-                    f"Tool {tool_name} does not support doc_type={ctx.doc_type}"
+                    f"Tool {tool_name} does not support the current document"
                 )
 
             # Restrict kwargs to this tool's schema so extra keys (e.g. image_model

--- a/plugin/modules/calc/cells.py
+++ b/plugin/modules/calc/cells.py
@@ -85,7 +85,7 @@ class ReadCellRange(ToolBase):
         },
         "required": ["range_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     tier = "core"
     is_mutation = False
 
@@ -133,7 +133,7 @@ class WriteCellRange(ToolBase):
         },
         "required": ["range_name", "formula_or_values"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     tier = "core"
     is_mutation = True
 
@@ -213,7 +213,7 @@ class SetCellStyle(ToolBase):
         },
         "required": ["range_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -302,7 +302,7 @@ class MergeCells(ToolBase):
         },
         "required": ["range_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -345,7 +345,7 @@ class ClearRange(ToolBase):
         },
         "required": ["range_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -408,7 +408,7 @@ class SortRange(ToolBase):
         },
         "required": ["range_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -460,7 +460,7 @@ class ImportCsv(ToolBase):
         },
         "required": ["csv_data"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -502,7 +502,7 @@ class DeleteStructure(ToolBase):
         },
         "required": ["structure_type", "start"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/calc/charts.py
+++ b/plugin/modules/calc/charts.py
@@ -39,7 +39,7 @@ class ListCharts(ToolBase):
         "properties": {},
         "required": [],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
 
     def execute(self, ctx, **kwargs):
         bridge = CalcBridge(ctx.doc)
@@ -69,7 +69,7 @@ class GetChartInfo(ToolBase):
         },
         "required": ["chart_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
 
     def execute(self, ctx, **kwargs):
         bridge = CalcBridge(ctx.doc)
@@ -115,7 +115,7 @@ class CreateChart(ToolBase):
         },
         "required": ["data_range", "chart_type"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -159,7 +159,7 @@ class EditChart(ToolBase):
         },
         "required": ["chart_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -189,7 +189,7 @@ class DeleteChart(ToolBase):
         },
         "required": ["chart_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/calc/comments.py
+++ b/plugin/modules/calc/comments.py
@@ -59,7 +59,7 @@ class ListCellComments(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -108,7 +108,7 @@ class AddCellComment(ToolBase):
         },
         "required": ["cell", "text"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -163,7 +163,7 @@ class DeleteCellComment(ToolBase):
         },
         "required": ["cell"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/calc/conditional.py
+++ b/plugin/modules/calc/conditional.py
@@ -45,7 +45,7 @@ class ListConditionalFormats(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
 
     def execute(self, ctx, **kwargs):
         bridge = CalcBridge(ctx.doc)
@@ -106,7 +106,7 @@ class AddConditionalFormat(ToolBase):
         },
         "required": ["range_name", "operator", "formula1", "style_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -147,7 +147,7 @@ class RemoveConditionalFormat(ToolBase):
         },
         "required": ["range_name", "rule_index"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -173,7 +173,7 @@ class ClearConditionalFormats(ToolBase):
         },
         "required": ["range_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/calc/formulas.py
+++ b/plugin/modules/calc/formulas.py
@@ -55,7 +55,7 @@ class DetectErrors(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = False
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/calc/navigation.py
+++ b/plugin/modules/calc/navigation.py
@@ -35,7 +35,7 @@ class ListNamedRanges(ToolBase):
         "properties": {},
         "required": [],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -78,7 +78,7 @@ class GetSheetOverview(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc

--- a/plugin/modules/calc/search.py
+++ b/plugin/modules/calc/search.py
@@ -72,7 +72,7 @@ class SearchInSpreadsheet(ToolBase):
         },
         "required": ["pattern"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     tier = "core"
 
     def execute(self, ctx, **kwargs):
@@ -163,7 +163,7 @@ class ReplaceInSpreadsheet(ToolBase):
         },
         "required": ["search", "replace"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     tier = "core"
     is_mutation = True
 

--- a/plugin/modules/calc/sheets.py
+++ b/plugin/modules/calc/sheets.py
@@ -40,7 +40,7 @@ class ListSheets(ToolBase):
         "type": "object",
         "properties": {},
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     tier = "core"
     is_mutation = False
 
@@ -66,7 +66,7 @@ class SwitchSheet(ToolBase):
         },
         "required": ["sheet_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -99,7 +99,7 @@ class CreateSheet(ToolBase):
         },
         "required": ["sheet_name"],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -128,7 +128,7 @@ class GetSheetSummary(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["calc"]
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     tier = "core"
     is_mutation = False
 

--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -72,7 +72,7 @@ class ToolCallingMixin:
 
         try:
             log.debug("_do_send: loading %s schema..." % doc_type_str)
-            active_tools = get_tools().get_schemas("openai", doc_type=doc_type_str)
+            active_tools = get_tools().get_schemas("openai", doc=model)
 
             def execute_fn(
                 name,

--- a/plugin/modules/chatbot/tools/todo.py
+++ b/plugin/modules/chatbot/tools/todo.py
@@ -36,7 +36,7 @@ class TodoTool(ToolBase):
         "completed immediately when done; cancel tasks that are no longer needed."
     )
     # Available for all document types
-    doc_types = None
+    uno_services = None
     tier = "core"
     intent = "navigate"
     is_mutation = False  # Does not touch the LibreOffice document itself

--- a/plugin/modules/chatbot/web_research.py
+++ b/plugin/modules/chatbot/web_research.py
@@ -81,7 +81,7 @@ class WebResearchTool(ToolBase):
         },
         "required": ["query"]
     }
-    doc_types = ["writer", "calc", "draw"]
+    uno_services = ["com.sun.star.text.TextDocument", "com.sun.star.sheet.SpreadsheetDocument", "com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
     tier = "agent"
     is_mutation = False
     long_running = True

--- a/plugin/modules/doc/diagnostics.py
+++ b/plugin/modules/doc/diagnostics.py
@@ -27,7 +27,7 @@ class DocumentHealthCheck(ToolBaseDummy):
         "properties": {},
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -242,7 +242,7 @@ class SetDocumentProtection(ToolBaseDummy):
         },
         "required": ["enabled"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/doc/print_doc.py
+++ b/plugin/modules/doc/print_doc.py
@@ -38,7 +38,7 @@ class PrintDocument(ToolBaseDummy):
         },
         "required": [],
     }
-    doc_types = None  # all document types
+    uno_services = None  # all document types
     is_mutation = False
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/doc/undo.py
+++ b/plugin/modules/doc/undo.py
@@ -33,7 +33,7 @@ class Undo(ToolBaseDummy):
         },
         "required": [],
     }
-    doc_types = None
+    uno_services = None
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -74,7 +74,7 @@ class Redo(ToolBaseDummy):
         },
         "required": [],
     }
-    doc_types = None
+    uno_services = None
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/draw/masters.py
+++ b/plugin/modules/draw/masters.py
@@ -32,7 +32,7 @@ class ListMasterSlides(ToolBase):
         "with name and dimensions."
     )
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["draw", "impress"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -70,7 +70,7 @@ class GetSlideMaster(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["draw", "impress"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
 
     def execute(self, ctx, **kwargs):
         page = _get_slide(ctx.doc, kwargs.get("page_index"))
@@ -103,7 +103,7 @@ class SetSlideMaster(ToolBase):
         },
         "required": ["master_name"],
     }
-    doc_types = ["draw", "impress"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/draw/notes.py
+++ b/plugin/modules/draw/notes.py
@@ -41,7 +41,7 @@ class GetSpeakerNotes(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["impress"]
+    uno_services = ["com.sun.star.presentation.PresentationDocument"]
 
     def execute(self, ctx, **kwargs):
         page = _get_slide(ctx.doc, kwargs.get("page_index"))
@@ -81,7 +81,7 @@ class SetSpeakerNotes(ToolBase):
         },
         "required": ["text"],
     }
-    doc_types = ["impress"]
+    uno_services = ["com.sun.star.presentation.PresentationDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/draw/pages.py
+++ b/plugin/modules/draw/pages.py
@@ -33,7 +33,7 @@ class AddSlide(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -57,7 +57,7 @@ class DeleteSlide(ToolBase):
         },
         "required": ["index"],
     }
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -85,7 +85,7 @@ class ReadSlideText(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
     tier = "core"
 
     def execute(self, ctx, **kwargs):
@@ -145,7 +145,7 @@ class GetPresentationInfo(ToolBase):
         "master slide names, and whether it is an Impress document."
     )
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
     tier = "core"
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/draw/placeholders.py
+++ b/plugin/modules/draw/placeholders.py
@@ -160,7 +160,7 @@ class ListPlaceholders(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["draw", "impress"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
 
     def execute(self, ctx, **kwargs):
         page = _get_slide(ctx.doc, kwargs.get("page_index"))
@@ -199,7 +199,7 @@ class GetPlaceholderText(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["draw", "impress"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
 
     def execute(self, ctx, **kwargs):
         page = _get_slide(ctx.doc, kwargs.get("page_index"))
@@ -261,7 +261,7 @@ class SetPlaceholderText(ToolBase):
         },
         "required": ["text"],
     }
-    doc_types = ["draw", "impress"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/draw/shapes.py
+++ b/plugin/modules/draw/shapes.py
@@ -48,7 +48,7 @@ class ListPages(ToolBase):
     name = "list_pages"
     description = "Lists all pages (slides) in the document."
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
     tier = "core"
 
     def execute(self, ctx, **kwargs):
@@ -76,7 +76,7 @@ class GetDrawSummary(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
 
     def execute(self, ctx, **kwargs):
         from plugin.modules.draw.bridge import DrawBridge
@@ -127,7 +127,7 @@ class CreateShape(ToolBase):
         },
         "required": ["shape_type", "x", "y", "width", "height"],
     }
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
     tier = "core"
     is_mutation = True
 
@@ -189,7 +189,7 @@ class EditShape(ToolBase):
         },
         "required": ["shape_index"],
     }
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -241,7 +241,7 @@ class DeleteShape(ToolBase):
         },
         "required": ["shape_index"],
     }
-    doc_types = ["draw"]
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/draw/transitions.py
+++ b/plugin/modules/draw/transitions.py
@@ -112,7 +112,7 @@ class GetSlideTransition(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["impress"]
+    uno_services = ["com.sun.star.presentation.PresentationDocument"]
 
     def execute(self, ctx, **kwargs):
         page = _get_slide(ctx.doc, kwargs.get("page_index"))
@@ -213,7 +213,7 @@ class SetSlideTransition(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["impress"]
+    uno_services = ["com.sun.star.presentation.PresentationDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -331,7 +331,7 @@ class GetSlideLayout(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["impress"]
+    uno_services = ["com.sun.star.presentation.PresentationDocument"]
 
     def execute(self, ctx, **kwargs):
         page = _get_slide(ctx.doc, kwargs.get("page_index"))
@@ -371,7 +371,7 @@ class SetSlideLayout(ToolBase):
         },
         "required": ["layout"],
     }
-    doc_types = ["impress"]
+    uno_services = ["com.sun.star.presentation.PresentationDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/http/mcp_protocol.py
+++ b/plugin/modules/http/mcp_protocol.py
@@ -356,16 +356,16 @@ class MCPProtocolHandler:
         return {}
 
     def _mcp_tools_list(self, params, document_url=None):
-        if document_url:
-            doc_type = execute_on_main_thread(
-                _resolve_doc_type_for_url, self.services, document_url,
-                timeout=10.0)
-            if doc_type is None:
-                doc_type = self._detect_active_doc_type()
-        else:
-            doc_type = self._detect_active_doc_type()
-        doc_type = doc_type or "writer"
-        schemas = self.tool_registry.get_schemas("mcp", doc_type=doc_type)
+        def _get_doc():
+            doc_svc = self.services.document
+            if document_url:
+                doc, _ = doc_svc.resolve_document_by_url(document_url)
+                return doc
+            return doc_svc.get_active_document()
+
+        doc = execute_on_main_thread(_get_doc, timeout=10.0)
+
+        schemas = self.tool_registry.get_schemas("mcp", doc=doc)
         return {"tools": schemas}
 
     def _mcp_resources_list(self, params):

--- a/plugin/modules/writer/comments.py
+++ b/plugin/modules/writer/comments.py
@@ -47,7 +47,7 @@ class ListComments(ToolBaseDummy):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         author_filter = kwargs.get("author_filter")
@@ -121,7 +121,7 @@ class AddComment(ToolBaseDummy):
         },
         "required": ["content"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -202,7 +202,7 @@ class DeleteComment(ToolBaseDummy):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -273,7 +273,7 @@ class ResolveComment(ToolBaseDummy):
         },
         "required": ["comment_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -364,7 +364,7 @@ class Workflow(ToolBaseDummy):
         },
         "required": ["action"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True  # set_status mutates
 
     def execute(self, ctx, **kwargs):
@@ -578,7 +578,7 @@ class AddAiSummary(ToolBaseDummy):
         },
         "required": ["summary"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -605,7 +605,7 @@ class GetAiSummaries(ToolBaseDummy):
     intent = "review"
     description = "List all MCP-AI summary annotations in the document."
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         tree_svc = ctx.services.writer_tree
@@ -631,7 +631,7 @@ class RemoveAiSummary(ToolBaseDummy):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/writer/content.py
+++ b/plugin/modules/writer/content.py
@@ -102,7 +102,7 @@ class GetDocumentContent(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     tier = "core"
 
     def execute(self, ctx, **kwargs):
@@ -214,7 +214,7 @@ class ApplyDocumentContent(ToolBase):
         },
         "required": ["content"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     tier = "core"
     is_mutation = True
 
@@ -394,7 +394,7 @@ class ReadParagraphs(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     tier = "core"
 
     def execute(self, ctx, **kwargs):
@@ -466,7 +466,7 @@ class InsertAtParagraph(ToolBase):
         },
         "required": ["text"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     tier = "core"
     is_mutation = True
 
@@ -555,7 +555,7 @@ class ModifyParagraph(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     tier = "core"
     is_mutation = True
 
@@ -624,7 +624,7 @@ class DeleteParagraph(ToolBase):
             },
         },
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -696,7 +696,7 @@ class DuplicateParagraph(ToolBase):
             },
         },
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -777,7 +777,7 @@ class CloneHeadingBlock(ToolBase):
             },
         },
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -890,7 +890,7 @@ class InsertParagraphsBatch(ToolBase):
         },
         "required": ["paragraphs"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -1006,7 +1006,7 @@ class GetDocumentStats(ToolBase):
         "properties": {},
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     tier = "core"
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/writer/frames.py
+++ b/plugin/modules/writer/frames.py
@@ -38,7 +38,7 @@ class ListTextFrames(ToolBaseDummy):
         "properties": {},
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -101,7 +101,7 @@ class GetTextFrameInfo(ToolBaseDummy):
         },
         "required": ["frame_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         frame_name = kwargs.get("frame_name", "")
@@ -222,7 +222,7 @@ class SetTextFrameProperties(ToolBaseDummy):
         },
         "required": ["frame_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/writer/images.py
+++ b/plugin/modules/writer/images.py
@@ -82,7 +82,7 @@ class GenerateImage(ToolBase):
         },
         "required": ["prompt"]
     }
-    doc_types = ["writer", "calc", "draw", "impress"]
+    uno_services = ["com.sun.star.text.TextDocument", "com.sun.star.sheet.SpreadsheetDocument", "com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
     is_mutation = True
     long_running = True
 
@@ -214,7 +214,7 @@ class ListImages(ToolBaseDummy):
         "properties": {},
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -304,7 +304,7 @@ class GetImageInfo(ToolBaseDummy):
         },
         "required": ["image_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         image_name = kwargs.get("image_name", "")
@@ -448,7 +448,7 @@ class SetImageProperties(ToolBaseDummy):
         },
         "required": ["image_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -556,7 +556,7 @@ class DownloadImage(ToolBaseDummy):
         },
         "required": ["url"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         url = kwargs.get("url", "")
@@ -616,7 +616,7 @@ class InsertImage(ToolBaseDummy):
         },
         "required": ["image_path"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -711,7 +711,7 @@ class DeleteImage(ToolBaseDummy):
         },
         "required": ["image_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -766,7 +766,7 @@ class ReplaceImage(ToolBaseDummy):
         },
         "required": ["image_name", "new_image_path"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/writer/navigation.py
+++ b/plugin/modules/writer/navigation.py
@@ -47,7 +47,7 @@ class NavigateHeading(ToolBaseDummy):
         },
         "required": ["locator", "direction"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         prox_svc = ctx.services.writer_proximity
@@ -91,7 +91,7 @@ class GetSurroundings(ToolBaseDummy):
         },
         "required": ["locator"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         prox_svc = ctx.services.writer_proximity

--- a/plugin/modules/writer/outline.py
+++ b/plugin/modules/writer/outline.py
@@ -56,7 +56,7 @@ class GetDocumentTree(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         tree_svc = ctx.services.writer_tree
@@ -103,7 +103,7 @@ class GetHeadingChildren(ToolBaseDummy):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         tree_svc = ctx.services.writer_tree

--- a/plugin/modules/writer/search.py
+++ b/plugin/modules/writer/search.py
@@ -67,7 +67,7 @@ class SearchInDocument(ToolBase):
         },
         "required": ["pattern"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     tier = "core"
 
     def execute(self, ctx, **kwargs):
@@ -235,7 +235,7 @@ class AdvancedSearch(ToolBaseDummy):
         },
         "required": ["query"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         idx_svc = ctx.services.writer_index
@@ -328,7 +328,7 @@ class GetIndexStats(ToolBase):
         "language, build time, and top 20 most frequent stems."
     )
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         idx_svc = ctx.services.writer_index

--- a/plugin/modules/writer/structural.py
+++ b/plugin/modules/writer/structural.py
@@ -25,7 +25,7 @@ class ListSections(ToolBaseDummy):
     intent = "navigate"
     description = "List all named sections in the document."
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -53,7 +53,7 @@ class GotoPage(ToolBaseDummy):
         },
         "required": ["page"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         controller = ctx.doc.getCurrentController()
@@ -76,7 +76,7 @@ class GetPageObjects(ToolBaseDummy):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -167,7 +167,7 @@ class RefreshIndexes(ToolBaseDummy):
     intent = "navigate"
     description = "Refresh all document indexes (TOC, bibliography, etc.)."
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -202,7 +202,7 @@ class ReadSection(ToolBaseDummy):
         },
         "required": ["section_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         section_name = kwargs.get("section_name", "")
@@ -260,7 +260,7 @@ class ResolveBookmark(ToolBaseDummy):
         },
         "required": ["bookmark_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         bookmark_name = kwargs.get("bookmark_name", "")
@@ -329,7 +329,7 @@ class UpdateFields(ToolBaseDummy):
         "Call after changes that affect computed fields."
     )
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -355,7 +355,7 @@ class ListBookmarks(ToolBaseDummy):
         "Includes both user bookmarks and _mcp_ heading bookmarks."
     )
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -380,7 +380,7 @@ class CleanupBookmarks(ToolBaseDummy):
         "Use when bookmarks become stale after major edits."
     )
     parameters = {"type": "object", "properties": {}, "required": []}
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/modules/writer/styles.py
+++ b/plugin/modules/writer/styles.py
@@ -64,7 +64,7 @@ class ListStyles(ToolBase):
         },
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         family = kwargs.get("family", "ParagraphStyles")
@@ -127,7 +127,7 @@ class GetStyleInfo(ToolBase):
         },
         "required": ["style_name"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         style_name = kwargs.get("style_name", "")

--- a/plugin/modules/writer/tables.py
+++ b/plugin/modules/writer/tables.py
@@ -42,7 +42,7 @@ log = logging.getLogger("writeragent.writer")
 #         "properties": {},
 #         "required": [],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 
 #     def execute(self, ctx, **kwargs):
 #         doc = ctx.doc
@@ -77,7 +77,7 @@ log = logging.getLogger("writeragent.writer")
 #         },
 #         "required": ["table_name"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 
 #     def execute(self, ctx, **kwargs):
 #         table_name = kwargs.get("table_name", "")
@@ -154,7 +154,7 @@ log = logging.getLogger("writeragent.writer")
 #         },
 #         "required": ["table_name", "data"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):
@@ -270,7 +270,7 @@ log = logging.getLogger("writeragent.writer")
 #         },
 #         "required": ["rows", "cols"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):
@@ -381,7 +381,7 @@ def _col_letter(c):
 #         },
 #         "required": ["table_name"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):
@@ -458,7 +458,7 @@ def _col_letter(c):
 #         },
 #         "required": ["table_name"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):
@@ -576,7 +576,7 @@ def _col_letter(c):
 #         },
 #         "required": ["table_name"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):
@@ -630,7 +630,7 @@ def _col_letter(c):
 #         },
 #         "required": ["table_name"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):
@@ -688,7 +688,7 @@ def _col_letter(c):
 #         },
 #         "required": ["table_name", "at_index"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):
@@ -739,7 +739,7 @@ def _col_letter(c):
 #         },
 #         "required": ["table_name", "at_index"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):
@@ -798,7 +798,7 @@ def _col_letter(c):
 #         },
 #         "required": ["table_name", "row", "values"],
 #     }
-#     doc_types = ["writer"]
+#     uno_services = ["com.sun.star.text.TextDocument"]
 #     is_mutation = True
 
 #     def execute(self, ctx, **kwargs):

--- a/plugin/modules/writer/tracking.py
+++ b/plugin/modules/writer/tracking.py
@@ -39,7 +39,7 @@ class SetTrackChanges(ToolBaseDummy):
         },
         "required": ["enabled"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
@@ -64,7 +64,7 @@ class GetTrackedChanges(ToolBaseDummy):
         "properties": {},
         "required": [],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -131,7 +131,7 @@ class ManageTrackedChanges(ToolBaseDummy):
         },
         "required": ["action"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):

--- a/plugin/tests/test_tool_registry.py
+++ b/plugin/tests/test_tool_registry.py
@@ -4,6 +4,16 @@ import pytest
 
 from plugin.framework.tool_base import ToolBase
 from plugin.framework.tool_context import ToolContext
+
+class MockDoc:
+    def __init__(self, doc_type="writer"):
+        self.doc_type = doc_type
+
+    def supportsService(self, svc):
+        if self.doc_type == "writer" and svc == "com.sun.star.text.TextDocument": return True
+        if self.doc_type == "calc" and svc == "com.sun.star.sheet.SpreadsheetDocument": return True
+        return False
+
 from plugin.framework.tool_registry import ToolRegistry
 from plugin.framework.service_registry import ServiceRegistry
 
@@ -16,7 +26,7 @@ class FakeTool(ToolBase):
         "properties": {"text": {"type": "string"}},
         "required": ["text"],
     }
-    doc_types = ["writer"]
+    uno_services = ["com.sun.star.text.TextDocument"]
 
     def execute(self, ctx, **kwargs):
         return {"status": "ok", "text": kwargs["text"]}
@@ -26,7 +36,7 @@ class AllDocTool(ToolBase):
     name = "universal_tool"
     description = "Works everywhere"
     parameters = {"type": "object", "properties": {}}
-    doc_types = None
+    uno_services = None
 
     def execute(self, ctx, **kwargs):
         return {"status": "ok"}
@@ -51,7 +61,7 @@ def _make_registry(*tools):
 
 def _make_ctx(doc_type="writer"):
     return ToolContext(
-        doc=None, ctx=None, doc_type=doc_type,
+        doc=MockDoc(doc_type), ctx=None, doc_type=doc_type,
         services=ServiceRegistry(), caller="test"
     )
 
@@ -125,20 +135,20 @@ class TestRegister:
 class TestDocTypeFiltering:
     def test_tools_for_writer(self):
         reg = _make_registry(FakeTool(), AllDocTool())
-        names = [t.name for t in reg.get_tools(doc_type="writer")]
+        names = [t.name for t in reg.get_tools(doc=MockDoc("writer"))]
         assert "fake_tool" in names
         assert "universal_tool" in names
 
     def test_tools_for_calc_excludes_writer_only(self):
         reg = _make_registry(FakeTool(), AllDocTool())
-        names = [t.name for t in reg.get_tools(doc_type="calc")]
+        names = [t.name for t in reg.get_tools(doc=MockDoc("calc"))]
         assert "fake_tool" not in names
         assert "universal_tool" in names
 
     def test_tools_for_none_returns_universal_only(self):
         """When doc_type is None (unknown), only universal tools are returned."""
         reg = _make_registry(FakeTool(), AllDocTool())
-        names = [t.name for t in reg.get_tools(doc_type=None)]
+        names = [t.name for t in reg.get_tools(doc=None)]
         assert names == ["universal_tool"]
 
 
@@ -198,7 +208,7 @@ class TestExecute:
 class TestSchemas:
     def test_openai_schemas(self):
         reg = _make_registry(FakeTool())
-        schemas = reg.get_schemas("openai", doc_type="writer")
+        schemas = reg.get_schemas("openai", doc=MockDoc("writer"))
         assert len(schemas) == 1
         s = schemas[0]
         assert s["type"] == "function"
@@ -206,7 +216,7 @@ class TestSchemas:
 
     def test_mcp_schemas(self):
         reg = _make_registry(FakeTool())
-        schemas = reg.get_schemas("mcp", doc_type="writer")
+        schemas = reg.get_schemas("mcp", doc=MockDoc("writer"))
         assert len(schemas) == 1
         s = schemas[0]
         assert s["name"] == "fake_tool"
@@ -228,7 +238,7 @@ class TestExecuteEventsAndInvalidation:
             name = "tool_with_params"
             description = "Tool with params"
             parameters = {"type": "object", "properties": {"arg1": {"type": "string"}}}
-            doc_types = ["writer"]
+            uno_services = ["com.sun.star.text.TextDocument"]
 
             def execute(self, ctx, **kwargs):
                 return {"status": "success"}
@@ -240,7 +250,7 @@ class TestExecuteEventsAndInvalidation:
         reg = ToolRegistry(services)
         reg.register(ToolWithParams())
 
-        ctx = ToolContext(doc=object(), ctx=None, doc_type="writer", services=services, caller="test")
+        ctx = ToolContext(doc=MockDoc("writer"), ctx=None, doc_type="writer", services=services, caller="test")
         result = reg.execute("tool_with_params", ctx, arg1="val1", extra="ignored")
 
         assert result == {"status": "success"}
@@ -260,7 +270,7 @@ class TestExecuteEventsAndInvalidation:
             name = "failing_tool_with_params"
             description = "Tool with params that fails"
             parameters = {"type": "object", "properties": {"arg1": {"type": "string"}}}
-            doc_types = ["writer"]
+            uno_services = ["com.sun.star.text.TextDocument"]
 
             def execute(self, ctx, **kwargs):
                 raise RuntimeError("something went wrong")
@@ -272,7 +282,7 @@ class TestExecuteEventsAndInvalidation:
         reg = ToolRegistry(services)
         reg.register(FailingToolWithParams())
 
-        ctx = ToolContext(doc=object(), ctx=None, doc_type="writer", services=services, caller="test")
+        ctx = ToolContext(doc=MockDoc("writer"), ctx=None, doc_type="writer", services=services, caller="test")
         result = reg.execute("failing_tool_with_params", ctx, arg1="val1")
 
         assert result["status"] == "error"


### PR DESCRIPTION
This submission refactors how tools are routed inside the ToolRegistry.

Instead of registering tools using custom `"writer"`, `"calc"`, `"draw"` string identifiers, tools now define an `uno_services` list using standard LibreOffice interface names (`com.sun.star.text.TextDocument`, `com.sun.star.sheet.SpreadsheetDocument`, etc). The registry iterates through the loaded tools and calls `supportsService(...)` on the active `doc` to pick only the tools that apply to the current application, fulfilling the roadmap cleanup item for a unified ToolRegistry without manual if/else doc type sprawl.

---
*PR created automatically by Jules for task [18077763847808774497](https://jules.google.com/task/18077763847808774497) started by @KeithCu*