### PR TITLE
Fix transcription infinite loop on error

### DIFF
--- a/plugin/modules/chatbot/send_handlers.py
+++ b/plugin/modules/chatbot/send_handlers.py
@@ -116,20 +116,19 @@ class SendHandlersMixin:
             transcript_text = run_blocking_in_thread(
                 self.ctx, cl.transcribe_audio, wav_path, model=stt_model
             )
-
-            import os
-            try:
-                os.remove(wav_path)
-            except Exception:
-                pass
-            self.audio_wav_path = None
-
             return transcript_text
 
         except Exception as e:
             log.error("Transcription error in _transcribe_audio: %s", e)
             self._append_response("\n" + _("[Transcription error: {0}]").format(str(e)) + "\n")
             raise e
+        finally:
+            import os
+            try:
+                os.remove(wav_path)
+            except Exception:
+                pass
+            self.audio_wav_path = None
 
     def _run_unified_worker_drain_loop(
         self: SendHandlerHost,


### PR DESCRIPTION
Moved the temporary wav file deletion and state clearance logic to a `finally` block in `_transcribe_audio` of `plugin/modules/chatbot/send_handlers.py`. This ensures that if the `run_blocking_in_thread` throws an error (e.g. 404 from Provider), the audio processing state doesn't stay stuck as "active" for the next chat interactions.

---
*PR created automatically by Jules for task [12398851937750655096](https://jules.google.com/task/12398851937750655096) started by @KeithCu*