### PR TITLE
Refactor doc module to use module-level imports

### DIFF
--- a/plugin/modules/doc/__init__.py
+++ b/plugin/modules/doc/__init__.py
@@ -6,6 +6,7 @@
 """Common tools for all document types."""
 
 from plugin.framework.module_base import ModuleBase
+from . import diagnostics, print_doc, undo
 
 
 class CommonModule(ModuleBase):
@@ -13,8 +14,6 @@ class CommonModule(ModuleBase):
 
     def initialize(self, services):
         self.services = services
-
-        from . import diagnostics, print_doc, undo
 
         for module in (diagnostics, print_doc, undo):
             services.tools.auto_discover(module)

--- a/plugin/modules/doc/print_doc.py
+++ b/plugin/modules/doc/print_doc.py
@@ -5,7 +5,14 @@
 
 """Print tool for all document types via XPrintable."""
 
+import typing
+
 from plugin.framework.tool_base import ToolBaseDummy
+
+try:
+    from com.sun.star.beans import PropertyValue
+except ImportError:
+    PropertyValue = typing.Any  # type: ignore
 
 
 class PrintDocument(ToolBaseDummy):
@@ -42,8 +49,6 @@ class PrintDocument(ToolBaseDummy):
     is_mutation = False
 
     def execute(self, ctx, **kwargs):
-        from com.sun.star.beans import PropertyValue
-
         doc = ctx.doc
         printer_name = kwargs.get("printer")
         pages = kwargs.get("pages")


### PR DESCRIPTION
This PR removes the local imports in `plugin/modules/doc/__init__.py` and `plugin/modules/doc/print_doc.py`. The imports are safely moved to the module level. `PropertyValue` from `com.sun.star.beans` is now wrapped in a `try...except ImportError` at the module level falling back to `typing.Any` so it handles the LibreOffice environment statically and dynamically, passing headless tests and type checking without breaking the `print` tool functionality.

---
*PR created automatically by Jules for task [568641941695083372](https://jules.google.com/task/568641941695083372) started by @KeithCu*