### PR TITLE
Expand specialized toolset for text fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ Paragraph tools in [`content.py`](plugin/modules/writer/content.py) are **`ToolB
 
 **Testing specialized tools**: Tests should retrieve tools via `plugin.main.get_tools().get("tool_name")` rather than direct internal imports. This avoids regressions when tools are moved between specialized modules and allows bypassing tier-based filtering.
 
+**Writer Fields Specialized Tools**: Text fields in LibreOffice are implemented using `doc.createInstance("com.sun.star.text.textfield.<TYPE>")` (like `PageNumber`, `DateTime`). See `plugin/modules/writer/fields.py` for tools to insert, list, and delete fields natively using property reflection.
+
 **Tool Compatibility**: `ToolRegistry` prioritizes `uno_services` matches (strict), but falls back to `doc_types` if no service match is found. This ensures tools remain accessible in test environments or across slightly different LibreOffice flavors.
 
 **Shared tool names (Writer vs Calc/Draw)**: [`plugin/modules/writer/charts.py`](plugin/modules/writer/charts.py) and [`plugin/modules/writer/shapes.py`](plugin/modules/writer/shapes.py) register the same `name` as Calc/Draw tools; the last class registered wins. Those Writer subclasses must list a **union** of every document `uno_services` the inherited `execute()` supports (e.g. Text + Spreadsheet for chart tools, Text + Drawing + Presentation for shape tools), or `ToolRegistry.execute` will reject Calc/Draw documents.

--- a/plugin/modules/writer/fields.py
+++ b/plugin/modules/writer/fields.py
@@ -61,27 +61,202 @@ class UpdateFieldsAlias(ToolWriterFieldBase):
         return {"status": "ok", "fields_refreshed": count}
 
 
+class FieldsList(ToolWriterFieldBase):
+    name = "fields_list"
+    intent = "examine"
+    description = (
+        "List all text fields in the document. Returns their types and text content, "
+        "allowing you to identify and inspect fields like page numbers or dates."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+
+    def execute(self, ctx, **kwargs):
+        doc = ctx.doc
+        if not hasattr(doc, "getTextFields"):
+            return self._tool_error("Document does not support text fields.")
+
+        fields = doc.getTextFields()
+        enum = fields.createEnumeration()
+
+        results = []
+        count = 0
+        while enum.hasMoreElements():
+            field = enum.nextElement()
+            count += 1
+
+            # Use getPresentation to get human-readable info
+            try:
+                presentation = field.getPresentation(False)
+            except Exception:
+                presentation = str(field)
+
+            try:
+                content = field.getPresentation(True)
+            except Exception:
+                content = ""
+
+            # Try to get the specific field type by checking supported services
+            # since we know fields start with com.sun.star.text.textfield.
+            # However, LibreOffice API does not have an easy introspection for this.
+            # Getting the PropertySetInfo is the best way to extract properties.
+            props = {}
+            if hasattr(field, "getPropertySetInfo"):
+                try:
+                    for prop in field.getPropertySetInfo().getProperties():
+                        try:
+                            # Avoid extracting complex types
+                            val = field.getPropertyValue(prop.Name)
+                            if isinstance(val, (int, float, str, bool)):
+                                props[prop.Name] = val
+                        except Exception:
+                            pass
+                except Exception:
+                    pass
+
+            results.append({
+                "id": count,
+                "presentation": presentation,
+                "content": content,
+                "properties": props
+            })
+
+        return {
+            "status": "ok",
+            "field_count": count,
+            "fields": results
+        }
+
+
+class FieldsDelete(ToolWriterFieldBase):
+    name = "fields_delete"
+    intent = "edit"
+    description = (
+        "Deletes one or more text fields from the document by their 1-based ID. "
+        "Use fields_list first to obtain the IDs of the fields you wish to remove."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "ids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "A list of 1-based IDs representing the text fields to delete.",
+            },
+        },
+        "required": ["ids"],
+    }
+    is_mutation = True
+
+    def execute(self, ctx, ids, **kwargs):
+        doc = ctx.doc
+        if not hasattr(doc, "getTextFields"):
+            return self._tool_error("Document does not support text fields.")
+
+        fields = doc.getTextFields()
+        enum = fields.createEnumeration()
+
+        fields_to_delete = []
+        count = 0
+        while enum.hasMoreElements():
+            field = enum.nextElement()
+            count += 1
+            if count in ids:
+                fields_to_delete.append(field)
+
+        if not fields_to_delete:
+            return {"status": "ok", "deleted_count": 0, "message": "No matching fields found to delete."}
+
+        deleted_count = 0
+        for field in fields_to_delete:
+            try:
+                # Text fields can be deleted by removing their anchor content
+                anchor = field.getAnchor()
+                anchor.setString("")
+                deleted_count += 1
+            except Exception as e:
+                return self._tool_error(f"Failed to delete field: {str(e)}")
+
+        return {
+            "status": "ok",
+            "message": f"Successfully deleted {deleted_count} field(s).",
+            "deleted_count": deleted_count
+        }
+
+
 class FieldsInsert(ToolWriterFieldBase):
     name = "fields_insert"
     intent = "edit"
     description = (
-        "Insert a text field (page number, date, cross-ref). "
-        "Reserved for future UNO implementation (masters + dependent fields)."
+        "Insert a text field at the current cursor position. Supports various "
+        "field types natively provided by LibreOffice. Common field types include: "
+        "'PageNumber', 'PageCount', 'DateTime', 'Author', 'FileName', 'WordCount', "
+        "'CharacterCount', 'ParagraphCount', 'TableCount', 'GraphicObjectCount', "
+        "'EmbeddedObjectCount', and 'Annotation'. Specify optional properties "
+        "to configure the field, such as 'NumberingType' (e.g., 4 for Arabic numerals) "
+        "or 'IsDate' (true/false) for DateTime fields."
     )
     parameters = {
         "type": "object",
         "properties": {
             "field_type": {
                 "type": "string",
-                "description": "Intended field kind (e.g. page, date, cross_ref).",
+                "description": (
+                    "The exact name of the text field service to create, excluding the "
+                    "'com.sun.star.text.textfield.' prefix. Examples: 'PageNumber', "
+                    "'PageCount', 'DateTime', 'Author', 'FileName', 'WordCount'."
+                ),
+            },
+            "properties": {
+                "type": "object",
+                "description": (
+                    "Optional dictionary of UNO properties to apply to the field. "
+                    "Example: {'NumberingType': 4} for Arabic numbering, or "
+                    "{'IsDate': true} to force a date display on a DateTime field."
+                ),
+                "default": {},
             },
         },
-        "required": [],
+        "required": ["field_type"],
     }
     is_mutation = True
 
-    def execute(self, ctx, **kwargs):
-        return self._tool_error(
-            "fields_insert is not implemented yet. Insert fields via LibreOffice "
-            "Insert > Field, then call fields_update_all."
-        )
+    def execute(self, ctx, field_type, properties=None, **kwargs):
+        doc = ctx.doc
+        if not hasattr(doc, "createInstance"):
+            return self._tool_error("Document does not support creating instances.")
+
+        properties = properties or {}
+        full_service_name = f"com.sun.star.text.textfield.{field_type}"
+
+        try:
+            field = doc.createInstance(full_service_name)
+            if not field:
+                return self._tool_error(f"Failed to create field of type '{field_type}'.")
+        except Exception as e:
+            return self._tool_error(f"Error creating field '{field_type}': {str(e)}")
+
+        # Apply properties
+        for key, value in properties.items():
+            try:
+                field.setPropertyValue(key, value)
+            except Exception as e:
+                return self._tool_error(f"Failed to set property '{key}' to '{value}': {str(e)}")
+
+        # Insert at current view cursor
+        try:
+            controller = doc.getCurrentController()
+            view_cursor = controller.getViewCursor()
+            text = view_cursor.getText()
+            text.insertTextContent(view_cursor, field, False)
+        except Exception as e:
+            return self._tool_error(f"Failed to insert field into document: {str(e)}")
+
+        return {
+            "status": "ok",
+            "message": f"Successfully inserted {field_type} field.",
+            "applied_properties": properties
+        }

--- a/plugin/tests/test_writer_fields.py
+++ b/plugin/tests/test_writer_fields.py
@@ -1,0 +1,126 @@
+import pytest
+import sys
+from unittest.mock import MagicMock
+
+# Ensure UNO is mocked if running outside LibreOffice
+try:
+    import uno
+except ImportError:
+    sys.modules["uno"] = MagicMock()
+    sys.modules["unohelper"] = MagicMock()
+    com_mock = MagicMock()
+    sys.modules["com"] = com_mock
+    sys.modules["com.sun.star.text"] = MagicMock()
+
+from plugin.modules.writer.fields import FieldsInsert, FieldsList, FieldsDelete
+
+
+@pytest.fixture
+def mock_ctx():
+    # Provide an ad-hoc ToolContext-like object
+    class DummyContext:
+        def __init__(self):
+            self.doc = MagicMock()
+            self.doc_type = "writer"
+    return DummyContext()
+
+
+def test_fields_list_empty(mock_ctx):
+    # Setup mock document
+    doc = mock_ctx.doc
+    mock_fields = MagicMock()
+    mock_enum = MagicMock()
+    mock_enum.hasMoreElements.return_value = False
+    mock_fields.createEnumeration.return_value = mock_enum
+    doc.getTextFields.return_value = mock_fields
+
+    tool = FieldsList()
+    res = tool.execute(mock_ctx)
+    assert res["status"] == "ok"
+    assert res["field_count"] == 0
+    assert len(res["fields"]) == 0
+
+
+def test_fields_list_with_items(mock_ctx):
+    doc = mock_ctx.doc
+    mock_fields = MagicMock()
+    mock_enum = MagicMock()
+
+    # Mock field object
+    mock_field = MagicMock()
+    mock_field.getPresentation.side_effect = ["Page 1", "1"]
+
+    # Setup a mock property set info for properties extraction
+    mock_prop_set_info = MagicMock()
+    mock_prop = MagicMock()
+    mock_prop.Name = "NumberingType"
+    mock_prop_set_info.getProperties.return_value = [mock_prop]
+    mock_field.getPropertySetInfo.return_value = mock_prop_set_info
+    mock_field.getPropertyValue.return_value = 4
+
+    mock_enum.hasMoreElements.side_effect = [True, False]
+    mock_enum.nextElement.return_value = mock_field
+    mock_fields.createEnumeration.return_value = mock_enum
+    doc.getTextFields.return_value = mock_fields
+
+    tool = FieldsList()
+    res = tool.execute(mock_ctx)
+    assert res["status"] == "ok"
+    assert res["field_count"] == 1
+    assert res["fields"][0]["presentation"] == "Page 1"
+    assert res["fields"][0]["content"] == "1"
+    assert res["fields"][0]["properties"]["NumberingType"] == 4
+
+
+def test_fields_insert(mock_ctx):
+    doc = mock_ctx.doc
+
+    # Setup mock document controller and view cursor
+    mock_controller = MagicMock()
+    mock_view_cursor = MagicMock()
+    mock_text = MagicMock()
+
+    doc.getCurrentController.return_value = mock_controller
+    mock_controller.getViewCursor.return_value = mock_view_cursor
+    mock_view_cursor.getText.return_value = mock_text
+
+    # Setup mock field instance
+    mock_field = MagicMock()
+    doc.createInstance.return_value = mock_field
+
+    tool = FieldsInsert()
+    props = {"NumberingType": 4, "IsDate": True}
+    res = tool.execute(mock_ctx, field_type="PageNumber", properties=props)
+
+    assert res["status"] == "ok"
+    doc.createInstance.assert_called_with("com.sun.star.text.textfield.PageNumber")
+    assert mock_field.setPropertyValue.call_count == 2
+    mock_text.insertTextContent.assert_called_with(mock_view_cursor, mock_field, False)
+
+
+def test_fields_delete(mock_ctx):
+    doc = mock_ctx.doc
+    mock_fields = MagicMock()
+    mock_enum = MagicMock()
+
+    # Mock field objects
+    mock_field_1 = MagicMock()
+    mock_field_2 = MagicMock()
+    mock_anchor_1 = MagicMock()
+    mock_anchor_2 = MagicMock()
+    mock_field_1.getAnchor.return_value = mock_anchor_1
+    mock_field_2.getAnchor.return_value = mock_anchor_2
+
+    mock_enum.hasMoreElements.side_effect = [True, True, False]
+    mock_enum.nextElement.side_effect = [mock_field_1, mock_field_2]
+    mock_fields.createEnumeration.return_value = mock_enum
+    doc.getTextFields.return_value = mock_fields
+
+    tool = FieldsDelete()
+    # Delete only the second field (ID 2)
+    res = tool.execute(mock_ctx, ids=[2])
+
+    assert res["status"] == "ok"
+    assert res["deleted_count"] == 1
+    mock_anchor_1.setString.assert_not_called()
+    mock_anchor_2.setString.assert_called_with("")


### PR DESCRIPTION
Expand specialized toolset for text fields to allow full CRUD capability for the agent natively leveraging LibreOffice API capabilities via property reflection.

---
*PR created automatically by Jules for task [13582959153848093045](https://jules.google.com/task/13582959153848093045) started by @KeithCu*