### PR TITLE
fix(writer): edit text inside table cells via apply_document_content

### DIFF
--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -728,7 +728,12 @@ def replace_preserving_format(model, target_range, new_text, ctx=None):
     character, preserving per-character formatting (bold, italic,
     font, color, etc.).
     """
-    text = model.getText()
+    # Use the range's OWN text object, not the document body. When target_range
+    # lives inside a table cell, model.getText() (the body) is the wrong XText and
+    # createTextCursorByRange() raises "End of content node doesn't have the proper
+    # start node". target_range.getText() resolves to the cell (or body) correctly,
+    # matching the markup path which already uses found.getText().
+    text = target_range.getText()
     old_text = _normalize(target_range.getString())
     new_text = _normalize(new_text)
     old_len = len(old_text)

--- a/tests/writer/test_apply_document_content_table_cell_uno.py
+++ b/tests/writer/test_apply_document_content_table_cell_uno.py
@@ -1,0 +1,57 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Regression test: apply_document_content(target='search') editing text inside a
+# table cell. replace_preserving_format built its cursor on the document body text
+# (model.getText()) instead of the matched range's own XText (the cell), raising the
+# UNO RuntimeException "End of content node doesn't have the proper start node" and
+# leaving the cell uneditable. The fix uses target_range.getText(), so the cursor
+# resolves to the cell.
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.writer.content import ApplyDocumentContent
+from plugin.tests.testing_utils import TestingFactory
+
+_test_doc = None
+_test_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+    _test_doc = TestingFactory.create_native_doc(ctx, doc_type="writer")
+
+
+@teardown
+def my_teardown(ctx):
+    global _test_doc
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+
+
+@native_test
+def test_apply_document_content_edits_table_cell_uno():
+    """Editing a cell's text via target='search' should work; it used to raise a
+    cursor RuntimeException (body XText vs the cell's XText)."""
+    doc = _test_doc
+    text = doc.getText()
+    tbl = doc.createInstance("com.sun.star.text.TextTable")
+    tbl.initialize(3, 2)
+    text.insertTextContent(text.createTextCursor(), tbl, False)
+    tbl.getCellByName("A2").setString("MinerU")
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    # plain-text content -> format-preserving path (where the bug lived).
+    res = ApplyDocumentContent().execute(
+        tool_ctx, content=["MinerU-EDIT"], old_content="MinerU", target="search"
+    )
+    assert res.get("status") == "ok", f"expected to edit the cell; got {res}"
+    assert "MinerU-EDIT" in tbl.getCellByName("A2").getString()


### PR DESCRIPTION
### Problem
`apply_document_content` fails when the matched text is inside a **table cell**, raising `End of content node doesn't have the proper start node` (a `com.sun.star.uno.RuntimeException`). As a result, text inside tables cannot be edited through this tool.

### Cause
The cursor for the matched range was created from the document **body** text (`model.getText()`). A range located inside a table cell belongs to that **cell's** own text object, not the body — spanning a cell range with a body-level cursor mixes two different text objects, which UNO rejects.

### Fix
Derive the text object from the **matched range itself** (`target_range.getText()`) instead of assuming the document body. Body paragraphs are unaffected (their range's text *is* the body); ranges inside table cells now resolve to the cell's text object and edit correctly.

### Test
`tests/writer/test_apply_document_content_table_cell_uno.py` — inserts a table, edits a cell via `apply_document_content`, and asserts the new cell text. Fails on the current code with the `RuntimeException` above; passes with the fix.
