### PR TITLE
refactor: Centralize and organize default models mapping

### DIFF
--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -703,9 +703,19 @@ def populate_combobox_with_lru(ctx, ctrl, current_val, lru_key, endpoint):
             for m in DEFAULT_MODELS:
                 caps = [c.strip() for c in m.get("capability", "text").split(",")]
                 if req_cap in caps:
-                    effective_id = resolve_model_id(m, provider)
-                    if effective_id and effective_id not in to_show:
-                        to_show.append(effective_id)
+                    # Only add models that are marked as default for this capability
+                    is_default = False
+                    if req_cap == "text" and m.get("default_text"):
+                        is_default = True
+                    elif req_cap == "image" and m.get("default_image"):
+                        is_default = True
+                    elif req_cap == "audio" and m.get("default_audio"):
+                        is_default = True
+
+                    if is_default:
+                        effective_id = resolve_model_id(m, provider)
+                        if effective_id and effective_id not in to_show:
+                            to_show.append(effective_id)
 
     curr_val_str = str(current_val).strip()
     if curr_val_str and curr_val_str not in to_show:
@@ -744,7 +754,14 @@ def update_lru_history(ctx, val, lru_key, endpoint, max_items=None):
 
 def get_text_model(ctx):
     """Return the text/chat model (stored as text_model, fallback to model)."""
-    return str(get_config(ctx, "text_model") or get_config(ctx, "model") or "").strip()
+    val = str(get_config(ctx, "text_model") or get_config(ctx, "model") or "").strip()
+    if val:
+        return val
+    from plugin.framework.default_models import get_provider_defaults
+    current_endpoint = get_current_endpoint(ctx)
+    provider = get_provider_from_endpoint(current_endpoint)
+    defaults = get_provider_defaults(provider)
+    return str(defaults.get("text_model", "")).strip()
 
 
 def get_stt_model(ctx):
@@ -859,7 +876,17 @@ def get_image_model(ctx):
     image_provider = get_config(ctx, "image_provider")
     if image_provider == "aihorde":
         return str(get_config(ctx, "aihorde_model") or "").strip()
-    return str(get_config(ctx, "image_model") or "").strip()
+    val = str(get_config(ctx, "image_model") or "").strip()
+    if val:
+        return val
+    from plugin.framework.default_models import get_provider_defaults
+    if image_provider == "endpoint":
+        current_endpoint = get_current_endpoint(ctx)
+        provider = get_provider_from_endpoint(current_endpoint)
+    else:
+        provider = image_provider
+    defaults = get_provider_defaults(provider)
+    return str(defaults.get("image_model", "")).strip()
 
 
 def set_image_model(ctx, val, update_lru=True):

--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -703,7 +703,6 @@ def populate_combobox_with_lru(ctx, ctrl, current_val, lru_key, endpoint):
             for m in DEFAULT_MODELS:
                 caps = [c.strip() for c in m.get("capability", "text").split(",")]
                 if req_cap in caps:
-                    # Only add models that are marked as default for this capability
                     is_default = False
                     if req_cap == "text" and m.get("default_text"):
                         is_default = True

--- a/plugin/framework/default_models.py
+++ b/plugin/framework/default_models.py
@@ -31,15 +31,21 @@ def resolve_model_id(model, provider):
 
 #FIXME, this should be a list, stored with the other endpoint pre-configured params
 def get_provider_defaults(provider):
-    """Return default models (stt_model, tts_model) mapped per provider."""
-    defaults = {
-        "together": {"stt_model": "openai/whisper-large-v3"},
-        "openrouter": {"stt_model": "google/gemini-3.1-flash-lite-preview"},
-        "mistral": {"stt_model": "voxtral-mini-2602"},
-    }
-    return defaults.get(provider, {})
-
-
+    """Return default models mapped per provider based on boolean flags in DEFAULT_MODELS."""
+    if not provider:
+        return {}
+    defaults = {}
+    for model in DEFAULT_MODELS:
+        effective_id = resolve_model_id(model, provider)
+        if not effective_id:
+            continue
+        if model.get("default_text") and "text_model" not in defaults:
+            defaults["text_model"] = effective_id
+        if model.get("default_image") and "image_model" not in defaults:
+            defaults["image_model"] = effective_id
+        if model.get("default_audio") and "stt_model" not in defaults:
+            defaults["stt_model"] = effective_id
+    return defaults
 def merge_catalogs(base, extension):
     """Merge extension models into a base catalog (flat list).
 
@@ -83,6 +89,7 @@ DEFAULT_MODELS = [
             "ollama": "llama3.3:70b-instruct",
         },
         "id": "meta-llama/llama-3.3-70b-instruct",
+        "default_text": True,
     },
     {
         "display_name": "Mistral Large 3",
@@ -95,6 +102,7 @@ DEFAULT_MODELS = [
             "mistral": "mistral-large-latest",
         },
         "id": "mistral-large-latest",
+        "default_text": True,
     },
     {
         "display_name": "GPT-OSS 120B",
@@ -107,6 +115,7 @@ DEFAULT_MODELS = [
             "openai": "gpt-oss-120b",
         },
         "id": "gpt-oss-120b",
+        "default_text": True,
     },
     {
         "display_name": "Mistral 7B Instruct v0.3",
@@ -208,6 +217,7 @@ DEFAULT_MODELS = [
         "notes": "Latest Google model, optimized for speed and low cost",
         "ids": {"openrouter": "google/gemini-3.1-flash-lite-preview"},
         "id": "google/gemini-3.1-flash-lite-preview",
+        "default_audio": True,
     },
 
     # ---- Image-only models -----------------------------------------------
@@ -219,6 +229,7 @@ DEFAULT_MODELS = [
         "notes": "Black Forest Labs image generation (Together AI)",
         "ids": {"together": "black-forest-labs/FLUX.2-pro"},
         "id": "black-forest-labs/FLUX.2-pro",
+        "default_image": True,
     },
     {
         "display_name": "Flash Image 2.5",
@@ -244,6 +255,7 @@ DEFAULT_MODELS = [
         "notes": "Excellent vision + reasoning, 1M context (Google)",
         "ids": {"openrouter": "google/gemini-3.1-pro-preview"},
         "id": "google/gemini-3.1-pro-preview",
+        "default_image": True,
     },
     {
         "display_name": "Pixtral Large",
@@ -256,6 +268,7 @@ DEFAULT_MODELS = [
             "mistral": "pixtral-large-latest",
         },
         "id": "pixtral-large-latest",
+        "default_image": True,
     },
     {
         "display_name": "LLaVA (vision local)",
@@ -265,6 +278,7 @@ DEFAULT_MODELS = [
         "notes": "Classic local multimodal",
         "ids": {"ollama": "llava"},
         "id": "llava",
+        "default_image": True,
     },
     # ---- Audio/STT models ------------------------------------------------
     {
@@ -274,6 +288,7 @@ DEFAULT_MODELS = [
         "notes": "Standard OpenAI transcription model",
         "ids": {"openai": "whisper-1"},
         "id": "whisper-1",
+        "default_audio": True,
     },
     {
         "display_name": "Whisper Large v3",
@@ -284,6 +299,7 @@ DEFAULT_MODELS = [
             "together": "openai/whisper-large-v3",
         },
         "id": "openai/whisper-large-v3",
+        "default_audio": True,
     },
     {
         "display_name": "Voxtral Mini",
@@ -292,5 +308,6 @@ DEFAULT_MODELS = [
         "notes": "Native audio model for Mistral",
         "ids": {"mistral": "voxtral-mini-2602"},
         "id": "voxtral-mini-2602",
+        "default_audio": True,
     },
 ]


### PR DESCRIPTION
This PR centralizes and organizes how default models for various capabilities and providers (like Openrouter and Together) are specified. Instead of hard-coding the defaults into small mappings, they are now specified by boolean flags (`default_text`, `default_image`, `default_audio`) directly on the model dicts in `DEFAULT_MODELS` in `plugin/framework/default_models.py`. 

The LRU list population for sites with too many models to show all now filters correctly, only showing models explicitly flagged as defaults for that capability. Lastly, the config getters (`get_text_model`, `get_image_model`, and `get_stt_model`) have all been updated to look up the centralized defaults if a user hasn't explicitly configured a model yet.

---
*PR created automatically by Jules for task [5900950027124725358](https://jules.google.com/task/5900950027124725358) started by @KeithCu*