### PR TITLE
Refactor track changes tools to specialized sub-agent domain

### DIFF
--- a/plugin/modules/writer/__init__.py
+++ b/plugin/modules/writer/__init__.py
@@ -38,6 +38,7 @@ class WriterModule(ModuleBase):
             indexes,
             fields,
             embedded,
+            tracking,
         )
 
         # Order matters: tree needs bookmarks, proximity/index need tree

--- a/plugin/modules/writer/specialized.py
+++ b/plugin/modules/writer/specialized.py
@@ -35,6 +35,7 @@ _AVAILABLE_DOMAINS = [
     "indexes",
     "fields",
     "bookmarks",
+    "tracking",
 ]
 
 
@@ -50,7 +51,7 @@ class DelegateToSpecializedWriter(ToolBase):
         "Delegates a specialized task to a sub-agent with a focused toolset. "
         "Use this for complex Writer operations like manipulating tables, "
         "charts, fields, styles, layout, embedded objects, shapes, indexes, "
-        "or bookmarks."
+        "bookmarks, or track changes (tracking)."
     )
     parameters = {
         "type": "object",

--- a/plugin/modules/writer/tracking.py
+++ b/plugin/modules/writer/tracking.py
@@ -22,15 +22,16 @@ Ported from nelson-mcp (MPL 2.0): nelson-mcp/plugin/modules/writer/tools/trackin
 
 import logging
 
-from plugin.framework.tool_base import ToolBase
+from plugin.modules.writer.base import ToolWriterSpecialBase
 
 log = logging.getLogger("writeragent.writer")
 
 
-class SetTrackChanges(ToolBase):
+class SetTrackChanges(ToolWriterSpecialBase):
     """Enable or disable change tracking."""
 
     name = "set_track_changes"
+    specialized_domain = "tracking"
     intent = "review"
     description = "Enable or disable track changes (change recording) in the document."
     parameters = {
@@ -55,10 +56,11 @@ class SetTrackChanges(ToolBase):
         return {"status": "ok", "record_changes": bool(enabled)}
 
 
-class GetTrackedChanges(ToolBase):
+class GetTrackedChanges(ToolWriterSpecialBase):
     """List all tracked changes (redlines) in the document."""
 
     name = "get_tracked_changes"
+    specialized_domain = "tracking"
     intent = "review"
     description = (
         "List all tracked changes (redlines) in the document, "
@@ -120,10 +122,11 @@ class GetTrackedChanges(ToolBase):
         }
 
 
-class ManageTrackedChanges(ToolBase):
+class ManageTrackedChanges(ToolWriterSpecialBase):
     """Accept or reject all tracked changes in the document."""
 
     name = "manage_tracked_changes"
+    specialized_domain = "tracking"
     intent = "review"
     description = "Accept or reject all tracked changes in the document."
     parameters = {


### PR DESCRIPTION
This commit refactors the "track changes" tools (`SetTrackChanges`, `GetTrackedChanges`, `ManageTrackedChanges`) so that they are now part of a specialized sub-agent toolset. They inherit from `ToolWriterSpecialBase`, have the `specialized_domain` attribute set to `"tracking"`, and the overarching gateway `DelegateToSpecializedWriter` tool has been updated to include "tracking" capabilities.

---
*PR created automatically by Jules for task [11967846323882131970](https://jules.google.com/task/11967846323882131970) started by @KeithCu*