### PR TITLE
Add Headers/Footers API to Draw/Impress Specialized Tools

### DIFF
--- a/docs/draw-impress-specialized-toolsets.md
+++ b/docs/draw-impress-specialized-toolsets.md
@@ -79,6 +79,8 @@ These are available only via `delegate_to_specialized_draw_toolset`:
 | `list_form_controls` | `forms` | `writer/forms.py` | List form controls |
 | `edit_form_control` | `forms` | `writer/forms.py` | Modify a form control |
 | `delete_form_control` | `forms` | `writer/forms.py` | Remove a form control |
+| `get_headers_footers` | `headers_footers` | `draw/headers_footers.py` | Read slide/master header and footer settings (Impress) |
+| `set_headers_footers` | `headers_footers` | `draw/headers_footers.py` | Update slide/master header and footer settings (Impress) |
 
 ----
 
@@ -103,7 +105,7 @@ These are available only via `delegate_to_specialized_draw_toolset`:
 | **Timings** | ❌ Missing | — | Rehearse, auto-advance |
 | **Themes** | ❌ Missing | — | Color/font schemes |
 | **Templates** | ❌ Missing | — | Document templates |
-| **Headers/Footers** | ❌ Missing | — | Slide numbering, date |
+| **Headers/Footers (specialized)** | ✅ Complete | 2 tools | `get_headers_footers`, `set_headers_footers` (Impress only) |
 | **Tables** | ❌ Missing | — | Insert/edit tables in Draw |
 | **3D Shapes** | ❌ Missing | — | 3D objects and scenes |
 | **Guides/Grid** | ❌ Missing | — | Snap settings, custom guides |
@@ -156,7 +158,6 @@ _ALL_CHART_DOCS = [
 |---------|----------|-------------|--------|
 | **Slide Animations** | `com.sun.star.presentation.Animation*` | Professional presentations | Medium |
 | **Slide Show Controls** | `com.sun.star.presentation.Presentation` | Start/stop presentations | Low |
-| **Headers/Footers** | `com.sun.star.presentation.*` | Page numbering, dates | Low |
 | **Layers** | `com.sun.star.drawing.Layer*` | Advanced Draw organization | Medium |
 | **Media Insertion** | `com.sun.star.presentation.Media*` | Audio/video in slides | Medium |
 | **Tables in Draw** | `com.sun.star.drawing.TableShape` | Tabular data | Medium |

--- a/plugin/modules/draw/__init__.py
+++ b/plugin/modules/draw/__init__.py
@@ -21,6 +21,7 @@ from plugin.framework.module_base import ModuleBase
 # Import submodules to ensure tools are registered via auto_discover_package
 from plugin.modules.draw import specialized as specialized
 from plugin.modules.draw import tree as tree
+from plugin.modules.draw import headers_footers as headers_footers
 
 class DrawModule(ModuleBase):
     """Registers Draw/Impress tools for shapes, pages/slides."""

--- a/plugin/modules/draw/base.py
+++ b/plugin/modules/draw/base.py
@@ -63,3 +63,9 @@ class ToolDrawFormBase(ToolDrawSpecialBase):
         "com.sun.star.drawing.DrawingDocument",
         "com.sun.star.presentation.PresentationDocument",
     ]
+
+class ToolDrawHeaderFooterBase(ToolDrawSpecialBase):
+    specialized_domain: ClassVar[str | None] = "headers_footers"
+    uno_services = [
+        "com.sun.star.presentation.PresentationDocument",
+    ]

--- a/plugin/modules/draw/headers_footers.py
+++ b/plugin/modules/draw/headers_footers.py
@@ -1,0 +1,194 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2024 John Balis
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tools for manipulating headers, footers, page numbers, and dates in presentations."""
+
+import logging
+from typing import Any, Dict
+
+from plugin.framework.errors import WriterAgentException
+from plugin.framework.tool_context import ToolContext
+from plugin.modules.draw.base import ToolDrawHeaderFooterBase
+from plugin.modules.draw.bridge import DrawBridge
+
+log = logging.getLogger("writeragent.draw.headers_footers")
+
+
+def _get_page(ctx: ToolContext, page_index: int, is_master_page: bool) -> Any:
+    bridge = DrawBridge(ctx.doc)
+    if is_master_page:
+        masters = ctx.doc.getMasterPages()
+        if page_index < 0 or page_index >= masters.getCount():
+            raise WriterAgentException(
+                "invalid_index",
+                f"Master page index {page_index} is out of bounds. Must be between 0 and {masters.getCount() - 1}",
+            )
+        return masters.getByIndex(page_index)
+    else:
+        pages = bridge.get_pages()
+        if page_index < 0 or page_index >= pages.getCount():
+            raise WriterAgentException(
+                "invalid_index",
+                f"Slide index {page_index} is out of bounds. Must be between 0 and {pages.getCount() - 1}",
+            )
+        return pages.getByIndex(page_index)
+
+
+class GetHeadersFooters(ToolDrawHeaderFooterBase):
+    """Tool for reading header and footer properties of a presentation slide or master page."""
+
+    name = "get_headers_footers"
+    description = (
+        "Retrieves header, footer, date/time, and slide number configuration "
+        "for a specific slide or master page in a presentation."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "page_index": {
+                "type": "integer",
+                "description": "Index of the slide or master page (0-based).",
+            },
+            "is_master_page": {
+                "type": "boolean",
+                "description": "If True, get the properties for the master page instead of a normal slide. Defaults to False.",
+            },
+        },
+        "required": ["page_index"],
+    }
+
+    def execute(self, ctx: ToolContext, **kwargs: Any) -> Dict[str, Any]:
+        page_index = int(kwargs["page_index"])
+        is_master_page = bool(kwargs.get("is_master_page", False))
+
+        page = _get_page(ctx, page_index, is_master_page)
+
+        result: Dict[str, Any] = {
+            "status": "ok",
+            "page_index": page_index,
+            "is_master_page": is_master_page,
+            "properties": {}
+        }
+
+        props_to_fetch = [
+            "HeaderText",
+            "FooterText",
+            "DateTimeText",
+            "IsHeaderVisible",
+            "IsFooterVisible",
+            "IsPageNumberVisible",
+            "IsDateTimeVisible",
+            "IsDateTimeFixed",
+            "DateTimeFormat",
+        ]
+
+        props = result["properties"]
+        for prop_name in props_to_fetch:
+            try:
+                props[prop_name] = page.getPropertyValue(prop_name)
+            except Exception as e:
+                log.debug("Could not read property %s: %s", prop_name, e)
+
+        return result
+
+
+class SetHeadersFooters(ToolDrawHeaderFooterBase):
+    """Tool for updating header and footer properties of a presentation slide or master page."""
+
+    name = "set_headers_footers"
+    description = (
+        "Updates header, footer, date/time, and slide number configuration "
+        "for a specific slide or master page in a presentation."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "page_index": {
+                "type": "integer",
+                "description": "Index of the slide or master page (0-based).",
+            },
+            "is_master_page": {
+                "type": "boolean",
+                "description": "If True, sets the properties for the master page instead of a normal slide. Defaults to False.",
+            },
+            "header_text": {
+                "type": "string",
+                "description": "The text for the header.",
+            },
+            "footer_text": {
+                "type": "string",
+                "description": "The text for the footer.",
+            },
+            "date_time_text": {
+                "type": "string",
+                "description": "The fixed date/time text.",
+            },
+            "is_header_visible": {
+                "type": "boolean",
+                "description": "Whether the header is visible.",
+            },
+            "is_footer_visible": {
+                "type": "boolean",
+                "description": "Whether the footer is visible.",
+            },
+            "is_page_number_visible": {
+                "type": "boolean",
+                "description": "Whether the slide number is visible.",
+            },
+            "is_date_time_visible": {
+                "type": "boolean",
+                "description": "Whether the date/time is visible.",
+            },
+            "is_date_time_fixed": {
+                "type": "boolean",
+                "description": "If True, uses 'date_time_text'. If False, LibreOffice automatically updates it.",
+            },
+        },
+        "required": ["page_index"],
+    }
+
+    def execute(self, ctx: ToolContext, **kwargs: Any) -> Dict[str, Any]:
+        page_index = int(kwargs["page_index"])
+        is_master_page = bool(kwargs.get("is_master_page", False))
+
+        page = _get_page(ctx, page_index, is_master_page)
+
+        prop_map = {
+            "header_text": "HeaderText",
+            "footer_text": "FooterText",
+            "date_time_text": "DateTimeText",
+            "is_header_visible": "IsHeaderVisible",
+            "is_footer_visible": "IsFooterVisible",
+            "is_page_number_visible": "IsPageNumberVisible",
+            "is_date_time_visible": "IsDateTimeVisible",
+            "is_date_time_fixed": "IsDateTimeFixed",
+        }
+
+        updated_count = 0
+        for kwarg_key, prop_name in prop_map.items():
+            if kwarg_key in kwargs:
+                val = kwargs[kwarg_key]
+                try:
+                    page.setPropertyValue(prop_name, val)
+                    updated_count += 1
+                except Exception as e:
+                    log.debug("Could not set property %s: %s", prop_name, e)
+
+        return {
+            "status": "ok",
+            "updated_properties": updated_count,
+            "message": f"Successfully updated {updated_count} header/footer properties on {'master page' if is_master_page else 'slide'} {page_index}."
+        }

--- a/plugin/tests/uno/test_impress_headers_footers.py
+++ b/plugin/tests/uno/test_impress_headers_footers.py
@@ -1,0 +1,120 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2024 John Balis
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+from plugin.framework.logging import log
+from plugin.framework.uno_context import get_desktop
+from plugin.testing_runner import setup, teardown, native_test
+
+_test_doc = None
+_test_ctx = None
+
+
+@setup
+def setup_impress_tests(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+
+    desktop = get_desktop(ctx)
+    import uno
+
+    hidden_prop = uno.createUnoStruct(
+        "com.sun.star.beans.PropertyValue",
+        Name="Hidden",
+        Value=True,
+    )
+
+    _test_doc = desktop.loadComponentFromURL("private:factory/simpress", "_blank", 0, (hidden_prop,))
+    assert _test_doc is not None, "Could not create Impress document"
+    assert hasattr(_test_doc, "getDrawPages"), "Not a valid Impress document"
+
+    log.info("[ImpressTests] test_impress_headers_footers: starting tests")
+
+
+@teardown
+def teardown_impress_tests(ctx):
+    global _test_doc, _test_ctx
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+    _test_ctx = None
+
+
+def _exec_tool(name, args):
+    from plugin.main import get_tools, get_services
+    from plugin.framework.tool_context import ToolContext
+    tctx = ToolContext(_test_doc, _test_ctx, "impress", get_services(), "test")
+    res = get_tools().execute(name, tctx, **args)
+    return json.dumps(res) if isinstance(res, dict) else res
+
+
+@native_test
+def test_headers_footers():
+    try:
+        import pytest
+        if _test_doc is None:
+            pytest.skip("Requires LibreOffice document from native runner")
+    except ImportError:
+        pass
+
+    # 1. Get initial headers/footers
+    result_str = _exec_tool("get_headers_footers", {"page_index": 0})
+    result = json.loads(result_str)
+
+    assert result.get("status") == "ok"
+    assert "properties" in result
+
+    # 2. Set headers/footers
+    set_result_str = _exec_tool("set_headers_footers", {
+        "page_index": 0,
+        "footer_text": "This is a test footer",
+        "is_footer_visible": True,
+        "is_page_number_visible": True,
+        "date_time_text": "2024-01-01",
+        "is_date_time_visible": True,
+        "is_date_time_fixed": True
+    })
+    set_result = json.loads(set_result_str)
+
+    assert set_result.get("status") == "ok"
+    assert set_result.get("updated_properties") > 0
+
+    # 3. Verify changes
+    result_str = _exec_tool("get_headers_footers", {"page_index": 0})
+    result = json.loads(result_str)
+
+    props = result.get("properties", {})
+    assert props.get("FooterText") == "This is a test footer"
+    assert props.get("IsFooterVisible") is True
+    assert props.get("IsPageNumberVisible") is True
+    assert props.get("DateTimeText") == "2024-01-01"
+    assert props.get("IsDateTimeVisible") is True
+    assert props.get("IsDateTimeFixed") is True
+
+    # 4. Test master page
+    set_result_str = _exec_tool("set_headers_footers", {
+        "page_index": 0,
+        "is_master_page": True,
+        "footer_text": "Master Footer"
+    })
+    set_result = json.loads(set_result_str)
+    assert set_result.get("status") == "ok"
+
+    result_str = _exec_tool("get_headers_footers", {"page_index": 0, "is_master_page": True})
+    result = json.loads(result_str)
+    props = result.get("properties", {})
+    assert props.get("FooterText") == "Master Footer"


### PR DESCRIPTION
Implements the `headers_footers` specialized domain for Impress documents.

This PR adds:
- `ToolDrawHeaderFooterBase` in `base.py` tailored to Impress (`PresentationDocument`).
- `get_headers_footers` and `set_headers_footers` tools in `headers_footers.py` to allow interacting with the `XDrawPage` header, footer, page number, and date/time visibility and text properties on normal slides and master slides.
- Integration tests simulating a headless Impress document (`test_impress_headers_footers.py`).
- Updated `docs/draw-impress-specialized-toolsets.md` reflecting the completion of the Headers/Footers API.
- Fixes to `pyright` and translation script typing issues across the codebase identified during testing.

---
*PR created automatically by Jules for task [10679341463964417965](https://jules.google.com/task/10679341463964417965) started by @KeithCu*