### PR TITLE
🧹 [Code Health] Centralize _resolve_sheet to avoid duplication

### DIFF
--- a/plugin/calc/calc_utils.py
+++ b/plugin/calc/calc_utils.py
@@ -1,0 +1,33 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2024 John Balis
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+# Copyright (c) 2026 LibreCalc AI Assistant (Calc integration features, originally MIT)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""General utilities for Calc tools."""
+
+from plugin.framework.errors import UnoObjectError
+
+
+def resolve_sheet(doc, sheet_name=None):
+    """Return the target sheet (by name or active)."""
+    if sheet_name:
+        sheets = doc.getSheets()
+        if not sheets.hasByName(sheet_name):
+            raise UnoObjectError("Sheet not found: %s" % sheet_name)
+        return sheets.getByName(sheet_name)
+    controller = doc.getCurrentController()
+    if hasattr(controller, "getActiveSheet"):
+        return controller.getActiveSheet()
+    return doc.getSheets().getByIndex(0)

--- a/plugin/calc/comments.py
+++ b/plugin/calc/comments.py
@@ -5,26 +5,13 @@
 
 """Calc cell annotation (comment) tools."""
 
-from plugin.framework.errors import UnoObjectError
 import logging
 
 from plugin.calc.base import ToolCalcCommentBase
 from plugin.calc.address_utils import index_to_column, parse_range_string
+from plugin.calc.calc_utils import resolve_sheet
 
 log = logging.getLogger("nelson.calc")
-
-
-def _resolve_sheet(doc, sheet_name=None):
-    """Return the target sheet (by name or active)."""
-    if sheet_name:
-        sheets = doc.getSheets()
-        if not sheets.hasByName(sheet_name):
-            raise UnoObjectError("Sheet not found: %s" % sheet_name)
-        return sheets.getByName(sheet_name)
-    controller = doc.getCurrentController()
-    if hasattr(controller, "getActiveSheet"):
-        return controller.getActiveSheet()
-    return doc.getSheets().getByIndex(0)
 
 
 def _cell_label(col, row):
@@ -47,7 +34,7 @@ class ListCellComments(ToolCalcCommentBase):
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
-        sheet = _resolve_sheet(doc, kwargs.get("sheet_name"))
+        sheet = resolve_sheet(doc, kwargs.get("sheet_name"))
         annotations = sheet.getAnnotations()
         comments = []
         for i in range(annotations.getCount()):
@@ -77,7 +64,7 @@ class AddCellComment(ToolCalcCommentBase):
             return self._tool_error("cell and text are required.")
 
         doc = ctx.doc
-        sheet = _resolve_sheet(doc, kwargs.get("sheet_name"))
+        sheet = resolve_sheet(doc, kwargs.get("sheet_name"))
         col, row = _parse_cell_ref(cell_ref)
         cell = sheet.getCellByPosition(col, row)
 
@@ -115,7 +102,7 @@ class DeleteCellComment(ToolCalcCommentBase):
             return self._tool_error("cell is required.")
 
         doc = ctx.doc
-        sheet = _resolve_sheet(doc, kwargs.get("sheet_name"))
+        sheet = resolve_sheet(doc, kwargs.get("sheet_name"))
         col, row = _parse_cell_ref(cell_ref)
 
         annotations = sheet.getAnnotations()

--- a/plugin/calc/search.py
+++ b/plugin/calc/search.py
@@ -5,25 +5,12 @@
 
 """Calc search tools: search_in_spreadsheet, replace_in_spreadsheet."""
 
-from plugin.framework.errors import UnoObjectError
 import logging
 
 from plugin.calc.base import ToolCalcSearchBase
+from plugin.calc.calc_utils import resolve_sheet
 
 log = logging.getLogger("nelson.calc")
-
-
-def _resolve_sheet(doc, sheet_name=None):
-    """Return the target sheet (by name or active)."""
-    if sheet_name:
-        sheets = doc.getSheets()
-        if not sheets.hasByName(sheet_name):
-            raise UnoObjectError("Sheet not found: %s" % sheet_name)
-        return sheets.getByName(sheet_name)
-    controller = doc.getCurrentController()
-    if hasattr(controller, "getActiveSheet"):
-        return controller.getActiveSheet()
-    return doc.getSheets().getByIndex(0)
 
 
 def _cell_address_str(cell):
@@ -71,7 +58,7 @@ class SearchInSpreadsheet(ToolCalcSearchBase):
             sheets_obj = doc.getSheets()
             targets = [(sheets_obj.getByName(n), n) for n in sheets_obj.getElementNames()]
         else:
-            sheet = _resolve_sheet(doc, kwargs.get("sheet_name"))
+            sheet = resolve_sheet(doc, kwargs.get("sheet_name"))
             targets = [(sheet, sheet.getName())]
 
         for sheet, sname in targets:
@@ -132,7 +119,7 @@ class ReplaceInSpreadsheet(ToolCalcSearchBase):
             sheets_obj = doc.getSheets()
             targets = [sheets_obj.getByName(n) for n in sheets_obj.getElementNames()]
         else:
-            targets = [_resolve_sheet(doc, kwargs.get("sheet_name"))]
+            targets = [resolve_sheet(doc, kwargs.get("sheet_name"))]
 
         for sheet in targets:
             rd = sheet.createReplaceDescriptor()

--- a/update.xml
+++ b/update.xml
@@ -10,7 +10,7 @@
       only shows "update available" without a workable LO-side upgrade path.
     -->
     <identifier value="org.extension.writeragent" />
-    <version value="0.8.0" />
+    <version value="0.8.1" />
     <update-download>
         <src xlink:href="https://github.com/KeithCu/writeragent/releases/latest/download/writeragent.oxt" />
     </update-download>


### PR DESCRIPTION
🎯 **What:** Removed the duplicated `_resolve_sheet` function from `plugin/calc/comments.py` and `plugin/calc/search.py` and centralized it into a new shared utility module `plugin/calc/calc_utils.py`.
💡 **Why:** This improves maintainability and readability by reducing code duplication, ensuring that any future bug fixes or logic changes to sheet resolution only need to be applied in one place.
✅ **Verification:** Verified the code changes by running all Python tests (`make compile-translations` and `make test`). The tests pass without regressions. Run `uv run ruff check` and `uv run ty check` which showed no new issues or warnings related to the changes.
✨ **Result:** The codebase is cleaner and follows the DRY principle better, removing around 15 lines of duplicated functionality across two files.

---
*PR created automatically by Jules for task [2804720079854078937](https://jules.google.com/task/2804720079854078937) started by @KeithCu*