### PR TITLE
Merge clear_range and write_formula_range in Calc tools

### DIFF
--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -136,12 +136,11 @@ READ:
 - get_sheet_summary: Summary of the active sheet (size, headers, used range).
 
 WRITE & FORMAT:
-- write_formula_range: Single string fills entire range; JSON array must match range size exactly (one value per cell). Use ranges for efficiency; avoid single-cell operations.
+- write_formula_range: Single string fills entire range; JSON array must match range size exactly (one value per cell). Use empty string/array to clear contents. Use ranges for efficiency; avoid single-cell operations.
 - set_cell_style: Formatting (bold, colors, alignment, number format) for a range. Prefer ranges for efficiency; use after bulk writes.
 - import_csv_from_string: Bulk insert CSV data into the sheet starting at a cell. Use for large datasets.
 - merge_cells: Merge a range (e.g. headers); then write and style with write_formula_range/set_cell_style.
 - sort_range: Sort a range by a column (ascending/descending, optional header row).
-- clear_range: Clear contents of a range.
 - delete_structure: Remove rows or columns at specific positions.
 
 SHEET MANAGEMENT:

--- a/plugin/modules/calc/cells.py
+++ b/plugin/modules/calc/cells.py
@@ -110,7 +110,8 @@ class WriteCellRange(ToolBase):
     description = (
         "Writes formulas or values to a cell range(s) efficiently. "
         "Single string fills entire range; JSON array must match range size "
-        "exactly (one value per cell). Supports lists for non-contiguous areas."
+        "exactly (one value per cell). Use an empty string or empty array to "
+        "clear contents. Supports lists for non-contiguous areas."
     )
     parameters = {
         "type": "object",
@@ -128,7 +129,8 @@ class WriteCellRange(ToolBase):
                 "description": (
                     "Single string: fills the entire range with that value or formula "
                     "(use '=' prefix for formulas). JSON array: must have exactly as "
-                    "many elements as cells in the range (e.g. '[\"a\", \"b\"]' for 2 cells)."
+                    "many elements as cells in the range (e.g. '[\"a\", \"b\"]' for 2 cells). "
+                    "Empty string/array clears the range."
                 ),
             },
         },
@@ -325,49 +327,6 @@ class MergeCells(ToolBase):
         return {
             "status": "ok",
             "message": f"Merged cells in {len(rn)} ranges",
-        }
-
-class ClearRange(ToolBase):
-    """Clear all contents in a cell range."""
-
-    name = "clear_range"
-    intent = "edit"
-    description = (
-        "Clears all contents (values, formulas) in the specified "
-        "range(s). Supports lists for non-contiguous areas."
-    )
-    parameters = {
-        "type": "object",
-        "properties": {
-            "range_name": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": (
-                    "Range(s) to clear (e.g. [\"A1:D10\"] or [\"A1\", \"B2:C3\"])."
-                ),
-            },
-        },
-        "required": ["range_name"],
-    }
-    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
-    is_mutation = True
-
-    def execute(self, ctx, **kwargs):
-        bridge = CalcBridge(ctx.doc)
-        manipulator = CellManipulator(bridge)
-        rn = kwargs.get("range_name") or []
-        rn = [rn] if isinstance(rn, str) else (rn or [])
-
-        if len(rn) == 0:
-            return self._tool_error("range_name is required")
-        if len(rn) == 1:
-            manipulator.clear_range(rn[0])
-            return {"status": "ok", "message": f"Cleared range {rn[0]}"}
-        for r in rn:
-            manipulator.clear_range(r)
-        return {
-            "status": "ok",
-            "message": f"Cleared {len(rn)} ranges",
         }
 
 class SortRange(ToolBase):

--- a/plugin/modules/calc/manipulator.py
+++ b/plugin/modules/calc/manipulator.py
@@ -583,6 +583,18 @@ class CellManipulator:
             Summary of the operation.
         """
         try:
+            # Handle empty values as a clear_range operation
+            is_empty = (
+                formula_or_values is None or
+                formula_or_values == "" or
+                formula_or_values == [] or
+                formula_or_values == "[]" or
+                formula_or_values == "{}"
+            )
+            if is_empty:
+                self.clear_range(range_str)
+                return f"Range {range_str} cleared."
+
             sheet = self.bridge.get_active_sheet()
             start, end = self.bridge.parse_range_string(range_str)
 

--- a/plugin/tests/uno/test_calc.py
+++ b/plugin/tests/uno/test_calc.py
@@ -162,7 +162,7 @@ def test_clear_range():
     active_sheet = _test_doc.getCurrentController().getActiveSheet()
     active_sheet.getCellByPosition(6, 0).setString("ClearMe")
     active_sheet.getCellByPosition(7, 0).setString("ClearMe")
-    _execute_calc_tool("clear_range", {"range_name": ["G1", "H1"]})
+    _execute_calc_tool("write_formula_range", {"range_name": ["G1", "H1"], "formula_or_values": ""})
     assert active_sheet.getCellByPosition(6, 0).getString() == "", "G1 not cleared"
     assert active_sheet.getCellByPosition(7, 0).getString() == "", "H1 not cleared"
 
@@ -429,8 +429,8 @@ def test_read_after_write_stability():
     assert grid_merged[0][0]["value"] == "Apple", f"Expected Apple in merged range, got {grid_merged[0][0]['value']}"
 
     # 4. Clear range and search
-    res_clear = _execute_calc_tool("clear_range", {"range_name": "Z1:Z2"})
-    assert res_clear.get("status") == "ok", f"clear_range failed: {res_clear}"
+    res_clear = _execute_calc_tool("write_formula_range", {"range_name": "Z1:Z2", "formula_or_values": ""})
+    assert res_clear.get("status") == "ok", f"write_formula_range clear failed: {res_clear}"
     res_search = _execute_calc_tool("search_in_spreadsheet", {"pattern": "Apple"})
     assert res_search.get("status") == "ok", f"search_in_spreadsheet failed: {res_search}"
     # Filter matches to only check Z column to avoid false positives from other tests


### PR DESCRIPTION
This submission addresses the issue outlined in AGENTS.md regarding the overlapping APIs between `clear_range` and `write_formula_range`. 

**Changes:**
1. Modified `write_formula_range` in `plugin/modules/calc/manipulator.py` to detect empty values (empty string, empty array, or null) and invoke `self.clear_range` directly, effectively clearing the contents while retaining the single API call.
2. Removed the `ClearRange` class entirely from `plugin/modules/calc/cells.py`.
3. Updated the system prompt in `plugin/framework/constants.py` to remove the mention of `clear_range` and instruct the model to use an empty string/array in `write_formula_range` to clear contents.
4. Updated parameter descriptions in `WriteCellRange` to make this behavior clear to the model.
5. Adjusted tests in `plugin/tests/uno/test_calc.py` to test clearing via `write_formula_range`.

All tests pass successfully.

---
*PR created automatically by Jules for task [1948224961252173072](https://jules.google.com/task/1948224961252173072) started by @KeithCu*