### PR TITLE
Fix type hint errors in Agent 4 test files

### DIFF
--- a/plugin/tests/uno/test_draw.py
+++ b/plugin/tests/uno/test_draw.py
@@ -15,13 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import json
+from typing import Any
+
 from plugin.framework.logging import log
 from plugin.framework.uno_context import get_desktop
 from plugin.testing_runner import setup, teardown, native_test
 
 
-_test_doc = None
-_test_ctx = None
+_test_doc: Any = None
+_test_ctx: Any = None
 
 
 @setup

--- a/plugin/tests/uno/test_history_db.py
+++ b/plugin/tests/uno/test_history_db.py
@@ -207,6 +207,7 @@ def test_session_id_stability():
 
     # 1. First run: Should generate a stable ID based on URL (hash) since no property exists
     panel._setup_sessions(model, "some instructions")
+    assert panel.session is not None
     first_session_id = panel.session.session_id
 
     assert first_session_id is not None
@@ -221,6 +222,7 @@ def test_session_id_stability():
     panel._setup_sessions(model, "different instructions")
 
     # It should reuse the ID stored in UserDefinedProperties, ignoring the new URL
+    assert panel.session is not None
     second_session_id = panel.session.session_id
     assert second_session_id == first_session_id
 
@@ -228,6 +230,7 @@ def test_session_id_stability():
     unsaved_model = MockDocumentModel("")
     panel._setup_sessions(unsaved_model, "")
 
+    assert panel.session is not None
     third_session_id = panel.session.session_id
     # It should generate a UUID
     assert third_session_id is not None

--- a/plugin/tests/uno/test_writer.py
+++ b/plugin/tests/uno/test_writer.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any
 
 from plugin.framework.document import (
     build_heading_tree,
@@ -10,8 +11,8 @@ from plugin.framework.uno_context import get_desktop
 from plugin.testing_runner import setup, teardown, native_test
 
 
-_test_doc = None
-_test_ctx = None
+_test_doc: Any = None
+_test_ctx: Any = None
 
 
 @setup

--- a/plugin/tests/uno/test_writer_bookmarks.py
+++ b/plugin/tests/uno/test_writer_bookmarks.py
@@ -4,6 +4,8 @@ try:
 except ImportError:
     pass
 
+from typing import Any
+
 try:
     from types import SimpleNamespace
 
@@ -15,8 +17,8 @@ try:
 except ImportError:
     setup, teardown, native_test = (lambda f: f), (lambda f: f), (lambda f: f)
 
-_test_doc = None
-_test_ctx = None
+_test_doc: Any = None
+_test_ctx: Any = None
 
 @setup
 def setup_bookmark_tests(ctx):
@@ -66,6 +68,7 @@ def test_ensure_heading_bookmarks_and_map():
     bookmark_svc = BookmarkService(SimpleNamespace(document=doc_svc))
 
     # Initially no bookmarks
+    assert _test_doc is not None
     bms = _test_doc.getBookmarks().getElementNames()
     assert len([b for b in bms if b.startswith("_mcp_")]) == 0
 
@@ -78,6 +81,7 @@ def test_ensure_heading_bookmarks_and_map():
     assert 2 in bookmark_map
 
     # Verify in document
+    assert _test_doc is not None
     bms = _test_doc.getBookmarks().getElementNames()
     mcp_bms = [b for b in bms if b.startswith("_mcp_")]
     assert len(mcp_bms) == 2
@@ -132,6 +136,7 @@ def test_cleanup_mcp_bookmarks():
     assert removed_count == 2
 
     # Verify they are gone from document
+    assert _test_doc is not None
     bms = _test_doc.getBookmarks().getElementNames()
     mcp_bms = [b for b in bms if b.startswith("_mcp_")]
     assert len(mcp_bms) == 0

--- a/plugin/tests/uno/test_writer_navigation.py
+++ b/plugin/tests/uno/test_writer_navigation.py
@@ -10,7 +10,7 @@ except ImportError:
     import types
     sys.modules['uno'] = types.ModuleType('uno')
     sys.modules['unohelper'] = types.ModuleType('unohelper')
-    sys.modules['unohelper'].Base = BaseStub
+    setattr(sys.modules['unohelper'], 'Base', BaseStub)
     sys.modules['com'] = types.ModuleType('com')
     sys.modules['com.sun'] = types.ModuleType('sun')
     sys.modules['com.sun.star'] = types.ModuleType('star')
@@ -19,12 +19,12 @@ except ImportError:
     class MockListener(object):
         pass
 
-    sys.modules['com.sun.star.awt'].XActionListener = MockListener
+    setattr(sys.modules['com.sun.star.awt'], 'XActionListener', MockListener)
     sys.modules['com.sun.star.datatransfer'] = types.ModuleType('datatransfer')
     sys.modules['com.sun.star.datatransfer.clipboard'] = types.ModuleType('clipboard')
     class MockClipboardListener(object):
         pass
-    sys.modules['com.sun.star.datatransfer.clipboard'].XClipboardListener = MockClipboardListener
+    setattr(sys.modules['com.sun.star.datatransfer.clipboard'], 'XClipboardListener', MockClipboardListener)
 
 from plugin.tests.testing_utils import ElementStub, WriterDocStub
 from plugin.framework.document import (


### PR DESCRIPTION
This PR addresses the 19 type hint errors assigned to Agent 4. The `_test_doc` and `_test_ctx` variables across testing scripts were annotated with `Any` to simplify handling generic UNO return types. Type guards (`assert panel.session is not None`) were properly placed before accessing `.session_id` in history DB tests. Finally, dynamic `sys.modules` patching in navigation tests was migrated to use `setattr()` to satisfy `ty`'s static analysis rules. All tests passed under `pytest` and `ty check`.

---
*PR created automatically by Jules for task [391264127477243470](https://jules.google.com/task/391264127477243470) started by @KeithCu*