### PR TITLE
Fix specialized agent tool threading and UI updates

### DIFF
--- a/plugin/framework/tool_base.py
+++ b/plugin/framework/tool_base.py
@@ -107,6 +107,17 @@ class ToolBase(ABC):
     def execute_safe(self, ctx, **kwargs):
         """Execute with simple error containment."""
         try:
+            # Check thread safety: If the tool is synchronous, it must not be called from a background thread
+            # unless it's being executed through the QueueExecutor. Direct UNO calls from background threads
+            # cause UI hangs and deadlocks in LibreOffice.
+            if not self.is_async():
+                import threading
+                if threading.current_thread() is not threading.main_thread():
+                    raise RuntimeError(
+                        f"Thread Safety Violation: Synchronous tool '{self.name}' was executed from a background thread. "
+                        "Synchronous tools execute UNO APIs which are not thread-safe. You must wrap this call "
+                        "using `execute_on_main_thread` from `plugin.framework.queue_executor`."
+                    )
             return self.execute(ctx, **kwargs)
         except Exception as e:
             return self._tool_error(

--- a/plugin/framework/tool_base.py
+++ b/plugin/framework/tool_base.py
@@ -104,6 +104,10 @@ class ToolBase(ABC):
             dict with at least ``{"status": "ok"|"error", ...}``.
         """
 
+    def is_async(self):
+        """Returns True if this tool should execute asynchronously in the background. Defaults to False."""
+        return False
+
     def execute_safe(self, ctx, **kwargs):
         """Execute with simple error containment."""
         try:

--- a/plugin/modules/calc/specialized.py
+++ b/plugin/modules/calc/specialized.py
@@ -159,8 +159,13 @@ class DelegateToSpecializedCalc(ToolBase):
                     return self.forward(*args, **kwargs)
 
                 def forward(self, *args, **kwargs):
-                    # Convert arguments and execute via the writer tool
-                    return self.writer_tool.execute_safe(self.ctx, **kwargs)
+                    from plugin.framework.queue_executor import execute_on_main_thread
+                    log.debug("Specialized agent executing tool '%s' on main thread", self.name)
+                    # Convert arguments and execute via the Calc tool on the main thread
+                    # to prevent deadlocking or blocking the background agent thread.
+                    res = execute_on_main_thread(self.writer_tool.execute_safe, self.ctx, **kwargs)
+                    log.debug("Specialized agent tool '%s' finished", self.name)
+                    return res
 
             smol_tools = [WrappedSmolTool(t, ctx) for t in domain_tools]
 

--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -785,7 +785,7 @@ class ToolCallingMixin:
             from plugin.main import get_tools as _get_tools_registry
             registry = _get_tools_registry()
             async_tools = frozenset([
-                tool.name for tool in registry.values()
+                tool.name for tool in registry.get_tools()
                 if getattr(tool, "is_async", lambda: False)()
             ])
         except Exception as e:

--- a/plugin/modules/chatbot/tool_loop.py
+++ b/plugin/modules/chatbot/tool_loop.py
@@ -785,7 +785,7 @@ class ToolCallingMixin:
             from plugin.main import get_tools as _get_tools_registry
             registry = _get_tools_registry()
             async_tools = frozenset([
-                tool.name for tool in registry.get_tools()
+                tool.name for tool in registry.get_tools(filter_doc_type=False, exclude_tiers=())
                 if getattr(tool, "is_async", lambda: False)()
             ])
         except Exception as e:

--- a/plugin/modules/writer/specialized.py
+++ b/plugin/modules/writer/specialized.py
@@ -171,8 +171,13 @@ class DelegateToSpecializedWriter(ToolBase):
                     return self.forward(*args, **kwargs)
 
                 def forward(self, *args, **kwargs):
-                    # Convert arguments and execute via the writer tool
-                    return self.writer_tool.execute_safe(self.ctx, **kwargs)
+                    from plugin.framework.queue_executor import execute_on_main_thread
+                    log.debug("Specialized agent executing tool '%s' on main thread", self.name)
+                    # Convert arguments and execute via the writer tool on the main thread
+                    # to prevent deadlocking or blocking the background agent thread.
+                    res = execute_on_main_thread(self.writer_tool.execute_safe, self.ctx, **kwargs)
+                    log.debug("Specialized agent tool '%s' finished", self.name)
+                    return res
 
             smol_tools = [WrappedSmolTool(t, ctx) for t in domain_tools]
 

--- a/plugin/tests/test_tool_registry.py
+++ b/plugin/tests/test_tool_registry.py
@@ -395,6 +395,10 @@ class TestToolIsolation:
             timeout = 0.1
             parameters = {"type": "object", "properties": {}}
 
+            def is_async(self):
+                # allow it to run in the test thread pool
+                return True
+
             def execute(self, ctx, **kwargs):
                 time.sleep(2)
                 return {"status": "ok"}


### PR DESCRIPTION
Fix UI hang during specialized sub-agent execution by correctly wrapping UNO tool calls using `execute_on_main_thread`, and strictly enforce this thread safety pattern across all synchronous tool executions.

---
*PR created automatically by Jules for task [4131972759496796281](https://jules.google.com/task/4131972759496796281) started by @KeithCu*