### PR TITLE
feat: implement create and add mark tools for Writer indexes

### DIFF
--- a/plugin/modules/writer/indexes.py
+++ b/plugin/modules/writer/indexes.py
@@ -60,39 +60,120 @@ class RefreshIndexesAlias(ToolWriterIndexBase):
         return {"status": "ok", "refreshed": refreshed, "count": count}
 
 
+class IndexesList(ToolWriterIndexBase):
+    name = "indexes_list"
+    intent = "navigate"
+    description = "List all document indexes (table of contents, alphabetical index, bibliography, etc.)."
+    parameters = {"type": "object", "properties": {}, "required": []}
+    is_mutation = False
+
+    def execute(self, ctx, **kwargs):
+        doc = ctx.doc
+        if not hasattr(doc, "getDocumentIndexes"):
+            return self._tool_error("Document does not support indexes")
+        indexes = doc.getDocumentIndexes()
+        count = indexes.getCount()
+        result = []
+        for i in range(count):
+            idx = indexes.getByIndex(i)
+            name = idx.getName() if hasattr(idx, "getName") else f"index_{i}"
+            title = idx.Title if hasattr(idx, "Title") else ""
+            # service name is useful for knowing the type
+            type_name = "unknown"
+            if hasattr(idx, "getImplementationName"):
+                type_name = idx.getImplementationName()
+                if type_name == "SwXDocumentIndex":
+                    type_name = "alphabetical"
+                elif type_name == "SwXContentIndex":
+                    type_name = "toc"
+                elif type_name == "SwXUserIndex":
+                    type_name = "user"
+            result.append({
+                "index": i,
+                "name": name,
+                "title": title,
+                "type": type_name
+            })
+        return {"status": "ok", "indexes": result, "count": count}
+
+
 class IndexesCreate(ToolWriterIndexBase):
     name = "indexes_create"
     intent = "edit"
     description = (
-        "Create a new document index (e.g. TOC). Full UNO setup is model-specific; "
-        "prefer inserting the index via LibreOffice (Insert > Table of Contents) "
-        "then call indexes_update_all."
+        "Create a new document index (e.g. toc, alphabetical, user, illustration, table, object, bibliography) "
+        "at the current selection/cursor."
     )
     parameters = {
         "type": "object",
         "properties": {
             "index_kind": {
                 "type": "string",
-                "description": "Intended index type label (e.g. toc, bibliography).",
+                "enum": ["toc", "alphabetical", "user", "illustration", "table", "object", "bibliography"],
+                "description": "The type of index to create.",
             },
+            "title": {
+                "type": "string",
+                "description": "The title for the index (e.g., 'Table of Contents').",
+            },
+            "create_from_outline": {
+                "type": "boolean",
+                "description": "Whether to create the index from the document outline (mainly for toc). Default true.",
+            }
         },
-        "required": [],
+        "required": ["index_kind"],
     }
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
-        return self._tool_error(
-            "indexes_create is not automated in WriterAgent yet. "
-            "Insert the index in LibreOffice, then use indexes_update_all."
-        )
+        doc = ctx.doc
+        index_kind = kwargs.get("index_kind", "toc")
+        title = kwargs.get("title")
+        create_from_outline = kwargs.get("create_from_outline", True)
+
+        try:
+            # Map simplified names to UNO services
+            service_map = {
+                "toc": "com.sun.star.text.ContentIndex",
+                "alphabetical": "com.sun.star.text.DocumentIndex",
+                "user": "com.sun.star.text.UserIndex",
+                "illustration": "com.sun.star.text.IllustrationsIndex",
+                "table": "com.sun.star.text.TableIndex",
+                "object": "com.sun.star.text.ObjectIndex",
+                "bibliography": "com.sun.star.text.Bibliography"
+            }
+            service_name = service_map.get(index_kind, "com.sun.star.text.ContentIndex")
+
+            index = doc.createInstance(service_name)
+            if title is not None and hasattr(index, "Title"):
+                index.Title = title
+
+            if index_kind == "toc" and hasattr(index, "CreateFromOutline"):
+                index.CreateFromOutline = create_from_outline
+
+            cursor = ctx.get_cursor()
+            if not cursor:
+                return self._tool_error("No current selection or cursor position to insert index.")
+
+            text = cursor.getText()
+            text.insertTextContent(cursor, index, False)
+            index.update()
+
+            return {
+                "status": "ok",
+                "message": f"Created '{index_kind}' index successfully",
+                "title": title
+            }
+        except Exception as e:
+            return self._tool_error(f"Failed to create index: {str(e)}")
 
 
 class IndexesAddMark(ToolWriterIndexBase):
     name = "indexes_add_mark"
     intent = "edit"
     description = (
-        "Add an index mark (e.g. TOC entry) at the current selection. "
-        "Reserved for future UNO wiring."
+        "Add an index mark (e.g. alphabetical index entry) at the current selection. "
+        "Can specify primary/secondary keys for alphabetical indexes."
     )
     parameters = {
         "type": "object",
@@ -101,13 +182,66 @@ class IndexesAddMark(ToolWriterIndexBase):
                 "type": "string",
                 "description": "Visible text or entry key for the mark.",
             },
+            "index_kind": {
+                "type": "string",
+                "enum": ["alphabetical", "user"],
+                "description": "The type of index mark to create (default 'alphabetical').",
+            },
+            "primary_key": {
+                "type": "string",
+                "description": "The primary key for an alphabetical index entry (optional).",
+            },
+            "secondary_key": {
+                "type": "string",
+                "description": "The secondary key for an alphabetical index entry (optional).",
+            }
         },
-        "required": [],
+        "required": ["mark_text"],
     }
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
-        return self._tool_error(
-            "indexes_add_mark is not implemented yet. "
-            "Use Writer menus to insert index marks."
-        )
+        doc = ctx.doc
+        mark_text = kwargs.get("mark_text")
+        index_kind = kwargs.get("index_kind", "alphabetical")
+        primary_key = kwargs.get("primary_key")
+        secondary_key = kwargs.get("secondary_key")
+
+        # FIXME: Currently applies to the current selection. Review supporting explicit document locations in the future.
+        cursor = ctx.get_cursor()
+        if not cursor:
+            return self._tool_error("No current selection to add index mark.")
+
+        try:
+            service_name = "com.sun.star.text.DocumentIndexMark"
+            if index_kind == "user":
+                service_name = "com.sun.star.text.UserIndexMark"
+
+            mark = doc.createInstance(service_name)
+
+            if hasattr(mark, "MarkEntry"):
+                mark.MarkEntry = mark_text
+            elif hasattr(mark, "PrimaryKey") and hasattr(mark, "SecondaryKey"):
+                pass # DocumentIndexMark handles these via properties
+
+            if index_kind == "alphabetical":
+                if hasattr(mark, "PrimaryKey") and primary_key is not None:
+                    mark.PrimaryKey = primary_key
+                if hasattr(mark, "SecondaryKey") and secondary_key is not None:
+                    mark.SecondaryKey = secondary_key
+                # SwXDocumentIndexMark uses these
+                try:
+                    mark.setPropertyValue("PrimaryKey", primary_key or "")
+                    mark.setPropertyValue("SecondaryKey", secondary_key or "")
+                except Exception:
+                    pass
+
+            text = cursor.getText()
+            text.insertTextContent(cursor, mark, False)
+
+            return {
+                "status": "ok",
+                "message": f"Added '{index_kind}' index mark for '{mark_text}'"
+            }
+        except Exception as e:
+            return self._tool_error(f"Failed to add index mark: {str(e)}")

--- a/plugin/tests/test_writer_indexes.py
+++ b/plugin/tests/test_writer_indexes.py
@@ -1,0 +1,85 @@
+import sys
+from unittest.mock import MagicMock
+
+class MockBase: pass
+sys.modules['uno'] = MagicMock()
+sys.modules['unohelper'] = MagicMock()
+sys.modules['unohelper.Base'] = MockBase
+sys.modules['com.sun.star.text'] = MagicMock()
+
+import pytest
+from plugin.modules.writer.indexes import IndexesList, IndexesCreate, IndexesAddMark
+
+def test_indexes_list():
+    tool = IndexesList()
+    ctx = MagicMock()
+    doc = ctx.doc
+    indexes_mock = MagicMock()
+    doc.getDocumentIndexes.return_value = indexes_mock
+    indexes_mock.getCount.return_value = 2
+
+    idx1 = MagicMock()
+    idx1.getName.return_value = "Index1"
+    idx1.Title = "Title1"
+    idx1.getImplementationName.return_value = "SwXContentIndex"
+
+    idx2 = MagicMock()
+    idx2.getName.return_value = "Index2"
+    idx2.Title = "Title2"
+    idx2.getImplementationName.return_value = "SwXDocumentIndex"
+
+    indexes_mock.getByIndex.side_effect = [idx1, idx2]
+
+    res = tool.execute(ctx)
+    assert res["status"] == "ok"
+    assert res["count"] == 2
+    assert len(res["indexes"]) == 2
+    assert res["indexes"][0]["name"] == "Index1"
+    assert res["indexes"][0]["title"] == "Title1"
+    assert res["indexes"][0]["type"] == "toc"
+    assert res["indexes"][1]["name"] == "Index2"
+    assert res["indexes"][1]["title"] == "Title2"
+    assert res["indexes"][1]["type"] == "alphabetical"
+
+def test_indexes_create():
+    tool = IndexesCreate()
+    ctx = MagicMock()
+    doc = ctx.doc
+    cursor_mock = MagicMock()
+    ctx.get_cursor.return_value = cursor_mock
+
+    index_mock = MagicMock()
+    doc.createInstance.return_value = index_mock
+
+    res = tool.execute(ctx, index_kind="toc", title="My TOC", create_from_outline=True)
+    assert res["status"] == "ok"
+    assert res["title"] == "My TOC"
+
+    doc.createInstance.assert_called_with("com.sun.star.text.ContentIndex")
+    assert index_mock.Title == "My TOC"
+    assert index_mock.CreateFromOutline == True
+
+    text_mock = cursor_mock.getText()
+    text_mock.insertTextContent.assert_called_with(cursor_mock, index_mock, False)
+    index_mock.update.assert_called()
+
+def test_indexes_add_mark():
+    tool = IndexesAddMark()
+    ctx = MagicMock()
+    doc = ctx.doc
+    cursor_mock = MagicMock()
+    ctx.get_cursor.return_value = cursor_mock
+
+    mark_mock = MagicMock()
+    doc.createInstance.return_value = mark_mock
+
+    res = tool.execute(ctx, mark_text="Important Term", index_kind="alphabetical", primary_key="Terms")
+    assert res["status"] == "ok"
+    assert res["message"] == "Added 'alphabetical' index mark for 'Important Term'"
+
+    doc.createInstance.assert_called_with("com.sun.star.text.DocumentIndexMark")
+    assert mark_mock.MarkEntry == "Important Term"
+    assert mark_mock.PrimaryKey == "Terms"
+
+    text_mock = cursor_mock.getText()
+    text_mock.insertTextContent.assert_called_with(cursor_mock, mark_mock, False)


### PR DESCRIPTION
Improved the specialized Writer toolset for managing document indexes. The stubbed tools `IndexesCreate` and `IndexesAddMark` have been fully implemented using LibreOffice UNO APIs (`com.sun.star.text.ContentIndex`, `com.sun.star.text.DocumentIndex`, etc.). A new tool `IndexesList` has also been added to allow listing all existing indexes and their types. Proper error handling and unit tests with mocked UNO context have been added.

---
*PR created automatically by Jules for task [11695577674709730220](https://jules.google.com/task/11695577674709730220) started by @KeithCu*