### PR TITLE
Surface detailed errors for upsert_memory tool

### DIFF
--- a/plugin/locales/writeragent.pot
+++ b/plugin/locales/writeragent.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-26 15:19-0400\n"
+"POT-Creation-Date: 2026-03-26 22:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,12 +35,10 @@ msgid "Register at "
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:617
-#, python-brace-format
 msgid "You have {} kudos"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:625
-#, python-brace-format
 msgid "«{}» is not a valid API KEY, double check it or create a new one"
 msgstr ""
 
@@ -68,7 +66,6 @@ msgid ""
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:662
-#, python-brace-format
 msgid ""
 "Seems that «{}» has problems, double check it, create a new one or join "
 "Discord to ask for help"
@@ -93,6 +90,13 @@ msgstr ""
 #: plugin/contrib/aihordeclient/__init__.py:821
 msgid ""
 "When trying to ask for the image, the Horde was too slow, try again later"
+msgstr ""
+
+#: plugin/contrib/aihordeclient/__init__.py:836
+#, python-brace-format
+msgid ""
+"Register at {REGISTER_AI_HORDE_URL} and use your key to improve your rate "
+"success. Detail:"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:843
@@ -139,7 +143,6 @@ msgid "Please try another model,"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:971
-#, python-brace-format
 msgid "{} would take more time than you configured,"
 msgstr ""
 
@@ -166,7 +169,6 @@ msgid "Please try again later."
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:1016
-#, python-brace-format
 msgid "Probably your image will take {} additional minutes."
 msgstr ""
 
@@ -201,266 +203,76 @@ msgstr ""
 msgid " with "
 msgstr ""
 
-#: plugin/framework/dialogs.py:107
-msgid "Agent requests approval"
+#: plugin/main.py:212 plugin/modules/chatbot/panel.py:736
+#: plugin/modules/chatbot/send_handlers.py:300
+#: plugin/modules/chatbot/send_handlers.py:310
+#: plugin/modules/chatbot/send_handlers.py:319
+#: plugin/framework/legacy_ui.py:346
+msgid "Error"
 msgstr ""
 
-#: plugin/framework/dialogs.py:108
-msgid "Proceed with this action?"
+#: plugin/main.py:212
+msgid "{error_msg}: {str(e)}"
 msgstr ""
 
-#: plugin/framework/dialogs.py:109
-#: plugin/modules/chatbot/web_research_chat.py:33
-#: plugin/modules/chatbot/web_research_chat.py:38
-#, python-format
-msgid "Tool: %s"
-msgstr ""
-
-#: plugin/framework/dialogs.py:155
-msgid "Edit search query"
-msgstr ""
-
-#: plugin/framework/dialogs.py:160
-msgid "Search query:"
-msgstr ""
-
-#: plugin/framework/dialogs.py:168 plugin/framework/dialogs.py:341
-#: plugin/framework/dialogs.py:413 plugin/framework/dialogs.py:500
-#: plugin/modules/http/__init__.py:247 plugin/xdl_strings.py:39
-msgid "OK"
-msgstr ""
-
-#: plugin/framework/dialogs.py:169
-msgid "Cancel"
-msgstr ""
-
-#: plugin/framework/dialogs.py:340
-msgid "Copy"
-msgstr ""
-
-#: plugin/framework/dialogs.py:360 plugin/framework/dialogs.py:435
-msgid "Copied!"
-msgstr ""
-
-#: plugin/framework/dialogs.py:410
-msgid "Copy URL"
-msgstr ""
-
-#: plugin/framework/dialogs.py:484 plugin/framework/dialogs.py:512
-#: plugin/main.py:316
-msgid "About WriterAgent"
-msgstr ""
-
-#: plugin/framework/dialogs.py:491
-#, python-format
-msgid "Version: %s"
-msgstr ""
-
-#: plugin/framework/dialogs.py:492
-msgid "AI-powered extension for LibreOffice"
-msgstr ""
-
-#: plugin/framework/dialogs.py:497
-msgid "GitHub: quazardous/localwriter"
-msgstr ""
-
-#: plugin/framework/dialogs.py:513
+#: plugin/main.py:229
 #, python-brace-format
-msgid "WriterAgent {0}"
+msgid "{0}: {1} passed, {2} failed."
 msgstr ""
 
-#: plugin/framework/errors.py:67
+#: plugin/main.py:232
 #, python-brace-format
-msgid "{resource_type} not found: {identifier}"
+msgid "Tests failed to run: {0}"
 msgstr ""
 
-#: plugin/framework/legacy_ui.py:294 plugin/main.py:307
+#: plugin/main.py:305
+msgid "Extend Selection"
+msgstr ""
+
+#: plugin/main.py:306
+msgid "Edit Selection"
+msgstr ""
+
+#: plugin/main.py:307 plugin/framework/legacy_ui.py:294
 #: plugin/xdl_strings.py:45
 msgid "Settings"
 msgstr ""
 
-#: plugin/framework/legacy_ui.py:346 plugin/modules/chatbot/panel.py:736
-#: plugin/modules/chatbot/send_handlers.py:300
-#: plugin/modules/chatbot/send_handlers.py:310
-#: plugin/modules/chatbot/send_handlers.py:319 plugin/main.py:212
-msgid "Error"
+#: plugin/main.py:308
+msgid "Toggle MCP Server"
 msgstr ""
 
-#: plugin/framework/legacy_ui.py:346
-#, python-brace-format
-msgid "Failed to open Settings: {0}"
+#: plugin/main.py:309
+msgid "MCP Server Status"
 msgstr ""
 
-#: plugin/framework/settings_dialog.py:156
-msgid "Invalid Setting"
+#: plugin/main.py:311
+msgid "Run format tests"
 msgstr ""
 
-#: plugin/framework/settings_dialog.py:156
-msgid "Temperature must be <= 1.0"
+#: plugin/main.py:312
+msgid "Run calc tests"
 msgstr ""
 
-#: plugin/framework/constants.py:193
-msgid ""
-"AI: I can edit or translate your document instantly with professional "
-"formatting and color. Try me!"
+#: plugin/main.py:313
+msgid "Run Calc API integration tests"
 msgstr ""
 
-#: plugin/framework/constants.py:194
-msgid ""
-"AI: I can help you with formulas, data analysis, and colorful charts. Try "
-"me!"
+#: plugin/main.py:314
+msgid "Run draw tests"
 msgstr ""
 
-#: plugin/framework/constants.py:195
-msgid ""
-"AI: I can help you create and edit polished, colorful shapes in Draw and "
-"Impress. Try me!"
+#: plugin/main.py:315
+msgid "Evaluation Dashboard"
 msgstr ""
 
-#: plugin/framework/constants.py:196
-msgid ""
-"AI: I can do web research to answer any question, or summarize a web page, "
-"without seeing or changing your document. Let's chat."
+#: plugin/main.py:316 plugin/framework/dialogs.py:484
+#: plugin/framework/dialogs.py:512
+msgid "About WriterAgent"
 msgstr ""
 
-#: plugin/modules/http/errors.py:15
-#, python-brace-format
-msgid "TLS/SSL Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:20
-msgid "Invalid API Key. Please check your settings."
-msgstr ""
-
-#: plugin/modules/http/errors.py:22
-msgid "API access Forbidden. Your key may lack permissions for this model."
-msgstr ""
-
-#: plugin/modules/http/errors.py:24
-msgid "Endpoint not found (404). Check your URL and Model name."
-msgstr ""
-
-#: plugin/modules/http/errors.py:26
-#, python-brace-format
-msgid "Server error ({0}). The AI provider is having issues."
-msgstr ""
-
-#: plugin/modules/http/errors.py:27 plugin/modules/http/errors.py:48
-#, python-brace-format
-msgid "HTTP Error {0}: {1}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:30
-msgid "Request Timed Out. Try increasing 'Request Timeout' in Settings."
-msgstr ""
-
-#: plugin/modules/http/errors.py:35
-msgid ""
-"Connection Refused. Is your local AI server (Ollama/LM Studio) running?"
-msgstr ""
-
-#: plugin/modules/http/errors.py:37
-msgid "DNS Error. Could not resolve the endpoint URL."
-msgstr ""
-
-#: plugin/modules/http/errors.py:38
-#, python-brace-format
-msgid "Connection Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:41
-msgid "The AI provider reported an error. Try again."
-msgstr ""
-
-#: plugin/modules/http/errors.py:69
-#, python-brace-format
-msgid "Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/client.py:534
-msgid "Stream ended with finish_reason=error"
-msgstr ""
-
-#: plugin/modules/http/client.py:547
-msgid ""
-"The model is repeating the same chunk (infinite loop). Try again or use a "
-"different model."
-msgstr ""
-
-#: plugin/modules/http/__init__.py:179
-msgid "Stop HTTP Server"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:180
-msgid "Start HTTP Server"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:201
-msgid "HTTP server stopped"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:208
-msgid "HTTP server started"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:211
-msgid "HTTP server failed to start"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:211
-msgid "Check ~/localwriter.log"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:220
-msgid "HTTP server is not running"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:226
-msgid "HTTP server not running"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:231
-msgid "HTTP server running"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:231
-#, python-brace-format
-msgid "Routes: {0}"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:238
-msgid "Server Status"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:259
-#, python-brace-format
-msgid "URL: {0}"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:32 plugin/modules/writer/legacy.py:70
-msgid "Please enter edit instructions!"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:32 plugin/modules/writer/legacy.py:70
-#: plugin/xdl_strings.py:32
-msgid "Input"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
-msgid "WriterAgent: Edit Selection (Calc)"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
-msgid "WriterAgent: Extend Selection (Calc)"
-msgstr ""
-
-#: plugin/modules/calc/specialized.py:97
-#: plugin/modules/writer/specialized.py:108
-#, python-brace-format
-msgid ""
-"Tool call switched to '{0}'. You are in a specialized toolset mode. You must"
-" call 'specialized_workflow_finished' when done to restore the full set of "
-"APIs."
+#: plugin/main.py:665
+msgid "Dispatch Error"
 msgstr ""
 
 #: plugin/modules/writer/legacy.py:43 plugin/modules/writer/legacy.py:54
@@ -469,10 +281,54 @@ msgstr ""
 msgid "WriterAgent: Extend Selection"
 msgstr ""
 
+#: plugin/modules/writer/legacy.py:70 plugin/modules/calc/legacy.py:32
+msgid "Please enter edit instructions!"
+msgstr ""
+
+#: plugin/modules/writer/legacy.py:70 plugin/modules/calc/legacy.py:32
+#: plugin/xdl_strings.py:32
+msgid "Input"
+msgstr ""
+
 #: plugin/modules/writer/legacy.py:78 plugin/modules/writer/legacy.py:88
 #: plugin/modules/writer/legacy.py:102 plugin/modules/chatbot/selection.py:290
 #: plugin/modules/chatbot/selection.py:404
 msgid "WriterAgent: Edit Selection"
+msgstr ""
+
+#: plugin/modules/writer/specialized.py:108
+#: plugin/modules/calc/specialized.py:97
+#, python-brace-format
+msgid ""
+"Tool call switched to '{0}'. You are in a specialized toolset mode. You must"
+" call 'specialized_workflow_finished' when done to restore the full set of "
+"APIs."
+msgstr ""
+
+#: plugin/modules/writer/specialized.py:234
+#: plugin/modules/calc/specialized.py:222
+#, python-brace-format
+msgid "Specialized task ({domain}) completed."
+msgstr ""
+
+#: plugin/modules/chatbot/panel_factory.py:485
+msgid "Size:"
+msgstr ""
+
+#: plugin/modules/chatbot/panel_factory.py:486
+msgid "Height:"
+msgstr ""
+
+#: plugin/modules/chatbot/panel_factory.py:487
+msgid "Width:"
+msgstr ""
+
+#: plugin/modules/chatbot/web_research.py:288
+msgid "Web research completed."
+msgstr ""
+
+#: plugin/modules/chatbot/librarian.py:72
+msgid "Switching to document mode..."
 msgstr ""
 
 #: plugin/modules/chatbot/panel_wiring.py:191 plugin/xdl_strings.py:41
@@ -551,6 +407,13 @@ msgstr ""
 msgid "[Web search]"
 msgstr ""
 
+#: plugin/modules/chatbot/web_research_chat.py:33
+#: plugin/modules/chatbot/web_research_chat.py:38
+#: plugin/framework/dialogs.py:109
+#, python-format
+msgid "Tool: %s"
+msgstr ""
+
 #: plugin/modules/chatbot/web_research_chat.py:37
 msgid "[Additional web search]"
 msgstr ""
@@ -565,10 +428,6 @@ msgstr ""
 
 #: plugin/modules/chatbot/web_research_chat.py:65
 msgid "Context for the research agent:"
-msgstr ""
-
-#: plugin/modules/chatbot/web_research.py:288
-msgid "Web research completed."
 msgstr ""
 
 #: plugin/modules/chatbot/send_handlers.py:39
@@ -638,20 +497,224 @@ msgstr ""
 msgid "[Research error: {0}]"
 msgstr ""
 
-#: plugin/modules/chatbot/librarian.py:72
-msgid "Switching to document mode..."
+#: plugin/modules/http/__init__.py:179
+msgid "Stop HTTP Server"
 msgstr ""
 
-#: plugin/modules/chatbot/panel_factory.py:485
-msgid "Size:"
+#: plugin/modules/http/__init__.py:180
+msgid "Start HTTP Server"
 msgstr ""
 
-#: plugin/modules/chatbot/panel_factory.py:486
-msgid "Height:"
+#: plugin/modules/http/__init__.py:201
+msgid "HTTP server stopped"
 msgstr ""
 
-#: plugin/modules/chatbot/panel_factory.py:487
-msgid "Width:"
+#: plugin/modules/http/__init__.py:208
+msgid "HTTP server started"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:211
+msgid "HTTP server failed to start"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:211
+msgid "Check ~/localwriter.log"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:220
+msgid "HTTP server is not running"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:226
+msgid "HTTP server not running"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:231
+msgid "HTTP server running"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:231
+#, python-brace-format
+msgid "Routes: {0}"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:238
+msgid "Server Status"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:247 plugin/framework/dialogs.py:168
+#: plugin/framework/dialogs.py:341 plugin/framework/dialogs.py:413
+#: plugin/framework/dialogs.py:500 plugin/xdl_strings.py:39
+msgid "OK"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:259
+#, python-brace-format
+msgid "URL: {0}"
+msgstr ""
+
+#: plugin/modules/http/client.py:534
+msgid "Stream ended with finish_reason=error"
+msgstr ""
+
+#: plugin/modules/http/client.py:547
+msgid ""
+"The model is repeating the same chunk (infinite loop). Try again or use a "
+"different model."
+msgstr ""
+
+#: plugin/modules/http/errors.py:15
+#, python-brace-format
+msgid "TLS/SSL Error: {0}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:20
+msgid "Invalid API Key. Please check your settings."
+msgstr ""
+
+#: plugin/modules/http/errors.py:22
+msgid "API access Forbidden. Your key may lack permissions for this model."
+msgstr ""
+
+#: plugin/modules/http/errors.py:24
+msgid "Endpoint not found (404). Check your URL and Model name."
+msgstr ""
+
+#: plugin/modules/http/errors.py:26
+#, python-brace-format
+msgid "Server error ({0}). The AI provider is having issues."
+msgstr ""
+
+#: plugin/modules/http/errors.py:27 plugin/modules/http/errors.py:48
+#, python-brace-format
+msgid "HTTP Error {0}: {1}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:30
+msgid "Request Timed Out. Try increasing 'Request Timeout' in Settings."
+msgstr ""
+
+#: plugin/modules/http/errors.py:35
+msgid ""
+"Connection Refused. Is your local AI server (Ollama/LM Studio) running?"
+msgstr ""
+
+#: plugin/modules/http/errors.py:37
+msgid "DNS Error. Could not resolve the endpoint URL."
+msgstr ""
+
+#: plugin/modules/http/errors.py:38
+#, python-brace-format
+msgid "Connection Error: {0}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:41
+msgid "The AI provider reported an error. Try again."
+msgstr ""
+
+#: plugin/modules/http/errors.py:69
+#, python-brace-format
+msgid "Error: {0}"
+msgstr ""
+
+#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
+msgid "WriterAgent: Edit Selection (Calc)"
+msgstr ""
+
+#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
+msgid "WriterAgent: Extend Selection (Calc)"
+msgstr ""
+
+#: plugin/framework/settings_dialog.py:156
+msgid "Invalid Setting"
+msgstr ""
+
+#: plugin/framework/settings_dialog.py:156
+msgid "Temperature must be <= 1.0"
+msgstr ""
+
+#: plugin/framework/constants.py:193
+msgid ""
+"AI: I can edit or translate your document instantly with professional "
+"formatting and color. Try me!"
+msgstr ""
+
+#: plugin/framework/constants.py:194
+msgid ""
+"AI: I can help you with formulas, data analysis, and colorful charts. Try "
+"me!"
+msgstr ""
+
+#: plugin/framework/constants.py:195
+msgid ""
+"AI: I can help you create and edit polished, colorful shapes in Draw and "
+"Impress. Try me!"
+msgstr ""
+
+#: plugin/framework/constants.py:196
+msgid ""
+"AI: I can do web research to answer any question, or summarize a web page, "
+"without seeing or changing your document. Let's chat."
+msgstr ""
+
+#: plugin/framework/legacy_ui.py:346
+#, python-brace-format
+msgid "Failed to open Settings: {0}"
+msgstr ""
+
+#: plugin/framework/dialogs.py:107
+msgid "Agent requests approval"
+msgstr ""
+
+#: plugin/framework/dialogs.py:108
+msgid "Proceed with this action?"
+msgstr ""
+
+#: plugin/framework/dialogs.py:155
+msgid "Edit search query"
+msgstr ""
+
+#: plugin/framework/dialogs.py:160
+msgid "Search query:"
+msgstr ""
+
+#: plugin/framework/dialogs.py:169
+msgid "Cancel"
+msgstr ""
+
+#: plugin/framework/dialogs.py:340
+msgid "Copy"
+msgstr ""
+
+#: plugin/framework/dialogs.py:360 plugin/framework/dialogs.py:435
+msgid "Copied!"
+msgstr ""
+
+#: plugin/framework/dialogs.py:410
+msgid "Copy URL"
+msgstr ""
+
+#: plugin/framework/dialogs.py:491
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: plugin/framework/dialogs.py:492
+msgid "AI-powered extension for LibreOffice"
+msgstr ""
+
+#: plugin/framework/dialogs.py:497
+msgid "GitHub: quazardous/localwriter"
+msgstr ""
+
+#: plugin/framework/dialogs.py:513
+#, python-brace-format
+msgid "WriterAgent {0}"
+msgstr ""
+
+#: plugin/framework/errors.py:67
+#, python-brace-format
+msgid "{resource_type} not found: {identifier}"
 msgstr ""
 
 #: plugin/tests/test_i18n.py:24
@@ -664,56 +727,6 @@ msgstr ""
 
 #: plugin/tests/test_i18n.py:195
 msgid "Backend"
-msgstr ""
-
-#: plugin/main.py:229
-#, python-brace-format
-msgid "{0}: {1} passed, {2} failed."
-msgstr ""
-
-#: plugin/main.py:232
-#, python-brace-format
-msgid "Tests failed to run: {0}"
-msgstr ""
-
-#: plugin/main.py:305
-msgid "Extend Selection"
-msgstr ""
-
-#: plugin/main.py:306
-msgid "Edit Selection"
-msgstr ""
-
-#: plugin/main.py:308
-msgid "Toggle MCP Server"
-msgstr ""
-
-#: plugin/main.py:309
-msgid "MCP Server Status"
-msgstr ""
-
-#: plugin/main.py:311
-msgid "Run format tests"
-msgstr ""
-
-#: plugin/main.py:312
-msgid "Run calc tests"
-msgstr ""
-
-#: plugin/main.py:313
-msgid "Run Calc API integration tests"
-msgstr ""
-
-#: plugin/main.py:314
-msgid "Run draw tests"
-msgstr ""
-
-#: plugin/main.py:315
-msgid "Evaluation Dashboard"
-msgstr ""
-
-#: plugin/main.py:665
-msgid "Dispatch Error"
 msgstr ""
 
 #: plugin/xdl_strings.py:4

--- a/plugin/modules/chatbot/memory.py
+++ b/plugin/modules/chatbot/memory.py
@@ -23,22 +23,14 @@ class MemoryStore:
         path = self._get_path(target)
         if not os.path.exists(path):
             return ""
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                return f.read()
-        except OSError as e:
-            log.error(f"Failed to read {target} memory: {e}")
-            return ""
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
 
     def write(self, target: str, content: str) -> bool:
         path = self._get_path(target)
-        try:
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(content)
-            return True
-        except OSError as e:
-            log.error(f"Failed to write {target} memory: {e}")
-            return False
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return True
 
 class MemoryTool(ToolBase):
     """Persistent file-backed memory for the agent (USER profile)."""
@@ -83,15 +75,17 @@ class MemoryTool(ToolBase):
             return self._tool_error(f"Failed to initialize memory store: {e}")
             
         target = "user"
-        current = store.read(target)
+        try:
+            current = store.read(target)
+        except OSError as e:
+            return self._tool_error(f"Failed to read existing memory: {e}")
         
         try:
             parsed = yaml.safe_load(current) if current.strip() else {}
             if not isinstance(parsed, dict):
                 parsed = {"_raw": current}
-        except Exception:
-            # Fallback if invalid yaml
-            parsed = {"_raw": current}
+        except Exception as e:
+            return self._tool_error(f"Failed to parse existing memory YAML: {e}")
 
         # Nested update
         parts = key.split(".")
@@ -104,6 +98,8 @@ class MemoryTool(ToolBase):
         current_dict[parts[-1]] = content
 
         new_content = yaml.dump(parsed, sort_keys=False, allow_unicode=True)
-        if store.write(target, new_content):
+        try:
+            store.write(target, new_content)
             return {"status": "ok", "message": f"Upserted key '{key}' in memory."}
-        return self._tool_error("Failed to update memory.")
+        except OSError as e:
+            return self._tool_error(f"Failed to write memory: {e}")


### PR DESCRIPTION
When the Librarian tries to `upsert_memory` on a system with permission issues, the user sees a generic failure message. This branch improves debuggability by catching specific file I/O (`OSError`) and YAML parsing exceptions in `MemoryTool.execute` and piping the exact error string (e.g., `str(e)`) to the chat interface using `_tool_error()`.

---
*PR created automatically by Jules for task [4292572804499595889](https://jules.google.com/task/4292572804499595889) started by @KeithCu*