### PR TITLE
feat: support in-place specialized toolset switching

### DIFF
--- a/docs/writer-specialized-toolsets.md
+++ b/docs/writer-specialized-toolsets.md
@@ -165,7 +165,7 @@ We currently support two alternative implementations for the `delegate_to_specia
 
 **Approach B: In-Place Tool Switching (`USE_SUB_AGENT = False`)**
 - The gateway tool simply sets an active domain flag on the current session and immediately returns control to the main chat model with a message like: `"Tool call switched to '{domain}'..."`.
-- On the next turn, the main chat model receives the normal core tools *plus* the specialized tools for that domain.
+- On the next turn, the main chat model receives *only* the specialized tools for that domain (plus the finish tool). All normal core/extended tools are hidden to keep the context clean and make the sub-task easy for the model.
 - The model continues its reasoning within the same context and explicitly calls `specialized_workflow_finished` when the sub-task is complete, which clears the active domain and restores the default toolset.
 
 ---

--- a/docs/writer-specialized-toolsets.md
+++ b/docs/writer-specialized-toolsets.md
@@ -156,17 +156,17 @@ While the "Fat API" approach drastically reduces tool count and could potentiall
 
 ### 1.4 Two Implementations for Specialized Workflows
 
-We currently support two alternative implementations for the `delegate_to_specialized_writer_toolset` tool. This allows us to experiment, research, and quantify which approach works best (e.g., perhaps smaller models need the sub-agent approach to avoid confusion, while larger models can handle in-place tool switching seamlessly). You can toggle between them using the `USE_SUB_AGENT` global variable in `plugin/modules/writer/specialized.py`.
+We currently support two alternative implementations for the `delegate_to_specialized_writer_toolset` tool. This allows us to experiment, research, and quantify which approach works best (e.g., perhaps smaller models need the sub-agent approach to avoid confusion, while larger models can handle in-place tool switching seamlessly). You can toggle between them using the `USE_SUB_AGENT` global variable in `plugin/modules/writer/specialized.py`. Both modes use a `final_answer` tool to explicitly return control and exit the mode.
 
 **Approach A: The Sub-Agent Model (`USE_SUB_AGENT = True`)**
 - The gateway tool launches a **short-lived sub-agent** (via `smolagents`) in a background thread.
-- This sub-agent receives the user's task description and has access *only* to the specialized domain tools and the `specialized_workflow_finished` tool.
-- The main chat model is blocked, waiting for the sub-agent to finish and return a final summary.
+- This sub-agent receives the user's task description and has access *only* to the specialized domain tools (and `smolagents`' built-in `final_answer` tool).
+- The main chat model is blocked, waiting for the sub-agent to finish and return its final answer.
 
 **Approach B: In-Place Tool Switching (`USE_SUB_AGENT = False`)**
 - The gateway tool simply sets an active domain flag on the current session and immediately returns control to the main chat model with a message like: `"Tool call switched to '{domain}'..."`.
-- On the next turn, the main chat model receives *only* the specialized tools for that domain (plus the finish tool). All normal core/extended tools are hidden to keep the context clean and make the sub-task easy for the model.
-- The model continues its reasoning within the same context and explicitly calls `specialized_workflow_finished` when the sub-task is complete, which clears the active domain and restores the default toolset.
+- On the next turn, the main chat model receives *only* the specialized tools for that domain, plus a custom `final_answer` tool (designed to perfectly mimic the smolagents exit approach). All normal core/extended tools are hidden to keep the context clean and make the sub-task easy for the model.
+- The model continues its reasoning within the same context and explicitly calls `final_answer` when the sub-task is complete, which clears the active domain and restores the default toolset.
 
 ---
 
@@ -191,8 +191,8 @@ flowchart LR
 
 1. **Tier filtering** on `ToolRegistry.get_tools` / `get_schemas` hides `specialized` and `specialized_control` from the default lists used by chat and MCP `tools/list`. The registry accepts an `active_domain` parameter to explicitly bypass this exclusion when the session is in a specialized mode.
 2. **Domain bases** (`ToolWriterTableBase`, …) set `tier = "specialized"` and a `specialized_domain` string.
-3. **Delegation** (Sub-Agent mode) collects tools where `isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == domain`, adds `specialized_workflow_finished`, wraps them for smolagents, and runs a bounded `ToolCallingAgent` loop in a **background thread** (`is_async()` on the gateway).
-4. **Delegation** (In-Place mode) sets the `active_specialized_domain` on the `ChatSession` and responds to the LLM to trigger a new cycle with the updated schema.
+3. **Delegation** (Sub-Agent mode) collects tools where `isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == domain`, wraps them for smolagents, and runs a bounded `ToolCallingAgent` loop in a **background thread** (`is_async()` on the gateway).
+4. **Delegation** (In-Place mode) sets the `active_specialized_domain` on the `ChatSession`, dynamically returning a customized `final_answer` tool along with the domain tools, and responds to the LLM to trigger a new cycle with the updated schema.
 
 ---
 
@@ -376,7 +376,7 @@ When implementing, align service names and includes with the installed LibreOffi
 | Smaller default tool list | `exclude_tiers` default in `ToolRegistry.get_tools` / `get_schemas` |
 | Domain grouping | `ToolWriter*Base.specialized_domain` + `tier = "specialized"` |
 | User/model entry point | `delegate_to_specialized_writer_toolset` (`tier = "core"`, async) |
-| Sub-agent completion | `specialized_workflow_finished` (`tier = "specialized_control"`) |
+| Sub-agent completion | `final_answer` (`tier = "specialized_control"`) |
 | Prompt teaching | `WRITER_SPECIALIZED_DELEGATION` in `constants.py` |
 | Execution by name | Unchanged `execute()` — tier only affects **listing**, not **dispatch** |
 

--- a/docs/writer-specialized-toolsets.md
+++ b/docs/writer-specialized-toolsets.md
@@ -150,9 +150,23 @@ While the "Fat API" approach drastically reduces tool count and could potentiall
 ### 1.3 What “success” looks like under the Delegation model
 
 - The **main** sidebar chat sees `core` / `extended` tools plus the **gateway** `delegate_to_specialized_writer_toolset`, not the full set of table/style/chart/… tools.
-- When the model (or product logic) calls the gateway with a **domain** and **task**, a **short-lived sub-agent** runs with **only** tools for that domain (plus a completion tool).
+- When the model (or product logic) calls the gateway with a **domain** and **task**, the system dynamically grants access to that domain's focused toolset.
 - **MCP** and **direct `execute(tool_name, …)`** remain able to run any registered tool by name (registry does not block execution by tier).
 - **Tests** can enumerate specialized tools with `exclude_tiers=()` when registration needs to be asserted.
+
+### 1.4 Two Implementations for Specialized Workflows
+
+We currently support two alternative implementations for the `delegate_to_specialized_writer_toolset` tool. This allows us to experiment, research, and quantify which approach works best (e.g., perhaps smaller models need the sub-agent approach to avoid confusion, while larger models can handle in-place tool switching seamlessly). You can toggle between them using the `USE_SUB_AGENT` global variable in `plugin/modules/writer/specialized.py`.
+
+**Approach A: The Sub-Agent Model (`USE_SUB_AGENT = True`)**
+- The gateway tool launches a **short-lived sub-agent** (via `smolagents`) in a background thread.
+- This sub-agent receives the user's task description and has access *only* to the specialized domain tools and the `specialized_workflow_finished` tool.
+- The main chat model is blocked, waiting for the sub-agent to finish and return a final summary.
+
+**Approach B: In-Place Tool Switching (`USE_SUB_AGENT = False`)**
+- The gateway tool simply sets an active domain flag on the current session and immediately returns control to the main chat model with a message like: `"Tool call switched to '{domain}'..."`.
+- On the next turn, the main chat model receives the normal core tools *plus* the specialized tools for that domain.
+- The model continues its reasoning within the same context and explicitly calls `specialized_workflow_finished` when the sub-task is complete, which clears the active domain and restores the default toolset.
 
 ---
 
@@ -175,9 +189,10 @@ flowchart LR
   T --> F
 ```
 
-1. **Tier filtering** on `ToolRegistry.get_tools` / `get_schemas` hides `specialized` and `specialized_control` from the default lists used by chat and MCP `tools/list`.
+1. **Tier filtering** on `ToolRegistry.get_tools` / `get_schemas` hides `specialized` and `specialized_control` from the default lists used by chat and MCP `tools/list`. The registry accepts an `active_domain` parameter to explicitly bypass this exclusion when the session is in a specialized mode.
 2. **Domain bases** (`ToolWriterTableBase`, …) set `tier = "specialized"` and a `specialized_domain` string.
-3. **Delegation** collects tools where `isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == domain`, adds `specialized_workflow_finished`, wraps them for smolagents, and runs a bounded `ToolCallingAgent` loop in a **background thread** (`is_async()` on the gateway).
+3. **Delegation** (Sub-Agent mode) collects tools where `isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == domain`, adds `specialized_workflow_finished`, wraps them for smolagents, and runs a bounded `ToolCallingAgent` loop in a **background thread** (`is_async()` on the gateway).
+4. **Delegation** (In-Place mode) sets the `active_specialized_domain` on the `ChatSession` and responds to the LLM to trigger a new cycle with the updated schema.
 
 ---
 
@@ -231,7 +246,7 @@ flowchart LR
 - Tool gathering:
   - `registry.get_tools(filter_doc_type=False, exclude_tiers=())` — **all** tiers, no doc filter (needed so specialized tools are discoverable server-side).
   - Filter to `ToolWriterSpecialBase` with matching `specialized_domain`, plus `specialized_workflow_finished`.
-- Uses `ToolCallingAgent` + `WriterAgentSmolModel` + shared chat config (`chat_max_tokens`, etc.), with optional `status_callback` / `append_thinking_callback` / `stop_checker` from `ToolContext`.
+- Depending on the `USE_SUB_AGENT` toggle, it either uses `ToolCallingAgent` + `WriterAgentSmolModel` to execute the task autonomously, or calls `ctx.set_active_domain_callback(domain)` to switch the context for the main model.
 
 ### 3.4 System prompt guidance
 

--- a/plugin/framework/tool_context.py
+++ b/plugin/framework/tool_context.py
@@ -44,6 +44,7 @@ class ToolContext:
         "stop_checker",
         "approval_callback",
         "chat_append_callback",
+        "set_active_domain_callback",
     )
 
     def __init__(
@@ -58,6 +59,7 @@ class ToolContext:
         stop_checker=None,
         approval_callback=None,
         chat_append_callback=None,
+        set_active_domain_callback=None,
     ):
         self.doc = doc
         self.ctx = ctx
@@ -69,3 +71,4 @@ class ToolContext:
         self.stop_checker = stop_checker
         self.approval_callback = approval_callback
         self.chat_append_callback = chat_append_callback
+        self.set_active_domain_callback = set_active_domain_callback

--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -197,19 +197,22 @@ class ToolRegistry:
         else:
             to_exclude = frozenset(exclude_tiers) if exclude_tiers else frozenset()
 
-        if to_exclude:
+        if active_domain:
+            # If an active domain is set, restrict the list ONLY to the specialized tools
+            # for that domain and the finish tool. Do not include normal core/extended tools.
             filtered_tools = []
             for t in tools:
-                tool_tier = getattr(t, "tier", None)
-                if tool_tier not in to_exclude:
+                if isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == active_domain:
                     filtered_tools.append(t)
-                elif active_domain:
-                    # If it's excluded but matches our active domain, include it
-                    if isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == active_domain:
-                        filtered_tools.append(t)
-                    elif getattr(t, "name", "") == "specialized_workflow_finished":
-                        filtered_tools.append(t)
+                elif getattr(t, "name", "") == "specialized_workflow_finished":
+                    filtered_tools.append(t)
             tools = filtered_tools
+        else:
+            if to_exclude:
+                tools = [
+                    t for t in tools
+                    if getattr(t, "tier", None) not in to_exclude
+                ]
 
         if tier:
             tools = [t for t in tools if t.tier == tier]

--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -204,7 +204,7 @@ class ToolRegistry:
             for t in tools:
                 if isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == active_domain:
                     filtered_tools.append(t)
-                elif getattr(t, "name", "") == "specialized_workflow_finished":
+                elif getattr(t, "name", "") == "final_answer":
                     filtered_tools.append(t)
             tools = filtered_tools
         else:

--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -139,6 +139,7 @@ class ToolRegistry:
         names=None,
         filter_doc_type=True,
         exclude_tiers=_UNSET_EXCLUDE_TIERS,
+        active_domain=None,
     ):
         """Return a list of ToolBase instances matching the given criteria.
 
@@ -152,6 +153,8 @@ class ToolRegistry:
             exclude_tiers: Tiers to omit from the result. If omitted, excludes
                 ``specialized`` and ``specialized_control`` so nested Writer tools
                 stay off the main tool list. Pass ``()`` or ``frozenset()`` to include all tiers.
+            active_domain: If provided, dynamically includes specialized tools for this domain
+                and the specialized_workflow_finished tool.
         """
         tools = self._tools.values()
 
@@ -185,15 +188,28 @@ class ToolRegistry:
 
         tools = [t for t in tools if supports_doc(t)]
 
+        # If we have an active domain, we want to include its tools (and the finish tool),
+        # even if they are in the excluded tiers.
+        from plugin.modules.writer.base import ToolWriterSpecialBase
+
         if exclude_tiers is _UNSET_EXCLUDE_TIERS:
             to_exclude = _DEFAULT_EXCLUDE_TIERS
         else:
             to_exclude = frozenset(exclude_tiers) if exclude_tiers else frozenset()
+
         if to_exclude:
-            tools = [
-                t for t in tools
-                if getattr(t, "tier", None) not in to_exclude
-            ]
+            filtered_tools = []
+            for t in tools:
+                tool_tier = getattr(t, "tier", None)
+                if tool_tier not in to_exclude:
+                    filtered_tools.append(t)
+                elif active_domain:
+                    # If it's excluded but matches our active domain, include it
+                    if isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == active_domain:
+                        filtered_tools.append(t)
+                    elif getattr(t, "name", "") == "specialized_workflow_finished":
+                        filtered_tools.append(t)
+            tools = filtered_tools
 
         if tier:
             tools = [t for t in tools if t.tier == tier]
@@ -203,14 +219,15 @@ class ToolRegistry:
             tools = [t for t in tools if t.name in names]
         return list(tools)
 
-    def get_schemas(self, protocol="openai", **kwargs):
+    def get_schemas(self, protocol="openai", active_domain=None, **kwargs):
         """Return schemas for tools matching the given kwargs criteria.
 
         Args:
             protocol: Either "openai" or "mcp".
+            active_domain: Optional active specialized domain.
             **kwargs: Filters passed to get_tools().
         """
-        tools = self.get_tools(**kwargs)
+        tools = self.get_tools(active_domain=active_domain, **kwargs)
         if protocol == "openai":
             return [to_openai_schema(t) for t in tools]
         elif protocol == "mcp":

--- a/plugin/modules/chatbot/panel.py
+++ b/plugin/modules/chatbot/panel.py
@@ -59,6 +59,8 @@ class ChatSession:
         self.db = None
         self.messages = []
         
+        self.active_specialized_domain = None
+
         if session_id:
             try:
                 self.db = get_chat_history(session_id)

--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -91,9 +91,16 @@ class ToolCallingMixin:
             self._terminal_status = "Error"
             return
 
+        # Callback for updating active domain in the session
+        def set_active_domain(domain):
+            if hasattr(self, "session") and self.session:
+                self.session.active_specialized_domain = domain
+                log.debug("_do_send: updated active specialized domain to: %s", domain)
+
         try:
             log.debug("_do_send: loading %s schema..." % doc_type_str)
-            active_tools = get_tools().get_schemas("openai", doc=model)
+            active_domain = getattr(self.session, "active_specialized_domain", None) if hasattr(self, "session") else None
+            active_tools = get_tools().get_schemas("openai", doc=model, active_domain=active_domain)
 
             def execute_fn(
                 name,
@@ -173,6 +180,7 @@ class ToolCallingMixin:
                     chat_append_callback=chat_append_callback
                     if name == "web_research"
                     else None,
+                    set_active_domain_callback=set_active_domain,
                 )
                 try:
                     res = _get_tools().execute(name, tctx, **args)

--- a/plugin/modules/writer/base.py
+++ b/plugin/modules/writer/base.py
@@ -87,20 +87,54 @@ class ToolWriterBookmarkBase(ToolWriterSpecialBase):
     uno_services = ["com.sun.star.text.TextDocument"]
 
 
-class SpecializedWorkflowFinished(ToolBase):
-    """Tool called by the sub-agent to indicate it has completed its task."""
+# class SpecializedWorkflowFinished(ToolBase):
+#     """Tool called by the sub-agent to indicate it has completed its task."""
+#
+#     name = "specialized_workflow_finished"
+#     description = "Call this tool when you have successfully completed the specialized task."
+#     parameters = {
+#         "type": "object",
+#         "properties": {
+#             "summary": {
+#                 "type": "string",
+#                 "description": "A brief summary of what you accomplished.",
+#             },
+#         },
+#         "required": ["summary"],
+#     }
+#     tier = "specialized_control"
+#
+#     def execute(self, ctx, **kwargs):
+#         # Allow the main LLM loop to exit specialized mode
+#         from plugin.modules.writer.specialized import USE_SUB_AGENT
+#         if not USE_SUB_AGENT:
+#             if getattr(ctx, "set_active_domain_callback", None):
+#                 ctx.set_active_domain_callback(None)
+#
+#         return {
+#             "status": "ok",
+#             "finished": True,
+#             "summary": kwargs.get("summary"),
+#             "message": "Specialized workflow finished. Normal toolset restored."
+#         }
 
-    name = "specialized_workflow_finished"
-    description = "Call this tool when you have successfully completed the specialized task."
+
+class SpecializedWorkflowFinalAnswer(ToolBase):
+    """Tool called by the main chat model to indicate it has completed its specialized task.
+    This mimics the built-in 'final_answer' tool of smolagents for the in-place switching approach.
+    """
+
+    name = "final_answer"
+    description = "Provides a final answer to the given task and exits the specialized toolset mode."
     parameters = {
         "type": "object",
         "properties": {
-            "summary": {
+            "answer": {
                 "type": "string",
-                "description": "A brief summary of what you accomplished.",
+                "description": "The final answer to the task.",
             },
         },
-        "required": ["summary"],
+        "required": ["answer"],
     }
     tier = "specialized_control"
 
@@ -114,6 +148,6 @@ class SpecializedWorkflowFinished(ToolBase):
         return {
             "status": "ok",
             "finished": True,
-            "summary": kwargs.get("summary"),
-            "message": "Specialized workflow finished. Normal toolset restored."
+            "answer": kwargs.get("answer"),
+            "message": "Specialized task complete. Normal toolset restored."
         }

--- a/plugin/modules/writer/base.py
+++ b/plugin/modules/writer/base.py
@@ -105,4 +105,15 @@ class SpecializedWorkflowFinished(ToolBase):
     tier = "specialized_control"
 
     def execute(self, ctx, **kwargs):
-        return {"status": "ok", "finished": True, "summary": kwargs.get("summary")}
+        # Allow the main LLM loop to exit specialized mode
+        from plugin.modules.writer.specialized import USE_SUB_AGENT
+        if not USE_SUB_AGENT:
+            if getattr(ctx, "set_active_domain_callback", None):
+                ctx.set_active_domain_callback(None)
+
+        return {
+            "status": "ok",
+            "finished": True,
+            "summary": kwargs.get("summary"),
+            "message": "Specialized workflow finished. Normal toolset restored."
+        }

--- a/plugin/modules/writer/specialized.py
+++ b/plugin/modules/writer/specialized.py
@@ -106,7 +106,7 @@ class DelegateToSpecializedWriter(ToolBase):
 
             from plugin.framework.i18n import _
             msg = _("Tool call switched to '{0}'. You are in a specialized toolset mode. "
-                    "You must call 'specialized_workflow_finished' when done to restore "
+                    "You must call 'final_answer' when done to restore "
                     "the full set of APIs.").format(domain)
 
             if status_callback:
@@ -135,8 +135,8 @@ class DelegateToSpecializedWriter(ToolBase):
                 # Check if it's a subclass of our special base and matches the domain
                 if isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == domain:
                     domain_tools.append(t)
-                elif getattr(t, "name", "") == "specialized_workflow_finished":
-                    domain_tools.append(t)
+                # Note: We do NOT append our custom 'final_answer' tool here because
+                # smolagents provides its own 'final_answer' tool natively.
 
             if not domain_tools:
                 return self._tool_error(
@@ -190,9 +190,7 @@ class DelegateToSpecializedWriter(ToolBase):
             instructions = (
                 f"You are a specialized Writer agent focused on the '{domain}' domain. "
                 f"You have a focused set of tools to accomplish your task. "
-                f"Use them to fulfill the user's request. When you are finished, "
-                f"you MUST call the 'specialized_workflow_finished' tool with a summary. "
-                f"Do not attempt to provide a final answer directly until you have called this tool."
+                f"Use them to fulfill the user's request."
             )
 
             agent = ToolCallingAgent(

--- a/plugin/modules/writer/specialized.py
+++ b/plugin/modules/writer/specialized.py
@@ -24,6 +24,10 @@ from plugin.modules.writer.base import ToolWriterSpecialBase
 log = logging.getLogger("writeragent.writer")
 
 
+# Global variable to toggle between the sub-agent approach (True) and the
+# in-place tool-switching approach (False).
+USE_SUB_AGENT = True
+
 # Available domains matching the specialized_domain attributes of subclasses
 _AVAILABLE_DOMAINS = [
     "tables",
@@ -94,6 +98,24 @@ class DelegateToSpecializedWriter(ToolBase):
         status_callback = getattr(ctx, "status_callback", None)
         append_thinking_callback = getattr(ctx, "append_thinking_callback", None)
         stop_checker = getattr(ctx, "stop_checker", None)
+
+        if not USE_SUB_AGENT:
+            # Tell the main LLM loop to switch tools for the next round
+            if getattr(ctx, "set_active_domain_callback", None):
+                ctx.set_active_domain_callback(domain)
+
+            from plugin.framework.i18n import _
+            msg = _("Tool call switched to '{0}'. You are in a specialized toolset mode. "
+                    "You must call 'specialized_workflow_finished' when done to restore "
+                    "the full set of APIs.").format(domain)
+
+            if status_callback:
+                status_callback(f"Switched to '{domain}' tools.")
+
+            return {
+                "status": "ok",
+                "message": msg,
+            }
 
         if status_callback:
             status_callback(f"Delegating to specialized agent ({domain})...")

--- a/plugin/tests/test_specialized_delegation.py
+++ b/plugin/tests/test_specialized_delegation.py
@@ -1,0 +1,159 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import sys
+
+# Mock uno and dependencies for headless testing
+class MockBase: pass
+sys.modules['uno'] = MagicMock()
+sys.modules['unohelper'] = MagicMock()
+sys.modules['unohelper'].Base = MockBase
+sys.modules['com.sun.star.text'] = MagicMock()
+sys.modules['com.sun.star.awt'] = MagicMock()
+
+from plugin.framework.tool_registry import ToolRegistry
+from plugin.framework.tool_context import ToolContext
+from plugin.modules.writer.base import ToolWriterSpecialBase, SpecializedWorkflowFinalAnswer
+from plugin.modules.writer.specialized import DelegateToSpecializedWriter
+
+
+class DummyTableTool(ToolWriterSpecialBase):
+    name = "dummy_table_tool"
+    description = "A dummy table tool."
+    parameters = None
+    specialized_domain = "tables"
+
+    def execute(self, ctx, **kwargs):
+        return {"status": "ok", "message": "Table created"}
+
+
+@pytest.fixture
+def registry():
+    r = ToolRegistry(services={})
+    r.register(DummyTableTool())
+    r.register(SpecializedWorkflowFinalAnswer())
+    r.register(DelegateToSpecializedWriter())
+    return r
+
+
+@pytest.fixture
+def mock_ctx(registry):
+    ctx = MagicMock()
+    ctx.services = {"tools": registry}
+    ctx.ctx = MagicMock()
+    return ctx
+
+
+def test_specialized_delegation_in_place_mode(registry, mock_ctx):
+    # Enable in-place switching mode
+    import plugin.modules.writer.specialized
+    plugin.modules.writer.specialized.USE_SUB_AGENT = False
+
+    active_domain = None
+
+    def mock_set_active_domain(domain):
+        nonlocal active_domain
+        active_domain = domain
+
+    mock_ctx.set_active_domain_callback = mock_set_active_domain
+
+    gateway_tool = registry.get("delegate_to_specialized_writer_toolset")
+
+    # Make sure stop_checker returns False so it doesn't abort immediately
+    mock_ctx.stop_checker = lambda: False
+
+    # Execute the gateway tool
+    result = gateway_tool.execute_safe(
+        mock_ctx,
+        domain="tables",
+        task="Create a 3x3 table"
+    )
+
+    # Verify callback was called
+    assert active_domain == "tables"
+    assert result["status"] == "ok"
+    assert "Tool call switched to 'tables'" in result["message"]
+
+    # Now simulate the next LLM turn using the active domain
+    schemas = registry.get_schemas("openai", active_domain=active_domain)
+
+    # It should only include the specialized domain tools and final_answer
+    tool_names = [s["function"]["name"] for s in schemas]
+    assert "dummy_table_tool" in tool_names
+    assert "final_answer" in tool_names
+    assert "delegate_to_specialized_writer_toolset" not in tool_names
+
+    # Now execute final_answer to finish
+    finish_tool = registry.get("final_answer")
+    finish_result = finish_tool.execute_safe(mock_ctx, answer="Done")
+
+    # Verify callback was called to clear the domain
+    assert active_domain is None
+    assert finish_result["status"] == "ok"
+    assert finish_result["answer"] == "Done"
+
+
+from plugin.contrib.smolagents.memory import ActionStep, FinalAnswerStep, ToolCall
+
+@patch("plugin.modules.writer.specialized.get_api_config", create=True)
+@patch("plugin.contrib.smolagents.agents.ToolCallingAgent")
+@patch("plugin.framework.smol_model.WriterAgentSmolModel")
+@patch("plugin.modules.http.client.LlmClient")
+def test_specialized_delegation_sub_agent_mode(
+    mock_llm, mock_smol_model, mock_agent_class, mock_get_config, registry, mock_ctx
+):
+    # Enable sub-agent mode
+    import plugin.modules.writer.specialized
+    plugin.modules.writer.specialized.USE_SUB_AGENT = True
+
+    mock_ctx.ctx = MagicMock()
+    mock_get_config.return_value = {"chat_max_tokens": 2048}
+
+    active_domain = "initial_value"
+
+    def mock_set_active_domain(domain):
+        nonlocal active_domain
+        active_domain = domain
+
+    mock_ctx.set_active_domain_callback = mock_set_active_domain
+
+    # Setup the mocked smolagents agent to yield a FinalAnswerStep
+    mock_agent_instance = MagicMock()
+
+    from plugin.contrib.smolagents.memory import FinalAnswerStep
+    dummy_final_step = FinalAnswerStep(output="Mocked agent summary")
+    mock_agent_instance.run.return_value = [dummy_final_step]
+
+    mock_agent_class.return_value = mock_agent_instance
+
+    gateway_tool = registry.get("delegate_to_specialized_writer_toolset")
+
+    mock_ctx.stop_checker = lambda: False
+
+    # Execute the gateway tool
+    result = gateway_tool.execute_safe(
+        mock_ctx,
+        domain="tables",
+        task="Create a 3x3 table"
+    )
+
+    # Verify callback was NOT called (it remains initial_value)
+    assert active_domain == "initial_value"
+
+    # Output the result for debugging if it fails
+    if result["status"] != "ok":
+        print(result)
+
+    # Verify smolagents was executed and returned the summary
+    assert result["status"] == "ok"
+    assert "completed" in result["message"]
+    assert result["result"] == "Mocked agent summary"
+
+    # Verify the tools passed to the sub-agent
+    call_args = mock_agent_class.call_args
+    assert call_args is not None
+    smol_tools = call_args.kwargs.get("tools", [])
+
+    # The sub-agent should only receive dummy_table_tool, NOT final_answer
+    smol_tool_names = [t.name for t in smol_tools]
+    assert "dummy_table_tool" in smol_tool_names
+    assert "final_answer" not in smol_tool_names


### PR DESCRIPTION
Adds an alternative implementation for `delegate_to_specialized_writer_toolset` that avoids spawning a background sub-agent. Instead, the gateway tool sets `active_specialized_domain` on the `ChatSession` (via a callback passed to `ToolContext`), and dynamically injects the specialized tools into the next main LLM completion cycle via `ToolRegistry.get_schemas`.

- Adds `USE_SUB_AGENT` global toggle to `specialized.py` to allow easy experimentation between both implementations.
- Extends `ToolRegistry.get_tools` and `get_schemas` to accept `active_domain` to cleanly bypass tier exclusions.
- Updates documentation in `docs/writer-specialized-toolsets.md` to detail both paradigms.

---
*PR created automatically by Jules for task [11832095028239928192](https://jules.google.com/task/11832095028239928192) started by @KeithCu*