### PR TITLE
fix: Hide Evaluation Dashboard in release builds

### DIFF
--- a/extension/Addons.xcu
+++ b/extension/Addons.xcu
@@ -120,18 +120,18 @@
                   <value>_self</value>
                 </prop>
               </node>
+              <node oor:name="M8" oor:op="replace">
+                <prop oor:name="Title">
+                  <value xml:lang="en-US">Evaluation Dashboard</value>
+                </prop>
+                <prop oor:name="URL">
+                  <value>org.extension.writeragent:main.EvaluationDashboard</value>
+                </prop>
+                <prop oor:name="Target" oor:type="xs:string">
+                  <value>_self</value>
+                </prop>
+              </node>
             </node>
-          </node>
-          <node oor:name="M8" oor:op="replace">
-            <prop oor:name="Title">
-              <value xml:lang="en-US">Evaluation Dashboard</value>
-            </prop>
-            <prop oor:name="URL">
-              <value>org.extension.writeragent:main.EvaluationDashboard</value>
-            </prop>
-            <prop oor:name="Target" oor:type="xs:string">
-              <value>_self</value>
-            </prop>
           </node>
         </node>
       </node>


### PR DESCRIPTION
Moves the Evaluation Dashboard menu option inside the Debug menu's Submenu in `extension/Addons.xcu`. This ensures it is properly stripped out during release builds, exactly like the rest of the debug menu.

---
*PR created automatically by Jules for task [17984438762261893109](https://jules.google.com/task/17984438762261893109) started by @KeithCu*