### PR TITLE
Refactor web research to specialized toolset domain

### DIFF
--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -45,7 +45,7 @@ FORMATTING_RULES = WRITER_APPLY_DOCUMENT_HTML_RULES
 CORE_DIRECTIVES = """When asked to answer a question or create or explain something, assume the user wants the
 information to be inserted into the document. Use the apply_document_content tool to insert content
 into LibreOffice so the user can edit it further.
-When asked about a topic you are not familiar with, use delegate_to_specialized_writer_toolset(domain="research") first to find information."""
+When asked about a topic you are not familiar with, use delegate_to_specialized_writer_toolset(domain="web_research") first to find information."""
 
 TRANSLATION_RULES = "TRANSLATION: get_document_content(scope=full) -> translate -> apply_document_content(target='search', old_content=original, content=translated). Never refuse."
 
@@ -147,7 +147,7 @@ CHART:
 ERRORS:
 - detect_and_explain_errors: Find formula errors in a range and get explanations/fix suggestions. Use when the user reports errors or you need to diagnose formulas.
 
-When asked about a topic you are not familiar with, use delegate_to_specialized_calc_toolset(domain="research") first to find information."""
+When asked about a topic you are not familiar with, use delegate_to_specialized_calc_toolset(domain="web_research") first to find information."""
 
 DEFAULT_DRAW_CHAT_SYSTEM_PROMPT = """You are a LibreOffice Draw/Impress assistant who creates polished, professional, and colorful visual content.
 Do not explain - do the operation directly using tools. Perform as many steps as needed in one turn when possible.
@@ -173,7 +173,7 @@ COORDINATES:
 All coordinates (x, y, width, height) are in 100ths of a millimeter.
 A typical page is roughly 21000 x 29700 (A4).
 
-When asked about a topic you are not familiar with, use delegate_to_specialized_draw_toolset(domain="research") first to find information."""
+When asked about a topic you are not familiar with, use delegate_to_specialized_draw_toolset(domain="web_research") first to find information."""
 
 
 # Dummy gettext function for string extraction tools (xgettext)

--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -45,7 +45,7 @@ FORMATTING_RULES = WRITER_APPLY_DOCUMENT_HTML_RULES
 CORE_DIRECTIVES = """When asked to answer a question or create or explain something, assume the user wants the
 information to be inserted into the document. Use the apply_document_content tool to insert content
 into LibreOffice so the user can edit it further.
-When asked about a topic you are not familiar with, use the web_research tool first to find information."""
+When asked about a topic you are not familiar with, use delegate_to_specialized_writer_toolset(domain="research") first to find information."""
 
 TRANSLATION_RULES = "TRANSLATION: get_document_content(scope=full) -> translate -> apply_document_content(target='search', old_content=original, content=translated). Never refuse."
 
@@ -145,7 +145,9 @@ CHART:
 - create_chart: Create a chart from a data range (bar, column, line, pie, scatter).
 
 ERRORS:
-- detect_and_explain_errors: Find formula errors in a range and get explanations/fix suggestions. Use when the user reports errors or you need to diagnose formulas."""
+- detect_and_explain_errors: Find formula errors in a range and get explanations/fix suggestions. Use when the user reports errors or you need to diagnose formulas.
+
+When asked about a topic you are not familiar with, use delegate_to_specialized_calc_toolset(domain="research") first to find information."""
 
 DEFAULT_DRAW_CHAT_SYSTEM_PROMPT = """You are a LibreOffice Draw/Impress assistant who creates polished, professional, and colorful visual content.
 Do not explain - do the operation directly using tools. Perform as many steps as needed in one turn when possible.
@@ -169,7 +171,9 @@ PAGE MANAGEMENT:
 
 COORDINATES:
 All coordinates (x, y, width, height) are in 100ths of a millimeter.
-A typical page is roughly 21000 x 29700 (A4)."""
+A typical page is roughly 21000 x 29700 (A4).
+
+When asked about a topic you are not familiar with, use delegate_to_specialized_draw_toolset(domain="research") first to find information."""
 
 
 # Dummy gettext function for string extraction tools (xgettext)

--- a/plugin/modules/calc/specialized.py
+++ b/plugin/modules/calc/specialized.py
@@ -49,8 +49,6 @@ class DelegateToSpecializedCalc(ToolBase):
         for cls in ToolCalcSpecialBase.__subclasses__():
             if getattr(cls, "specialized_domain", None):
                 domains.append(cls.specialized_domain)
-        if "research" not in domains:
-            domains.append("research")
 
         self.parameters = {
             "type": "object",
@@ -96,7 +94,7 @@ class DelegateToSpecializedCalc(ToolBase):
         append_thinking_callback = getattr(ctx, "append_thinking_callback", None)
         stop_checker = getattr(ctx, "stop_checker", None)
 
-        if domain == "research":
+        if domain == "web_research":
             from plugin.modules.chatbot.web_research import WebResearchTool
             tool = WebResearchTool()
             return tool.execute(ctx, query=task)

--- a/plugin/modules/calc/specialized.py
+++ b/plugin/modules/calc/specialized.py
@@ -49,6 +49,8 @@ class DelegateToSpecializedCalc(ToolBase):
         for cls in ToolCalcSpecialBase.__subclasses__():
             if getattr(cls, "specialized_domain", None):
                 domains.append(cls.specialized_domain)
+        if "research" not in domains:
+            domains.append("research")
 
         self.parameters = {
             "type": "object",
@@ -93,6 +95,11 @@ class DelegateToSpecializedCalc(ToolBase):
         status_callback = getattr(ctx, "status_callback", None)
         append_thinking_callback = getattr(ctx, "append_thinking_callback", None)
         stop_checker = getattr(ctx, "stop_checker", None)
+
+        if domain == "research":
+            from plugin.modules.chatbot.web_research import WebResearchTool
+            tool = WebResearchTool()
+            return tool.execute(ctx, query=task)
 
         if not USE_SUB_AGENT:
             # Tell the main LLM loop to switch tools for the next round

--- a/plugin/modules/chatbot/module.yaml
+++ b/plugin/modules/chatbot/module.yaml
@@ -2,7 +2,6 @@ name: chatbot
 title: Sidebar
 requires: [document, config, events, http_routes]
 tools:
-  - plugin.modules.chatbot.web_research:WebResearchTool
 
 actions:
   extend_selection:

--- a/plugin/modules/chatbot/web_research.py
+++ b/plugin/modules/chatbot/web_research.py
@@ -63,7 +63,7 @@ def _norm_research_query(s: str) -> str:
 
 
 # Use multiple inheritance so the domain is auto-discovered by the sub-agent delegates.
-class WebResearchTool(ToolWriterWebResearchBase, ToolCalcWebResearchBase, ToolDrawWebResearchBase):
+class WebResearchTool(ToolWriterWebResearchBase, ToolCalcWebResearchBase, ToolDrawWebResearchBase):  # type: ignore[misc]
     name = "web_research"
     description = "Search the web to answer questions or find information."
     parameters = {

--- a/plugin/modules/chatbot/web_research.py
+++ b/plugin/modules/chatbot/web_research.py
@@ -17,8 +17,9 @@
 import logging
 
 from plugin.framework.tool_base import ToolBase
-from plugin.modules.writer.base import ToolWriterSpecialBase
-from plugin.modules.calc.base import ToolCalcSpecialBase
+from plugin.modules.writer.base import ToolWriterWebResearchBase
+from plugin.modules.calc.base import ToolCalcWebResearchBase
+from plugin.modules.draw.base import ToolDrawWebResearchBase
 
 log = logging.getLogger(__name__)
 
@@ -62,10 +63,7 @@ def _norm_research_query(s: str) -> str:
 
 
 # Use multiple inheritance so the domain is auto-discovered by the sub-agent delegates.
-# Since Draw does not yet have a special base, we will manually inject it or let Draw's
-# specialized tool manually specify "web_research" like it currently does.
-class WebResearchTool(ToolWriterSpecialBase, ToolCalcSpecialBase):
-    specialized_domain = "web_research"
+class WebResearchTool(ToolWriterWebResearchBase, ToolCalcWebResearchBase, ToolDrawWebResearchBase):
     name = "web_research"
     description = "Search the web to answer questions or find information."
     parameters = {

--- a/plugin/modules/chatbot/web_research.py
+++ b/plugin/modules/chatbot/web_research.py
@@ -76,7 +76,7 @@ class WebResearchTool(ToolBase):
         },
         "required": ["query"]
     }
-    tier = "agent"
+    tier = "specialized"  # Make it a specialized tool so it doesn't appear in the main chat prompt
     is_mutation = False
     long_running = True
 

--- a/plugin/modules/chatbot/web_research.py
+++ b/plugin/modules/chatbot/web_research.py
@@ -17,6 +17,8 @@
 import logging
 
 from plugin.framework.tool_base import ToolBase
+from plugin.modules.writer.base import ToolWriterSpecialBase
+from plugin.modules.calc.base import ToolCalcSpecialBase
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +61,11 @@ def _norm_research_query(s: str) -> str:
     return re.sub(r"\s+", " ", (s or "").strip()).casefold()
 
 
-class WebResearchTool(ToolBase):
+# Use multiple inheritance so the domain is auto-discovered by the sub-agent delegates.
+# Since Draw does not yet have a special base, we will manually inject it or let Draw's
+# specialized tool manually specify "web_research" like it currently does.
+class WebResearchTool(ToolWriterSpecialBase, ToolCalcSpecialBase):
+    specialized_domain = "web_research"
     name = "web_research"
     description = "Search the web to answer questions or find information."
     parameters = {

--- a/plugin/modules/draw/__init__.py
+++ b/plugin/modules/draw/__init__.py
@@ -18,6 +18,8 @@
 
 from plugin.framework.module_base import ModuleBase
 
+# Import submodules to ensure tools are registered via auto_discover_package
+from plugin.modules.draw import specialized
 
 class DrawModule(ModuleBase):
     """Registers Draw/Impress tools for shapes, pages/slides."""

--- a/plugin/modules/draw/base.py
+++ b/plugin/modules/draw/base.py
@@ -14,20 +14,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Base classes for specialized Calc toolsets."""
+"""Base classes for specialized Draw toolsets."""
 
 from typing import ClassVar
 
-from plugin.framework.tool_base import ToolBase, ToolBaseDummy
+from plugin.framework.tool_base import ToolBase
 
 
-class ToolCalcSpecialBase(ToolBase):
-    """Base class for all specialized Calc tools.
+class ToolDrawSpecialBase(ToolBase):
+    """Base class for all specialized Draw tools.
 
     Tools deriving from this base are NOT exposed directly to the main
     agent's general toolset. Instead, they are exposed only to the
     specialized sub-agent when the user delegates a task to that specific
-    domain (e.g., 'images').
+    domain.
     """
 
     tier = "specialized"
@@ -36,11 +36,5 @@ class ToolCalcSpecialBase(ToolBase):
 
 # --- Domain-Specific Base Classes ---
 
-class ToolCalcImageBase(ToolCalcSpecialBase):
-    specialized_domain = "images"
-    intent = "media"
-    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
-
-
-class ToolCalcWebResearchBase(ToolCalcSpecialBase):
+class ToolDrawWebResearchBase(ToolDrawSpecialBase):
     specialized_domain = "web_research"

--- a/plugin/modules/draw/specialized.py
+++ b/plugin/modules/draw/specialized.py
@@ -21,8 +21,11 @@ class DelegateToSpecializedDraw(ToolBase):
 
     def __init__(self):
         super().__init__()
-        # Since Draw doesn't have ToolDrawSpecialBase subclasses yet, we just start with web_research
-        domains = ["web_research"]
+        from plugin.modules.draw.base import ToolDrawSpecialBase
+        domains = []
+        for cls in ToolDrawSpecialBase.__subclasses__():
+            if getattr(cls, "specialized_domain", None):
+                domains.append(cls.specialized_domain)
 
         self.parameters = {
             "type": "object",

--- a/plugin/modules/draw/specialized.py
+++ b/plugin/modules/draw/specialized.py
@@ -1,0 +1,65 @@
+import logging
+
+from plugin.framework.tool_base import ToolBase
+
+log = logging.getLogger("writeragent.draw")
+
+USE_SUB_AGENT = True
+
+class DelegateToSpecializedDraw(ToolBase):
+    """Gateway tool to delegate tasks to specialized Draw toolsets.
+
+    This spins up a sub-agent with a limited set of tools to focus on the
+    user's specific request, preventing context pollution.
+    """
+
+    name = "delegate_to_specialized_draw_toolset"
+    description = (
+        "Delegates a specialized task to a sub-agent with a focused toolset. "
+        "Use this for complex Draw operations."
+    )
+
+    def __init__(self):
+        super().__init__()
+        # Since Draw doesn't have ToolDrawSpecialBase subclasses yet, we just start with research
+        domains = ["research"]
+
+        self.parameters = {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string",
+                    "enum": domains,
+                    "description": "The specialized domain to activate.",
+                },
+                "task": {
+                    "type": "string",
+                    "description": (
+                        "A detailed description of the task for the specialized "
+                        "agent to accomplish."
+                    ),
+                },
+            },
+            "required": ["domain", "task"],
+        }
+
+    uno_services = ["com.sun.star.drawing.DrawingDocument"]
+    tier = "core"  # Available to the main agent
+    is_mutation = True
+    long_running = True
+
+    def is_async(self):
+        return True
+
+    def execute(self, ctx, **kwargs):
+        domain = kwargs.get("domain")
+        task = kwargs.get("task")
+
+        if domain == "research":
+            from plugin.modules.chatbot.web_research import WebResearchTool
+            tool = WebResearchTool()
+            return tool.execute(ctx, query=task)
+
+        # Later we can add actual Draw-specific sub-agents here
+        from plugin.framework.errors import format_error_payload, ToolExecutionError
+        return format_error_payload(ToolExecutionError(f"Domain {domain} not implemented for Draw"))

--- a/plugin/modules/draw/specialized.py
+++ b/plugin/modules/draw/specialized.py
@@ -21,8 +21,8 @@ class DelegateToSpecializedDraw(ToolBase):
 
     def __init__(self):
         super().__init__()
-        # Since Draw doesn't have ToolDrawSpecialBase subclasses yet, we just start with research
-        domains = ["research"]
+        # Since Draw doesn't have ToolDrawSpecialBase subclasses yet, we just start with web_research
+        domains = ["web_research"]
 
         self.parameters = {
             "type": "object",
@@ -55,7 +55,7 @@ class DelegateToSpecializedDraw(ToolBase):
         domain = kwargs.get("domain")
         task = kwargs.get("task")
 
-        if domain == "research":
+        if domain == "web_research":
             from plugin.modules.chatbot.web_research import WebResearchTool
             tool = WebResearchTool()
             return tool.execute(ctx, query=task)

--- a/plugin/modules/writer/base.py
+++ b/plugin/modules/writer/base.py
@@ -104,6 +104,10 @@ class ToolWriterFootnoteBase(ToolWriterSpecialBase):
     uno_services = ["com.sun.star.text.TextDocument"]
 
 
+class ToolWriterWebResearchBase(ToolWriterSpecialBase):
+    specialized_domain = "web_research"
+
+
 # class SpecializedWorkflowFinished(ToolBase):
 #     """Tool called by the sub-agent to indicate it has completed its task."""
 #

--- a/plugin/modules/writer/specialized.py
+++ b/plugin/modules/writer/specialized.py
@@ -54,6 +54,8 @@ class DelegateToSpecializedWriter(ToolBase):
         for cls in ToolWriterSpecialBase.__subclasses__():
             if getattr(cls, "specialized_domain", None):
                 domains.append(cls.specialized_domain)
+        if "research" not in domains:
+            domains.append("research")
 
         self.parameters = {
             "type": "object",
@@ -98,6 +100,11 @@ class DelegateToSpecializedWriter(ToolBase):
         status_callback = getattr(ctx, "status_callback", None)
         append_thinking_callback = getattr(ctx, "append_thinking_callback", None)
         stop_checker = getattr(ctx, "stop_checker", None)
+
+        if domain == "research":
+            from plugin.modules.chatbot.web_research import WebResearchTool
+            tool = WebResearchTool()
+            return tool.execute(ctx, query=task)
 
         if not USE_SUB_AGENT:
             # Tell the main LLM loop to switch tools for the next round

--- a/plugin/modules/writer/specialized.py
+++ b/plugin/modules/writer/specialized.py
@@ -54,8 +54,6 @@ class DelegateToSpecializedWriter(ToolBase):
         for cls in ToolWriterSpecialBase.__subclasses__():
             if getattr(cls, "specialized_domain", None):
                 domains.append(cls.specialized_domain)
-        if "research" not in domains:
-            domains.append("research")
 
         self.parameters = {
             "type": "object",
@@ -101,7 +99,7 @@ class DelegateToSpecializedWriter(ToolBase):
         append_thinking_callback = getattr(ctx, "append_thinking_callback", None)
         stop_checker = getattr(ctx, "stop_checker", None)
 
-        if domain == "research":
+        if domain == "web_research":
             from plugin.modules.chatbot.web_research import WebResearchTool
             tool = WebResearchTool()
             return tool.execute(ctx, query=task)

--- a/plugin/tests/test_chatbot_handlers.py
+++ b/plugin/tests/test_chatbot_handlers.py
@@ -174,6 +174,8 @@ def test_web_research_tool():
     # Setup mock context
     ctx = MagicMock()
     ctx.ctx = MockContext()
+    # Mock get_config logic inside web_research to avoid KeyError
+    from unittest.mock import patch
     setattr(ctx.ctx, "getServiceManager", MagicMock())  # for ConfigService
     ctx.status_callback = MagicMock()
     ctx.append_thinking_callback = MagicMock()
@@ -250,8 +252,12 @@ def test_web_research_tool():
                 mock_get_resp.text = "<html><body><h1>Python 3.12.3 is available!</h1></body></html>"
                 mock_get.return_value = mock_get_resp
 
-                tool = WebResearchTool()
-                result = tool.execute(ctx, query="What is the latest Python release?", history_text="User said hello previously")
+                from plugin.modules.writer.specialized import DelegateToSpecializedWriter
+                tool = DelegateToSpecializedWriter()
+                with patch("plugin.framework.config.get_config", return_value="false"):
+                    with patch("plugin.framework.config.get_config_int", return_value=10):
+                        with patch("plugin.framework.config.get_api_config", return_value={"chat_max_tokens": 2048}):
+                            result = tool.execute(ctx, domain="research", task="What is the latest Python release?")
 
                 assert result["status"] == "ok"
                 assert "3.12.3" in result["result"]
@@ -265,14 +271,19 @@ def test_web_research_tool():
 def test_web_research_tool_stop():
     ctx = MagicMock()
     ctx.ctx = MockContext()
+    from unittest.mock import patch
     setattr(ctx.ctx, "getServiceManager", MagicMock())  # for ConfigService
     ctx.stop_checker = lambda: True  # Stop immediately
 
     with patch("plugin.framework.smol_model.WriterAgentSmolModel.generate", return_value=ChatMessage(role=MessageRole.ASSISTANT, content="")):
         with patch("urllib.request.urlopen"):
             with patch("requests.get"):
-                tool = WebResearchTool()
-                result = tool.execute(ctx, query="What is the latest Python release?", history_text="")
+                from plugin.modules.writer.specialized import DelegateToSpecializedWriter
+                tool = DelegateToSpecializedWriter()
+                with patch("plugin.framework.config.get_config", return_value="false"):
+                    with patch("plugin.framework.config.get_config_int", return_value=10):
+                        with patch("plugin.framework.config.get_api_config", return_value={"chat_max_tokens": 2048}):
+                            result = tool.execute(ctx, domain="research", task="What is the latest Python release?")
 
                 assert result["status"] == "error"
                 assert result["message"] == "Web search stopped by user."

--- a/plugin/tests/test_chatbot_handlers.py
+++ b/plugin/tests/test_chatbot_handlers.py
@@ -257,7 +257,7 @@ def test_web_research_tool():
                 with patch("plugin.framework.config.get_config", return_value="false"):
                     with patch("plugin.framework.config.get_config_int", return_value=10):
                         with patch("plugin.framework.config.get_api_config", return_value={"chat_max_tokens": 2048}):
-                            result = tool.execute(ctx, domain="research", task="What is the latest Python release?")
+                            result = tool.execute(ctx, domain="web_research", task="What is the latest Python release?")
 
                 assert result["status"] == "ok"
                 assert "3.12.3" in result["result"]
@@ -283,7 +283,7 @@ def test_web_research_tool_stop():
                 with patch("plugin.framework.config.get_config", return_value="false"):
                     with patch("plugin.framework.config.get_config_int", return_value=10):
                         with patch("plugin.framework.config.get_api_config", return_value={"chat_max_tokens": 2048}):
-                            result = tool.execute(ctx, domain="research", task="What is the latest Python release?")
+                            result = tool.execute(ctx, domain="web_research", task="What is the latest Python release?")
 
                 assert result["status"] == "error"
                 assert result["message"] == "Web search stopped by user."


### PR DESCRIPTION
This PR refactors the `web_research` tool so that it is no longer exposed directly to the top-level chat loop tool list. Instead, web research is treated as a specialized domain (`"research"`). The AI is directed via its system prompts to call `delegate_to_specialized_{writer|calc|draw}_toolset(domain="research")`. This handles the request, reducing the number of top-level tool calls presented to the AI.

---
*PR created automatically by Jules for task [16364415998373201370](https://jules.google.com/task/16364415998373201370) started by @KeithCu*