### PR TITLE
Truncate base64 data for images and audio in HTTP client logging

### DIFF
--- a/filter_log_test.py
+++ b/filter_log_test.py
@@ -1,0 +1,44 @@
+import json
+
+def truncate_large_data(messages):
+    import copy
+    copied = copy.deepcopy(messages)
+    for m in copied:
+        content = m.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict):
+                    # For audio
+                    if part.get("type") == "input_audio":
+                        audio = part.get("input_audio", {})
+                        if isinstance(audio, dict) and "data" in audio:
+                            data_len = len(audio["data"])
+                            audio["data"] = f"<audio base64 data truncated, length={data_len}>"
+                    # For images
+                    if part.get("type") == "image_url":
+                        img = part.get("image_url", {})
+                        if isinstance(img, dict) and "url" in img and isinstance(img["url"], str):
+                            url = img["url"]
+                            if url.startswith("data:image"):
+                                img["url"] = f"<image base64 data truncated, length={len(url)}>"
+    return copied
+
+messages = [
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "text",
+        "text": "Transcribe this audio exactly. Output ONLY the transcript. No preamble, no markers."
+      },
+      {
+        "type": "input_audio",
+        "input_audio": {
+          "data": "UklGRkLFAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YR7FAAAAAAAAAAAAA"
+        }
+      }
+    ]
+  }
+]
+
+print(json.dumps(truncate_large_data(messages), indent=2))

--- a/plugin/locales/writeragent.pot
+++ b/plugin/locales/writeragent.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-28 15:21-0400\n"
+"POT-Creation-Date: 2026-04-02 20:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: plugin/contrib/aihordeclient/__init__.py:262
-#: plugin/modules/chatbot/panel.py:672
+#: plugin/modules/chatbot/panel.py:687
 msgid "Starting..."
 msgstr ""
 
@@ -35,12 +35,10 @@ msgid "Register at "
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:617
-#, python-brace-format
 msgid "You have {} kudos"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:625
-#, python-brace-format
 msgid "«{}» is not a valid API KEY, double check it or create a new one"
 msgstr ""
 
@@ -68,7 +66,6 @@ msgid ""
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:662
-#, python-brace-format
 msgid ""
 "Seems that «{}» has problems, double check it, create a new one or join "
 "Discord to ask for help"
@@ -93,6 +90,13 @@ msgstr ""
 #: plugin/contrib/aihordeclient/__init__.py:821
 msgid ""
 "When trying to ask for the image, the Horde was too slow, try again later"
+msgstr ""
+
+#: plugin/contrib/aihordeclient/__init__.py:836
+#, python-brace-format
+msgid ""
+"Register at {REGISTER_AI_HORDE_URL} and use your key to improve your rate "
+"success. Detail:"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:843
@@ -139,7 +143,6 @@ msgid "Please try another model,"
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:971
-#, python-brace-format
 msgid "{} would take more time than you configured,"
 msgstr ""
 
@@ -166,7 +169,6 @@ msgid "Please try again later."
 msgstr ""
 
 #: plugin/contrib/aihordeclient/__init__.py:1016
-#, python-brace-format
 msgid "Probably your image will take {} additional minutes."
 msgstr ""
 
@@ -201,277 +203,101 @@ msgstr ""
 msgid " with "
 msgstr ""
 
-#: plugin/framework/dialogs.py:107
-msgid "Agent requests approval"
+#: plugin/main.py:297 plugin/modules/chatbot/panel.py:764
+#: plugin/modules/chatbot/send_handlers.py:378
+#: plugin/modules/chatbot/send_handlers.py:388
+#: plugin/modules/chatbot/send_handlers.py:397
+#: plugin/framework/legacy_ui.py:362
+msgid "Error"
 msgstr ""
 
-#: plugin/framework/dialogs.py:108
-msgid "Proceed with this action?"
+#: plugin/main.py:297
+msgid "{error_msg}: {str(e)}"
 msgstr ""
 
-#: plugin/framework/dialogs.py:109
-#: plugin/modules/chatbot/web_research_chat.py:33
-#: plugin/modules/chatbot/web_research_chat.py:38
-#, python-format
-msgid "Tool: %s"
-msgstr ""
-
-#: plugin/framework/dialogs.py:155
-msgid "Edit search query"
-msgstr ""
-
-#: plugin/framework/dialogs.py:160
-msgid "Search query:"
-msgstr ""
-
-#: plugin/framework/dialogs.py:168 plugin/framework/dialogs.py:341
-#: plugin/framework/dialogs.py:413 plugin/framework/dialogs.py:501
-#: plugin/modules/http/__init__.py:247 plugin/xdl_strings.py:39
-msgid "OK"
-msgstr ""
-
-#: plugin/framework/dialogs.py:169
-msgid "Cancel"
-msgstr ""
-
-#: plugin/framework/dialogs.py:340
-msgid "Copy"
-msgstr ""
-
-#: plugin/framework/dialogs.py:360 plugin/framework/dialogs.py:435
-msgid "Copied!"
-msgstr ""
-
-#: plugin/framework/dialogs.py:410
-msgid "Copy URL"
-msgstr ""
-
-#: plugin/framework/dialogs.py:485 plugin/framework/dialogs.py:513
-#: plugin/main.py:386
-msgid "About WriterAgent"
-msgstr ""
-
-#: plugin/framework/dialogs.py:492
-#, python-format
-msgid "Version: %s"
-msgstr ""
-
-#: plugin/framework/dialogs.py:493
-msgid "AI-powered extension for LibreOffice"
-msgstr ""
-
-#: plugin/framework/dialogs.py:498
-msgid "GitHub: quazardous/localwriter"
-msgstr ""
-
-#: plugin/framework/dialogs.py:514
+#: plugin/main.py:314
 #, python-brace-format
-msgid "WriterAgent {0}"
+msgid "{0}: {1} passed, {2} failed."
 msgstr ""
 
-#: plugin/framework/errors.py:82
+#: plugin/main.py:317
 #, python-brace-format
-msgid "{resource_type} not found: {identifier}"
+msgid "Tests failed to run: {0}"
 msgstr ""
 
-#: plugin/framework/legacy_ui.py:300 plugin/main.py:377
+#: plugin/main.py:390
+msgid "Extend Selection"
+msgstr ""
+
+#: plugin/main.py:391
+msgid "Edit Selection"
+msgstr ""
+
+#: plugin/main.py:392 plugin/framework/legacy_ui.py:310
 #: plugin/xdl_strings.py:45
 msgid "Settings"
 msgstr ""
 
-#: plugin/framework/legacy_ui.py:352 plugin/modules/chatbot/panel.py:749
-#: plugin/modules/chatbot/send_handlers.py:371
-#: plugin/modules/chatbot/send_handlers.py:381
-#: plugin/modules/chatbot/send_handlers.py:390 plugin/main.py:282
-msgid "Error"
+#: plugin/main.py:393
+msgid "Toggle MCP Server"
 msgstr ""
 
-#: plugin/framework/legacy_ui.py:352
-#, python-brace-format
-msgid "Failed to open Settings: {0}"
+#: plugin/main.py:394
+msgid "MCP Server Status"
 msgstr ""
 
-#: plugin/framework/settings_dialog.py:167
-msgid "Invalid Setting"
+#: plugin/main.py:396
+msgid "Run format tests"
 msgstr ""
 
-#: plugin/framework/settings_dialog.py:167
-msgid "Temperature must be <= 1.0"
+#: plugin/main.py:397
+msgid "Run calc tests"
 msgstr ""
 
-#: plugin/framework/constants.py:196
-msgid ""
-"AI: I can edit or translate your document instantly with professional "
-"formatting and color. Try me!"
+#: plugin/main.py:398
+msgid "Run Calc API integration tests"
 msgstr ""
 
-#: plugin/framework/constants.py:197
-msgid ""
-"AI: I can help you with formulas, data analysis, and colorful charts. Try "
-"me!"
+#: plugin/main.py:399
+msgid "Run draw tests"
 msgstr ""
 
-#: plugin/framework/constants.py:198
-msgid ""
-"AI: I can help you create and edit polished, colorful shapes in Draw and "
-"Impress. Try me!"
+#: plugin/main.py:400
+msgid "Evaluation Dashboard"
 msgstr ""
 
-#: plugin/framework/constants.py:199
-msgid ""
-"AI: I can do web research to answer any question, or summarize a web page, "
-"without seeing or changing your document. Let's chat."
+#: plugin/main.py:401 plugin/framework/dialogs.py:486
+#: plugin/framework/dialogs.py:514
+msgid "About WriterAgent"
 msgstr ""
 
-#: plugin/framework/extension_update_check.py:149
-msgid "Update available"
+#: plugin/main.py:777
+msgid "Dispatch Error"
 msgstr ""
 
-#: plugin/framework/extension_update_check.py:151
-#, python-format
-msgid ""
-"A newer WriterAgent (%s) is available. Use Tools → Extension Manager to "
-"check for updates and install the latest extension."
+#: plugin/modules/writer/legacy.py:46 plugin/modules/writer/legacy.py:57
+#: plugin/modules/chatbot/selection.py:80
+#: plugin/modules/chatbot/selection.py:165
+msgid "WriterAgent: Extend Selection"
 msgstr ""
 
-#: plugin/modules/http/errors.py:15
-#, python-brace-format
-msgid "TLS/SSL Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:20
-msgid "Invalid API Key. Please check your settings."
-msgstr ""
-
-#: plugin/modules/http/errors.py:22
-msgid "API access Forbidden. Your key may lack permissions for this model."
-msgstr ""
-
-#: plugin/modules/http/errors.py:24
-msgid "Endpoint not found (404). Check your URL and Model name."
-msgstr ""
-
-#: plugin/modules/http/errors.py:26
-#, python-brace-format
-msgid "Server error ({0}). The AI provider is having issues."
-msgstr ""
-
-#: plugin/modules/http/errors.py:27
-#, python-brace-format
-msgid "HTTP Error {0}: {1}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:30
-msgid "Request Timed Out. Try increasing 'Request Timeout' in Settings."
-msgstr ""
-
-#: plugin/modules/http/errors.py:35
-msgid ""
-"Connection Refused. Is your local AI server (Ollama/LM Studio) running?"
-msgstr ""
-
-#: plugin/modules/http/errors.py:37
-msgid "DNS Error. Could not resolve the endpoint URL."
-msgstr ""
-
-#: plugin/modules/http/errors.py:38
-#, python-brace-format
-msgid "Connection Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:41
-msgid "The AI provider reported an error. Try again."
-msgstr ""
-
-#: plugin/modules/http/errors.py:48
-#, python-brace-format
-msgid "HTTP Error {0} from AI Provider: {1}"
-msgstr ""
-
-#: plugin/modules/http/errors.py:69
-#, python-brace-format
-msgid "Error: {0}"
-msgstr ""
-
-#: plugin/modules/http/client.py:534
-msgid "Stream ended with finish_reason=error"
-msgstr ""
-
-#: plugin/modules/http/client.py:547
-msgid ""
-"The model is repeating the same chunk (infinite loop). Try again or use a "
-"different model."
-msgstr ""
-
-#: plugin/modules/http/__init__.py:179
-msgid "Stop HTTP Server"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:180
-msgid "Start HTTP Server"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:201
-msgid "HTTP server stopped"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:208
-msgid "HTTP server started"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:211
-msgid "HTTP server failed to start"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:211
-msgid "Check ~/localwriter.log"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:220
-msgid "HTTP server is not running"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:226
-msgid "HTTP server not running"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:231
-msgid "HTTP server running"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:231
-#, python-brace-format
-msgid "Routes: {0}"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:238
-msgid "Server Status"
-msgstr ""
-
-#: plugin/modules/http/__init__.py:259
-#, python-brace-format
-msgid "URL: {0}"
-msgstr ""
-
-#: plugin/modules/calc/legacy.py:32 plugin/modules/writer/legacy.py:70
+#: plugin/modules/writer/legacy.py:73 plugin/modules/calc/legacy.py:34
 msgid "Please enter edit instructions!"
 msgstr ""
 
-#: plugin/modules/calc/legacy.py:32 plugin/modules/writer/legacy.py:70
+#: plugin/modules/writer/legacy.py:73 plugin/modules/calc/legacy.py:34
 #: plugin/xdl_strings.py:32
 msgid "Input"
 msgstr ""
 
-#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
-msgid "WriterAgent: Edit Selection (Calc)"
+#: plugin/modules/writer/legacy.py:81 plugin/modules/writer/legacy.py:91
+#: plugin/modules/writer/legacy.py:105 plugin/modules/chatbot/selection.py:290
+#: plugin/modules/chatbot/selection.py:404
+msgid "WriterAgent: Edit Selection"
 msgstr ""
 
-#: plugin/modules/calc/legacy.py:73 plugin/modules/calc/legacy.py:98
-msgid "WriterAgent: Extend Selection (Calc)"
-msgstr ""
-
-#: plugin/modules/calc/specialized.py:98
-#: plugin/modules/writer/specialized.py:110
+#: plugin/modules/writer/specialized.py:108
+#: plugin/modules/calc/specialized.py:103
 #, python-brace-format
 msgid ""
 "Tool call switched to '{0}'. You are in a specialized toolset mode. You must"
@@ -479,75 +305,89 @@ msgid ""
 "APIs."
 msgstr ""
 
-#: plugin/modules/writer/legacy.py:43 plugin/modules/writer/legacy.py:54
-#: plugin/modules/chatbot/selection.py:80
-#: plugin/modules/chatbot/selection.py:165
-msgid "WriterAgent: Extend Selection"
+#: plugin/modules/writer/specialized.py:262
+#: plugin/modules/calc/specialized.py:252
+#, python-brace-format
+msgid "Specialized task ({domain}) completed."
 msgstr ""
 
-#: plugin/modules/writer/legacy.py:78 plugin/modules/writer/legacy.py:88
-#: plugin/modules/writer/legacy.py:102 plugin/modules/chatbot/selection.py:290
-#: plugin/modules/chatbot/selection.py:404
-msgid "WriterAgent: Edit Selection"
+#: plugin/modules/chatbot/panel_factory.py:497
+msgid "Size:"
+msgstr ""
+
+#: plugin/modules/chatbot/panel_factory.py:498
+msgid "Height:"
+msgstr ""
+
+#: plugin/modules/chatbot/panel_factory.py:499
+msgid "Width:"
+msgstr ""
+
+#: plugin/modules/chatbot/web_research.py:298
+msgid "Web research completed."
+msgstr ""
+
+#: plugin/modules/chatbot/librarian.py:90
+msgid "Switching to document mode..."
 msgstr ""
 
 #: plugin/modules/chatbot/panel_wiring.py:191 plugin/xdl_strings.py:41
 msgid "Ready"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:328 plugin/modules/chatbot/panel.py:647
+#: plugin/modules/chatbot/panel.py:343 plugin/modules/chatbot/panel.py:662
 msgid "Accept"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:344 plugin/modules/chatbot/panel.py:865
+#: plugin/modules/chatbot/panel.py:359 plugin/modules/chatbot/panel.py:880
 msgid "Change"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:348 plugin/modules/chatbot/panel.py:872
+#: plugin/modules/chatbot/panel.py:363 plugin/modules/chatbot/panel.py:887
 msgid "Reject"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:365
+#: plugin/modules/chatbot/panel.py:380
 msgid "Waiting for approval…"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:653
+#: plugin/modules/chatbot/panel.py:668
 msgid "Record"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:655
+#: plugin/modules/chatbot/panel.py:670
 msgid "Stop Rec"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:657 plugin/xdl_strings.py:44
+#: plugin/modules/chatbot/panel.py:672 plugin/xdl_strings.py:44
 msgid "Send"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:681
+#: plugin/modules/chatbot/panel.py:696
 msgid "Getting document..."
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:686
+#: plugin/modules/chatbot/panel.py:701
 msgid ""
 "[No compatible LibreOffice document (Writer, Calc, or Draw) found in the "
 "active window.]"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:695
+#: plugin/modules/chatbot/panel.py:710
 #, python-brace-format
 msgid ""
 "[Internal Error: Document type changed from {0} to {1}! Please file an "
 "error.]"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:702
+#: plugin/modules/chatbot/panel.py:717
 #, python-brace-format
 msgid ""
 "[Internal Error: Could not identify document type for {0}. Please report "
 "this!]"
 msgstr ""
 
-#: plugin/modules/chatbot/panel.py:746
+#: plugin/modules/chatbot/panel.py:761
 #, python-brace-format
 msgid ""
 "[Model {0} does not support native audio. Please select an STT Model in "
@@ -567,6 +407,13 @@ msgstr ""
 msgid "[Web search]"
 msgstr ""
 
+#: plugin/modules/chatbot/web_research_chat.py:33
+#: plugin/modules/chatbot/web_research_chat.py:38
+#: plugin/framework/dialogs.py:110
+#, python-format
+msgid "Tool: %s"
+msgstr ""
+
 #: plugin/modules/chatbot/web_research_chat.py:37
 msgid "[Additional web search]"
 msgstr ""
@@ -583,15 +430,11 @@ msgstr ""
 msgid "Context for the research agent:"
 msgstr ""
 
-#: plugin/modules/chatbot/web_research.py:294
-msgid "Web research completed."
-msgstr ""
-
-#: plugin/modules/chatbot/send_handlers.py:104
+#: plugin/modules/chatbot/send_handlers.py:112
 msgid "Transcribing audio..."
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:105
+#: plugin/modules/chatbot/send_handlers.py:113
 msgid "[Transcribing audio...]"
 msgstr ""
 
@@ -600,136 +443,306 @@ msgstr ""
 msgid "[Transcription error: {0}]"
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:154
+#: plugin/modules/chatbot/send_handlers.py:161
 #, python-brace-format
 msgid "[Error: {0}]"
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:369
+#: plugin/modules/chatbot/send_handlers.py:376
 #, python-brace-format
 msgid "[Document context error: {0}]"
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:379
+#: plugin/modules/chatbot/send_handlers.py:386
 #, python-brace-format
 msgid "[Agent backend '{0}' not found.]"
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:386
+#: plugin/modules/chatbot/send_handlers.py:393
 #, python-brace-format
 msgid ""
 "[Agent backend '{0}' is not available. Check Settings (path, install).]"
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:631
 #: plugin/modules/chatbot/send_handlers.py:638
+#: plugin/modules/chatbot/send_handlers.py:645
 #, python-brace-format
 msgid "Librarian: {0}"
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:637
+#: plugin/modules/chatbot/send_handlers.py:644
 msgid "Perfect! I'm switching you to the main assistant now."
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:643
+#: plugin/modules/chatbot/send_handlers.py:650
 msgid "Unknown librarian error."
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:644
+#: plugin/modules/chatbot/send_handlers.py:651
 #, python-brace-format
 msgid "[Librarian error: {0}]"
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:667
+#: plugin/modules/chatbot/send_handlers.py:674
 #, python-brace-format
 msgid "AI (research): {0}"
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:673
+#: plugin/modules/chatbot/send_handlers.py:680
 msgid "Unknown research error."
 msgstr ""
 
-#: plugin/modules/chatbot/send_handlers.py:674
+#: plugin/modules/chatbot/send_handlers.py:681
 #, python-brace-format
 msgid "[Research error: {0}]"
 msgstr ""
 
-#: plugin/modules/chatbot/librarian.py:90
-msgid "Switching to document mode..."
+#: plugin/modules/http/__init__.py:180
+msgid "Stop HTTP Server"
 msgstr ""
 
-#: plugin/modules/chatbot/panel_factory.py:493
-msgid "Size:"
+#: plugin/modules/http/__init__.py:181
+msgid "Start HTTP Server"
 msgstr ""
 
-#: plugin/modules/chatbot/panel_factory.py:494
-msgid "Height:"
+#: plugin/modules/http/__init__.py:202
+msgid "HTTP server stopped"
 msgstr ""
 
-#: plugin/modules/chatbot/panel_factory.py:495
-msgid "Width:"
+#: plugin/modules/http/__init__.py:209
+msgid "HTTP server started"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:212
+msgid "HTTP server failed to start"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:212
+msgid "Check ~/localwriter.log"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:221
+msgid "HTTP server is not running"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:227
+msgid "HTTP server not running"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:232
+msgid "HTTP server running"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:232
+#, python-brace-format
+msgid "Routes: {0}"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:243
+msgid "Server Status"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:252 plugin/framework/dialogs.py:169
+#: plugin/framework/dialogs.py:342 plugin/framework/dialogs.py:414
+#: plugin/framework/dialogs.py:502 plugin/xdl_strings.py:39
+msgid "OK"
+msgstr ""
+
+#: plugin/modules/http/__init__.py:264
+#, python-brace-format
+msgid "URL: {0}"
+msgstr ""
+
+#: plugin/modules/http/client.py:590
+msgid "Stream ended with finish_reason=error"
+msgstr ""
+
+#: plugin/modules/http/client.py:603
+msgid ""
+"The model is repeating the same chunk (infinite loop). Try again or use a "
+"different model."
+msgstr ""
+
+#: plugin/modules/http/errors.py:14
+#, python-brace-format
+msgid "TLS/SSL Error: {0}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:25
+msgid "Invalid API Key. Please check your settings."
+msgstr ""
+
+#: plugin/modules/http/errors.py:27
+msgid "API access Forbidden. Your key may lack permissions for this model."
+msgstr ""
+
+#: plugin/modules/http/errors.py:29
+msgid "Endpoint not found (404). Check your URL and Model name."
+msgstr ""
+
+#: plugin/modules/http/errors.py:31
+#, python-brace-format
+msgid "Server error ({0}). The AI provider is having issues."
+msgstr ""
+
+#: plugin/modules/http/errors.py:32
+#, python-brace-format
+msgid "HTTP Error {0}: {1}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:35
+msgid "Request Timed Out. Try increasing 'Request Timeout' in Settings."
+msgstr ""
+
+#: plugin/modules/http/errors.py:43
+msgid ""
+"Connection Refused. Is your local AI server (Ollama/LM Studio) running?"
+msgstr ""
+
+#: plugin/modules/http/errors.py:45
+msgid "DNS Error. Could not resolve the endpoint URL."
+msgstr ""
+
+#: plugin/modules/http/errors.py:46
+#, python-brace-format
+msgid "Connection Error: {0}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:49
+msgid "The AI provider reported an error. Try again."
+msgstr ""
+
+#: plugin/modules/http/errors.py:56
+#, python-brace-format
+msgid "HTTP Error {0} from AI Provider: {1}"
+msgstr ""
+
+#: plugin/modules/http/errors.py:77
+#, python-brace-format
+msgid "Error: {0}"
+msgstr ""
+
+#: plugin/modules/calc/legacy.py:75 plugin/modules/calc/legacy.py:100
+msgid "WriterAgent: Edit Selection (Calc)"
+msgstr ""
+
+#: plugin/modules/calc/legacy.py:75 plugin/modules/calc/legacy.py:100
+msgid "WriterAgent: Extend Selection (Calc)"
+msgstr ""
+
+#: plugin/framework/settings_dialog.py:173
+msgid "Invalid Setting"
+msgstr ""
+
+#: plugin/framework/settings_dialog.py:173
+msgid "Temperature must be <= 1.0"
+msgstr ""
+
+#: plugin/framework/constants.py:190
+msgid ""
+"AI: I can edit or translate your document instantly with professional "
+"formatting and color. Try me!"
+msgstr ""
+
+#: plugin/framework/constants.py:191
+msgid ""
+"AI: I can help you with formulas, data analysis, and colorful charts. Try "
+"me!"
+msgstr ""
+
+#: plugin/framework/constants.py:192
+msgid ""
+"AI: I can help you create and edit polished, colorful shapes in Draw and "
+"Impress. Try me!"
+msgstr ""
+
+#: plugin/framework/constants.py:193
+msgid ""
+"AI: I can do web research to answer any question, or summarize a web page, "
+"without seeing or changing your document. Let's chat."
+msgstr ""
+
+#: plugin/framework/legacy_ui.py:362
+#, python-brace-format
+msgid "Failed to open Settings: {0}"
+msgstr ""
+
+#: plugin/framework/extension_update_check.py:150
+msgid "Update available"
+msgstr ""
+
+#: plugin/framework/extension_update_check.py:152
+#, python-format
+msgid ""
+"A newer WriterAgent (%s) is available. Use Tools → Extension Manager to "
+"check for updates and install the latest extension."
+msgstr ""
+
+#: plugin/framework/dialogs.py:108
+msgid "Agent requests approval"
+msgstr ""
+
+#: plugin/framework/dialogs.py:109
+msgid "Proceed with this action?"
+msgstr ""
+
+#: plugin/framework/dialogs.py:156
+msgid "Edit search query"
+msgstr ""
+
+#: plugin/framework/dialogs.py:161
+msgid "Search query:"
+msgstr ""
+
+#: plugin/framework/dialogs.py:170
+msgid "Cancel"
+msgstr ""
+
+#: plugin/framework/dialogs.py:341
+msgid "Copy"
+msgstr ""
+
+#: plugin/framework/dialogs.py:361 plugin/framework/dialogs.py:436
+msgid "Copied!"
+msgstr ""
+
+#: plugin/framework/dialogs.py:411
+msgid "Copy URL"
+msgstr ""
+
+#: plugin/framework/dialogs.py:493
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: plugin/framework/dialogs.py:494
+msgid "AI-powered extension for LibreOffice"
+msgstr ""
+
+#: plugin/framework/dialogs.py:499
+msgid "GitHub: quazardous/localwriter"
+msgstr ""
+
+#: plugin/framework/dialogs.py:515
+#, python-brace-format
+msgid "WriterAgent {0}"
+msgstr ""
+
+#: plugin/framework/errors.py:84
+#, python-brace-format
+msgid "{resource_type} not found: {identifier}"
 msgstr ""
 
 #: plugin/tests/test_i18n.py:24
 msgid "ThisIsAnUntranslatedString999"
 msgstr ""
 
-#: plugin/tests/test_i18n.py:194
+#: plugin/tests/test_i18n.py:209
 msgid "Built-in"
 msgstr ""
 
-#: plugin/tests/test_i18n.py:195
+#: plugin/tests/test_i18n.py:210
 msgid "Backend"
-msgstr ""
-
-#: plugin/main.py:299
-#, python-brace-format
-msgid "{0}: {1} passed, {2} failed."
-msgstr ""
-
-#: plugin/main.py:302
-#, python-brace-format
-msgid "Tests failed to run: {0}"
-msgstr ""
-
-#: plugin/main.py:375
-msgid "Extend Selection"
-msgstr ""
-
-#: plugin/main.py:376
-msgid "Edit Selection"
-msgstr ""
-
-#: plugin/main.py:378
-msgid "Toggle MCP Server"
-msgstr ""
-
-#: plugin/main.py:379
-msgid "MCP Server Status"
-msgstr ""
-
-#: plugin/main.py:381
-msgid "Run format tests"
-msgstr ""
-
-#: plugin/main.py:382
-msgid "Run calc tests"
-msgstr ""
-
-#: plugin/main.py:383
-msgid "Run Calc API integration tests"
-msgstr ""
-
-#: plugin/main.py:384
-msgid "Run draw tests"
-msgstr ""
-
-#: plugin/main.py:385
-msgid "Evaluation Dashboard"
-msgstr ""
-
-#: plugin/main.py:755
-msgid "Dispatch Error"
 msgstr ""
 
 #: plugin/xdl_strings.py:4

--- a/plugin/modules/http/client.py
+++ b/plugin/modules/http/client.py
@@ -227,7 +227,33 @@ class LlmClient:
         json_data = json.dumps(data).encode("utf-8")
         path = get_url_path_and_query(url)
 
-        log.debug("Request data: %s" % json.dumps(data, indent=2))
+        log_data = data.copy()
+        if "messages" in log_data and isinstance(log_data["messages"], list):
+            import copy
+            try:
+                log_messages = copy.deepcopy(log_data["messages"])
+                for m in log_messages:
+                    if not isinstance(m, dict):
+                        continue
+                    content = m.get("content")
+                    if isinstance(content, list):
+                        for part in content:
+                            if isinstance(part, dict):
+                                if part.get("type") == "input_audio":
+                                    audio = part.get("input_audio", {})
+                                    if isinstance(audio, dict) and "data" in audio:
+                                        audio["data"] = "<audio base64 data truncated, length=%d>" % len(audio["data"])
+                                if part.get("type") == "image_url":
+                                    img = part.get("image_url", {})
+                                    if isinstance(img, dict) and "url" in img and isinstance(img["url"], str):
+                                        url_val = img["url"]
+                                        if url_val.startswith("data:image"):
+                                            img["url"] = "<image base64 data truncated, length=%d>" % len(url_val)
+                log_data["messages"] = log_messages
+            except Exception:
+                log_data["messages"] = [{"note": "<failed to truncate messages for log>"}]
+
+        log.debug("Request data: %s" % json.dumps(log_data, indent=2))
         return "POST", path, json_data, self._headers()
 
     def extract_content_from_response(self, chunk):
@@ -315,7 +341,31 @@ class LlmClient:
             "=== Chat Request (tools=%s, stream=%s) ===" % (bool(tools), stream)
         )
         log.debug("URL: %s" % url)
-        log.debug("Messages: %s" % json.dumps(messages, indent=2))
+
+        # Truncate large base64 data for logging
+        log_messages = []
+        import copy
+        try:
+            log_messages = copy.deepcopy(messages)
+            for m in log_messages:
+                content = m.get("content")
+                if isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict):
+                            if part.get("type") == "input_audio":
+                                audio = part.get("input_audio", {})
+                                if isinstance(audio, dict) and "data" in audio:
+                                    audio["data"] = "<audio base64 data truncated, length=%d>" % len(audio["data"])
+                            if part.get("type") == "image_url":
+                                img = part.get("image_url", {})
+                                if isinstance(img, dict) and "url" in img and isinstance(img["url"], str):
+                                    url_val = img["url"]
+                                    if url_val.startswith("data:image"):
+                                        img["url"] = "<image base64 data truncated, length=%d>" % len(url_val)
+        except Exception:
+            log_messages = [{"note": "<failed to truncate messages for log>"}]
+
+        log.debug("Messages: %s" % json.dumps(log_messages, indent=2))
         
         path = get_url_path_and_query(url)
             
@@ -348,7 +398,13 @@ class LlmClient:
         init_logging(self.ctx)
         log.debug("=== Image Request ===")
         log.debug("URL: %s" % url)
-        log.debug("Data: %s" % json.dumps(data, indent=2))
+
+        log_data = data.copy()
+        image_url = log_data.get("image_url")
+        if image_url and isinstance(image_url, str) and image_url.startswith("data:image"):
+            log_data["image_url"] = "<image base64 data truncated, length=%d>" % len(image_url)
+
+        log.debug("Data: %s" % json.dumps(log_data, indent=2))
         
         path = get_url_path_and_query(url)
             


### PR DESCRIPTION
Truncates base64 data for images and audio in HTTP client logging to avoid huge log outputs.

---
*PR created automatically by Jules for task [15038045918216979875](https://jules.google.com/task/15038045918216979875) started by @KeithCu*