### PR TITLE
feat: surface detailed tool execution errors in chat window

### DIFF
--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -186,14 +186,22 @@ class ToolCallingMixin:
                     res = _get_tools().execute(name, tctx, **args)
                     return json.dumps(res) if isinstance(res, dict) else str(res)
                 except (ToolExecutionError, UnoObjectError) as e:
+                    import traceback
+                    tb = traceback.format_exc()
                     log.error("Tool execution failed: %s" % e, extra={"context": "tool_execution"})
                     agent_log("tool_loop.py:execute_fn", "Tool execution failed", data={"type": type(e).__name__, "message": str(e)})
-                    return json.dumps(format_error_payload(e))
+                    err_payload = format_error_payload(e)
+                    if "details" not in err_payload:
+                        err_payload["details"] = {}
+                    err_payload["details"]["traceback"] = tb
+                    return json.dumps(err_payload)
                 except Exception as e:
+                    import traceback
+                    tb = traceback.format_exc()
                     wrapped_error = ToolExecutionError(
                         "Unexpected error executing tool '%s'" % name,
                         code="TOOL_UNEXPECTED_ERROR",
-                        details={"tool_name": name, "original_error": str(e), "type": type(e).__name__}
+                        details={"tool_name": name, "original_error": str(e), "type": type(e).__name__, "traceback": tb}
                     )
                     log.error("Unexpected tool error: %s" % wrapped_error)
                     return json.dumps(format_error_payload(wrapped_error))

--- a/plugin/modules/chatbot/tool_loop_state.py
+++ b/plugin/modules/chatbot/tool_loop_state.py
@@ -238,9 +238,26 @@ def next_state(state: ToolLoopState, event: ToolLoopEvent) -> FsmTransition[Tool
             if not isinstance(result_data, dict):
                 result_data = {}
 
-            note = result_data.get("message", result_data.get("status", "done"))
             effects.append(UIEffect(kind="debug", text=f"Tool result: {result}"))
-            effects.append(UIEffect(kind="append", text=f"[{func_name}: {note}]\n"))
+
+            if result_data.get("status") == "error":
+                import json
+                error_msg = result_data.get("message", "Unknown error")
+                details = result_data.get("details", {})
+
+                detailed_text = f"[{func_name} failed: {error_msg}]\n"
+                if details:
+                    tb = details.pop("traceback", None)
+                    if details:
+                        detailed_text += f"Details: {json.dumps(details, indent=2)}\n"
+                    if tb and tb.strip() != "NoneType: None":
+                        detailed_text += f"Traceback:\n{tb}\n"
+
+                effects.append(UIEffect(kind="append", text=detailed_text))
+                note = error_msg
+            else:
+                note = result_data.get("message", result_data.get("status", "done"))
+                effects.append(UIEffect(kind="append", text=f"[{func_name}: {note}]\n"))
 
             if func_name == "apply_document_content" and isinstance(note, str) and note.strip().startswith("Replaced 0 occurrence"):
                 params_display = func_args_str if len(func_args_str) <= 800 else func_args_str[:800] + "..."


### PR DESCRIPTION
When tools fail in the chat loop, detailed error messages and stack traces are now correctly surfaced in the chat window, rather than silently writing to a log file. 

This gives users and developers immediate insight into what is going wrong without asking for or digging through log files.

- Captured `traceback.format_exc()` in `execute_fn` when catching execution errors.
- Augmented `format_error_payload` usages inside `tool_loop.py` to append the traceback to the `details` dict.
- Updated the `ToolLoopState` transition logic (`EventKind.TOOL_RESULT`) to identify errors (`status == "error"`), serialize the `details` nicely, and dump the traceback directly into the chat UI via `UIEffect`.

---
*PR created automatically by Jules for task [16243841333980590841](https://jules.google.com/task/16243841333980590841) started by @KeithCu*