### PR TITLE
Consolidate CSV import logic into write_formula_range

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Their client-side tool call parsers (from `environments/tool_call_parsers/`) pro
 To handle complex spreadsheet tasks, WriterAgent is optimized for high-throughput "batch" operations:
 
 *   **Batch Tool-Calling**: Instead of making one-by-one changes, tools like `write_formula_range` and `set_cell_style` operate on entire ranges in a single call.
-*   **High-Volume Insertion**: The `import_csv_from_string` tool allows the AI to generate and inject large datasets instantly. This is orders of magnitude faster than inserting data cell-by-cell; we found that providing these batch tools encourages the AI to perform far more ambitious spreadsheet automation and data analysis.
+*   **High-Volume Insertion**: The `write_formula_range` tool allows the AI to generate and inject large CSV datasets instantly. This is orders of magnitude faster than inserting data cell-by-cell; we found that providing these batch tools encourages the AI to perform far more ambitious spreadsheet automation and data analysis.
 *   **Optimized Ranges**: Formatting and number formats are applied at the range level, minimizing UNO calls and ensuring the UI remains fluid even during heavy document analysis.
 
 ## Recent Progress & Benchmarks (Feb 2026)

--- a/docs/calc-integration.md
+++ b/docs/calc-integration.md
@@ -256,9 +256,9 @@ Your current 11 tools cover the essentials, but expanding to more advanced opera
 - Range number formats now apply to entire range (new `set_range_number_format` method).
 - Exposed `delete_rows`, `delete_columns` (backend methods existed; now full tools). Insert tools removed as CSV import provides better bulk data insertion.
 - Added `write_formula_range` tool: Efficiently writes formulas or values to ranges. Accepts single value for entire range or array for individual cells.
-- Added `import_csv_from_string` tool: Parses CSV string (e.g., "Name,Age\nAlice,30\nBob,25") and bulk-inserts into sheet starting at a cell. No file I/O required—ideal for AI-generated or pasted data.
+- Enhanced `write_formula_range` tool: Parses CSV string (e.g., "Name,Age\nAlice,30\nBob,25") and bulk-inserts into sheet starting at a cell. No file I/O required—ideal for AI-generated or pasted data.
 - The method handles text/number detection automatically, supports custom delimiters (',', ';', etc.), and provides error handling for malformed CSV.
-- Updated `DEFAULT_CALC_CHAT_SYSTEM_PROMPT` to reference new tools: "Use `write_formula_range` for bulk writes, `import_csv_from_string` for bulk data inserts. `set_cell_style` works on ranges (e.g. 'A1:D10') for efficient formatting."
+- Updated `DEFAULT_CALC_CHAT_SYSTEM_PROMPT` to reference new tools: "Use `write_formula_range` for bulk writes or bulk CSV data inserts. `set_cell_style` works on ranges (e.g. 'A1:D10') for efficient formatting."
 
 **Next Steps** (Future Enhancements):
 - Add `write_formula_batch` for bulk cell writes (dict of cell->value) to avoid loops.

--- a/docs/llm-hacks.md
+++ b/docs/llm-hacks.md
@@ -6,7 +6,7 @@ This document tracks technical workarounds and "hacks" implemented to handle the
 **Problem**: LLMs are inconsistent with CSV delimiters. Since Calc formula syntax favors semicolons (`;`), models often use them for CSV data even when asked for commas (`,`). This leads to data being imported into a single column.
 
 ### [Workaround] Auto-Detection
-Instead of requiring a `delimiter` parameter, the tool `import_csv_from_string` now handles it automatically in `core/calc_manipulator.py`.
+Instead of requiring a `delimiter` parameter, the tool `write_formula_range` now handles it automatically in `plugin/modules/calc/manipulator.py` when CSV data is provided.
 - **Implementation**: The tool peeks at the first few lines. If semicolons are significantly more prevalent than commas, it switches the CSV reader to `;`. Otherwise, it defaults to `,`.
 - **Reasoning**: Reduces the cognitive load on the LLM and makes the tool "just work" regardless of the model's preferred separator.
 
@@ -32,7 +32,7 @@ In `core/calc_manipulator.py`, we use a regular expression to normalize JSON arr
 ### [Workaround] Explicit Prompt Rules
 In `core/constants.py`, the system prompt includes high-pressure instructions on formula syntax.
 - **Constraint**: "FORMULA SYNTAX: LibreOffice uses semicolon (;) as the formula argument separator. Wrong: =SUM(A1,A10) (no commas)."
-- **Duality**: We also explicitly warn about CSV: "CSV DATA: Use comma (,) for import_csv_from_string." to counteract the formula semicolon rule.
+- **Duality**: We also explicitly warn about CSV: "CSV DATA: Use comma (,) for write_formula_range." to counteract the formula semicolon rule.
 
 ## 5. Defensive Parameter Handling
 **Problem**: Models sometimes pass range names as lists or wrap them in extra quotes.

--- a/patch2.py
+++ b/patch2.py
@@ -1,0 +1,69 @@
+import re
+
+with open("plugin/modules/calc/manipulator.py", "r") as f:
+    content = f.read()
+
+# in write_formula_range we need to handle the new return type from _parse_formula_or_values_string
+# If it's a 2D list (i.e. first element is a list), we flatten it, BUT we also calculate new `end` if
+# total_cells == 1 and we have a 2D array. This handles the import_csv behavior where they specify a single cell.
+
+diff = """<<<<<<< SEARCH
+            # Normalise string-as-array from AI callers.
+            if isinstance(formula_or_values, str):
+                parsed = _parse_formula_or_values_string(formula_or_values)
+                if parsed is not None:
+                    formula_or_values = parsed
+
+            if isinstance(formula_or_values, (list, tuple)):
+                if len(formula_or_values) != total_cells:
+                    raise UnoObjectError(
+                        f"Array has {len(formula_or_values)} values but range has "
+                        f"total_cells cells. Use a single string to fill the whole "
+                        "range, or an array with exactly that many values for "
+                        "cell-by-cell control."
+                    )
+                values = formula_or_values
+=======
+            # Normalise string-as-array from AI callers.
+            if isinstance(formula_or_values, str):
+                parsed = _parse_formula_or_values_string(formula_or_values)
+                if parsed is not None:
+                    formula_or_values = parsed
+
+            if isinstance(formula_or_values, (list, tuple)):
+                # Detect 2D array (e.g. from multiline CSV or JSON array of arrays)
+                if len(formula_or_values) > 0 and isinstance(formula_or_values[0], (list, tuple)):
+                    rows = len(formula_or_values)
+                    cols = max(len(r) for r in formula_or_values)
+
+                    # If target range is a single cell, expand it to fit the 2D array
+                    if total_cells == 1:
+                        end = (start[0] + cols - 1, start[1] + rows - 1)
+                        num_rows = end[1] - start[1] + 1
+                        num_cols = end[0] - start[0] + 1
+                        total_cells = num_rows * num_cols
+
+                        # Pad the 2D array to ensure it matches the full rectangular dimensions
+                        padded_values = []
+                        for r in formula_or_values:
+                            row_vals = list(r)
+                            row_vals.extend([""] * (cols - len(row_vals)))
+                            padded_values.extend(row_vals)
+                        formula_or_values = padded_values
+                    else:
+                        # Otherwise flatten it to compare with total_cells
+                        flat_vals = []
+                        for r in formula_or_values:
+                            flat_vals.extend(r)
+                        formula_or_values = flat_vals
+
+                if len(formula_or_values) != total_cells:
+                    raise UnoObjectError(
+                        f"Array has {len(formula_or_values)} values but range has "
+                        f"{total_cells} cells. Use a single string to fill the whole "
+                        "range, or an array with exactly that many values for "
+                        "cell-by-cell control."
+                    )
+                values = formula_or_values
+>>>>>>> REPLACE"""
+# wait, I'll just use replace_with_git_merge_diff directly

--- a/patch3.py
+++ b/patch3.py
@@ -1,0 +1,24 @@
+import re
+
+with open("plugin/modules/calc/manipulator.py", "r") as f:
+    content = f.read()
+
+diff = """<<<<<<< SEARCH
+                    # Pad rows to ensure uniform width, and flatten into 1D
+                    flat_vals = []
+                    for r in formula_or_values:
+                        row_vals = list(r)
+                        row_vals.extend([""] * (num_cols - len(row_vals)))
+                        flat_vals.extend(row_vals)
+                    formula_or_values = flat_vals
+=======
+                    # Pad rows to ensure uniform width, and flatten into 1D
+                    flat_vals = []
+                    for r in formula_or_values:
+                        row_vals = list(r)
+                        if num_cols > len(row_vals):
+                            row_vals.extend([""] * (num_cols - len(row_vals)))
+                        flat_vals.extend(row_vals[:num_cols])
+                    formula_or_values = flat_vals
+>>>>>>> REPLACE"""
+# replace_with_git_merge_diff

--- a/patch_cleanup.py
+++ b/patch_cleanup.py
@@ -1,0 +1,21 @@
+import re
+
+with open("plugin/modules/calc/manipulator.py", "r") as f:
+    content = f.read()
+
+# remove import_csv_from_string
+match = re.search(r'    def import_csv_from_string\(self, csv_data: str, target_cell: str = "A1"\):(.*?)    # ── Chart ──', content, flags=re.DOTALL)
+if match:
+    content = content.replace(match.group(0), '    # ── Chart ──')
+    with open("plugin/modules/calc/manipulator.py", "w") as f:
+        f.write(content)
+
+with open("plugin/modules/calc/cells.py", "r") as f:
+    content = f.read()
+
+# remove ImportCsv class
+match = re.search(r'class ImportCsv\(ToolBase\):(.*?)class DeleteStructure\(ToolBase\):', content, flags=re.DOTALL)
+if match:
+    content = content.replace(match.group(0), 'class DeleteStructure(ToolBase):')
+    with open("plugin/modules/calc/cells.py", "w") as f:
+        f.write(content)

--- a/patch_docs.py
+++ b/patch_docs.py
@@ -1,0 +1,21 @@
+import os
+
+def replace_in_file(path, search, replace):
+    with open(path, "r") as f:
+        content = f.read()
+    content = content.replace(search, replace)
+    with open(path, "w") as f:
+        f.write(content)
+
+replace_in_file("docs/llm-hacks.md", "Instead of requiring a `delimiter` parameter, the tool `import_csv_from_string` now handles it automatically in `core/calc_manipulator.py`.", "Instead of requiring a `delimiter` parameter, the tool `write_formula_range` now handles it automatically in `plugin/modules/calc/manipulator.py` when CSV data is provided.")
+replace_in_file("docs/llm-hacks.md", "CSV DATA: Use comma (,) for import_csv_from_string.", "CSV DATA: Use comma (,) for write_formula_range.")
+
+replace_in_file("docs/calc-integration.md", "- Added `import_csv_from_string` tool: Parses CSV string (e.g., \"Name,Age\\nAlice,30\\nBob,25\") and bulk-inserts into sheet starting at a cell. No file I/O required—ideal for AI-generated or pasted data.", "- Enhanced `write_formula_range` tool: Parses CSV string (e.g., \"Name,Age\\nAlice,30\\nBob,25\") and bulk-inserts into sheet starting at a cell. No file I/O required—ideal for AI-generated or pasted data.")
+replace_in_file("docs/calc-integration.md", "Use `write_formula_range` for bulk writes, `import_csv_from_string` for bulk data inserts.", "Use `write_formula_range` for bulk writes or bulk CSV data inserts.")
+
+replace_in_file("README.md", "The `import_csv_from_string` tool allows the AI to generate and inject large datasets instantly.", "The `write_formula_range` tool allows the AI to generate and inject large CSV datasets instantly.")
+
+replace_in_file("plugin/framework/constants.py", "CSV DATA: Use comma (,) for import_csv_from_string.", "CSV DATA: Use comma (,) for write_formula_range.")
+replace_in_file("plugin/framework/constants.py", "- import_csv_from_string: Bulk insert CSV data into the sheet starting at a cell. Use for large datasets.", "")
+replace_in_file("plugin/framework/constants.py", "- write_formula_range: Single string fills entire range; JSON array must match range size exactly (one value per cell). Use ranges for efficiency; avoid single-cell operations.", "- write_formula_range: Single string fills entire range; JSON array must match range size exactly (one value per cell). Alternatively, provide multiline CSV data to bulk insert starting at a cell. Use ranges for efficiency.")
+replace_in_file("plugin/framework/constants.py", "set_cell_style after merging.", "set_cell_style after merging.\n") # Just to make sure formatting is good, might need manual check.

--- a/patch_manipulator.py
+++ b/patch_manipulator.py
@@ -1,0 +1,29 @@
+import re
+
+with open("plugin/modules/calc/manipulator.py", "r") as f:
+    content = f.read()
+
+# We need to detect multiline CSV inside _parse_formula_or_values_string
+# Or we can handle it directly in write_formula_range.
+# Wait, if we return a 2D list from _parse_formula_or_values_string, we can use it.
+# Currently, _parse_formula_or_values_string returns a flat list (1D).
+# If it's a multiline CSV, returning a 2D list makes sense.
+# Wait, the comment says:
+# "If the AI sends formula_or_values as a JSON-encoded string... We normalise LibreOffice-style semicolon separators and return a flat list."
+
+# What if formula_or_values is a list of lists (2D array)?
+# In write_formula_range:
+# if isinstance(formula_or_values, (list, tuple)):
+#    if len(formula_or_values) != total_cells:
+#       raise UnoObjectError(
+#           f"Array has {len(formula_or_values)} values but range has "
+#           f"{total_cells} cells. Use a single string to fill the whole "
+#           "range, or an array with exactly that many values for "
+#           "cell-by-cell control."
+#       )
+#    values = formula_or_values
+
+# So `formula_or_values` is currently expected to be a 1D list (flattened).
+
+# For multiline CSV, if we parse it into a 2D array, we should calculate the target range
+# if the provided range is just a single cell (e.g., "A1").

--- a/patch_tests.py
+++ b/patch_tests.py
@@ -1,0 +1,11 @@
+import re
+
+with open("plugin/tests/test_csv_import_logic.py", "r") as f:
+    content = f.read()
+
+# Add a mock for self.bridge.parse_range_string which returns ((0, 0), (0, 0)) or similar.
+# A1 is ((0,0), (0,0))
+content = content.replace("self.bridge._index_to_column.return_value = \"A\"", "self.bridge._index_to_column.return_value = \"A\"\n        self.bridge.parse_range_string.return_value = ((0,0), (0,0))")
+
+with open("plugin/tests/test_csv_import_logic.py", "w") as f:
+    f.write(content)

--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -127,7 +127,7 @@ Do not explain—do the operation directly using tools. Perform as many steps as
 
 {CALC_FORMULA_SYNTAX}
 
-CSV DATA: Use comma (,) for import_csv_from_string.
+CSV DATA: Use comma (,) for write_formula_range.
 
 TOOLS (grouped by use):
 
@@ -136,9 +136,9 @@ READ:
 - get_sheet_summary: Summary of the active sheet (size, headers, used range).
 
 WRITE & FORMAT:
-- write_formula_range: Single string fills entire range; JSON array must match range size exactly (one value per cell). Use ranges for efficiency; avoid single-cell operations.
+- write_formula_range: Single string fills entire range; JSON array must match range size exactly (one value per cell). Alternatively, provide multiline CSV data to bulk insert starting at a cell. Use ranges for efficiency.
 - set_cell_style: Formatting (bold, colors, alignment, number format) for a range. Prefer ranges for efficiency; use after bulk writes.
-- import_csv_from_string: Bulk insert CSV data into the sheet starting at a cell. Use for large datasets.
+
 - merge_cells: Merge a range (e.g. headers); then write and style with write_formula_range/set_cell_style.
 - sort_range: Sort a range by a column (ascending/descending, optional header row).
 - clear_range: Clear contents of a range.

--- a/plugin/modules/calc/cells.py
+++ b/plugin/modules/calc/cells.py
@@ -443,41 +443,6 @@ class SortRange(ToolBase):
             "message": f"Sorted {len(rn)} ranges",
         }
 
-class ImportCsv(ToolBase):
-    """Import CSV data into the sheet."""
-
-    name = "import_csv_from_string"
-    intent = "edit"
-    description = (
-        "Inserts CSV data into the sheet starting at a cell. "
-        "Handles large datasets efficiently."
-    )
-    parameters = {
-        "type": "object",
-        "properties": {
-            "csv_data": {
-                "type": "string",
-                "description": "CSV content as string (rows separated by \\n).",
-            },
-            "target_cell": {
-                "type": "string",
-                "description": "Starting cell (default 'A1').",
-            },
-        },
-        "required": ["csv_data"],
-    }
-    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
-    is_mutation = True
-
-    def execute(self, ctx, **kwargs):
-        bridge = CalcBridge(ctx.doc)
-        manipulator = CellManipulator(bridge)
-        csv_data = kwargs["csv_data"]
-        target_cell = kwargs.get("target_cell", "A1")
-
-        result = manipulator.import_csv_from_string(csv_data, target_cell=target_cell)
-        return {"status": "ok", "message": result}
-
 class DeleteStructure(ToolBase):
     """Delete rows or columns."""
 

--- a/plugin/modules/calc/manipulator.py
+++ b/plugin/modules/calc/manipulator.py
@@ -90,18 +90,33 @@ def _parse_formula_or_values_string(s: str):
         except TypeError:
             pass
 
-    # Case 2: Raw semicolon-separated string e.g. "Name;Age;Country"
-    # Only if it is not a formula (starting with =) and not a single value.
-    if ";" in s and not s_strip.startswith("="):
-        try:
-            reader = csv.reader(
-                io.StringIO(s), delimiter=";", skipinitialspace=True,
-            )
-            rows = list(reader)
-            if rows:
-                return [val.strip() for val in rows[0]]
-        except Exception as e:
-            logger.debug("Failed to read sample csv: %s", e)
+    # Case 2: Raw semicolon-separated string or multiline CSV
+    # Only if it is not a formula (starting with =)
+    if not s_strip.startswith("="):
+        # Could be multiline CSV or single line with delimiter
+        delimiter = ","
+        first_line = s.split('\n')[0] if s else ""
+        if ";" in first_line and "," not in first_line:
+            delimiter = ";"
+
+        # If it has a delimiter or is multiline, try to parse it
+        if delimiter in s or "\n" in s:
+            try:
+                reader = csv.reader(
+                    io.StringIO(s), delimiter=delimiter, skipinitialspace=True,
+                )
+                rows = list(reader)
+                if rows:
+                    if len(rows) == 1:
+                        # 1D row
+                        return [val.strip() for val in rows[0]]
+                    else:
+                        # 2D array representing multiline CSV
+                        # We return it as a list of lists, but write_formula_range needs to flatten it
+                        # Wait, if we return a 2D array, write_formula_range can process it and adjust its target range.
+                        return [[val.strip() for val in row] for row in rows]
+            except Exception as e:
+                logger.debug("Failed to read sample csv: %s", e)
 
     return None
 
@@ -597,6 +612,32 @@ class CellManipulator:
                     formula_or_values = parsed
 
             if isinstance(formula_or_values, (list, tuple)):
+                if len(formula_or_values) > 0 and isinstance(formula_or_values[0], (list, tuple)):
+                    rows_cnt = len(formula_or_values)
+                    cols_cnt = max(len(r) for r in formula_or_values)
+
+                    if total_cells == 1:
+                        # Expand single cell target to fit the 2D array
+                        end = (start[0] + cols_cnt - 1, start[1] + rows_cnt - 1)
+                        num_rows = end[1] - start[1] + 1
+                        num_cols = end[0] - start[0] + 1
+                        total_cells = num_rows * num_cols
+
+                        range_str = (
+                            f"{self.bridge._index_to_column(start[0])}{start[1]}"
+                            f":"
+                            f"{self.bridge._index_to_column(end[0])}{end[1]}"
+                        )
+
+                    # Pad rows to ensure uniform width, and flatten into 1D
+                    flat_vals = []
+                    for r in formula_or_values:
+                        row_vals = list(r)
+                        if num_cols > len(row_vals):
+                            row_vals.extend([""] * (num_cols - len(row_vals)))
+                        flat_vals.extend(row_vals[:num_cols])
+                    formula_or_values = flat_vals
+
                 if len(formula_or_values) != total_cells:
                     raise UnoObjectError(
                         f"Array has {len(formula_or_values)} values but range has "
@@ -668,71 +709,6 @@ class CellManipulator:
             return f"Range {range_str} filled with {len(values)} values."
         except Exception as e:
             logger.error("Range formula write error (%s): %s", range_str, str(e))
-            raise ToolExecutionError(str(e)) from e
-
-    def import_csv_from_string(self, csv_data: str, target_cell: str = "A1"):
-        """Import CSV data into the sheet starting at *target_cell*.
-
-        Automatically detects comma vs semicolon delimiter.
-
-        Args:
-            csv_data: CSV content as a string.
-            target_cell: Starting cell (e.g. "A1").
-
-        Returns:
-            Summary string.
-        """
-        try:
-            delimiter = ","
-            first_line = csv_data.split('\n')[0] if csv_data else ""
-            if ";" in first_line and "," not in first_line:
-                delimiter = ";"
-
-            col_start, row_start = parse_address(target_cell)
-            reader = csv.reader(io.StringIO(csv_data), delimiter=delimiter)
-            rows = list(reader)
-            if not rows:
-                return "No data to import."
-
-            sheet = self.bridge.get_active_sheet()
-            total_rows = len(rows)
-            total_cols = max(len(r) for r in rows) if rows else 0
-
-            data_array = []
-            for row_data in rows:
-                data_row = []
-                for c_idx in range(total_cols):
-                    if c_idx < len(row_data):
-                        cell_value = row_data[c_idx]
-                        try:
-                            # Convert to float if possible, but keeping it as a string
-                            # if we just want to import it as string. Wait, if we use
-                            # setDataArray, it takes floats and strings.
-                            data_row.append(float(cell_value))
-                        except ValueError:
-                            data_row.append(cell_value)
-                    else:
-                        data_row.append("")
-                data_array.append(tuple(data_row))
-
-            range_imported = (
-                f"{target_cell}:"
-                f"{self.bridge._index_to_column(col_start + total_cols - 1)}"
-                f"{row_start + total_rows}"
-            )
-            # -1 because rows are 1-based in address strings but total_rows is count
-            end_col = col_start + total_cols - 1
-            end_row = row_start + total_rows - 1
-
-            cell_range = sheet.getCellRangeByPosition(
-                col_start, row_start, end_col, end_row
-            )
-            cell_range.setDataArray(tuple(data_array))
-
-            logger.info("CSV imported to range %s.", range_imported)
-            return f"Imported {total_rows} rows, {total_cols} cols to {range_imported}."
-        except Exception as e:
-            logger.error("CSV import error: %s", str(e))
             raise ToolExecutionError(str(e)) from e
 
     # ── Chart ──────────────────────────────────────────────────────────

--- a/plugin/tests/test_csv_import_logic.py
+++ b/plugin/tests/test_csv_import_logic.py
@@ -22,11 +22,12 @@ class TestCSVImportLogic(unittest.TestCase):
         self.sheet = MagicMock()
         self.bridge.get_active_sheet.return_value = self.sheet
         self.bridge._index_to_column.return_value = "A"
+        self.bridge.parse_range_string.return_value = ((0,0), (0,0))
 
     def test_detect_comma(self):
         csv_data = "Name,Age,Country\nJohn,28,USA"
         with patch('csv.reader', side_effect=csv.reader) as mock_reader:
-            self.manipulator.import_csv_from_string(csv_data)
+            self.manipulator.write_formula_range("A1", csv_data)
             # Check if csv.reader was called with delimiter=','
             args, kwargs = mock_reader.call_args
             self.assertEqual(kwargs['delimiter'], ',')
@@ -34,7 +35,7 @@ class TestCSVImportLogic(unittest.TestCase):
     def test_detect_semicolon(self):
         csv_data = "Name;Age;Country\nJohn;28;USA"
         with patch('csv.reader', side_effect=csv.reader) as mock_reader:
-            self.manipulator.import_csv_from_string(csv_data)
+            self.manipulator.write_formula_range("A1", csv_data)
             # Check if csv.reader was called with delimiter=';'
             args, kwargs = mock_reader.call_args
             self.assertEqual(kwargs['delimiter'], ';')
@@ -45,14 +46,14 @@ class TestCSVImportLogic(unittest.TestCase):
         # So mixed should be ","
         csv_data = "Name,Age;Country\nJohn,28;USA"
         with patch('csv.reader', side_effect=csv.reader) as mock_reader:
-            self.manipulator.import_csv_from_string(csv_data)
+            self.manipulator.write_formula_range("A1", csv_data)
             args, kwargs = mock_reader.call_args
             self.assertEqual(kwargs['delimiter'], ',')
 
     def test_no_delimiter_defaults_to_comma(self):
         csv_data = "NameAgeCountry\nJohn28USA"
         with patch('csv.reader', side_effect=csv.reader) as mock_reader:
-            self.manipulator.import_csv_from_string(csv_data)
+            self.manipulator.write_formula_range("A1", csv_data)
             args, kwargs = mock_reader.call_args
             self.assertEqual(kwargs['delimiter'], ',')
 

--- a/plugin/tests/uno/test_calc.py
+++ b/plugin/tests/uno/test_calc.py
@@ -327,9 +327,9 @@ def test_import_csv_from_string():
 
     # Test case 1: Standard comma-separated
     csv_1 = "Name,Age\nAlice,30\nBob,25"
-    res1 = _execute_calc_tool("import_csv_from_string", {
-        "csv_data": csv_1,
-        "target_cell": "E1"
+    res1 = _execute_calc_tool("write_formula_range", {
+        "formula_or_values": csv_1,
+        "range_name": "E1"
     })
     assert res1.get("status") == "ok", f"CSV import failed: {res1}"
     assert active_sheet.getCellByPosition(4, 0).getString() == "Name" # E1
@@ -340,9 +340,9 @@ def test_import_csv_from_string():
 
     # Test case 2: Semicolon-separated
     csv_2 = "Item;Price\nApple;1.5\nBanana;0.75"
-    res2 = _execute_calc_tool("import_csv_from_string", {
-        "csv_data": csv_2,
-        "target_cell": "G1"
+    res2 = _execute_calc_tool("write_formula_range", {
+        "formula_or_values": csv_2,
+        "range_name": "G1"
     })
     assert res2.get("status") == "ok", f"Semicolon CSV import failed: {res2}"
     assert active_sheet.getCellByPosition(6, 0).getString() == "Item" # G1
@@ -352,9 +352,9 @@ def test_import_csv_from_string():
 
     # Test case 3: CSV with quoted commas
     csv_3 = "Person,Description\nCarol,\"Smart, Funny, Tall\"\nDave,Cool"
-    res3 = _execute_calc_tool("import_csv_from_string", {
-        "csv_data": csv_3,
-        "target_cell": "E5"
+    res3 = _execute_calc_tool("write_formula_range", {
+        "formula_or_values": csv_3,
+        "range_name": "E5"
     })
     assert res3.get("status") == "ok", f"Quoted CSV import failed: {res3}"
     assert active_sheet.getCellByPosition(4, 5).getString() == "Carol" # E6

--- a/run_calc_tests.sh
+++ b/run_calc_tests.sh
@@ -1,0 +1,1 @@
+uv run pytest plugin/tests/test_csv_import_logic.py


### PR DESCRIPTION
- Enhanced `write_formula_range` tool to support parsing multiline CSV strings directly, dynamically calculating and padding target ranges when a single starting cell is specified, matching the previous `import_csv_from_string` logic.
- Removed `import_csv_from_string` tool completely from `plugin/modules/calc/cells.py` and its underlying execution method from `plugin/modules/calc/manipulator.py`.
- Updated all related tests (`test_csv_import_logic.py`, `test_calc.py`) to test CSV capability via `write_formula_range`.
- Updated constants (`plugin/framework/constants.py`) and documentation (`docs/llm-hacks.md`, `docs/calc-integration.md`, `README.md`) to reflect the changes.

---
*PR created automatically by Jules for task [550411641896994929](https://jules.google.com/task/550411641896994929) started by @KeithCu*