### PR TITLE
feat(grammar): incremental improvements to AI grammar checker

### DIFF
--- a/plugin/modules/http/client.py
+++ b/plugin/modules/http/client.py
@@ -311,7 +311,7 @@ class LlmClient:
 
         return content, finish_reason, thinking, delta
 
-    def make_chat_request(self, messages, max_tokens=512, tools=None, stream=False, model=None):
+    def make_chat_request(self, messages, max_tokens=512, tools=None, stream=False, model=None, response_format=None):
         """Build a chat completions request from a full messages array (provider-aware)."""
         try:
             max_tokens = int(max_tokens)
@@ -504,6 +504,8 @@ class LlmClient:
             data["tools"] = tools
             data["tool_choice"] = "auto"
             data["parallel_tool_calls"] = False
+        if response_format:
+            data["response_format"] = response_format
 
         if self.config.get("is_openrouter"):
             extra = self.config.get("openrouter_chat_extra")
@@ -869,6 +871,7 @@ class LlmClient:
         body_override=None,
         model=None,
         stream=False,
+        response_format=None,
     ):
         """Chat request with support for tools and streaming.
         
@@ -879,7 +882,7 @@ class LlmClient:
         """
         init_logging(self.ctx)
         method, path, body, headers = self.make_chat_request(
-            messages, max_tokens, tools=tools, stream=stream, model=model
+            messages, max_tokens, tools=tools, stream=stream, model=model, response_format=response_format
         )
         if body_override is not None:
             body = body_override.encode("utf-8") if isinstance(body_override, str) else body_override
@@ -1012,12 +1015,12 @@ class LlmClient:
         return self.request_with_tools(*args, **kwargs)
 
 
-    def chat_completion_sync(self, messages, max_tokens=512, model=None):
+    def chat_completion_sync(self, messages, max_tokens=512, model=None, response_format=None):
         """
         Synchronous chat completion (no streaming, no tools).
         Returns the assistant message content string.
         """
         result = self.request_with_tools(
-            messages, max_tokens=max_tokens, tools=None, model=model
+            messages, max_tokens=max_tokens, tools=None, model=model, response_format=response_format
         )
         return result.get("content") or ""

--- a/plugin/modules/writer/ai_grammar_proofreader.py
+++ b/plugin/modules/writer/ai_grammar_proofreader.py
@@ -422,7 +422,10 @@ def _run_llm_and_cache(
         client = LlmClient(get_api_config(ctx), ctx)
         with llm_request_lane():
             content = client.chat_completion_sync(
-                messages, max_tokens=max_tok, model=model or None
+                messages,
+                max_tokens=max_tok,
+                model=model or None,
+                response_format={"type": "json_object"},
             )
         elapsed_ms = int((time.monotonic() - request_start) * 1000)
         log.debug("[grammar] LLM raw response length=%s", len(content or ""))
@@ -600,8 +603,8 @@ class WriterAgentAiGrammarProofreader(
                     max_chars,
                 )
                 return a_res
-            cache_key = engine.make_cache_key(aDocumentIdentifier, loc_key)
             fp = engine.fingerprint_for_text(slice_txt)
+            cache_key = engine.make_cache_key(aDocumentIdentifier, loc_key, fingerprint=fp)
             cached = engine.cache_get(cache_key, fp)
             if cached is not None:
                 try:
@@ -619,7 +622,7 @@ class WriterAgentAiGrammarProofreader(
                         pass
                 return a_res
 
-            map_key = cache_key
+            map_key = engine.make_cache_key(aDocumentIdentifier, loc_key)
             inflight_key = _inflight_key(cache_key, fp)
             start_worker = False
             with _INFLIGHT_LOCK:

--- a/plugin/modules/writer/grammar_proofread_engine.py
+++ b/plugin/modules/writer/grammar_proofread_engine.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import collections
 import re
 import threading
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
-from plugin.framework.errors import safe_json_loads
+from plugin.framework.json_utils import safe_json_loads
 
 log = logging.getLogger(__name__)
 _grammar_diag = logging.getLogger("writeragent.grammar")
@@ -24,8 +25,9 @@ GRAMMAR_REGISTRY_LOCALE_TAGS: tuple[str, ...] = ("en-US", "en-GB")
 
 _CACHE_LOCK = threading.Lock()
 # cache_key -> (text_fingerprint, tuple of normalized error dicts)
-_proofread_cache: dict[str, tuple[str, tuple[dict[str, Any], ...]]] = {}
+_proofread_cache: collections.OrderedDict[str, tuple[str, tuple[dict[str, Any], ...]]] = collections.OrderedDict()
 _ignored_rules: set[str] = set()
+MAX_CACHE_SIZE = 128
 
 
 def cache_clear() -> None:
@@ -56,7 +58,10 @@ def fingerprint_for_text(text: str) -> str:
 def make_cache_key(
     doc_id: Any,
     locale_key: str,
+    fingerprint: str = "",
 ) -> str:
+    if fingerprint:
+        return f"{doc_id!s}|{locale_key}|{fingerprint}"
     return f"{doc_id!s}|{locale_key}"
 
 
@@ -68,12 +73,16 @@ def cache_get(key: str, fingerprint: str) -> tuple[dict[str, Any], ...] | None:
         cached_fp, errors = hit
         if cached_fp != fingerprint:
             return None
+        _proofread_cache.move_to_end(key)
         return errors
 
 
 def cache_put(key: str, fingerprint: str, errors: Sequence[dict[str, Any]]) -> None:
     with _CACHE_LOCK:
         _proofread_cache[key] = (fingerprint, tuple(errors))
+        _proofread_cache.move_to_end(key)
+        while len(_proofread_cache) > MAX_CACHE_SIZE:
+            _proofread_cache.popitem(last=False)
 
 
 @dataclass(frozen=True)
@@ -102,8 +111,16 @@ def parse_grammar_json(content: str) -> list[dict[str, Any]]:
     try:
         data = safe_json_loads(text)
     except Exception as e:
-        _grammar_diag.warning("[grammar] parse_grammar_json: JSON parse failed: %s", e, exc_info=True)
-        return []
+        _grammar_diag.info("[grammar] parse_grammar_json: strict JSON parse failed, attempting fallback: %s", e)
+        try:
+            import json_repair
+            data = json_repair.repair_json(text, return_objects=True)
+        except ImportError:
+            _grammar_diag.warning("[grammar] parse_grammar_json: json_repair not installed; parse failed: %s", e)
+            return []
+        except Exception as e2:
+            _grammar_diag.warning("[grammar] parse_grammar_json: json_repair failed: %s", e2)
+            return []
     if not isinstance(data, Mapping):
         return []
     raw = data.get("errors")

--- a/plugin/tests/uno/test_ai_grammar_proofreader.py
+++ b/plugin/tests/uno/test_ai_grammar_proofreader.py
@@ -49,8 +49,8 @@ def test_do_proofreading_returns_cached_errors() -> None:
     text = "Hello they is fine."
     n_start = 0
     n_end = len(text)
-    key = eng.make_cache_key(42, "en_US_")
     fp = eng.fingerprint_for_text(text[n_start:n_end])
+    key = eng.make_cache_key(42, "en_US_", fingerprint=fp)
     from dataclasses import asdict
 
     norms = eng.normalize_errors_for_text(
@@ -82,8 +82,8 @@ def test_ignore_rule_filters_cached_error() -> None:
     text = "Hello they is fine."
     n_start = 0
     n_end = len(text)
-    key = eng.make_cache_key(99, "en_US_")
     fp = eng.fingerprint_for_text(text[n_start:n_end])
+    key = eng.make_cache_key(99, "en_US_", fingerprint=fp)
     from dataclasses import asdict
 
     norms = eng.normalize_errors_for_text(

--- a/update.xml
+++ b/update.xml
@@ -10,7 +10,7 @@
       only shows "update available" without a workable LO-side upgrade path.
     -->
     <identifier value="org.extension.writeragent" />
-    <version value="0.7.5" />
+    <version value="0.7.6" />
     <update-download>
         <src xlink:href="https://github.com/KeithCu/writeragent/releases/latest/download/writeragent.oxt" />
     </update-download>


### PR DESCRIPTION
This PR adds 5 incremental stability and reliability improvements to the AI Grammar Checker engine:

1. **Import Fix**: Corrected the `safe_json_loads` import which was incorrectly pointing to `errors` instead of `json_utils`.
2. **JSON Format Enforcement**: Added native plumbing for OpenAI's `response_format` through `LlmClient` and utilized `{"type": "json_object"}` in the grammar proofreader to force strictly valid JSON structure from the API.
3. **Robust Parsing Fallback**: Refactored the internal JSON parsing to optionally leverage `json_repair.repair_json` (if installed) when standard parsing fails, protecting against mildly malformed LLM outputs.
4. **Bounded Memory Cache**: Swapped the unbound `_proofread_cache` `dict` to an `collections.OrderedDict`-based LRU cache with a hard size limit (128) to prevent memory ballooning during prolonged sessions.
5. **Multi-paragraph Support**: Extended `make_cache_key` to optionally embed the text fingerprint natively into the cache map key. This resolves a prior limitation where the document-level cache map would continuously overwrite itself, allowing simultaneous highlighting of issues across multiple paragraphs in the same active document window.

---
*PR created automatically by Jules for task [13563057008217009983](https://jules.google.com/task/13563057008217009983) started by @KeithCu*