### PR TITLE
Refactor local imports in writer module to global scope

### DIFF
--- a/plugin/modules/writer/__init__.py
+++ b/plugin/modules/writer/__init__.py
@@ -18,6 +18,23 @@
 
 from plugin.framework.module_base import ModuleBase
 
+from . import bookmarks, tree, proximity, index
+from . import (
+    base as base,
+    specialized as specialized,
+    styles as styles,
+    shapes as shapes,
+    charts as charts,
+    bookmark_tools as bookmark_tools,
+    indexes as indexes,
+    fields as fields,
+    footnotes as footnotes,
+    embedded as embedded,
+    tracking as tracking,
+    forms as forms,
+)
+
+
 
 class WriterModule(ModuleBase):
     """Registers Writer tools for outline, content, comments, styles, etc."""
@@ -26,21 +43,6 @@ class WriterModule(ModuleBase):
         self.services = services
 
         # Initialize core Writer services via auto-discovery
-        from . import bookmarks, tree, proximity, index
-        from . import (
-            base as base,
-            specialized as specialized,
-            styles as styles,
-            shapes as shapes,
-            charts as charts,
-            bookmark_tools as bookmark_tools,
-            indexes as indexes,
-            fields as fields,
-            footnotes as footnotes,
-            embedded as embedded,
-            tracking as tracking,
-            forms as forms,
-        )
 
         # Order matters: tree needs bookmarks, proximity/index need tree
         for module in (bookmarks, tree, proximity, index):

--- a/plugin/modules/writer/base.py
+++ b/plugin/modules/writer/base.py
@@ -20,6 +20,8 @@ from typing import ClassVar
 
 from plugin.framework.tool_base import ToolBase
 from plugin.modules.calc.base import ToolCalcSpecialBase
+from plugin.framework.constants import USE_SUB_AGENT
+
 
 
 class ToolWriterSpecialBase(ToolBase):
@@ -177,7 +179,6 @@ class SpecializedWorkflowFinished(ToolBase):
 
     def execute(self, ctx, **kwargs):
         # Allow the main LLM loop to exit specialized mode
-        from plugin.framework.constants import USE_SUB_AGENT
         if not USE_SUB_AGENT:
             if getattr(ctx, "set_active_domain_callback", None):
                 ctx.set_active_domain_callback(None)

--- a/plugin/modules/writer/content.py
+++ b/plugin/modules/writer/content.py
@@ -21,6 +21,9 @@ import logging
 from plugin.framework.tool_base import ToolBase, ToolBaseDummy
 from plugin.framework.document import normalize_linebreaks
 from plugin.modules.writer import format_support
+from plugin.framework.errors import safe_json_loads
+import re as re_mod
+
 
 log = logging.getLogger("writeragent.writer")
 
@@ -58,7 +61,6 @@ def _normalize_search_string_for_find(s):
     """Collapse horizontal whitespace only; preserve newlines for literal find.
     (LibreOffice regex search does not work across paragraphs.)
     """
-    import re as re_mod
     return re_mod.sub(r"[ \t]+", " ", s).strip()
 
 
@@ -237,7 +239,6 @@ class ApplyDocumentContent(ToolBase):
         if isinstance(content, str):
             stripped = content.strip()
             if stripped.startswith("[") and "<" in stripped:
-                from plugin.framework.errors import safe_json_loads
                 parsed = safe_json_loads(stripped)
                 if isinstance(parsed, list):
                     content = parsed
@@ -270,7 +271,6 @@ class ApplyDocumentContent(ToolBase):
         # target == "search" from here on
         old_stripped = str(old_content).strip()
 
-        import re as re_mod
         search_string = old_stripped
         if format_support.content_has_markup(search_string):
             search_string = format_support.html_to_plain_text(

--- a/plugin/modules/writer/embedded.py
+++ b/plugin/modules/writer/embedded.py
@@ -10,6 +10,8 @@
 """Embedded OLE objects in Writer — specialized embedded domain."""
 
 from plugin.modules.writer.base import ToolWriterEmbeddedBase
+from plugin.modules.writer.target_resolver import resolve_target_cursor
+
 
 
 class EmbeddedInsert(ToolWriterEmbeddedBase):
@@ -45,7 +47,6 @@ class EmbeddedInsert(ToolWriterEmbeddedBase):
         target = kwargs.get("target", "selection")
         old_content = kwargs.get("old_content")
 
-        from plugin.modules.writer.target_resolver import resolve_target_cursor
         try:
             cursor = resolve_target_cursor(ctx, target, old_content)
         except ValueError as ve:

--- a/plugin/modules/writer/fields.py
+++ b/plugin/modules/writer/fields.py
@@ -10,6 +10,8 @@
 """Writer text fields — specialized fields domain."""
 
 from plugin.modules.writer.base import ToolWriterFieldBase
+from plugin.modules.writer.target_resolver import resolve_target_cursor
+
 
 
 class FieldsUpdateAll(ToolWriterFieldBase):
@@ -245,7 +247,6 @@ class FieldsInsert(ToolWriterFieldBase):
         target = kwargs.get("target", "selection")
         old_content = kwargs.get("old_content")
 
-        from plugin.modules.writer.target_resolver import resolve_target_cursor
         try:
             cursor = resolve_target_cursor(ctx, target, old_content)
         except ValueError as ve:

--- a/plugin/modules/writer/format_support.py
+++ b/plugin/modules/writer/format_support.py
@@ -74,6 +74,12 @@ import re
 import tempfile
 
 from plugin.framework.errors import ToolExecutionError
+import urllib.parse
+import urllib.request
+from typing import Any, cast
+import html as html_mod
+from plugin.modules.writer.ops import get_selection_range
+from plugin.modules.writer.ops import get_text_cursor_at_range
 
 log = logging.getLogger("writeragent.writer")
 
@@ -105,8 +111,6 @@ def _get_format_props(config_svc=None):
 
 def _file_url(path):
     """Return a ``file://`` URL for *path*."""
-    import urllib.parse
-    import urllib.request
     return urllib.parse.urljoin(
         "file:", urllib.request.pathname2url(os.path.abspath(path))
     )
@@ -114,7 +118,6 @@ def _file_url(path):
 
 def _create_property_value(name, value):
     """Create a ``com.sun.star.beans.PropertyValue``."""
-    from typing import Any, cast
     p = cast("Any", uno.createUnoStruct("com.sun.star.beans.PropertyValue"))
     p.Name = name
     p.Value = value
@@ -184,7 +187,6 @@ def _ensure_html_linebreaks(content):
     """
     if not isinstance(content, str) or not content:
         return content
-    import html as html_mod
     content = _normalize(content)
     unescaped = html_mod.unescape(content)
     html_tags = [
@@ -354,7 +356,6 @@ def document_to_content(model, ctx, services, max_chars=None,
     config_svc = services.get("config") if services else None
 
     if scope == "selection":
-        from plugin.modules.writer.ops import get_selection_range
         start, end = get_selection_range(model)
         return _range_to_content_via_temp_doc(
             model, ctx, start, end, max_chars, config_svc
@@ -396,7 +397,6 @@ def insert_content_at_position(model, ctx, content, position,
     """Insert formatted content at *position* (``'beginning'``,
     ``'end'``, or ``'selection'``) using ``insertDocumentFromURL``.
     """
-    import html as html_mod
     content = html_mod.unescape(content)
     content = _ensure_html_linebreaks(content)
 
@@ -431,7 +431,6 @@ def insert_content_at_position(model, ctx, content, position,
 
 def replace_full_document(model, ctx, content, config_svc=None):
     """Clear the document and insert *content*."""
-    import html as html_mod
     content = html_mod.unescape(content)
     content = _ensure_html_linebreaks(content)
 
@@ -450,7 +449,6 @@ def replace_full_document(model, ctx, content, config_svc=None):
 def apply_content_at_range(model, ctx, content, start, end,
                            config_svc=None):
     """Replace character range ``[start, end)`` with rendered *content*."""
-    from plugin.modules.writer.ops import get_text_cursor_at_range
 
     cursor = get_text_cursor_at_range(model, start, end)
     if cursor is None:
@@ -458,7 +456,6 @@ def apply_content_at_range(model, ctx, content, start, end,
             "Invalid range or could not create cursor for (%d, %d)" % (start, end)
         )
 
-    import html as html_mod
     content = html_mod.unescape(content)
     content = _ensure_html_linebreaks(content)
 
@@ -476,7 +473,6 @@ def apply_content_at_search(model, ctx, content, search,
 
     Returns the number of replacements made.
     """
-    import html as html_mod
     prepared = html_mod.unescape(content)
     prepared = _ensure_html_linebreaks(prepared)
 
@@ -508,7 +504,6 @@ def apply_content_at_search(model, ctx, content, search,
 def replace_single_range_with_content(model, text_range, content, ctx,
                                       config_svc=None):
     """Replace the given text range with rendered *content* (HTML path)."""
-    import html as html_mod
     prepared = html_mod.unescape(content)
     prepared = _ensure_html_linebreaks(prepared)
     with _with_temp_buffer(prepared, config_svc) as (_path, file_url):

--- a/plugin/modules/writer/images.py
+++ b/plugin/modules/writer/images.py
@@ -30,6 +30,13 @@ import os
 import tempfile
 
 from plugin.modules.writer.base import ToolWriterImageBase
+import typing
+import urllib.request
+import ssl
+from plugin.framework.queue_executor import execute_on_main_thread
+from plugin.framework.image_utils import ImageService
+from plugin.framework.config import get_config, get_text_model, get_config_int, get_config_bool, get_config_str, update_lru_history
+from plugin.framework.config import get_config, get_text_model, get_config_int, get_config_bool, get_config_str, update_lru_history
 from plugin.framework.image_tools import (
     insert_image, replace_image_in_place, get_selected_image_base64,
     get_selected_image_dimensions_px,
@@ -86,7 +93,6 @@ class GenerateImage(ToolWriterImageBase):
     is_mutation = True
     long_running = True
 
-    import typing
 
     def is_async(self) -> bool:
         """HTTP generation runs on the tool worker; UNO is marshalled in execute()."""
@@ -94,12 +100,6 @@ class GenerateImage(ToolWriterImageBase):
 
     def execute(self, ctx: typing.Any, **args: typing.Any) -> typing.Any:
         prompt = args.get("prompt", "")
-        from plugin.framework.config import (
-            get_config, get_text_model,
-            get_config_int, get_config_bool, get_config_str,
-            update_lru_history,
-        )
-        from plugin.framework.queue_executor import execute_on_main_thread
 
         status_callback = getattr(ctx, "status_callback", None)
         mt_timeout = float(get_config_int(ctx.ctx, "request_timeout"))
@@ -167,7 +167,6 @@ class GenerateImage(ToolWriterImageBase):
         width = args.get("width", edit_width if is_edit else w)
         height = args.get("height", edit_height if is_edit else h)
 
-        from plugin.framework.image_utils import ImageService
         image_svc = ImageService(ctx.ctx, config=None) # ImageService should use accessors too, or we pass dict
         args_copy = {
             k: v
@@ -900,8 +899,6 @@ def _download_image_to_cache(url, verify_ssl=False, force=False):
 
     Returns the local file path. Uses a URL-based hash for caching.
     """
-    import urllib.request
-    import ssl
 
     os.makedirs(_IMAGE_CACHE_DIR, exist_ok=True)
 

--- a/plugin/modules/writer/indexes.py
+++ b/plugin/modules/writer/indexes.py
@@ -10,6 +10,8 @@
 """Writer document indexes (TOC, bibliography) — specialized indexes domain."""
 
 from plugin.modules.writer.base import ToolWriterIndexBase
+from plugin.modules.writer.target_resolver import resolve_target_cursor
+
 
 
 class IndexesUpdateAll(ToolWriterIndexBase):
@@ -164,7 +166,6 @@ class IndexesCreate(ToolWriterIndexBase):
             if index_kind == "toc" and hasattr(index, "CreateFromOutline"):
                 index.CreateFromOutline = create_from_outline
 
-            from plugin.modules.writer.target_resolver import resolve_target_cursor
             try:
                 cursor = resolve_target_cursor(ctx, target, old_content)
             except ValueError as ve:
@@ -241,7 +242,6 @@ class IndexesAddMark(ToolWriterIndexBase):
         target = kwargs.get("target", "selection")
         old_content = kwargs.get("old_content")
 
-        from plugin.modules.writer.target_resolver import resolve_target_cursor
         try:
             cursor = resolve_target_cursor(ctx, target, old_content)
         except ValueError as ve:

--- a/plugin/modules/writer/legacy.py
+++ b/plugin/modules/writer/legacy.py
@@ -23,6 +23,9 @@ from plugin.modules.http.errors import format_error_message
 from plugin.framework.async_stream import run_stream_completion_async
 from plugin.framework.dialogs import msgbox
 from plugin.framework.i18n import _
+from plugin.framework.config import set_config
+from plugin.modules.http.client import LlmClient
+
 
 def do_extend_selection(ctx, model, input_box_fn):
     selection = model.CurrentController.getSelection()
@@ -46,7 +49,6 @@ def do_extend_selection(ctx, model, input_box_fn):
         msgbox(ctx, _("WriterAgent: Extend Selection"), _(err_msg))
         return
 
-    from plugin.modules.http.client import LlmClient
     client = LlmClient(api_config, ctx)
 
     def apply_chunk(chunk_text, is_thinking=False):
@@ -74,7 +76,6 @@ def do_edit_selection(ctx, model, input_box_fn):
         if not user_input:
             return
         if extra_instructions:
-            from plugin.framework.config import set_config
             set_config(ctx, "additional_instructions", extra_instructions)
             update_lru_history(ctx, extra_instructions, "prompt_lru", get_current_endpoint(ctx))
     except Exception as e:
@@ -91,7 +92,6 @@ def do_edit_selection(ctx, model, input_box_fn):
         msgbox(ctx, _("WriterAgent: Edit Selection"), _(err_msg))
         return
 
-    from plugin.modules.http.client import LlmClient
     client = LlmClient(api_config, ctx)
 
     text_range.setString("")

--- a/plugin/modules/writer/proximity.py
+++ b/plugin/modules/writer/proximity.py
@@ -25,6 +25,8 @@ import logging
 
 from plugin.framework.errors import ToolExecutionError
 from plugin.framework.service_base import ServiceBase
+import typing
+
 
 log = logging.getLogger("writeragent.writer.nav.proximity")
 
@@ -151,7 +153,6 @@ class ProximityService(ServiceBase):
             from_info["context_bookmark"] = bookmark_map.get(
                 ctx_node["para_index"])
 
-        import typing
         target_entry = typing.cast("typing.Optional[typing.Dict[str, typing.Any]]", None)
         error_msg = None
 

--- a/plugin/modules/writer/search.py
+++ b/plugin/modules/writer/search.py
@@ -19,6 +19,9 @@
 import logging
 
 from plugin.framework.tool_base import ToolBase, ToolBaseDummy
+from plugin.modules.writer import format_support
+import re as re_mod
+
 
 log = logging.getLogger("writeragent.writer")
 
@@ -71,7 +74,6 @@ class SearchInDocument(ToolBase):
     tier = "core"
 
     def execute(self, ctx, **kwargs):
-        import re as re_mod
 
         pattern = kwargs.get("pattern", "")
         if not pattern:
@@ -84,7 +86,6 @@ class SearchInDocument(ToolBase):
         return_offsets = kwargs.get("return_offsets", False)
 
         if return_offsets:
-            from plugin.modules.writer import format_support
             ranges = format_support.find_text_ranges(
                 ctx.doc, ctx.ctx, pattern,
                 start=0, limit=max_results, case_sensitive=case_sensitive,

--- a/plugin/modules/writer/specialized.py
+++ b/plugin/modules/writer/specialized.py
@@ -21,6 +21,19 @@ import logging
 from plugin.framework.tool_base import ToolBase
 from plugin.modules.writer.base import ToolWriterSpecialBase
 from plugin.framework.constants import DELEGATE_SPECIALIZED_TASK_PARAM_HINT, USE_SUB_AGENT
+from plugin.contrib.smolagents.agents import ToolCallingAgent
+from plugin.contrib.smolagents.memory import ActionStep, FinalAnswerStep, ToolCall
+from plugin.contrib.smolagents.toolcalling_agent_prompts import SPECIALIZED_EXAMPLES_BLOCK
+from plugin.contrib.smolagents.tools import Tool as SmolTool
+from plugin.framework.config import get_api_config, get_config_int
+from plugin.framework.errors import format_error_payload, ToolExecutionError
+from plugin.framework.i18n import _
+from plugin.framework.queue_executor import execute_on_main_thread
+from plugin.framework.smol_model import WriterAgentSmolModel
+from plugin.modules.chatbot.web_research import WebResearchTool
+from plugin.modules.http.client import LlmClient
+from typing import cast, Iterable
+
 
 log = logging.getLogger("writeragent.writer")
 
@@ -46,7 +59,6 @@ class DelegateToSpecializedWriter(ToolBase):
 
     def __init__(self):
         super().__init__()
-        from plugin.modules.writer.base import ToolWriterSpecialBase
         domains = []
         for cls in ToolWriterSpecialBase.__subclasses__():
             if getattr(cls, "specialized_domain", None):
@@ -78,13 +90,6 @@ class DelegateToSpecializedWriter(ToolBase):
         return True
 
     def execute(self, ctx, **kwargs):
-        from plugin.framework.errors import format_error_payload, ToolExecutionError
-        from plugin.framework.config import get_api_config, get_config_int
-        from plugin.modules.http.client import LlmClient
-        from plugin.framework.smol_model import WriterAgentSmolModel
-        from plugin.contrib.smolagents.agents import ToolCallingAgent
-        from plugin.contrib.smolagents.memory import ActionStep, FinalAnswerStep, ToolCall
-        from plugin.contrib.smolagents.toolcalling_agent_prompts import SPECIALIZED_EXAMPLES_BLOCK
 
         domain = kwargs.get("domain")
         task = kwargs.get("task")
@@ -94,7 +99,6 @@ class DelegateToSpecializedWriter(ToolBase):
         stop_checker = getattr(ctx, "stop_checker", None)
 
         if domain == "web_research":
-            from plugin.modules.chatbot.web_research import WebResearchTool
             tool = WebResearchTool()
             return tool.execute(ctx, query=task)
 
@@ -103,7 +107,6 @@ class DelegateToSpecializedWriter(ToolBase):
             if getattr(ctx, "set_active_domain_callback", None):
                 ctx.set_active_domain_callback(domain)
 
-            from plugin.framework.i18n import _
             msg = _("Tool call switched to '{0}'. You are in a specialized toolset mode. "
                     "You must call 'specialized_workflow_finished' when done to restore "
                     "the full set of APIs.").format(domain)
@@ -142,7 +145,6 @@ class DelegateToSpecializedWriter(ToolBase):
                 )
 
             # Create a simple wrapper for each ToolBase to expose it to smolagents
-            from plugin.contrib.smolagents.tools import Tool as SmolTool
 
             class WrappedSmolTool(SmolTool):
                 skip_forward_signature_validation = True
@@ -170,7 +172,6 @@ class DelegateToSpecializedWriter(ToolBase):
                     return self.forward(*args, **kwargs)
 
                 def forward(self, *args, **kwargs):
-                    from plugin.framework.queue_executor import execute_on_main_thread
 
                     tool = self.writer_tool
                     if getattr(tool, "is_async", lambda: False)():
@@ -209,8 +210,6 @@ class DelegateToSpecializedWriter(ToolBase):
 
             max_steps = get_config_int(ctx.ctx, "chat_max_tool_rounds")
 
-            from typing import cast, Iterable
-            from plugin.contrib.smolagents.tools import Tool as SmolTool
             agent = ToolCallingAgent(
                 tools=cast("list[SmolTool]", smol_tools),
                 model=smol_model,
@@ -253,7 +252,6 @@ class DelegateToSpecializedWriter(ToolBase):
                 elif isinstance(step, FinalAnswerStep):
                     final_ans = step.output
 
-            from plugin.framework.i18n import _
 
             return {
                 "status": "ok",

--- a/plugin/modules/writer/styles.py
+++ b/plugin/modules/writer/styles.py
@@ -20,6 +20,8 @@ import logging
 
 from plugin.framework.tool_base import ToolBase as FrameworkToolBase
 from plugin.modules.writer.base import ToolWriterStyleBase as ToolBase
+from plugin.modules.writer.target_resolver import resolve_target_cursor
+
 
 log = logging.getLogger("writeragent.writer")
 
@@ -212,7 +214,6 @@ class StylesApply(FrameworkToolBase):
         target = kwargs.get("target", "selection")
         old_content = kwargs.get("old_content")
 
-        from plugin.modules.writer.target_resolver import resolve_target_cursor
         try:
             cursor = resolve_target_cursor(ctx, target, old_content)
         except ValueError as ve:

--- a/plugin/modules/writer/target_resolver.py
+++ b/plugin/modules/writer/target_resolver.py
@@ -1,5 +1,8 @@
 import re as re_mod
 import logging
+from plugin.modules.writer.content import _normalize_search_string_for_find, _find_range_by_offset
+from plugin.modules.writer.format_support import content_has_markup, html_to_plain_text
+
 log = logging.getLogger("writeragent.writer")
 
 
@@ -51,8 +54,6 @@ def resolve_target_cursor(ctx, target, old_content):
     # target == "search" or fallback to search if old_content is provided
 
     # target == "search"
-    from plugin.modules.writer.content import _normalize_search_string_for_find, _find_range_by_offset
-    from plugin.modules.writer.format_support import content_has_markup, html_to_plain_text
 
     search_string = str(old_content).strip() if old_content is not None else ""
     if content_has_markup(search_string):

--- a/plugin/modules/writer/tree.py
+++ b/plugin/modules/writer/tree.py
@@ -23,6 +23,8 @@ import logging
 
 from plugin.framework.errors import ToolExecutionError
 from plugin.framework.service_base import ServiceBase
+from typing import Any
+
 
 log = logging.getLogger("writeragent.writer.nav.tree")
 
@@ -63,7 +65,6 @@ class TreeService(ServiceBase):
         if key in self._tree_cache:
             return self._tree_cache[key]
 
-        from typing import Any
         text = doc.getText()
         enum = text.createEnumeration()
         root: dict[str, Any] = {"level": 0, "text": "root", "para_index": -1,


### PR DESCRIPTION
This PR moves local imports inside the `writer` module to the global (module) level where it's safe to do so. 

- Over 40 imports in `plugin/modules/writer/` were moved to the top of their respective files.
- Refactored files include `base.py`, `content.py`, `fields.py`, `images.py`, `specialized.py`, `target_resolver.py`, and more.
- `uno` and `com.sun.star.*` pyuno imports were intentionally left as local imports to prevent `ModuleNotFoundError` outside of the LibreOffice context (e.g. during `ty` check or standard headless `pytest` runs).
- Imports that cause `ImportError` due to circular dependency loops (e.g., in `ops.py`, `forms.py`) were left unchanged as requested to maintain stability without triggering larger architectural refactors at this stage.

---
*PR created automatically by Jules for task [2927805444024079433](https://jules.google.com/task/2927805444024079433) started by @KeithCu*