### PR TITLE
⚡ Optimize stop sequences string splitting

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,31 @@
+import timeit
+
+def original(content, stop_sequences):
+    if content is None or not stop_sequences:
+        return content
+
+    for stop_seq in stop_sequences:
+        split = content.split(stop_seq)
+        content = split[0]
+    return content
+
+def optimized(content, stop_sequences):
+    if content is None or not stop_sequences:
+        return content
+
+    for stop_seq in stop_sequences:
+        idx = content.find(stop_seq)
+        if idx != -1:
+            content = content[:idx]
+    return content
+
+content = "This is a very long string " * 1000 + "STOP" + " and more stuff " * 1000
+stop_sequences = ["STOP", "END", "HALT"]
+
+# Benchmark
+orig_time = timeit.timeit("original(content, stop_sequences)", globals=globals(), number=10000)
+opt_time = timeit.timeit("optimized(content, stop_sequences)", globals=globals(), number=10000)
+
+print(f"Original: {orig_time:.5f}s")
+print(f"Optimized: {opt_time:.5f}s")
+print(f"Speedup: {orig_time/opt_time:.2f}x")

--- a/plugin/contrib/smolagents/models.py
+++ b/plugin/contrib/smolagents/models.py
@@ -86,8 +86,9 @@ def remove_content_after_stop_sequences(content: str | None, stop_sequences: lis
         return content
 
     for stop_seq in stop_sequences:
-        split = content.split(stop_seq)
-        content = split[0]
+        idx = content.find(stop_seq)
+        if idx != -1:
+            content = content[:idx]
     return content
 
 


### PR DESCRIPTION
💡 **What:** Replaced the use of `content.split(stop_seq)[0]` with `content.find(stop_seq)` and subsequent string slicing (`content[:idx]`) in the `remove_content_after_stop_sequences` function.
🎯 **Why:** The previous implementation using `split()` allocated intermediate list objects in memory for the split parts, which is unnecessary since we only care about the string up to the first occurrence of the stop sequence. Using `find()` and slicing avoids these list allocations and executes faster.
📊 **Measured Improvement:** Created a local benchmark executing the function 10,000 times against a long string with the target stop sequence in the middle. The original implementation took 0.77797s, whereas the optimized version took 0.66681s, representing a 1.17x speedup with a reduced memory allocation overhead.

---
*PR created automatically by Jules for task [3272275197027660731](https://jules.google.com/task/3272275197027660731) started by @KeithCu*