### PR TITLE
Refactor config listener to use shared EventBus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ UNO split (no monolithic `uno_helpers.py`): context helpers → [`plugin/framewo
 **Scope**: Sidebar + menu chat for **Writer and Calc** (same deck). Draw supported for chat/tools per product code paths.
 
 - **Theming**: Native VCL (light/dark); no custom color probing.
-- **Config sync**: `add_config_listener` / `notify_config_changed` in [`plugin/framework/config.py`](plugin/framework/config.py); weakref on listeners.
+- **Config sync**: `global_event_bus.subscribe("config:changed", ...)` and `global_event_bus.emit("config:changed", ...)` using [`plugin/framework/event_bus.py`](plugin/framework/event_bus.py).
 - **Lifecycle**: Send disabled / Stop enabled at start of `actionPerformed`; restored in **`finally`** after `_do_send()` returns. `_set_button_states` uses per-control try/except. `_send_busy` mirrors that window.
 - **FSM** ([`plugin/framework/state.py`](plugin/framework/state.py)): Pure `next_state(state, event) → FsmTransition`; **no** UNO/I/O/logging/`EventBus` inside transitions. Effects run in panel/mixins/MCP. Composite: [`sidebar_state.py`](plugin/modules/chatbot/sidebar_state.py) (`send`, `tool_loop`, mirrored `audio`). `ToolCallingMixin` clears the tool-loop slice in **`finally`** after drain. **`EventBus`**: loose notifications only (e.g. config, `mcp:request`), not the FSM driver. Other `*_state.py` modules under `chatbot/` and `http/mcp_state.py` for domains.
 - **Panel**: [`panel_factory.py`](plugin/modules/chatbot/panel_factory.py) + `ChatPanelDialog.xdl`; **`setVisible(True)`** after `createContainerWindow()`. Resize: [`panel_resize.py`](plugin/modules/chatbot/panel_resize.py), wired from [`panel_wiring.py`](plugin/modules/chatbot/panel_wiring.py).

--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -26,6 +26,7 @@ import logging
 import dataclasses
 import time
 from typing import Dict, Any, Optional, TYPE_CHECKING
+from plugin.framework.event_bus import global_event_bus
 try:
     import uno
     import unohelper
@@ -488,6 +489,8 @@ def set_config(ctx, key, value):
         _cached_config_mtime = 0
         _cached_config_mtime_last_checked = 0.0
 
+        global_event_bus.emit("config:changed", ctx=ctx)
+
     except OSError as e:
         log.error("Error writing to %s: %s", config_file_path, e)
         raise ConfigError(f"Failed to save config: {e}", "CONFIG_SAVE_ERROR") from e
@@ -519,31 +522,13 @@ def remove_config(ctx, key):
         _cached_config_mtime = 0
         _cached_config_mtime_last_checked = 0.0
 
+        global_event_bus.emit("config:changed", ctx=ctx)
+
     except OSError as e:
         log.error("Error writing to %s: %s", config_file_path, e)
         raise ConfigError(f"Failed to remove config key: {e}", "CONFIG_SAVE_ERROR") from e
 
 
-# Listeners are called when config is changed (e.g. after Settings dialog).
-# Sidebar uses weakref in its callback so panels can be GC'd without unregistering.
-# FIXME: These duplicated pieces of functionality (add_config_listener / notify_config_changed)
-# could be combined into the shared EventBus. This custom pub/sub code can be removed
-# and changed to use EventBus. When that happens, update dependent UI code and remove the test code.
-_config_listeners = []
-
-
-def add_config_listener(callback):
-    """Register a callable(ctx) to be invoked when config changes (e.g. after Settings OK)."""
-    _config_listeners.append(callback)
-
-
-def notify_config_changed(ctx):
-    """Call all registered listeners so UI (e.g. sidebar) can refresh from config."""
-    for cb in list(_config_listeners):
-        try:
-            cb(ctx)
-        except Exception as e:
-            log.warning("notify_config_changed: listener %s failed: %s", cb, e)
 
 
 def as_bool(value):
@@ -913,8 +898,8 @@ def set_image_model(ctx, val, update_lru=True):
         set_config(ctx, "image_model", val_str)
         if update_lru:
             update_lru_history(ctx, val_str, "image_model_lru", get_current_endpoint(ctx))
-    
-    notify_config_changed(ctx)
+
+    global_event_bus.emit("config:changed", ctx=ctx)
 
 
 def get_text_model_options(services):
@@ -1140,18 +1125,23 @@ class ConfigService(ServiceBase):
                 ctx = get_ctx()
                 endpoint = get_current_endpoint(ctx)
                 set_api_key_for_endpoint(ctx, endpoint, value or "")
-                if self._events and value != old_value:
-                    self._events.emit("config:changed", key=key, value=value, old_value=old_value)
+                if value != old_value:
+                    bus = self._events or global_event_bus
+                    bus.emit("config:changed", key=key, value=value, old_value=old_value, ctx=ctx)
                 return
             elif field == "horde_model":
-                set_image_model(get_ctx(), value or "", update_lru=True)
-                if self._events and value != old_value:
-                    self._events.emit("config:changed", key=key, value=value, old_value=old_value)
+                ctx = get_ctx()
+                set_image_model(ctx, value or "", update_lru=True)
+                if value != old_value:
+                    bus = self._events or global_event_bus
+                    bus.emit("config:changed", key=key, value=value, old_value=old_value, ctx=ctx)
                 return
             elif field == "horde_api_key":
-                set_config(get_ctx(), "aihorde_api_key", value)
-                if self._events and value != old_value:
-                    self._events.emit("config:changed", key=key, value=value, old_value=old_value)
+                ctx = get_ctx()
+                set_config(ctx, "aihorde_api_key", value)
+                if value != old_value:
+                    bus = self._events or global_event_bus
+                    bus.emit("config:changed", key=key, value=value, old_value=old_value, ctx=ctx)
                 return
 
             if field in AI_SIMPLE_FIELDS:
@@ -1174,12 +1164,14 @@ class ConfigService(ServiceBase):
                     # Direct 1:1 mapping to top-level key.
                     set_config(ctx, field, value)
 
-                if self._events and value != old_value:
-                    self._events.emit(
+                if value != old_value:
+                    bus = self._events or global_event_bus
+                    bus.emit(
                         "config:changed",
                         key=key,
                         value=value,
                         old_value=old_value,
+                        ctx=ctx
                     )
                 return
 
@@ -1200,11 +1192,15 @@ class ConfigService(ServiceBase):
                     json.dump(data, f)
             except OSError as e:
                 log.error("ConfigService.set config file save error: %s", e)
-        else:
-            set_config(get_ctx(), key, value)
 
-        if self._events and value != old_value:
-            self._events.emit("config:changed", key=key, value=value, old_value=old_value)
+            ctx = None # No UNO context in file-based test mode
+        else:
+            ctx = get_ctx()
+            set_config(ctx, key, value)
+
+        if value != old_value:
+            bus = self._events or global_event_bus
+            bus.emit("config:changed", key=key, value=value, old_value=old_value, ctx=ctx)
 
     def set_batch(self, changes, old_values=None):
         """Set multiple config values at once. Returns dict of changed keys.

--- a/plugin/framework/settings_dialog.py
+++ b/plugin/framework/settings_dialog.py
@@ -14,7 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from plugin.framework.config import get_config, set_config, get_current_endpoint, as_bool, endpoint_from_selector_text, get_image_model, set_image_model, get_api_key_for_endpoint, set_api_key_for_endpoint, notify_config_changed
+from plugin.framework.config import get_config, set_config, get_current_endpoint, as_bool, endpoint_from_selector_text, get_image_model, set_image_model, get_api_key_for_endpoint, set_api_key_for_endpoint
+from plugin.framework.event_bus import global_event_bus
 
 import logging
 from plugin.framework.i18n import _
@@ -197,7 +198,7 @@ def apply_settings_result(ctx, result):
     if "api_key" in result:
         set_api_key_for_endpoint(ctx, current_endpoint, result["api_key"])
 
-    notify_config_changed(ctx)
+    global_event_bus.emit("config:changed", ctx=ctx)
 
 
 def _call_options_provider(ctx, provider_path):

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -145,6 +145,12 @@ def bootstrap(ctx=None):
         _tools = ToolRegistry(_services)
         _services.register("tools", _tools)
 
+        # Wire config service to events
+        config_svc = _services.get("config")
+        events_svc = _services.get("events")
+        if config_svc and events_svc:
+            config_svc.set_events(events_svc)
+
         # Initialize i18n
         from plugin.framework.i18n import init_i18n
         init_i18n(ctx)

--- a/plugin/modules/chatbot/panel_factory.py
+++ b/plugin/modules/chatbot/panel_factory.py
@@ -247,6 +247,10 @@ class ChatPanelElement(unohelper.Base, XUIElement):
         self.m_panelRootWindow = None
         self.session = None  # Created in _wireControls
 
+    def _on_config_changed(self, **kwargs):
+        """Event bus listener for config changes."""
+        self._refresh_controls_from_config()
+
     def getRealInterface(self):
         log.debug("=== getRealInterface called ===")
         if not self.toolpanel:

--- a/plugin/modules/chatbot/panel_wiring.py
+++ b/plugin/modules/chatbot/panel_wiring.py
@@ -264,13 +264,8 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):
     self._update_backend_indicator(root_window)
 
     # 6. Global Config Listener
-    from plugin.framework.config import add_config_listener
-    _self_ref = weakref.ref(self)
-    def on_config_changed(ctx):
-        panel = _self_ref()
-        if panel is not None:
-            panel._refresh_controls_from_config()
-    add_config_listener(on_config_changed)
+    from plugin.framework.event_bus import global_event_bus
+    global_event_bus.subscribe("config:changed", self._on_config_changed, weak=True)
 
     # Weekly extension update check: run once per process, late (after sidebar UI is wired)
     # so logging is initialized and AsyncCallback/msgbox are reliable.

--- a/plugin/tests/test_config_sync.py
+++ b/plugin/tests/test_config_sync.py
@@ -18,9 +18,9 @@ sys.path.insert(0, os.path.dirname(get_plugin_dir()))
 
 from plugin.framework.config import (
     get_image_model, set_image_model, get_api_key_for_endpoint, set_api_key_for_endpoint,
-    add_config_listener, notify_config_changed, _config_listeners,
     update_lru_history, get_config
 )
+from plugin.framework.event_bus import global_event_bus
 
 class TestConfigSync(unittest.TestCase):
     def setUp(self):
@@ -36,34 +36,33 @@ class TestConfigSync(unittest.TestCase):
             
         self.get_patcher = patch('plugin.framework.config.get_config', side_effect=mock_get_config)
         self.set_patcher = patch('plugin.framework.config.set_config', side_effect=mock_set_config)
-        self.notify_patcher = patch('plugin.framework.config.notify_config_changed')
         
         self.mock_get = self.get_patcher.start()
         self.mock_set = self.set_patcher.start()
-        self.mock_notify = self.notify_patcher.start()
 
     def tearDown(self):
         self.get_patcher.stop()
         self.set_patcher.stop()
-        self.notify_patcher.stop()
 
     def test_set_image_model_aihorde(self):
         self.config_data["image_provider"] = "aihorde"
-        set_image_model(self.ctx, "new-horde-model")
-        
-        self.assertEqual(self.config_data.get("aihorde_model"), "new-horde-model")
-        self.assertIsNone(self.config_data.get("image_model"))
-        self.mock_notify.assert_called_once_with(self.ctx)
+        with patch.object(global_event_bus, 'emit') as mock_emit:
+            set_image_model(self.ctx, "new-horde-model")
+
+            self.assertEqual(self.config_data.get("aihorde_model"), "new-horde-model")
+            self.assertIsNone(self.config_data.get("image_model"))
+            mock_emit.assert_called_once_with("config:changed", ctx=self.ctx)
 
     def test_set_image_model_endpoint(self):
         self.config_data["image_provider"] = "endpoint"
-        with patch('plugin.framework.config.update_lru_history') as mock_lru:
+        with patch('plugin.framework.config.update_lru_history') as mock_lru, \
+             patch.object(global_event_bus, 'emit') as mock_emit:
             set_image_model(self.ctx, "new-endpoint-model")
             
             self.assertEqual(self.config_data.get("image_model"), "new-endpoint-model")
             self.assertIsNone(self.config_data.get("aihorde_model"))
             mock_lru.assert_called_once_with(self.ctx, "new-endpoint-model", "image_model_lru", "")
-            self.mock_notify.assert_called_once_with(self.ctx)
+            mock_emit.assert_called_once_with("config:changed", ctx=self.ctx)
 
     def test_update_lru_history_scoping(self):
         # Test with endpoint
@@ -114,37 +113,27 @@ class TestConfigSync(unittest.TestCase):
         set_api_key_for_endpoint(self.ctx, "http://localhost:11434/", "updated-key")
         self.assertEqual(self.config_data.get("api_keys_by_endpoint", {}).get("http://localhost:11434"), "updated-key")
 
-    def test_add_config_listener_and_notify(self):
-        # Temporarily clear listeners to isolate the test
-        original_listeners = list(_config_listeners)
-        _config_listeners.clear()
+    def test_event_bus_listener_and_emit(self):
+        called = []
+        def my_callback(ctx=None, **kwargs):
+            called.append(ctx)
+
+        global_event_bus.subscribe("config:changed", my_callback)
         try:
-            called = []
-            def my_callback(ctx):
-                called.append(ctx)
+            global_event_bus.emit("config:changed", ctx=self.ctx)
+            self.assertEqual(len(called), 1)
+            self.assertEqual(called[0], self.ctx)
 
-            add_config_listener(my_callback)
+            # Test exception swallowing (already tested in event_bus tests, but good to verify integration)
+            def bad_callback(**kwargs):
+                raise ValueError("Simulated error")
+            global_event_bus.subscribe("config:changed", bad_callback)
 
-            # Since notify_config_changed is mocked in setUp, we need to temporarily stop the patch
-            # to test its actual implementation
-            self.notify_patcher.stop()
-            try:
-                notify_config_changed(self.ctx)
-                self.assertEqual(len(called), 1)
-                self.assertEqual(called[0], self.ctx)
-
-                # Test exception swallowing
-                def bad_callback(ctx):
-                    raise ValueError("Simulated error")
-                add_config_listener(bad_callback)
-
-                notify_config_changed(self.ctx)
-                self.assertEqual(len(called), 2) # First callback still gets called again
-            finally:
-                self.mock_notify = self.notify_patcher.start()
+            global_event_bus.emit("config:changed", ctx=self.ctx)
+            self.assertEqual(len(called), 2) # First callback still gets called again
         finally:
-            _config_listeners.clear()
-            _config_listeners.extend(original_listeners)
+            global_event_bus.unsubscribe("config:changed", my_callback)
+            global_event_bus.unsubscribe("config:changed", bad_callback)
 
 
 class TestConfigSyncFileIO(unittest.TestCase):


### PR DESCRIPTION
Refactored the custom pub/sub logic in `plugin/framework/config.py` to use the shared `EventBus`. Removed `_config_listeners`, `add_config_listener`, and `notify_config_changed`. Updated `ConfigService`, `set_config`, `remove_config`, and `set_image_model` to emit `"config:changed"` events. Updated the chatbot panel and settings dialog to subscribe/emit via the event bus, and updated tests and documentation accordingly.