### PR TITLE
Refactor main thread dispatch into unified QueueExecutor

### DIFF
--- a/plugin/framework/main_thread.py
+++ b/plugin/framework/main_thread.py
@@ -128,50 +128,37 @@ def _poke_vcl():
             log.warning("_poke_vcl failed: %s", e2)
 
 
+import warnings
+
 def execute_on_main_thread(fn, *args, timeout=30.0, **kwargs):
-    """Execute fn(*args, **kwargs) on the LibreOffice main (VCL) thread.
+    """DEPRECATED: Use plugin.framework.queue_executor.execute_on_main_thread instead.
+
+    Execute fn(*args, **kwargs) on the LibreOffice main (VCL) thread.
 
     If already on the main thread, calls directly (avoids deadlock).
     Otherwise blocks the calling thread up to *timeout* seconds.
     Raises TimeoutError if the main thread doesn't process the item in time.
     Re-raises any exception thrown by *fn*.
     """
-    # Already on main thread — call directly to avoid deadlock
-    if threading.current_thread() is threading.main_thread():
-        return fn(*args, **kwargs)
-
-    svc = _get_async_callback()
-
-    if svc is None:
-        # Fallback: call directly (not thread-safe).
-        return fn(*args, **kwargs)
-
-    item = _WorkItem(fn, args, kwargs)
-    _work_queue.put(item)
-    _poke_vcl()
-
-    if not item.event.wait(timeout):
-        raise TimeoutError(
-            "Main-thread execution of %s timed out after %ss"
-            % (getattr(fn, "__name__", str(fn)), timeout))
-
-    if item.exception is not None:
-        raise item.exception
-
-    return item.result
+    warnings.warn(
+        "plugin.framework.main_thread is deprecated. Use plugin.framework.queue_executor instead.",
+        DeprecationWarning, stacklevel=2
+    )
+    from plugin.framework.queue_executor import execute_on_main_thread as executor_exec
+    return executor_exec(fn, *args, timeout=timeout, **kwargs)
 
 
-def post_to_main_thread(fn):
-    """Fire-and-forget: post fn() to the VCL main thread.
+def post_to_main_thread(fn, *args, **kwargs):
+    """DEPRECATED: Use plugin.framework.queue_executor.post_to_main_thread instead.
+
+    Fire-and-forget: post fn() to the VCL main thread.
 
     Unlike execute_on_main_thread, does not block or return a result.
     Used for UI updates from background threads.
     """
-    svc = _get_async_callback()
-    if svc is None:
-        fn()
-        return
-
-    item = _WorkItem(fn, (), {})
-    _work_queue.put(item)
-    _poke_vcl()
+    warnings.warn(
+        "plugin.framework.main_thread is deprecated. Use plugin.framework.queue_executor instead.",
+        DeprecationWarning, stacklevel=2
+    )
+    from plugin.framework.queue_executor import post_to_main_thread as executor_post
+    return executor_post(fn, *args, **kwargs)

--- a/plugin/framework/queue_executor.py
+++ b/plugin/framework/queue_executor.py
@@ -1,0 +1,189 @@
+"""Unified main thread execution via queue system.
+
+The MCP HTTP server runs in daemon threads. UNO is NOT thread-safe:
+calling it from a background thread causes black menus, crashes on large
+docs, and random corruption.
+
+Solution: use com.sun.star.awt.AsyncCallback.addCallback() to post work
+into the VCL event loop. The HTTP thread blocks on a threading.Event
+until the main thread has executed the work item and stored the result.
+
+Fallback: if AsyncCallback is unavailable (unit-test, headless without
+a toolkit), the function is called directly with a warning.
+"""
+
+import logging
+import queue
+import threading
+import uuid
+from typing import Callable, Any
+
+log = logging.getLogger("writeragent.framework.queue_executor")
+
+class _WorkItem:
+    __slots__ = ("id", "fn", "args", "kwargs", "blocking", "event", "result", "exception")
+
+    def __init__(self, item_id, fn, args, kwargs, blocking=True):
+        self.id = item_id
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+        self.blocking = blocking
+        self.event = threading.Event() if blocking else None
+        self.result = None
+        self.exception = None
+
+class QueueExecutor:
+    """Execute functions on main thread using queue system."""
+
+    def __init__(self):
+        self._work_queue = queue.Queue()
+        self._async_callback_service = None
+        self._callback_instance = None
+        self._init_lock = threading.Lock()
+        self._initialized = False
+
+    def _get_async_callback(self):
+        """Lazily create the AsyncCallback UNO service and XCallback instance."""
+        if self._initialized:
+            return self._async_callback_service
+        with self._init_lock:
+            if self._initialized:
+                return self._async_callback_service
+            try:
+                import uno
+                ctx = uno.getComponentContext()
+                smgr = ctx.ServiceManager
+                self._async_callback_service = smgr.createInstanceWithContext(
+                    "com.sun.star.awt.AsyncCallback", ctx)
+                if self._async_callback_service is None:
+                    raise RuntimeError("createInstance returned None")
+                self._callback_instance = self._make_callback_instance()
+                log.info("QueueExecutor initialized (AsyncCallback ready)")
+            except Exception as exc:
+                log.warning(
+                    "AsyncCallback unavailable (%s) — UNO calls will run "
+                    "in the HTTP thread (legacy behaviour)", exc)
+                self._async_callback_service = None
+            self._initialized = True
+            return self._async_callback_service
+
+    def _make_callback_instance(self):
+        """Create a UNO XCallback that processes work items one at a time."""
+        import unohelper
+        from com.sun.star.awt import XCallback
+
+        # We must keep a reference to `self` accessible inside the inner class
+        executor = self
+
+        class _MainThreadCallback(unohelper.Base, XCallback):
+            """XCallback that processes ONE item per call.
+
+            Processing one item at a time lets the VCL event loop handle
+            other events (redraws, user input) between tool executions.
+            """
+
+            def notify(self, _ignored):
+                executor.process_queue()
+
+        return _MainThreadCallback()
+
+    def process_queue(self):
+        """Process one item from queue (called from main thread via AsyncCallback)."""
+        try:
+            item = self._work_queue.get_nowait()
+        except queue.Empty:
+            return
+
+        try:
+            item.result = item.fn(*item.args, **item.kwargs)
+        except Exception as exc:
+            item.exception = exc
+        finally:
+            if item.blocking and item.event:
+                item.event.set()
+
+        # Re-poke if more items waiting
+        if not self._work_queue.empty():
+            self._poke_main_thread()
+
+    def _poke_main_thread(self):
+        """Ask the VCL event loop to call our notify() callback."""
+        if self._async_callback_service is None or self._callback_instance is None:
+            return
+        try:
+            import uno
+            self._async_callback_service.addCallback(
+                self._callback_instance, uno.Any("void", None))
+        except Exception as e:
+            log.debug("_poke_main_thread with Any failed, retrying without: %s", e)
+            try:
+                self._async_callback_service.addCallback(self._callback_instance, None)
+            except Exception as e2:
+                log.warning("_poke_main_thread failed: %s", e2)
+
+    def _enqueue_work(self, fn, args, kwargs, blocking=True):
+        """Add work item to queue."""
+        item_id = str(uuid.uuid4())
+        item = _WorkItem(item_id, fn, args, kwargs, blocking)
+        self._work_queue.put(item)
+        self._poke_main_thread()
+        return item
+
+    def _wait_for_result(self, item, timeout):
+        """Wait for and return result from main thread."""
+        if not item.event.wait(timeout):
+            raise TimeoutError(
+                "Main-thread execution of %s timed out after %ss"
+                % (getattr(item.fn, "__name__", str(item.fn)), timeout))
+
+        if item.exception is not None:
+            raise item.exception
+
+        return item.result
+
+    def execute(self, fn: Callable, *args, timeout: float = 30.0, **kwargs) -> Any:
+        """Execute function on main thread (blocking).
+
+        If already on the main thread, calls directly (avoids deadlock).
+        Otherwise blocks the calling thread up to *timeout* seconds.
+        Raises TimeoutError if the main thread doesn't process the item in time.
+        Re-raises any exception thrown by *fn*.
+        """
+        # Already on main thread — call directly to avoid deadlock
+        if threading.current_thread() is threading.main_thread():
+            return fn(*args, **kwargs)
+
+        svc = self._get_async_callback()
+
+        if svc is None:
+            # Fallback: call directly (not thread-safe).
+            return fn(*args, **kwargs)
+
+        item = self._enqueue_work(fn, args, kwargs, blocking=True)
+        return self._wait_for_result(item, timeout)
+
+    def post(self, fn: Callable, *args, **kwargs) -> None:
+        """Post function to main thread (non-blocking).
+
+        Unlike execute, does not block or return a result.
+        Used for UI updates from background threads.
+        """
+        svc = self._get_async_callback()
+        if svc is None:
+            fn(*args, **kwargs)
+            return
+
+        self._enqueue_work(fn, args, kwargs, blocking=False)
+
+# We can keep a global default instance to mimic the old main_thread behavior
+# until everything is fully DI injected.
+default_executor = QueueExecutor()
+
+def execute_on_main_thread(fn, *args, timeout=30.0, **kwargs):
+    """Legacy helper: Use default_executor.execute instead."""
+    return default_executor.execute(fn, *args, timeout=timeout, **kwargs)
+
+def post_to_main_thread(fn, *args, **kwargs):
+    """Legacy helper: Use default_executor.post instead."""
+    return default_executor.post(fn, *args, **kwargs)

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -128,7 +128,7 @@ def bootstrap(ctx=None):
         events_svc = _services.get("events")
         if events_svc:
             # Subscribe to menu:update for dynamic menu text + icons
-            from plugin.framework.main_thread import execute_on_main_thread
+            from plugin.framework.queue_executor import execute_on_main_thread
             events_svc.subscribe("menu:update",
                                  lambda **kw: execute_on_main_thread(notify_menu_update))
 

--- a/plugin/modules/chatbot/panel.py
+++ b/plugin/modules/chatbot/panel.py
@@ -471,7 +471,7 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
 
     def _on_mcp_result(self, tool="", result_snippet="", **kwargs):
         """Handle MCP result events from the bus (background thread)."""
-        from plugin.framework.main_thread import execute_on_main_thread
+        from plugin.framework.queue_executor import execute_on_main_thread
 
         def _update_ui():
             try:

--- a/plugin/modules/http/mcp_protocol.py
+++ b/plugin/modules/http/mcp_protocol.py
@@ -28,7 +28,7 @@ import threading
 import time
 import uuid
 
-from plugin.framework.main_thread import execute_on_main_thread
+from plugin.framework.queue_executor import QueueExecutor
 from plugin.framework.errors import WriterAgentException, safe_json_loads
 from plugin.modules.http.mcp_state import (
     MCPState, MCPStateStr, EventKind, MCPEvent,
@@ -97,6 +97,7 @@ class MCPProtocolHandler:
 
     def __init__(self, services):
         self.services = services
+        self.queue_executor = QueueExecutor()
         self.tool_registry = services.tools
         self.event_bus = getattr(services, "events", None)
         self.version = "unknown"
@@ -363,7 +364,7 @@ class MCPProtocolHandler:
                 return doc
             return doc_svc.get_active_document()
 
-        doc = execute_on_main_thread(_get_doc, timeout=10.0)
+        doc = self.queue_executor.execute(_get_doc, timeout=10.0)
 
         schemas = self.tool_registry.get_schemas("mcp", doc=doc)
         return {"tools": schemas}
@@ -541,7 +542,7 @@ class MCPProtocolHandler:
                 "LibreOffice is busy processing another tool call. "
                 "Please wait a moment and retry.")
         try:
-            return execute_on_main_thread(
+            return self.queue_executor.execute(
                 self._execute_tool_on_main, tool_name, arguments, document_url,
                 timeout=_PROCESS_TIMEOUT)
         finally:
@@ -566,7 +567,7 @@ class MCPProtocolHandler:
             ctx = uno.getComponentContext()
             return doc, doc_type, ctx
 
-        doc, doc_type, ctx = execute_on_main_thread(_get_context, timeout=10.0)
+        doc, doc_type, ctx = self.queue_executor.execute(_get_context, timeout=10.0)
 
         if doc is None and not document_url:
             return {
@@ -671,7 +672,7 @@ class MCPProtocolHandler:
             from plugin.framework.settings_dialog import show_settings
             from plugin._manifest import MODULES
             config_svc = get_services().config
-            execute_on_main_thread(
+            self.queue_executor.execute(
                 show_settings, None, config_svc, MODULES,
                 timeout=120.0)
             return "Settings dialog shown"

--- a/plugin/modules/http/server.py
+++ b/plugin/modules/http/server.py
@@ -71,7 +71,7 @@ class GenericRequestHandler(BaseHTTPRequestHandler):
         try:
             if route.raw:
                 if route.main_thread:
-                    from plugin.framework.main_thread import execute_on_main_thread
+                    from plugin.framework.queue_executor import execute_on_main_thread
                     execute_on_main_thread(route.handler, self)
                 else:
                     route.handler(self)
@@ -81,7 +81,7 @@ class GenericRequestHandler(BaseHTTPRequestHandler):
                     return  # _read_body already sent error response
                 query = get_url_query_dict(self.path)
                 if route.main_thread:
-                    from plugin.framework.main_thread import execute_on_main_thread
+                    from plugin.framework.queue_executor import execute_on_main_thread
                     status, data = execute_on_main_thread(
                         route.handler, body, self.headers, query)
                 else:

--- a/plugin/tests/test_main_thread.py
+++ b/plugin/tests/test_main_thread.py
@@ -5,35 +5,25 @@ from unittest.mock import patch, MagicMock
 
 from plugin.framework.worker_pool import run_in_background
 
-from plugin.framework.main_thread import (
+from plugin.framework.queue_executor import (
     _WorkItem,
     execute_on_main_thread,
     post_to_main_thread,
-    _work_queue,
-    _get_async_callback,
-    _make_callback_instance,
-    _poke_vcl,
-    _init_lock
+    default_executor
 )
-from plugin.framework.main_thread import (
-    _get_async_callback,
-    _make_callback_instance,
-    _poke_vcl,
-    _init_lock
-)
-import plugin.framework.main_thread as mt
+import plugin.framework.queue_executor as mt
 
 @pytest.fixture(autouse=True)
 def empty_work_queue():
-    while not _work_queue.empty():
+    while not default_executor._work_queue.empty():
         try:
-            _work_queue.get_nowait()
+            default_executor._work_queue.get_nowait()
         except queue.Empty:
             break
 
 def test_work_item():
     def func(x): return x * 2
-    item = _WorkItem(func, (5,), {})
+    item = _WorkItem("id", func, (5,), {})
 
     assert item.fn is func
     assert item.args == (5,)
@@ -51,8 +41,8 @@ def test_execute_on_main_thread_direct():
     assert res == 42
 
 
-@patch("plugin.framework.main_thread._get_async_callback")
-@patch("plugin.framework.main_thread._poke_vcl")
+@patch.object(mt.QueueExecutor, "_get_async_callback")
+@patch.object(mt.QueueExecutor, "_poke_main_thread")
 
 def test_execute_on_main_thread_background(mock_poke, mock_get_async):
     """
@@ -66,20 +56,11 @@ def test_execute_on_main_thread_background(mock_poke, mock_get_async):
             raise ValueError("Zero not allowed")
         return x * 10
 
-    def mock_poke_vcl():
+    def mock_poke_main_thread():
         # Simulate VCL event loop calling notify()
-        try:
-            item = _work_queue.get_nowait()
-            try:
-                item.result = item.fn(*item.args, **item.kwargs)
-            except Exception as e:
-                item.exception = e
-            finally:
-                item.event.set()
-        except queue.Empty:
-            pass
+        default_executor.process_queue()
 
-    mock_poke.side_effect = mock_poke_vcl
+    mock_poke.side_effect = mock_poke_main_thread
 
     results = {}
     exceptions = {}
@@ -102,8 +83,8 @@ def test_execute_on_main_thread_background(mock_poke, mock_get_async):
     assert str(exceptions[0]) == "Zero not allowed"
 
 
-@patch("plugin.framework.main_thread._get_async_callback")
-@patch("plugin.framework.main_thread._poke_vcl")
+@patch.object(mt.QueueExecutor, "_get_async_callback")
+@patch.object(mt.QueueExecutor, "_poke_main_thread")
 
 def test_execute_on_main_thread_timeout(mock_poke, mock_get_async):
     """
@@ -132,13 +113,13 @@ def test_execute_on_main_thread_timeout(mock_poke, mock_get_async):
     assert "timed out after 0.1s" in str(exc_caught)
 
 
-@patch("plugin.framework.main_thread._get_async_callback")
-@patch("plugin.framework.main_thread._poke_vcl")
+@patch.object(mt.QueueExecutor, "_get_async_callback")
+@patch.object(mt.QueueExecutor, "_poke_main_thread")
 
 def test_post_to_main_thread_fire_and_forget(mock_poke, mock_get_async):
     """
     Test for post_to_main_thread() that ensures it enqueues the work item
-    without blocking (and still calls _poke_vcl()).
+    without blocking (and still calls _poke_main_thread()).
     """
     mock_get_async.return_value = MagicMock()
 
@@ -148,28 +129,28 @@ def test_post_to_main_thread_fire_and_forget(mock_poke, mock_get_async):
     post_to_main_thread(my_func)
 
     # Check that it enqueued the item
-    item = _work_queue.get_nowait()
+    item = default_executor._work_queue.get_nowait()
     assert item.fn is my_func
 
-    # Check that it called _poke_vcl
+    # Check that it called _poke_main_thread
     mock_poke.assert_called_once()
 
 @pytest.fixture(autouse=True)
 def reset_mt_globals():
-    mt._initialized = False
-    mt._async_callback_service = None
-    mt._callback_instance = None
-    with mt._init_lock:
+    default_executor._initialized = False
+    default_executor._async_callback_service = None
+    default_executor._callback_instance = None
+    with default_executor._init_lock:
         pass
-    while not _work_queue.empty():
+    while not default_executor._work_queue.empty():
         try:
-            _work_queue.get_nowait()
+            default_executor._work_queue.get_nowait()
         except queue.Empty:
             break
     yield
-    mt._initialized = False
-    mt._async_callback_service = None
-    mt._callback_instance = None
+    default_executor._initialized = False
+    default_executor._async_callback_service = None
+    default_executor._callback_instance = None
 
 def test_get_async_callback_success(monkeypatch):
     import sys
@@ -183,21 +164,21 @@ def test_get_async_callback_success(monkeypatch):
 
     monkeypatch.setitem(sys.modules, 'uno', mock_uno)
 
-    with patch('plugin.framework.main_thread._make_callback_instance') as mock_make:
+    with patch.object(default_executor, '_make_callback_instance') as mock_make:
         mock_instance = MagicMock()
         mock_make.return_value = mock_instance
-        res = mt._get_async_callback()
+        res = default_executor._get_async_callback()
 
     assert res == mock_service
-    assert mt._initialized == True
-    assert mt._async_callback_service == mock_service
-    assert mt._callback_instance == mock_instance
+    assert default_executor._initialized == True
+    assert default_executor._async_callback_service == mock_service
+    assert default_executor._callback_instance == mock_instance
 
 def test_get_async_callback_already_init():
-    mt._initialized = True
+    default_executor._initialized = True
     mock_svc = MagicMock()
-    mt._async_callback_service = mock_svc
-    assert mt._get_async_callback() == mock_svc
+    default_executor._async_callback_service = mock_svc
+    assert default_executor._get_async_callback() == mock_svc
 
 def test_get_async_callback_failure(monkeypatch):
     import sys
@@ -205,12 +186,12 @@ def test_get_async_callback_failure(monkeypatch):
     mock_uno.getComponentContext.side_effect = Exception("No UNO")
     monkeypatch.setitem(sys.modules, 'uno', mock_uno)
 
-    with patch('plugin.framework.main_thread.log.warning') as mock_warn:
-        res = mt._get_async_callback()
+    with patch('plugin.framework.queue_executor.log.warning') as mock_warn:
+        res = default_executor._get_async_callback()
 
     assert res is None
-    assert mt._initialized == True
-    assert mt._async_callback_service is None
+    assert default_executor._initialized == True
+    assert default_executor._async_callback_service is None
     mock_warn.assert_called()
 
 def test_get_async_callback_returns_none(monkeypatch):
@@ -223,11 +204,11 @@ def test_get_async_callback_returns_none(monkeypatch):
     mock_smgr.createInstanceWithContext.return_value = None
     monkeypatch.setitem(sys.modules, 'uno', mock_uno)
 
-    with patch('plugin.framework.main_thread.log.warning') as mock_warn:
-        res = mt._get_async_callback()
+    with patch('plugin.framework.queue_executor.log.warning') as mock_warn:
+        res = default_executor._get_async_callback()
 
     assert res is None
-    assert mt._initialized == True
+    assert default_executor._initialized == True
     mock_warn.assert_called()
 
 def test_make_callback_instance():
@@ -249,7 +230,7 @@ def test_make_callback_instance():
             pass
         sys.modules['com.sun.star.awt'].XCallback = MockXCallback
 
-        instance = mt._make_callback_instance()
+        instance = default_executor._make_callback_instance()
         assert instance is not None
         assert hasattr(instance, 'notify')
 
@@ -269,17 +250,17 @@ def test_make_callback_instance_notify(monkeypatch):
     with patch.dict(sys.modules, monkeypatch_modules):
         class MockXCallback: pass
         sys.modules['com.sun.star.awt'].XCallback = MockXCallback
-        instance = mt._make_callback_instance()
+        instance = default_executor._make_callback_instance()
 
         # Test empty queue
         instance.notify(None)
 
         # Test valid item
         def dummy_fn(x): return x * 2
-        item = _WorkItem(dummy_fn, (10,), {})
-        mt._work_queue.put(item)
+        item = _WorkItem("id1", dummy_fn, (10,), {})
+        default_executor._work_queue.put(item)
 
-        with patch('plugin.framework.main_thread._poke_vcl') as mock_poke:
+        with patch.object(default_executor, '_poke_main_thread') as mock_poke:
             instance.notify(None)
             assert item.result == 20
             assert item.exception is None
@@ -288,14 +269,14 @@ def test_make_callback_instance_notify(monkeypatch):
 
         # Test item that raises exception
         def dummy_fn_exc(): raise ValueError("test error")
-        item2 = _WorkItem(dummy_fn_exc, (), {})
-        mt._work_queue.put(item2)
+        item2 = _WorkItem("id2", dummy_fn_exc, (), {})
+        default_executor._work_queue.put(item2)
 
         # Test queue not empty after popping
-        item3 = _WorkItem(lambda: 1, (), {})
-        mt._work_queue.put(item3)
+        item3 = _WorkItem("id3", lambda: 1, (), {})
+        default_executor._work_queue.put(item3)
 
-        with patch('plugin.framework.main_thread._poke_vcl') as mock_poke:
+        with patch.object(default_executor, '_poke_main_thread') as mock_poke:
             instance.notify(None)
             assert item2.result is None
             assert isinstance(item2.exception, ValueError)
@@ -303,7 +284,7 @@ def test_make_callback_instance_notify(monkeypatch):
             mock_poke.assert_called_once()
 
         # Clear queue
-        mt._work_queue.get_nowait()
+        default_executor._work_queue.get_nowait()
 
 def test_poke_vcl(monkeypatch):
     import sys
@@ -311,32 +292,32 @@ def test_poke_vcl(monkeypatch):
     mock_uno.Any.return_value = "AnyVal"
     monkeypatch.setitem(sys.modules, 'uno', mock_uno)
 
-    mt._async_callback_service = MagicMock()
-    mt._callback_instance = MagicMock()
+    default_executor._async_callback_service = MagicMock()
+    default_executor._callback_instance = MagicMock()
 
     # Success case
-    mt._poke_vcl()
-    mt._async_callback_service.addCallback.assert_called_with(mt._callback_instance, "AnyVal")
+    default_executor._poke_main_thread()
+    default_executor._async_callback_service.addCallback.assert_called_with(default_executor._callback_instance, "AnyVal")
 
     # Failure case 1: Any fails, retry without
-    mt._async_callback_service.addCallback.side_effect = [Exception("error"), None]
-    mt._poke_vcl()
-    mt._async_callback_service.addCallback.assert_called_with(mt._callback_instance, None)
+    default_executor._async_callback_service.addCallback.side_effect = [Exception("error"), None]
+    default_executor._poke_main_thread()
+    default_executor._async_callback_service.addCallback.assert_called_with(default_executor._callback_instance, None)
 
     # Failure case 2: Both fail
-    mt._async_callback_service.addCallback.side_effect = Exception("error")
-    with patch('plugin.framework.main_thread.log.warning') as mock_warn:
-        mt._poke_vcl()
+    default_executor._async_callback_service.addCallback.side_effect = Exception("error")
+    with patch('plugin.framework.queue_executor.log.warning') as mock_warn:
+        default_executor._poke_main_thread()
         mock_warn.assert_called_once()
 
-    mt._async_callback_service = None
-    mt._poke_vcl() # Should do nothing
+    default_executor._async_callback_service = None
+    default_executor._poke_main_thread() # Should do nothing
 
 def test_execute_on_main_thread_no_service():
-    mt._async_callback_service = None
-    mt._initialized = True # prevent initialization
+    default_executor._async_callback_service = None
+    default_executor._initialized = True # prevent initialization
 
-    with patch('plugin.framework.main_thread._get_async_callback') as mock_get:
+    with patch.object(default_executor, '_get_async_callback') as mock_get:
         mock_get.return_value = None
 
         # Test fallback path when not on main thread
@@ -356,7 +337,7 @@ def test_execute_on_main_thread_no_service():
             assert res == 10
 
 def test_post_to_main_thread_no_service():
-    with patch('plugin.framework.main_thread._get_async_callback') as mock_get:
+    with patch.object(default_executor, '_get_async_callback') as mock_get:
         mock_get.return_value = None
 
         # Test fallback
@@ -369,17 +350,15 @@ def test_post_to_main_thread_no_service():
 def test_execute_on_main_thread_success():
     with patch('threading.current_thread') as mock_thread, \
          patch('threading.main_thread') as mock_main, \
-         patch('plugin.framework.main_thread._get_async_callback') as mock_get, \
-         patch('plugin.framework.main_thread._poke_vcl') as mock_poke:
+         patch.object(default_executor, '_get_async_callback') as mock_get, \
+         patch.object(default_executor, '_poke_main_thread') as mock_poke:
 
         mock_thread.return_value = "Thread-1"
         mock_main.return_value = "Thread-2"
         mock_get.return_value = MagicMock()
 
         def mock_vcl():
-            item = mt._work_queue.get_nowait()
-            item.result = item.fn(*item.args, **item.kwargs)
-            item.event.set()
+            default_executor.process_queue()
 
         mock_poke.side_effect = mock_vcl
 
@@ -387,22 +366,22 @@ def test_execute_on_main_thread_success():
         assert res == 10
 
 def test_get_async_callback_already_init_with_lock():
-    mt._initialized = False
+    default_executor._initialized = False
     mock_svc = MagicMock()
 
     # We want to test the case where _initialized becomes true while waiting for lock.
     # To do this, we can make the lock acquisition call a side effect that sets _initialized=True
-    real_lock = mt._init_lock
+    real_lock = default_executor._init_lock
     class FakeLock:
         def __enter__(self):
-            mt._initialized = True
-            mt._async_callback_service = mock_svc
+            default_executor._initialized = True
+            default_executor._async_callback_service = mock_svc
             return self
         def __exit__(self, exc_type, exc_val, exc_tb):
             pass
 
-    mt._init_lock = FakeLock()
+    default_executor._init_lock = FakeLock()
     try:
-        assert mt._get_async_callback() == mock_svc
+        assert default_executor._get_async_callback() == mock_svc
     finally:
-        mt._init_lock = real_lock
+        default_executor._init_lock = real_lock


### PR DESCRIPTION
Migrates the background-to-main thread dispatch logic from a procedural pattern in `main_thread.py` to an object-oriented `QueueExecutor` pattern in `queue_executor.py`. This unified queue-based system handles LibreOffice's `AsyncCallback` execution and improves UI responsiveness by explicitly processing one item at a time from the queue before re-poking the loop. `mcp_protocol.py` and other core handlers have been migrated to the new system. Existing imports were updated, and `main_thread.py` functions were deprecated.

---
*PR created automatically by Jules for task [8086096659899089222](https://jules.google.com/task/8086096659899089222) started by @KeithCu*