### PR TITLE
Rename Calc tool set_cell_style to set_style

### DIFF
--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -132,9 +132,9 @@ READ:
 
 WRITE & FORMAT:
 - write_formula_range: Single string fills entire range; JSON array must match range size exactly (one value per cell). Alternatively, provide multiline CSV data to bulk insert starting at a cell. Use empty string/array to clear contents. Use ranges for efficiency; avoid single-cell operations.
-- set_cell_style: Formatting (bold, colors, alignment, number format) for a range. Prefer ranges for efficiency; use after bulk writes.
+- set_style: Formatting (bold, colors, alignment, number format) for a range. Prefer ranges for efficiency; use after bulk writes.
 
-- merge_cells: Merge a range (e.g. headers); then write and style with write_formula_range/set_cell_style.
+- merge_cells: Merge a range (e.g. headers); then write and style with write_formula_range/set_style.
 - sort_range: Sort a range by a column (ascending/descending, optional header row).
 - delete_structure: Remove rows or columns at specific positions.
 

--- a/plugin/modules/calc/cells.py
+++ b/plugin/modules/calc/cells.py
@@ -164,7 +164,7 @@ class WriteCellRange(ToolBase):
 class SetCellStyle(ToolBase):
     """Apply style and formatting to cells or ranges."""
 
-    name = "set_cell_style"
+    name = "set_style"
     intent = "edit"
     description = (
         "Applies style and formatting to the specified cell(s) or "
@@ -287,7 +287,7 @@ class MergeCells(ToolBase):
     description = (
         "Merges the specified cell range(s). Typically used for main "
         "headers. Write text with write_formula_range and style with "
-        "set_cell_style after merging. Supports lists for non-contiguous "
+        "set_style after merging. Supports lists for non-contiguous "
         "areas."
     )
     parameters = {

--- a/plugin/tests/uno/test_calc.py
+++ b/plugin/tests/uno/test_calc.py
@@ -131,7 +131,7 @@ def test_write_formula_range():
 @native_test
 def test_set_cell_style_and_details():
     active_sheet = _test_doc.getCurrentController().getActiveSheet()
-    _execute_calc_tool("set_cell_style", {"range_name": "A1", "bold": True, "bg_color": "yellow"})
+    _execute_calc_tool("set_style", {"range_name": "A1", "bold": True, "bg_color": "yellow"})
     cell = active_sheet.getCellByPosition(0, 0)
     from com.sun.star.awt.FontWeight import BOLD
     assert cell.getPropertyValue("CharWeight") == BOLD, "Bold not set"
@@ -398,7 +398,7 @@ def test_consistent_error_payloads():
     # assert len(res_range["message"]) > 0, "Error message should not be empty"
 
     # 2. Invalid color string (standardized tool error: status/code/message/details)
-    res_color = _execute_calc_tool("set_cell_style", {"range_name": "A1", "bg_color": "not_a_real_color"})
+    res_color = _execute_calc_tool("set_style", {"range_name": "A1", "bg_color": "not_a_real_color"})
     assert res_color.get("status") == "error", f"Expected error for invalid color, got {res_color.get('status')}"
     assert "message" in res_color, f"Expected 'message' key in payload: {res_color}"
     assert isinstance(res_color["message"], str), "Error message should be a string"


### PR DESCRIPTION
Renames the Calc tool `set_cell_style` to `set_style` because it operates on cell ranges, not just single cells. Updated all references across `plugin/modules/calc/cells.py`, `plugin/framework/constants.py`, and `plugin/tests/uno/test_calc.py`. Tests have been verified to ensure the renamed tool passes properly.

---
*PR created automatically by Jules for task [389603578513478951](https://jules.google.com/task/389603578513478951) started by @KeithCu*