### PR TITLE
feat: add specialized footnotes and endnotes toolset

### DIFF
--- a/docs/footnotes-api-reference.md
+++ b/docs/footnotes-api-reference.md
@@ -84,6 +84,31 @@ if footnotes.getCount() > 0:
     # Alternatively: anchor.getText().removeTextContent(note)
 ```
 
+## Settings (FootnoteSettings / EndnoteSettings)
+The `getFootnoteSettings()` and `getEndnoteSettings()` methods return an `XPropertySet` that allows managing formatting and numbering rules for the respective note type. The `EndnoteSettings` service includes the properties from `FootnoteSettings`.
+
+Key Properties:
+- `Prefix` (string): Text before the footnote symbol.
+- `Suffix` (string): Text after the footnote symbol.
+- `StartAt` (short): The first number for automatic numbering.
+- `NumberingType` (short): Specifies the numbering style (e.g., Arabic, Roman).
+- `CharStyleName` (string): Character style for the note symbol.
+- `AnchorCharStyleName` (string): Character style for the note anchor in the text.
+- `PageStyleName` (string): Page style for the page containing note texts.
+- `ParaStyleName` (string): Paragraph style for the note text.
+- `BeginNotice` (string): Text at the restart of the note text after a page break (footnotes only).
+- `EndNotice` (string): Text at the end of a note part before a page break (footnotes only).
+- `PositionEndOfDoc` (boolean): If TRUE, footnote text is shown at the end of the document (footnotes only).
+- `FootnoteCounting` (short): How note numbers are counted (e.g., per page, per chapter, per document).
+
+Example of updating settings:
+```python
+settings = doc.getFootnoteSettings()
+settings.setPropertyValue("Prefix", "[")
+settings.setPropertyValue("Suffix", "]")
+settings.setPropertyValue("StartAt", 1)
+```
+
 ## Exceptions and Edge Cases
 - Inserting a note at an invalid position or inside another note may throw `IllegalArgumentException`.
 - Modifying notes inside read-only sections or locked text frames may fail.

--- a/docs/footnotes-api-reference.md
+++ b/docs/footnotes-api-reference.md
@@ -1,0 +1,90 @@
+# Footnotes and Endnotes API Reference
+
+## Overview
+
+LibreOffice provides UNO APIs to manage Footnotes and Endnotes within a `TextDocument`. Both Footnotes and Endnotes are considered text contents that can be inserted into the document at a specific `XTextRange` (anchor). They also provide an `XText` interface allowing for rich text formatting and insertion inside the note area itself.
+
+## Core Interfaces and Services
+
+### 1. Document Level Collections
+The main document (`com.sun.star.text.TextDocument`) implements two supplier interfaces to access all notes in the document:
+
+- **`com.sun.star.text.XFootnotesSupplier`**
+  - `getFootnotes()`: Returns an `XIndexAccess` collection of all footnotes in the document.
+  - `getFootnoteSettings()`: Returns an `XPropertySet` of footnote formatting settings (e.g., prefix, suffix, numbering style).
+
+- **`com.sun.star.text.XEndnotesSupplier`**
+  - `getEndnotes()`: Returns an `XIndexAccess` collection of all endnotes in the document.
+  - `getEndnoteSettings()`: Returns an `XPropertySet` of endnote formatting settings.
+
+### 2. Note Instances
+A single footnote or endnote is created using the document's `XMultiServiceFactory` (`createInstance` method):
+
+- `com.sun.star.text.Footnote` (for footnotes)
+- `com.sun.star.text.Endnote` (for endnotes)
+
+Both instances implement the following key interfaces:
+- **`com.sun.star.text.XFootnote`**
+  - `getLabel()`: Gets the custom anchor mark string (if any). If it's an automatically numbered note, this is usually empty.
+  - `setLabel(label: str)`: Sets a custom anchor mark string for the note. If set to an empty string `""`, it reverts to automatic numbering.
+- **`com.sun.star.text.XTextContent`**
+  - Allows it to be attached (inserted) into the document via `doc.getText().insertTextContent(cursor, note, False)`.
+  - `getAnchor()`: Returns the `XTextRange` in the document body where the note is anchored.
+- **`com.sun.star.text.XText`**
+  - The note object *itself* is an `XText`, meaning you can insert strings, paragraphs, or other elements inside the note's text area (at the bottom of the page or document).
+  - You can use `note.setString("This is the note text.")` or create a cursor inside it via `note.createTextCursor()`.
+
+## Workflows
+
+### 1. Creating a Footnote/Endnote
+```python
+# Create the instance
+note = doc.createInstance("com.sun.star.text.Footnote") # or Endnote
+
+# Optional: set a custom label instead of auto-numbering
+note.setLabel("*")
+
+# Insert it at the current cursor position in the document
+doc.getText().insertTextContent(cursor, note, False)
+
+# Set the text inside the footnote area
+note.setString("This is the text at the bottom of the page.")
+```
+
+### 2. Listing Footnotes/Endnotes
+```python
+footnotes = doc.getFootnotes()
+for i in range(footnotes.getCount()):
+    note = footnotes.getByIndex(i)
+    label = note.getLabel() # "" if auto-numbered
+    text = note.getString()
+    print(f"Footnote {i}: [{label}] {text}")
+```
+
+### 3. Editing a Footnote/Endnote
+```python
+footnotes = doc.getFootnotes()
+if footnotes.getCount() > 0:
+    note = footnotes.getByIndex(0)
+    # Update text
+    note.setString("Updated note text.")
+    # Update label
+    note.setLabel("†")
+```
+
+### 4. Deleting a Footnote/Endnote
+```python
+footnotes = doc.getFootnotes()
+if footnotes.getCount() > 0:
+    note = footnotes.getByIndex(0)
+    # The note object itself is anchored somewhere.
+    # We can delete it by setting its anchor's string to empty, or by using removeTextContent.
+    anchor = note.getAnchor()
+    anchor.setString("")
+    # Alternatively: anchor.getText().removeTextContent(note)
+```
+
+## Exceptions and Edge Cases
+- Inserting a note at an invalid position or inside another note may throw `IllegalArgumentException`.
+- Modifying notes inside read-only sections or locked text frames may fail.
+- Auto-numbered footnotes have a label of `""`. When retrieving the visible number, it's maintained by LibreOffice formatting; the API mostly exposes the label property if it's explicitly overridden.

--- a/plugin/modules/writer/__init__.py
+++ b/plugin/modules/writer/__init__.py
@@ -36,6 +36,7 @@ class WriterModule(ModuleBase):
             bookmark_tools,
             indexes,
             fields,
+            footnotes,
             embedded,
             tracking,
         )

--- a/plugin/modules/writer/base.py
+++ b/plugin/modules/writer/base.py
@@ -88,6 +88,12 @@ class ToolWriterBookmarkBase(ToolWriterSpecialBase):
     uno_services = ["com.sun.star.text.TextDocument"]
 
 
+class ToolWriterFootnoteBase(ToolWriterSpecialBase):
+    specialized_domain = "footnotes"
+    intent = "edit"
+    uno_services = ["com.sun.star.text.TextDocument"]
+
+
 # class SpecializedWorkflowFinished(ToolBase):
 #     """Tool called by the sub-agent to indicate it has completed its task."""
 #

--- a/plugin/modules/writer/footnotes.py
+++ b/plugin/modules/writer/footnotes.py
@@ -1,0 +1,272 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Specialized tools for managing Footnotes and Endnotes in Writer."""
+
+from typing import Any
+
+from plugin.modules.writer.base import ToolWriterFootnoteBase
+from plugin.framework.errors import ToolExecutionError
+
+
+def _get_note_supplier(doc: Any, note_type: str) -> Any:
+    if note_type == "footnote":
+        if not doc.supportsService("com.sun.star.text.GenericTextDocument"):
+            raise ToolExecutionError("Document does not support footnotes.")
+        return doc.getFootnotes()
+    elif note_type == "endnote":
+        if not doc.supportsService("com.sun.star.text.GenericTextDocument"):
+            raise ToolExecutionError("Document does not support endnotes.")
+        return doc.getEndnotes()
+    else:
+        raise ToolExecutionError(f"Invalid note_type '{note_type}'. Must be 'footnote' or 'endnote'.")
+
+
+class FootnotesInsert(ToolWriterFootnoteBase):
+    name = "footnotes_insert"
+    description = (
+        "Inserts a new footnote or endnote at the current cursor position in the document. "
+        "The note text will be placed at the bottom of the page (for footnotes) or the end "
+        "of the document (for endnotes). You can optionally provide a custom label/mark, "
+        "otherwise it will be auto-numbered."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "note_type": {
+                "type": "string",
+                "enum": ["footnote", "endnote"],
+                "description": "Whether to insert a footnote or an endnote.",
+            },
+            "text": {
+                "type": "string",
+                "description": "The content of the footnote or endnote.",
+            },
+            "label": {
+                "type": "string",
+                "description": "Optional custom mark (e.g., '*'). If omitted or empty, it uses auto-numbering.",
+            },
+        },
+        "required": ["note_type", "text"],
+    }
+    is_mutation = True
+
+    def execute(self, ctx: Any, **kwargs: Any) -> dict[str, Any]:
+        note_type = str(kwargs.get("note_type"))
+        text = str(kwargs.get("text"))
+        label = kwargs.get("label", "")
+
+        doc = ctx.doc
+
+        try:
+            # We need the current cursor to insert the note.
+            # Use the view cursor for the active location.
+            ctrl = doc.getCurrentController()
+            if not ctrl:
+                return self._tool_error("Cannot access current document controller to find cursor position.")
+
+            v_cursor = ctrl.getViewCursor()
+            if not v_cursor:
+                return self._tool_error("Cannot access view cursor.")
+
+            # Create a text cursor at the view cursor position
+            # We must collapse it to not replace text, or just insert at its start/end.
+            t_cursor = v_cursor.getText().createTextCursorByRange(v_cursor)
+            t_cursor.collapseToEnd()
+
+            # Create the note instance
+            service_name = "com.sun.star.text.Footnote" if note_type == "footnote" else "com.sun.star.text.Endnote"
+            note = doc.createInstance(service_name)
+
+            if label:
+                note.setLabel(label)
+
+            # Insert into document
+            t_cursor.getText().insertTextContent(t_cursor, note, False)
+
+            # Set text inside the note
+            note.setString(text)
+
+            return {
+                "status": "ok",
+                "message": f"Successfully inserted {note_type}.",
+                "label": note.getLabel(),
+            }
+
+        except Exception as e:
+            return self._tool_error(f"Failed to insert {note_type}: {str(e)}")
+
+
+class FootnotesList(ToolWriterFootnoteBase):
+    name = "footnotes_list"
+    description = (
+        "Lists all existing footnotes or endnotes in the document, including their indices, "
+        "labels (if custom), and text content. Use this index for editing or deleting."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "note_type": {
+                "type": "string",
+                "enum": ["footnote", "endnote"],
+                "description": "Whether to list footnotes or endnotes.",
+            },
+        },
+        "required": ["note_type"],
+    }
+    is_mutation = False
+
+    def execute(self, ctx: Any, **kwargs: Any) -> dict[str, Any]:
+        note_type = str(kwargs.get("note_type"))
+        doc = ctx.doc
+
+        try:
+            notes = _get_note_supplier(doc, note_type)
+            count = notes.getCount()
+
+            results = []
+            for i in range(count):
+                note = notes.getByIndex(i)
+                label = note.getLabel()
+                text = note.getString()
+                results.append({
+                    "index": i,
+                    "label": label,
+                    "text": text
+                })
+
+            return {
+                "status": "ok",
+                "count": count,
+                "notes": results,
+            }
+        except Exception as e:
+            return self._tool_error(f"Failed to list {note_type}s: {str(e)}")
+
+
+class FootnotesEdit(ToolWriterFootnoteBase):
+    name = "footnotes_edit"
+    description = (
+        "Edits an existing footnote or endnote. You must provide the index (from footnotes_list) "
+        "and the new text content. You can optionally provide a new custom label, or set it to an "
+        "empty string to revert to auto-numbering."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "note_type": {
+                "type": "string",
+                "enum": ["footnote", "endnote"],
+                "description": "Whether to edit a footnote or an endnote.",
+            },
+            "index": {
+                "type": "integer",
+                "description": "The 0-based index of the note to edit (from footnotes_list).",
+            },
+            "text": {
+                "type": "string",
+                "description": "The new text content for the note.",
+            },
+            "label": {
+                "type": "string",
+                "description": "Optional custom mark (e.g., '*'). Leave empty to revert to auto-numbering.",
+            },
+        },
+        "required": ["note_type", "index"],
+    }
+    is_mutation = True
+
+    def execute(self, ctx: Any, **kwargs: Any) -> dict[str, Any]:
+        note_type = str(kwargs.get("note_type"))
+        index_val = kwargs.get("index")
+        index = int(index_val) if index_val is not None else -1
+
+        doc = ctx.doc
+
+        try:
+            notes = _get_note_supplier(doc, note_type)
+            count = notes.getCount()
+
+            if index < 0 or index >= count:
+                return self._tool_error(f"Invalid index {index}. The document has {count} {note_type}(s).")
+
+            note = notes.getByIndex(index)
+
+            if "text" in kwargs:
+                note.setString(kwargs["text"])
+
+            if "label" in kwargs:
+                note.setLabel(kwargs["label"])
+
+            return {
+                "status": "ok",
+                "message": f"Successfully edited {note_type} at index {index}.",
+            }
+
+        except Exception as e:
+            return self._tool_error(f"Failed to edit {note_type}: {str(e)}")
+
+
+class FootnotesDelete(ToolWriterFootnoteBase):
+    name = "footnotes_delete"
+    description = (
+        "Deletes an existing footnote or endnote based on its index (from footnotes_list)."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "note_type": {
+                "type": "string",
+                "enum": ["footnote", "endnote"],
+                "description": "Whether to delete a footnote or an endnote.",
+            },
+            "index": {
+                "type": "integer",
+                "description": "The 0-based index of the note to delete (from footnotes_list).",
+            },
+        },
+        "required": ["note_type", "index"],
+    }
+    is_mutation = True
+
+    def execute(self, ctx: Any, **kwargs: Any) -> dict[str, Any]:
+        note_type = str(kwargs.get("note_type"))
+        index_val = kwargs.get("index")
+        index = int(index_val) if index_val is not None else -1
+
+        doc = ctx.doc
+
+        try:
+            notes = _get_note_supplier(doc, note_type)
+            count = notes.getCount()
+
+            if index < 0 or index >= count:
+                return self._tool_error(f"Invalid index {index}. The document has {count} {note_type}(s).")
+
+            note = notes.getByIndex(index)
+
+            # The note object itself is anchored somewhere.
+            # We delete it by removing it from its anchor's text content.
+            anchor = note.getAnchor()
+            # Deleting the anchor text removes the footnote
+            anchor.setString("")
+
+            return {
+                "status": "ok",
+                "message": f"Successfully deleted {note_type} at index {index}.",
+            }
+
+        except Exception as e:
+            return self._tool_error(f"Failed to delete {note_type}: {str(e)}")

--- a/plugin/modules/writer/footnotes.py
+++ b/plugin/modules/writer/footnotes.py
@@ -33,6 +33,18 @@ def _get_note_supplier(doc: Any, note_type: str) -> Any:
     else:
         raise ToolExecutionError(f"Invalid note_type '{note_type}'. Must be 'footnote' or 'endnote'.")
 
+def _get_note_settings(doc: Any, note_type: str) -> Any:
+    if note_type == "footnote":
+        if not doc.supportsService("com.sun.star.text.GenericTextDocument"):
+            raise ToolExecutionError("Document does not support footnotes.")
+        return doc.getFootnoteSettings()
+    elif note_type == "endnote":
+        if not doc.supportsService("com.sun.star.text.GenericTextDocument"):
+            raise ToolExecutionError("Document does not support endnotes.")
+        return doc.getEndnoteSettings()
+    else:
+        raise ToolExecutionError(f"Invalid note_type '{note_type}'. Must be 'footnote' or 'endnote'.")
+
 
 class FootnotesInsert(ToolWriterFootnoteBase):
     name = "footnotes_insert"
@@ -270,3 +282,109 @@ class FootnotesDelete(ToolWriterFootnoteBase):
 
         except Exception as e:
             return self._tool_error(f"Failed to delete {note_type}: {str(e)}")
+
+
+class FootnotesSettingsGet(ToolWriterFootnoteBase):
+    name = "footnotes_settings_get"
+    description = (
+        "Gets the current formatting and numbering settings for footnotes or endnotes. "
+        "These include prefix, suffix, starting number, and styles."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "note_type": {
+                "type": "string",
+                "enum": ["footnote", "endnote"],
+                "description": "Whether to get settings for footnotes or endnotes.",
+            },
+        },
+        "required": ["note_type"],
+    }
+    is_mutation = False
+
+    def execute(self, ctx: Any, **kwargs: Any) -> dict[str, Any]:
+        note_type = str(kwargs.get("note_type"))
+        doc = ctx.doc
+
+        try:
+            settings = _get_note_settings(doc, note_type)
+
+            # Common properties
+            props = {
+                "Prefix": settings.getPropertyValue("Prefix"),
+                "Suffix": settings.getPropertyValue("Suffix"),
+                "StartAt": settings.getPropertyValue("StartAt"),
+                "NumberingType": settings.getPropertyValue("NumberingType"),
+                "CharStyleName": settings.getPropertyValue("CharStyleName"),
+                "AnchorCharStyleName": settings.getPropertyValue("AnchorCharStyleName"),
+                "PageStyleName": settings.getPropertyValue("PageStyleName"),
+                "ParaStyleName": settings.getPropertyValue("ParaStyleName"),
+            }
+
+            # Footnote-specific properties
+            if note_type == "footnote":
+                props["BeginNotice"] = settings.getPropertyValue("BeginNotice")
+                props["EndNotice"] = settings.getPropertyValue("EndNotice")
+                props["PositionEndOfDoc"] = settings.getPropertyValue("PositionEndOfDoc")
+                props["FootnoteCounting"] = settings.getPropertyValue("FootnoteCounting")
+
+            return {
+                "status": "ok",
+                "settings": props,
+            }
+        except Exception as e:
+            return self._tool_error(f"Failed to get {note_type} settings: {str(e)}")
+
+
+class FootnotesSettingsUpdate(ToolWriterFootnoteBase):
+    name = "footnotes_settings_update"
+    description = (
+        "Updates the formatting and numbering settings for footnotes or endnotes. "
+        "You can specify which properties to change (e.g., Prefix, Suffix, StartAt, NumberingType)."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "note_type": {
+                "type": "string",
+                "enum": ["footnote", "endnote"],
+                "description": "Whether to update settings for footnotes or endnotes.",
+            },
+            "properties": {
+                "type": "object",
+                "description": "A dictionary of properties to update (e.g., {'Prefix': '[', 'Suffix': ']'})",
+            },
+        },
+        "required": ["note_type", "properties"],
+    }
+    is_mutation = True
+
+    def execute(self, ctx: Any, **kwargs: Any) -> dict[str, Any]:
+        note_type = str(kwargs.get("note_type"))
+        props_to_update = kwargs.get("properties", {})
+        doc = ctx.doc
+
+        if not isinstance(props_to_update, dict):
+            return self._tool_error("Properties must be a dictionary.")
+
+        try:
+            settings = _get_note_settings(doc, note_type)
+
+            updated_props = []
+            for prop_name, prop_val in props_to_update.items():
+                try:
+                    # UNO sometimes requires specific types like shorts for certain properties
+                    # e.g., StartAt and NumberingType are shorts, but let pyuno handle the coercion mostly
+                    settings.setPropertyValue(prop_name, prop_val)
+                    updated_props.append(prop_name)
+                except Exception as e:
+                    return self._tool_error(f"Failed to set property '{prop_name}' to '{prop_val}': {str(e)}")
+
+            return {
+                "status": "ok",
+                "message": f"Successfully updated {note_type} settings.",
+                "updated_properties": updated_props,
+            }
+        except Exception as e:
+            return self._tool_error(f"Failed to update {note_type} settings: {str(e)}")

--- a/plugin/modules/writer/specialized.py
+++ b/plugin/modules/writer/specialized.py
@@ -41,8 +41,8 @@ class DelegateToSpecializedWriter(ToolBase):
         "Delegates a specialized task to a sub-agent with a focused toolset. "
         "Use this for complex Writer operations like manipulating tables, "
         "charts, fields, styles, layout, embedded objects, shapes, indexes, "
-        "bookmarks, track changes (tracking), or in-document image work "
-        "(domain=images: generate, list, insert, replace images, etc.)."
+        "bookmarks, track changes (tracking), footnotes/endnotes (domain=footnotes), "
+        "or in-document image work (domain=images: generate, list, insert, replace images, etc.)."
     )
 
     def __init__(self):

--- a/plugin/tests/test_writer_footnotes.py
+++ b/plugin/tests/test_writer_footnotes.py
@@ -10,18 +10,21 @@ sys.modules["unohelper"] = MagicMock()
 
 # Mock com.sun.star hierarchy
 star = types.ModuleType("com.sun.star")
-star.text = types.ModuleType("com.sun.star.text")
+setattr(star, "text", types.ModuleType("com.sun.star.text"))
 
 class MockBase: pass
-setattr(star.text, "Footnote", MockBase)
-setattr(star.text, "Endnote", MockBase)
+setattr(getattr(star, "text"), "Footnote", MockBase)
+setattr(getattr(star, "text"), "Endnote", MockBase)
 
 sys.modules["com"] = types.ModuleType("com")
 setattr(sys.modules["com"], "sun", types.ModuleType("com.sun"))
 setattr(sys.modules["com"].sun, "star", star)
 
 # Now we can safely import our module
-from plugin.modules.writer.footnotes import FootnotesInsert, FootnotesList, FootnotesEdit, FootnotesDelete
+from plugin.modules.writer.footnotes import (
+    FootnotesInsert, FootnotesList, FootnotesEdit, FootnotesDelete,
+    FootnotesSettingsGet, FootnotesSettingsUpdate
+)
 
 # Fake Context
 class FakeCtx:
@@ -139,3 +142,42 @@ def test_invalid_note_type():
     res = tool.execute(ctx, note_type="invalid_type")
     assert res["status"] == "error"
     assert "Invalid note_type" in res["message"]
+
+def test_footnotes_settings_get():
+    doc = MagicMock()
+    doc.supportsService.return_value = True
+
+    settings = MagicMock()
+
+    def get_property_value(name):
+        return f"value_for_{name}"
+
+    settings.getPropertyValue.side_effect = get_property_value
+    doc.getFootnoteSettings.return_value = settings
+
+    tool = FootnotesSettingsGet()
+    ctx = FakeCtx(doc)
+
+    res = tool.execute(ctx, note_type="footnote")
+
+    assert res["status"] == "ok"
+    assert res["settings"]["Prefix"] == "value_for_Prefix"
+    assert res["settings"]["BeginNotice"] == "value_for_BeginNotice"
+
+def test_footnotes_settings_update():
+    doc = MagicMock()
+    doc.supportsService.return_value = True
+
+    settings = MagicMock()
+    doc.getFootnoteSettings.return_value = settings
+
+    tool = FootnotesSettingsUpdate()
+    ctx = FakeCtx(doc)
+
+    res = tool.execute(ctx, note_type="footnote", properties={"Prefix": "[", "Suffix": "]"})
+
+    assert res["status"] == "ok"
+    assert "Prefix" in res["updated_properties"]
+    assert "Suffix" in res["updated_properties"]
+    settings.setPropertyValue.assert_any_call("Prefix", "[")
+    settings.setPropertyValue.assert_any_call("Suffix", "]")

--- a/plugin/tests/test_writer_footnotes.py
+++ b/plugin/tests/test_writer_footnotes.py
@@ -1,0 +1,141 @@
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+import pytest
+
+# Mock UNO modules before any plugin imports
+sys.modules["uno"] = MagicMock()
+sys.modules["unohelper"] = MagicMock()
+
+# Mock com.sun.star hierarchy
+star = types.ModuleType("com.sun.star")
+star.text = types.ModuleType("com.sun.star.text")
+
+class MockBase: pass
+setattr(star.text, "Footnote", MockBase)
+setattr(star.text, "Endnote", MockBase)
+
+sys.modules["com"] = types.ModuleType("com")
+setattr(sys.modules["com"], "sun", types.ModuleType("com.sun"))
+setattr(sys.modules["com"].sun, "star", star)
+
+# Now we can safely import our module
+from plugin.modules.writer.footnotes import FootnotesInsert, FootnotesList, FootnotesEdit, FootnotesDelete
+
+# Fake Context
+class FakeCtx:
+    def __init__(self, doc):
+        self.doc = doc
+
+def test_footnotes_insert():
+    doc = MagicMock()
+    doc.supportsService.return_value = True
+
+    ctrl = MagicMock()
+    v_cursor = MagicMock()
+    t_cursor = MagicMock()
+
+    ctrl.getViewCursor.return_value = v_cursor
+    v_cursor.getText.return_value.createTextCursorByRange.return_value = t_cursor
+
+    doc.getCurrentController.return_value = ctrl
+
+    note = MagicMock()
+    note.getLabel.return_value = "*"
+    doc.createInstance.return_value = note
+
+    tool = FootnotesInsert()
+    ctx = FakeCtx(doc)
+
+    res = tool.execute(ctx, note_type="footnote", text="My footnote text", label="*")
+
+    assert res["status"] == "ok"
+    doc.createInstance.assert_called_with("com.sun.star.text.Footnote")
+    note.setLabel.assert_called_with("*")
+    note.setString.assert_called_with("My footnote text")
+    t_cursor.getText.return_value.insertTextContent.assert_called_with(t_cursor, note, False)
+
+def test_footnotes_list():
+    doc = MagicMock()
+    doc.supportsService.return_value = True
+
+    supplier = MagicMock()
+    supplier.getCount.return_value = 2
+
+    note1 = MagicMock()
+    note1.getLabel.return_value = ""
+    note1.getString.return_value = "Auto numbered note"
+
+    note2 = MagicMock()
+    note2.getLabel.return_value = "*"
+    note2.getString.return_value = "Custom marked note"
+
+    def side_effect(idx):
+        if idx == 0: return note1
+        if idx == 1: return note2
+
+    supplier.getByIndex.side_effect = side_effect
+    doc.getFootnotes.return_value = supplier
+
+    tool = FootnotesList()
+    ctx = FakeCtx(doc)
+
+    res = tool.execute(ctx, note_type="footnote")
+
+    assert res["status"] == "ok"
+    assert res["count"] == 2
+    assert len(res["notes"]) == 2
+    assert res["notes"][0]["label"] == ""
+    assert res["notes"][1]["label"] == "*"
+
+def test_footnotes_edit():
+    doc = MagicMock()
+    doc.supportsService.return_value = True
+
+    supplier = MagicMock()
+    supplier.getCount.return_value = 1
+
+    note = MagicMock()
+    supplier.getByIndex.return_value = note
+    doc.getFootnotes.return_value = supplier
+
+    tool = FootnotesEdit()
+    ctx = FakeCtx(doc)
+
+    res = tool.execute(ctx, note_type="footnote", index=0, text="New text", label="")
+
+    assert res["status"] == "ok"
+    note.setString.assert_called_with("New text")
+    note.setLabel.assert_called_with("")
+
+def test_footnotes_delete():
+    doc = MagicMock()
+    doc.supportsService.return_value = True
+
+    supplier = MagicMock()
+    supplier.getCount.return_value = 1
+
+    note = MagicMock()
+    anchor = MagicMock()
+    note.getAnchor.return_value = anchor
+
+    supplier.getByIndex.return_value = note
+    doc.getFootnotes.return_value = supplier
+
+    tool = FootnotesDelete()
+    ctx = FakeCtx(doc)
+
+    res = tool.execute(ctx, note_type="footnote", index=0)
+
+    assert res["status"] == "ok"
+    anchor.setString.assert_called_with("")
+
+def test_invalid_note_type():
+    doc = MagicMock()
+    tool = FootnotesList()
+    ctx = FakeCtx(doc)
+
+    res = tool.execute(ctx, note_type="invalid_type")
+    assert res["status"] == "error"
+    assert "Invalid note_type" in res["message"]

--- a/test_writer_init.py
+++ b/test_writer_init.py
@@ -1,0 +1,12 @@
+from plugin.modules.writer import WriterModule
+class MockTools:
+    def auto_discover_package(self, p):
+        pass
+class MockServices:
+    def __init__(self):
+        self.tools = MockTools()
+    def auto_discover(self, m):
+        pass
+
+w = WriterModule()
+w.initialize(MockServices())


### PR DESCRIPTION
This PR introduces a specialized toolset for Footnotes and Endnotes within LibreOffice Writer. It follows the "skinny but full-featured" API design preference, implementing granular tools `footnotes_insert`, `footnotes_list`, `footnotes_edit`, and `footnotes_delete`. 

It includes:
- Research and API documentation in `docs/footnotes-api-reference.md`.
- Base classes in `plugin/modules/writer/base.py`.
- Tool implementations in `plugin/modules/writer/footnotes.py`
- Integration in `plugin/modules/writer/__init__.py`.
- Test suite in `plugin/tests/test_writer_footnotes.py`.

---
*PR created automatically by Jules for task [4172254140045783599](https://jules.google.com/task/4172254140045783599) started by @KeithCu*