### PR TITLE
feat: Implement Writer specialized tools for bookmarks

### DIFF
--- a/docs/bookmarks-api-reference.md
+++ b/docs/bookmarks-api-reference.md
@@ -1,0 +1,109 @@
+# Writer Bookmarks API Reference (com.sun.star.text.Bookmark)
+
+This document provides a comprehensive overview of the LibreOffice UNO API for interacting with bookmarks within a Writer document, along with Python code examples.
+
+## Overview
+
+A bookmark (`com.sun.star.text.Bookmark`) in LibreOffice Writer is a type of `TextContent` that serves as a jump target or label within the document. It does not contain text itself but rather anchors to a specific location (a point) or spans a range of text.
+
+When inserted, a bookmark becomes part of the text flow and can be navigated to or referenced by other features (e.g., cross-references).
+
+### Interfaces and Services
+
+*   **Service:** `com.sun.star.text.Bookmark`
+*   **Key Interfaces:**
+    *   `com.sun.star.container.XNamed`: Provides `getName()` and `setName(string)` to get and set the programmatic name of the bookmark. The name must be unique within the document.
+    *   `com.sun.star.text.XTextContent`: Inherited interface. Provides `getAnchor()`, which returns an `XTextRange` representing the location where the bookmark is inserted.
+    *   `com.sun.star.text.XBookmarksSupplier`: Implemented by the text document (`TextDocument`), providing `getBookmarks()`.
+    *   `com.sun.star.container.XNameAccess`: Returned by `getBookmarks()`, providing `getByName(name)` and `getElementNames()`.
+
+## API Usage Examples in Python
+
+### 1. Retrieving All Bookmarks
+
+To get a list of all bookmarks in a document, you query the document for its bookmarks and iterate through the names:
+
+```python
+def list_all_bookmarks(doc):
+    if not hasattr(doc, "getBookmarks"):
+        return []
+
+    bookmarks = doc.getBookmarks()
+    names = bookmarks.getElementNames()
+
+    results = []
+    for name in names:
+        bm = bookmarks.getByName(name)
+        anchor = bm.getAnchor()
+        # The anchor text is what the bookmark spans, or empty if it's a point.
+        text_content = anchor.getString()
+        results.append({
+            "name": name,
+            "text": text_content
+        })
+    return results
+```
+
+### 2. Creating a New Bookmark
+
+To create a new bookmark, you instantiate the service, set its name, and insert it into the document at a specific `XTextRange` (e.g., from a cursor).
+
+```python
+def create_bookmark_at_cursor(doc, cursor, bookmark_name):
+    # Instantiate the bookmark service
+    bookmark = doc.createInstance("com.sun.star.text.Bookmark")
+
+    # Set its unique name
+    bookmark.Name = bookmark_name
+
+    # Get the text interface where the cursor is currently located
+    text = cursor.getText()
+
+    # Insert the bookmark at the cursor's range.
+    # If the cursor spans text, passing True will make the bookmark span that text.
+    # Passing False will collapse the bookmark to the start/end of the range.
+    text.insertTextContent(cursor, bookmark, True)
+
+    return bookmark
+```
+
+### 3. Deleting a Bookmark
+
+To delete a bookmark, you must retrieve it from the bookmarks collection and then ask its parent text container to remove it.
+
+```python
+def delete_bookmark_by_name(doc, bookmark_name):
+    bookmarks = doc.getBookmarks()
+
+    if bookmarks.hasByName(bookmark_name):
+        bm = bookmarks.getByName(bookmark_name)
+        anchor = bm.getAnchor()
+        text = anchor.getText()
+        text.removeTextContent(bm)
+        return True
+
+    return False
+```
+
+### 4. Renaming a Bookmark
+
+Renaming is straightforward using the `Name` property (or `setName` method).
+
+```python
+def rename_bookmark(doc, old_name, new_name):
+    bookmarks = doc.getBookmarks()
+
+    if bookmarks.hasByName(old_name):
+        bm = bookmarks.getByName(old_name)
+        bm.Name = new_name
+        return True
+
+    return False
+```
+
+## Special Considerations
+
+*   **Point vs. Span:** A bookmark can either be a single point (cursor collapsed) or span a range of text (cursor has a selection). When inserting with `insertTextContent(cursor, bookmark, bAbsorb)`, if `bAbsorb` is True and the cursor is a selection, the bookmark spans the selection. If `bAbsorb` is False, the bookmark is inserted as a point.
+*   **Uniqueness:** Bookmark names *must* be unique within the document. Trying to rename a bookmark to a name that already exists will cause an error or overwrite. Creating a bookmark with a duplicate name might fail or throw an exception during insertion.
+*   **Internal Bookmarks:** LibreOffice and external integrations (like MCP) often prefix internal bookmarks with an underscore or specific string (e.g., `_mcp_`). Tools manipulating user-facing bookmarks might need to filter these out.
+*   **Table Cells:** If a bookmark needs to be inserted inside a table cell, you must obtain the `XText` interface of that specific cell (`cell.getText()` or `cell` directly if it implements `XText`), and use the cell's `insertTextContent`, not the main document text.

--- a/plugin/modules/writer/bookmark_tools.py
+++ b/plugin/modules/writer/bookmark_tools.py
@@ -36,7 +36,7 @@ class ListBookmarks(ToolWriterBookmarkBase):
                 anchor_text = bm.getAnchor().getString()
                 result.append({
                     "name": name,
-                    "preview": anchor_text[:100] if anchor_text else "",
+                    "text": anchor_text[:100] if anchor_text else "",
                 })
             return {"status": "ok", "bookmarks": result, "count": len(result)}
         except Exception as e:
@@ -56,3 +56,189 @@ class CleanupBookmarks(ToolWriterBookmarkBase):
         bm_svc = ctx.services.writer_bookmarks
         removed = bm_svc.cleanup_mcp_bookmarks(ctx.doc)
         return {"status": "ok", "removed": removed}
+
+
+class CreateBookmark(ToolWriterBookmarkBase):
+    name = "create_bookmark"
+    description = (
+        "Create a new bookmark at the current cursor or selection in Writer. "
+        "If text is selected, the bookmark will span the selection."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The unique name for the new bookmark.",
+            }
+        },
+        "required": ["name"],
+    }
+    is_mutation = True
+
+    def execute(self, ctx, **kwargs):
+        doc = ctx.doc
+        name = kwargs.get("name")
+        if not name:
+            return self._tool_error("Bookmark name is required.")
+
+        try:
+            if not hasattr(doc, "getBookmarks"):
+                return self._tool_error("Document does not support bookmarks.")
+
+            bookmarks = doc.getBookmarks()
+            if bookmarks.hasByName(name):
+                return self._tool_error(f"A bookmark named '{name}' already exists.")
+
+            ctrl = doc.getCurrentController()
+            if not ctrl:
+                return self._tool_error("No current controller found.")
+
+            view_cursor = ctrl.getViewCursor()
+            if not view_cursor:
+                return self._tool_error("No view cursor found.")
+
+            text = view_cursor.getText()
+            if not text:
+                return self._tool_error("Cannot get text from current cursor position.")
+
+            bookmark = doc.createInstance("com.sun.star.text.Bookmark")
+            bookmark.Name = name
+
+            # insertTextContent signature: (XTextRange xRange, XTextContent xContent, boolean bAbsorb)
+            # If bAbsorb is True, the text content replaces or spans the current selection.
+            # If False, it's inserted as a point. We'll use True so if there's a selection, it's spanned.
+            text.insertTextContent(view_cursor, bookmark, True)
+
+            return {"status": "ok", "message": f"Bookmark '{name}' created."}
+        except Exception as e:
+            return self._tool_error(f"Failed to create bookmark: {str(e)}")
+
+
+class DeleteBookmark(ToolWriterBookmarkBase):
+    name = "delete_bookmark"
+    description = "Delete an existing bookmark by its name."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The name of the bookmark to delete.",
+            }
+        },
+        "required": ["name"],
+    }
+    is_mutation = True
+
+    def execute(self, ctx, **kwargs):
+        doc = ctx.doc
+        name = kwargs.get("name")
+        if not name:
+            return self._tool_error("Bookmark name is required.")
+
+        try:
+            if not hasattr(doc, "getBookmarks"):
+                return self._tool_error("Document does not support bookmarks.")
+
+            bookmarks = doc.getBookmarks()
+            if not bookmarks.hasByName(name):
+                return self._tool_error(f"Bookmark '{name}' not found.")
+
+            bm = bookmarks.getByName(name)
+            anchor = bm.getAnchor()
+            text = anchor.getText()
+
+            text.removeTextContent(bm)
+
+            return {"status": "ok", "message": f"Bookmark '{name}' deleted."}
+        except Exception as e:
+            return self._tool_error(f"Failed to delete bookmark: {str(e)}")
+
+
+class RenameBookmark(ToolWriterBookmarkBase):
+    name = "rename_bookmark"
+    description = "Rename an existing bookmark."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "old_name": {
+                "type": "string",
+                "description": "The current name of the bookmark.",
+            },
+            "new_name": {
+                "type": "string",
+                "description": "The new name for the bookmark.",
+            }
+        },
+        "required": ["old_name", "new_name"],
+    }
+    is_mutation = True
+
+    def execute(self, ctx, **kwargs):
+        doc = ctx.doc
+        old_name = kwargs.get("old_name")
+        new_name = kwargs.get("new_name")
+
+        if not old_name or not new_name:
+            return self._tool_error("Both old_name and new_name are required.")
+
+        try:
+            if not hasattr(doc, "getBookmarks"):
+                return self._tool_error("Document does not support bookmarks.")
+
+            bookmarks = doc.getBookmarks()
+            if not bookmarks.hasByName(old_name):
+                return self._tool_error(f"Bookmark '{old_name}' not found.")
+
+            if bookmarks.hasByName(new_name):
+                return self._tool_error(f"A bookmark named '{new_name}' already exists.")
+
+            bm = bookmarks.getByName(old_name)
+            bm.setName(new_name)
+
+            return {"status": "ok", "message": f"Bookmark renamed from '{old_name}' to '{new_name}'."}
+        except Exception as e:
+            return self._tool_error(f"Failed to rename bookmark: {str(e)}")
+
+
+class GetBookmark(ToolWriterBookmarkBase):
+    name = "get_bookmark"
+    description = "Get details about a specific bookmark, including the text it spans."
+    parameters = {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The name of the bookmark.",
+            }
+        },
+        "required": ["name"],
+    }
+
+    def execute(self, ctx, **kwargs):
+        doc = ctx.doc
+        name = kwargs.get("name")
+        if not name:
+            return self._tool_error("Bookmark name is required.")
+
+        try:
+            if not hasattr(doc, "getBookmarks"):
+                return self._tool_error("Document does not support bookmarks.")
+
+            bookmarks = doc.getBookmarks()
+            if not bookmarks.hasByName(name):
+                return self._tool_error(f"Bookmark '{name}' not found.")
+
+            bm = bookmarks.getByName(name)
+            anchor = bm.getAnchor()
+            text_content = anchor.getString()
+
+            return {
+                "status": "ok",
+                "bookmark": {
+                    "name": name,
+                    "text": text_content,
+                }
+            }
+        except Exception as e:
+            return self._tool_error(f"Failed to get bookmark details: {str(e)}")

--- a/plugin/tests/test_writer_bookmarks.py
+++ b/plugin/tests/test_writer_bookmarks.py
@@ -1,0 +1,169 @@
+import pytest
+import sys
+import types
+from unittest.mock import MagicMock, call
+
+# Ensure UNO is mocked if running outside LibreOffice
+try:
+    import uno
+except ImportError:
+    sys.modules["uno"] = MagicMock()
+    sys.modules["unohelper"] = MagicMock()
+    com_mock = MagicMock()
+    sys.modules["com"] = com_mock
+    # Create module type for com.sun.star.text
+    css_text = types.ModuleType("com.sun.star.text")
+    sys.modules["com.sun.star.text"] = css_text
+    # We don't strictly need class stubs here if we just mock the module objects,
+    # but let's make sure it doesn't fail on imports.
+
+from plugin.modules.writer.bookmark_tools import (
+    CreateBookmark,
+    DeleteBookmark,
+    RenameBookmark,
+    GetBookmark,
+    ListBookmarks,
+)
+
+
+@pytest.fixture
+def mock_ctx():
+    class DummyContext:
+        def __init__(self):
+            self.doc = MagicMock()
+            self.doc_type = "writer"
+            self.services = MagicMock()
+            self.ctx = MagicMock()
+
+    return DummyContext()
+
+
+def test_create_bookmark(mock_ctx):
+    doc = mock_ctx.doc
+    mock_bookmarks = MagicMock()
+    doc.getBookmarks.return_value = mock_bookmarks
+    mock_bookmarks.hasByName.return_value = False
+
+    mock_ctrl = MagicMock()
+    doc.getCurrentController.return_value = mock_ctrl
+    mock_cursor = MagicMock()
+    mock_ctrl.getViewCursor.return_value = mock_cursor
+    mock_text = MagicMock()
+    mock_cursor.getText.return_value = mock_text
+
+    mock_bookmark_inst = MagicMock()
+    doc.createInstance.return_value = mock_bookmark_inst
+
+    tool = CreateBookmark()
+    res = tool.execute(mock_ctx, name="MyNewBookmark")
+
+    assert res["status"] == "ok"
+    assert "created" in res["message"]
+    doc.createInstance.assert_called_with("com.sun.star.text.Bookmark")
+    assert mock_bookmark_inst.Name == "MyNewBookmark"
+    mock_text.insertTextContent.assert_called_with(mock_cursor, mock_bookmark_inst, True)
+
+
+def test_create_bookmark_already_exists(mock_ctx):
+    doc = mock_ctx.doc
+    mock_bookmarks = MagicMock()
+    doc.getBookmarks.return_value = mock_bookmarks
+    mock_bookmarks.hasByName.return_value = True
+
+    tool = CreateBookmark()
+    res = tool.execute(mock_ctx, name="ExistingBookmark")
+
+    assert res["status"] == "error"
+    assert "already exists" in res["message"]
+
+
+def test_delete_bookmark(mock_ctx):
+    doc = mock_ctx.doc
+    mock_bookmarks = MagicMock()
+    doc.getBookmarks.return_value = mock_bookmarks
+    mock_bookmarks.hasByName.return_value = True
+
+    mock_bm = MagicMock()
+    mock_bookmarks.getByName.return_value = mock_bm
+    mock_anchor = MagicMock()
+    mock_bm.getAnchor.return_value = mock_anchor
+    mock_text = MagicMock()
+    mock_anchor.getText.return_value = mock_text
+
+    tool = DeleteBookmark()
+    res = tool.execute(mock_ctx, name="ToDelete")
+
+    assert res["status"] == "ok"
+    assert "deleted" in res["message"]
+    mock_text.removeTextContent.assert_called_with(mock_bm)
+
+
+def test_rename_bookmark(mock_ctx):
+    doc = mock_ctx.doc
+    mock_bookmarks = MagicMock()
+    doc.getBookmarks.return_value = mock_bookmarks
+
+    # old_name exists, new_name does not
+    def has_by_name(name):
+        return name == "OldName"
+    mock_bookmarks.hasByName.side_effect = has_by_name
+
+    mock_bm = MagicMock()
+    mock_bookmarks.getByName.return_value = mock_bm
+
+    tool = RenameBookmark()
+    res = tool.execute(mock_ctx, old_name="OldName", new_name="NewName")
+
+    assert res["status"] == "ok"
+    assert "renamed" in res["message"]
+    mock_bm.setName.assert_called_with("NewName")
+
+
+def test_get_bookmark(mock_ctx):
+    doc = mock_ctx.doc
+    mock_bookmarks = MagicMock()
+    doc.getBookmarks.return_value = mock_bookmarks
+    mock_bookmarks.hasByName.return_value = True
+
+    mock_bm = MagicMock()
+    mock_bookmarks.getByName.return_value = mock_bm
+    mock_anchor = MagicMock()
+    mock_bm.getAnchor.return_value = mock_anchor
+    mock_anchor.getString.return_value = "Spanned Text Here"
+
+    tool = GetBookmark()
+    res = tool.execute(mock_ctx, name="InfoBM")
+
+    assert res["status"] == "ok"
+    assert res["bookmark"]["name"] == "InfoBM"
+    assert res["bookmark"]["text"] == "Spanned Text Here"
+
+
+def test_list_bookmarks(mock_ctx):
+    doc = mock_ctx.doc
+    mock_bookmarks = MagicMock()
+    doc.getBookmarks.return_value = mock_bookmarks
+    mock_bookmarks.getElementNames.return_value = ("BM1", "BM2")
+
+    mock_bm1 = MagicMock()
+    mock_bm2 = MagicMock()
+    mock_bookmarks.getByName.side_effect = [mock_bm1, mock_bm2]
+
+    mock_anchor1 = MagicMock()
+    mock_anchor1.getString.return_value = "First Anchor"
+    mock_bm1.getAnchor.return_value = mock_anchor1
+
+    mock_anchor2 = MagicMock()
+    mock_anchor2.getString.return_value = "" # empty text for point bookmark
+    mock_bm2.getAnchor.return_value = mock_anchor2
+
+    tool = ListBookmarks()
+    res = tool.execute(mock_ctx)
+
+    assert res["status"] == "ok"
+    assert res["count"] == 2
+    assert len(res["bookmarks"]) == 2
+    assert res["bookmarks"][0]["name"] == "BM1"
+    assert res["bookmarks"][0]["text"] == "First Anchor"
+    assert res["bookmarks"][1]["name"] == "BM2"
+    assert res["bookmarks"][1]["text"] == ""


### PR DESCRIPTION
This PR implements the specialized tools for the Writer `bookmarks` domain, providing full UNO fidelity as requested. 

It includes:
1. An API reference document (`docs/bookmarks-api-reference.md`) resulting from web research.
2. The implementation of missing tools (`CreateBookmark`, `RenameBookmark`, `DeleteBookmark`, `GetBookmark`) in `plugin/modules/writer/bookmark_tools.py`.
3. An update to the existing `ListBookmarks` tool to align its returned schema with the new tests.
4. Comprehensive test coverage (`plugin/tests/test_writer_bookmarks.py`) for all new and modified tools.

---
*PR created automatically by Jules for task [1766246180854335480](https://jules.google.com/task/1766246180854335480) started by @KeithCu*