### PR TITLE
fix(writer): match NBSP and exotic spaces in apply_document_content search

### DIFF
--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -26,6 +26,12 @@ import re as re_mod
 
 log = logging.getLogger("writeragent.writer")
 
+# Non-breaking / exotic spaces -> ASCII space. Length-preserving (each maps to a
+# single char) so character offsets into the document text stay valid. NBSP
+# (U+00A0) in particular is a common artifact of prior edits and breaks literal
+# search when old_content uses a normal space.
+_SPACE_NORMALIZE_MAP = {0x00A0: " ", 0x202F: " ", 0x2007: " ", 0x2009: " "}
+
 
 def _find_range_by_offset(doc, search_string):
     """Find search_string in the document by getting full text and doing a Python
@@ -37,7 +43,10 @@ def _find_range_by_offset(doc, search_string):
         cursor = text.createTextCursor()
         cursor.gotoStart(False)
         cursor.gotoEnd(True)
-        full = normalize_linebreaks(cursor.getString())
+        # Normalize NBSP & friends so a normal-space search matches them. The map
+        # is 1:1, so offsets below (goRight) stay aligned with the original text.
+        full = normalize_linebreaks(cursor.getString()).translate(_SPACE_NORMALIZE_MAP)
+        search_string = search_string.translate(_SPACE_NORMALIZE_MAP)
     except Exception:
         return None
     idx = full.find(search_string)
@@ -57,10 +66,79 @@ def _find_range_by_offset(doc, search_string):
 
 
 def _normalize_search_string_for_find(s):
-    """Collapse horizontal whitespace only; preserve newlines for literal find.
-    (LibreOffice regex search does not work across paragraphs.)
+    """Collapse horizontal whitespace (incl. NBSP & friends) to a single ASCII
+    space; preserve newlines for literal find. (LibreOffice regex search does not
+    work across paragraphs.)
     """
-    return re_mod.sub(r"[ \t]+", " ", s).strip()
+    return re_mod.sub(r"[ \t\u00a0\u202f\u2007\u2009]+", " ", s).strip()
+
+
+def _all_start_indices(haystack, needle):
+    """Non-overlapping start indices of *needle* in *haystack*."""
+    out = []
+    if not needle:
+        return out
+    i = haystack.find(needle)
+    while i >= 0:
+        out.append(i)
+        i = haystack.find(needle, i + len(needle))
+    return out
+
+
+def _find_all_ranges_by_offset(doc, search_string):
+    """All occurrences of *search_string* as TextRanges via NBSP-normalized full-text
+    matching \u2014 the all-matches counterpart of _find_range_by_offset, so the
+    all_matches path inherits the same NBSP handling as the single-match path."""
+    try:
+        text = doc.getText()
+        cursor = text.createTextCursor()
+        cursor.gotoStart(False)
+        cursor.gotoEnd(True)
+        full = normalize_linebreaks(cursor.getString()).translate(_SPACE_NORMALIZE_MAP)
+    except Exception:
+        return []
+    needle = (search_string or "").translate(_SPACE_NORMALIZE_MAP)
+    if not needle:
+        return []
+    starts = _all_start_indices(full, needle)
+    if not starts:
+        starts = _all_start_indices(full.lower(), needle.lower())
+    ranges = []
+    for s in starts:
+        rc = text.createTextCursor()
+        rc.gotoStart(False)
+        if not rc.goRight(s, False):
+            continue
+        if not rc.goRight(len(needle), True):
+            continue
+        ranges.append(rc)
+    return ranges
+
+
+def _find_all_ranges(doc, search_string):
+    """All occurrences of *search_string* as TextRanges, in document order. Uses
+    findFirst/findNext; falls back to the NBSP-normalized offset finder. Lets the
+    all_matches replace path reuse the SAME find logic (and fixes) as single-match."""
+    sd = doc.createSearchDescriptor()
+    sd.SearchRegularExpression = False
+    for try_string in (search_string, re_mod.sub(r" +", " ", (search_string or "").replace("\n", " ")).strip()):
+        if not try_string:
+            continue
+        for case_sens in (True, False):
+            sd.SearchString = try_string
+            sd.SearchCaseSensitive = case_sens
+            found = doc.findFirst(sd)
+            if found is None:
+                continue
+            collected = []
+            guard = 0
+            while found is not None and guard < 1000:
+                guard += 1
+                collected.append(found)
+                found = doc.findNext(found.getEnd(), sd)
+            if collected:
+                return collected
+    return _find_all_ranges_by_offset(doc, search_string)
 
 
 # ------------------------------------------------------------------

--- a/tests/writer/test_apply_document_content_whitespace_uno.py
+++ b/tests/writer/test_apply_document_content_whitespace_uno.py
@@ -1,0 +1,60 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Regression test: apply_document_content(target='search') failed to match document
+# text containing a non-breaking space (U+00A0) when old_content used a normal space.
+# The fix normalizes NBSP & relatives (U+00A0/202F/2007/2009) to a normal space on
+# both the search string and the document text (1:1, so cursor offsets stay aligned).
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.writer.content import ApplyDocumentContent
+from plugin.tests.testing_utils import TestingFactory
+
+_NBSP = chr(0xA0)  # non-breaking space U+00A0 (ASCII-safe in source)
+
+_test_doc = None
+_test_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+    _test_doc = TestingFactory.create_native_doc(ctx, doc_type="writer")
+
+
+@teardown
+def my_teardown(ctx):
+    global _test_doc
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+
+
+@native_test
+def test_apply_document_content_search_matches_nbsp_uno():
+    """Searching with a normal space should match text containing a NBSP."""
+    doc = _test_doc
+    text = doc.getText()
+    cur = text.createTextCursor()
+    # Document with a NBSP between ')' and 'by' — a common artifact left by a
+    # previous replacement (the bug-report scenario).
+    text.insertString(cur, "Result figures)" + _NBSP + "by a judge, final.", False)
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    # old_content uses a NORMAL SPACE; it should match the document's NBSP.
+    res = ApplyDocumentContent().execute(
+        tool_ctx,
+        content=["figures) BY A JUDGE"],
+        old_content="figures) by a judge",
+        target="search",
+    )
+    assert res.get("status") == "ok", f"apply_document_content did not match the NBSP: {res}"
+    body = doc.getText().getString()
+    assert "BY A JUDGE" in body, f"replacement did not happen; text={body!r}"


### PR DESCRIPTION
### Problem
`apply_document_content` cannot find text that contains a **non-breaking space** when the search string is typed with normal spaces. It returns `old_content not found in document`, even though the text is visibly present. This is common in real documents — NBSP before units, narrow NBSP introduced by autocorrect, figure/thin spaces, etc.

### Cause
The search compared characters literally, so a normal space (U+0020) in the search string did not match a non-breaking space (U+00A0) — or other exotic spaces — stored in the document.

### Fix
Normalize non-breaking and exotic spaces to a normal space on **both** the search string and the scanned document text before matching: U+00A0 (NBSP), U+202F (narrow NBSP), U+2007 (figure space), U+2009 (thin space). Matching now succeeds regardless of which space variant is stored, and the replacement targets the correct range.

### Test
`tests/writer/test_apply_document_content_whitespace_uno.py` — inserts text containing a NBSP, searches for it with normal spaces, and asserts the replacement happens. Fails on the current code (`old_content not found`); passes with the fix.
