### PR TITLE
Fix: use json instead of yaml for memory tool

### DIFF
--- a/plugin/modules/chatbot/memory.py
+++ b/plugin/modules/chatbot/memory.py
@@ -70,7 +70,7 @@ class MemoryTool(ToolBase):
     }
 
     def execute(self, ctx, **kwargs):
-        import yaml
+        import json
         key = kwargs.get("key")
         content = kwargs.get("content", "")
         
@@ -86,12 +86,13 @@ class MemoryTool(ToolBase):
         current = store.read(target)
         
         try:
-            parsed = yaml.safe_load(current) if current.strip() else {}
+            parsed = json.loads(current) if current.strip() else {}
             if not isinstance(parsed, dict):
-                parsed = {"_raw": current}
-        except Exception:
-            # Fallback if invalid yaml
-            parsed = {"_raw": current}
+                # Throw it away and start over if it's not a valid JSON dictionary
+                parsed = {}
+        except json.JSONDecodeError:
+            # Fallback if invalid JSON (or legacy YAML format): we throw it away and have the librarian start over
+            parsed = {}
 
         # Nested update
         parts = key.split(".")
@@ -103,7 +104,7 @@ class MemoryTool(ToolBase):
 
         current_dict[parts[-1]] = content
 
-        new_content = yaml.dump(parsed, sort_keys=False, allow_unicode=True)
+        new_content = json.dumps(parsed, indent=2, ensure_ascii=False)
         if store.write(target, new_content):
             return {"status": "ok", "message": f"Upserted key '{key}' in memory."}
         return self._tool_error("Failed to update memory.")

--- a/plugin/tests/test_memory_tool_context.py
+++ b/plugin/tests/test_memory_tool_context.py
@@ -49,7 +49,7 @@ class TestMemoryToolContext(unittest.TestCase):
         self.assertEqual(result.get("status"), "ok")
         user_memory_path = os.path.join(self.tmp_dir, "memories", "USER.md")
         with open(user_memory_path, "r", encoding="utf-8") as f:
-            self.assertIn("user_name: Keith", f.read())
+            self.assertIn('"user_name": "Keith"', f.read())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Switch memory tool serialization from YAML to JSON to fix `ModuleNotFoundError: No module named 'yaml'` on some platforms (like Debian Linux) where LibreOffice Python environment lacks third-party packages. Gracefully discards old legacy YAML data if read using `json.JSONDecodeError`. Update relevant unit tests for JSON syntax.

---
*PR created automatically by Jules for task [17063500825010071484](https://jules.google.com/task/17063500825010071484) started by @KeithCu*