### PR TITLE
🧹 Refactor ToolRegistry to dynamically identify final answer tools

### DIFF
--- a/plugin/framework/tool_base.py
+++ b/plugin/framework/tool_base.py
@@ -44,6 +44,8 @@ class ToolBase(ABC):
         is_mutation:  Whether the tool mutates the document.  ``None``
                      means auto-detect from name prefix.
         long_running: Hint that the tool may take a while (e.g. image gen).
+    is_final_answer_tool: Whether this tool represents a final answer or
+                          workflow completion (e.g., "final_answer").
     """
 
     name: str | None = None
@@ -54,6 +56,7 @@ class ToolBase(ABC):
     intent: str | None = None
     is_mutation: bool | None = None
     long_running: bool = False
+    is_final_answer_tool: bool = False
 
     def detects_mutation(self):
         """Return True if the tool mutates the document."""

--- a/plugin/framework/tool_registry.py
+++ b/plugin/framework/tool_registry.py
@@ -207,8 +207,7 @@ class ToolRegistry:
             for t in tools:
                 if isinstance(t, ToolWriterSpecialBase) and t.specialized_domain == active_domain:
                     filtered_tools.append(t)
-                #FIXME, these strings should be calculated or handled another way
-                elif getattr(t, "name", "") in ["final_answer", "specialized_workflow_finished", "reply_to_user"]:
+                elif getattr(t, "is_final_answer_tool", False):
                     filtered_tools.append(t)
             tools = filtered_tools
         else:

--- a/plugin/modules/writer/base.py
+++ b/plugin/modules/writer/base.py
@@ -127,6 +127,7 @@ class SpecializedWorkflowFinished(ToolBase):
 
     name = "specialized_workflow_finished"
     description = "Provides a final answer to the given task and exits the specialized toolset mode."
+    is_final_answer_tool = True
     parameters = {
         "type": "object",
         "properties": {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the hardcoded list of strings (`["final_answer", "specialized_workflow_finished", "reply_to_user"]`) in `plugin/framework/tool_registry.py` and replaced it with a dynamic boolean check `getattr(t, "is_final_answer_tool", False)`. Added `is_final_answer_tool = False` to `ToolBase` and overrode it as `True` in the `SpecializedWorkflowFinished` tool.

💡 **Why:** How this improves maintainability
This prevents the `ToolRegistry` from needing to know the specific names of final answer tools across different domains. Hardcoding class names/identifiers in a central registry makes adding new tools brittle and couples the registry to specific features (e.g. Writer specialized tools, Librarian). By using a boolean flag, tools can self-declare their role in the workflow.

✅ **Verification:** How you confirmed the change is safe
Ran `uv run ty check plugin/framework/tool_registry.py` to verify type safety. Ran the full pytest suite (`uv run pytest plugin/tests/`) and confirmed all tests pass without introducing new failures. Validated that `reply_to_user` and `final_answer` are handled dynamically as `final_answer_tool_name` parameters within `smolagents` and thus never needed to be in the `ToolBase` list anyway.

✨ **Result:** The improvement achieved
A cleaner, decoupled `ToolRegistry` that scales safely with new tools and cleanly relies on properties of the `ToolBase` hierarchy.

---
*PR created automatically by Jules for task [9247852521992975344](https://jules.google.com/task/9247852521992975344) started by @KeithCu*