### PR TITLE
Remove legacy chat API handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,9 +396,8 @@ If logs appear empty, check both versioned user dirs (e.g. `4/user` and `24/user
 
 ---
 
-## 5c. Chatbot REST API & Calc chart tool cleanup
+## 5c. Calc chart tool cleanup
 
-- **Chatbot REST API handler (optional)**: `plugin/modules/chatbot/__init__.py` now treats the legacy Chat API handler (`plugin.modules.chatbot.handler.ChatApiHandler`) as **optional**. If the handler module/class is missing, route registration for `/api/chat` is skipped with a clear warning log instead of failing module initialization, so `make test` and other entry points no longer emit repeated “Failed to load module chatbot” errors. When a handler implementation is added back in the future, the routes will be registered automatically again.
 - **Calc `create_chart` tool de-duplication**: A duplicate `create_chart` tool definition in `plugin/modules/calc/sheets.py` was removed so the canonical implementation in `plugin/modules/calc/charts.py` is the only one discovered by the tool registry. This eliminates noisy “Tool already registered, replacing: create_chart” warnings while preserving the existing chart-creation behavior.
 
 ## 6. Build and Install

--- a/plugin/modules/chatbot/__init__.py
+++ b/plugin/modules/chatbot/__init__.py
@@ -28,8 +28,6 @@ class ChatbotModule(ModuleBase):
 
     def initialize(self, services):
         self._services = services
-        self._routes_registered = False
-        self._api_handler = None
 
         from . import web_research
         # from .tools import memory, skills
@@ -37,53 +35,6 @@ class ChatbotModule(ModuleBase):
         # services.tools.auto_discover(memory)
         # services.tools.auto_discover(skills)        # Chat tool routing is now handled natively by main.py's get_tools() instead of ChatToolAdapter
         self._adapter = None
-
-        # Always register API routes (legacy Chat API) when http_routes is available.
-        # The old chatbot.api_enabled toggle was removed from the manifest, so the
-        # routes are now unconditionally enabled for the HTTP server.
-        self._register_routes(services)
-
-    def _register_routes(self, services):
-        routes = services.get("http_routes")
-        if not routes:
-            log.warning("http_routes service not available")
-            return
-
-        try:
-            from plugin.modules.chatbot.handler import ChatApiHandler
-            self._api_handler = ChatApiHandler(services)
-            routes.add("POST", "/api/chat",
-                       self._api_handler.handle_chat, raw=True)
-            routes.add("GET", "/api/chat",
-                       self._api_handler.handle_history)
-            routes.add("DELETE", "/api/chat",
-                       self._api_handler.handle_reset)
-            routes.add("GET", "/api/providers",
-                       self._api_handler.handle_providers)
-            self._routes_registered = True
-            log.info("Chat API routes registered")
-        except (ImportError, AttributeError, ValueError) as exc:
-            log.info(
-                "Chat API handler not available; skipping /api/chat routes: %s",
-                exc,
-            )
-            self._api_handler = None
-
-    def _unregister_routes(self, services):
-        routes = services.get("http_routes")
-        if routes:
-            for method, path in [
-                ("POST", "/api/chat"),
-                ("GET", "/api/chat"),
-                ("DELETE", "/api/chat"),
-                ("GET", "/api/providers"),
-            ]:
-                try:
-                    routes.remove(method, path)
-                except ValueError as e:
-                    log.debug("Route %s %s not found during unregister: %s", method, path, e)
-        self._routes_registered = False
-        log.info("Chat API routes unregistered")
 
     def get_adapter(self):
         """Return the ChatToolAdapter for use by the panel factory."""


### PR DESCRIPTION
Removed unused legacy chat API handler logic from `plugin/modules/chatbot/__init__.py` and removed the corresponding mention from `AGENTS.md`. The functionality has been superseded by ACP.

---
*PR created automatically by Jules for task [14646828744400707039](https://jules.google.com/task/14646828744400707039) started by @KeithCu*