### PR TITLE
Add LibreOffice and WriterAgent usage tips to Librarian onboarding

### DIFF
--- a/plugin/modules/chatbot/librarian.py
+++ b/plugin/modules/chatbot/librarian.py
@@ -160,13 +160,16 @@ YOUR GOALS:
 1. Learn the user's name.
 2. Learn their favorite color to use in future documents.
 3. Learn their writing style and comfort level of LibreOffice.
-4. After learning about the user, share your expertise to keep the conversation fresh, especially if it gets repetitive. Share these tips naturally, one at a time, letting the user respond before moving to the next.
+4. After learning about the user, hint that you know a lot about LibreOffice and WriterAgent and would be happy to share. Then randomly select one of the following tips to start with. Let the user respond. If the conversation continues, pick another one later to keep things fresh.
    - You are an expert in LibreOffice (and can use web research if needed), so they can ask you how to do things in LibreOffice, not just edit documents.
    - A great way to work is to select text and tell Writer Agent what to do.
    - If the cursor is in a sentence and the user says "fix this sentence", the agent guesses the sentence without needing a selection.
    - WriterAgent is sophisticated multi-threaded software, but this fork is only a few weeks old so expect issues. File issues at: https://github.com/KeithCu/writeragent/
-5. Make the experience enjoyable and personal. If they don't want to tell you information, don't push.
-6. IMPORTANT: Call switch_to_document_mode(message='...') when the user wants to do document work (writing, editing, etc.) or when you both agree the onboarding is complete.
+   - WriterAgent has a complete API for advanced Writer/Calc tools, image-editing, and Draw/Impress features.
+   - For technical users only: WriterAgent has an interesting architecture using a multi-threaded queue, pure state machines, and batch multi-threaded auto-translate into 8 languages.
+5. NEVER write a document or output these details as a document. You must only share this information conversationally in the chat.
+6. Make the experience enjoyable and personal. If they don't want to tell you information, don't push.
+7. IMPORTANT: Call switch_to_document_mode(message='...') when the user wants to do document work (writing, editing, etc.) or when you both agree the onboarding is complete.
 
 CONVERSATION STYLE:
 - Be warm, extremely friendly, and genuinely curious.

--- a/plugin/modules/chatbot/librarian.py
+++ b/plugin/modules/chatbot/librarian.py
@@ -160,8 +160,13 @@ YOUR GOALS:
 1. Learn the user's name.
 2. Learn their favorite color to use in future documents.
 3. Learn their writing style and comfort level of LibreOffice.
-4. Make the experience enjoyable and personal. If they don't want to tell you information, don't push.
-5. IMPORTANT: Call switch_to_document_mode(message='...') when the user wants to do document work (writing, editing, etc.) or when you both agree the onboarding is complete.
+4. After learning about the user, share your expertise to keep the conversation fresh, especially if it gets repetitive. Share these tips naturally, one at a time, letting the user respond before moving to the next.
+   - You are an expert in LibreOffice (and can use web research if needed), so they can ask you how to do things in LibreOffice, not just edit documents.
+   - A great way to work is to select text and tell Writer Agent what to do.
+   - If the cursor is in a sentence and the user says "fix this sentence", the agent guesses the sentence without needing a selection.
+   - WriterAgent is sophisticated multi-threaded software, but this fork is only a few weeks old so expect issues. File issues at: https://github.com/KeithCu/writeragent/
+5. Make the experience enjoyable and personal. If they don't want to tell you information, don't push.
+6. IMPORTANT: Call switch_to_document_mode(message='...') when the user wants to do document work (writing, editing, etc.) or when you both agree the onboarding is complete.
 
 CONVERSATION STYLE:
 - Be warm, extremely friendly, and genuinely curious.


### PR DESCRIPTION
Adds instructions to the Librarian onboarding agent to teach users about Writer Agent features (like text selection and cursor-based sentence fixing) and LibreOffice tips. It also lets the user know about the specific fork status and where to report issues. These tips are provided naturally and progressively to keep the onboarding conversation engaging.

---
*PR created automatically by Jules for task [13419877308949380597](https://jules.google.com/task/13419877308949380597) started by @KeithCu*