### PR TITLE
fix(writer): preserve heading/paragraph style on inline content replace

### DIFF
--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -597,9 +597,40 @@ def replace_single_range_with_content(model, text_range, content, ctx, config_sv
     """Replace the given text range with rendered *content* (HTML path)."""
     prepared = html_mod.unescape(content)
     text_obj = text_range.getText()
+
+    # Preserve the target paragraph style for INLINE replacements. The StarWriter
+    # HTML import resets the paragraph to a default body style, silently demoting
+    # headings (e.g. "Heading 3" -> "Text body"). For inline-only content (no
+    # block-level tags, no math), insert without jumping the cursor to the document
+    # end so we can reapply the original paragraph style across the inserted range.
+    inline_preserve = not _content_has_block_markup(prepared) and not html_fragment_contains_mixed_math(prepared)
+    saved_style = None
+    if inline_preserve:
+        try:
+            saved_style = text_obj.createTextCursorByRange(
+                text_range.getStart()).getPropertyValue("ParaStyleName")
+        except Exception:
+            saved_style = None
+
     cursor = text_obj.createTextCursorByRange(text_range)
     cursor.setString("")
-    _insert_mixed_or_plain_html(model, ctx, cursor, prepared, config_svc=config_svc)
+
+    if saved_style is not None:
+        anchor = text_obj.createTextCursorByRange(cursor.getStart())
+        # Insert the inline fragment RAW (do not route through _ensure_html_linebreaks:
+        # it does not recognise <span> as HTML and would wrap it in <p>, creating an
+        # extra body paragraph). model=None leaves the cursor at the end of the
+        # INSERTED content (not the document end), so [anchor, cursor] bounds it.
+        inline_html = prepared.replace("\\n", "\n").replace("\\t", "\t")
+        insert_html_fragment_at_cursor(cursor, inline_html, wrap=False, config_svc=config_svc, model=None)
+        try:
+            restore = text_obj.createTextCursorByRange(anchor.getStart())
+            restore.gotoRange(cursor.getEnd(), True)
+            restore.setPropertyValue("ParaStyleName", saved_style)
+        except Exception:
+            log.debug("replace_single_range_with_content: could not restore ParaStyleName", exc_info=True)
+    else:
+        _insert_mixed_or_plain_html(model, ctx, cursor, prepared, config_svc=config_svc)
 
 
 def _preserving_search_replace(model, uno_ctx, new_text, search_string, all_matches=False, case_sensitive=True):
@@ -721,6 +752,23 @@ def content_has_markup(content):
         return False
     lower = content.lower()
     return any(p.lower() in lower for p in _MARKUP_PATTERNS)
+
+
+# Block-level HTML tags: their presence means the content defines its own
+# paragraph structure, so we must NOT force the original paragraph style onto it.
+_BLOCK_MARKUP_PATTERNS = [
+    "<p>", "<p ", "<h1", "<h2", "<h3", "<h4", "<h5", "<h6",
+    "<div", "<ul", "<ol", "<li", "<table", "<tr", "<td", "<th",
+    "<blockquote", "<pre", "<hr", "<section", "<article",
+]
+
+
+def _content_has_block_markup(content):
+    """Return ``True`` if *content* contains block-level HTML (paragraph-defining)."""
+    if not content or not isinstance(content, str):
+        return False
+    lower = content.lower()
+    return any(p in lower for p in _BLOCK_MARKUP_PATTERNS)
 
 
 def replace_preserving_format(model, target_range, new_text, ctx=None):

--- a/tests/writer/test_apply_document_content_heading_rewrite_uno.py
+++ b/tests/writer/test_apply_document_content_heading_rewrite_uno.py
@@ -1,0 +1,68 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Regression test: replacing text inside a heading paragraph with inline HTML (e.g. a
+# <span>) used to silently downgrade the paragraph to a normal one, losing the heading
+# level (and its outline semantics). The fix preserves the target paragraph style for
+# inline-only content and inserts the fragment raw, so the StarWriter HTML filter does
+# not wrap it in an extra <p>.
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.writer.content import ApplyDocumentContent
+from plugin.tests.testing_utils import TestingFactory
+
+_test_doc = None
+_test_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+    _test_doc = TestingFactory.create_native_doc(ctx, doc_type="writer")
+
+
+@teardown
+def my_teardown(ctx):
+    global _test_doc
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+
+
+@native_test
+def test_apply_document_content_preserves_heading_level_uno():
+    """Replacing text inside a Heading 3 (with content that has a <span>) must not
+    demote the paragraph to Standard."""
+    doc = _test_doc
+    text = doc.getText()
+    cur = text.createTextCursor()
+    text.insertString(cur, "4.1.1 Engine selection", False)
+
+    # make the paragraph a Heading 3
+    pcur = text.createTextCursorByRange(text.getStart())
+    pcur.gotoEnd(True)
+    pcur.setPropertyValue("ParaStyleName", "Heading 3")
+    chk0 = text.createTextCursorByRange(text.getStart())
+    assert chk0.getPropertyValue("ParaStyleName") == "Heading 3"
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    res = ApplyDocumentContent().execute(
+        tool_ctx,
+        content=['<span style="background: transparent">4.1.1 Engine selection</span>'],
+        old_content="4.1.1 Engine selection",
+        target="search",
+    )
+    assert res.get("status") == "ok", f"apply_document_content failed: {res}"
+
+    # EXPECTED: the paragraph is still Heading 3
+    chk = text.createTextCursorByRange(text.getStart())
+    para_style = chk.getPropertyValue("ParaStyleName")
+    assert para_style == "Heading 3", \
+        f"apply_document_content demoted the heading to '{para_style}'"


### PR DESCRIPTION
### Problem
Rewriting the inline text of a **heading** via `apply_document_content` (for example, replacing the run with a `<span>`) silently **demotes the heading** to body text — the paragraph loses its `Heading N` style and becomes default body text.

### Cause
When replacing a single matched range with inline content, the paragraph style was reset to the default instead of being preserved.

### Fix
When the replacement content is **inline-only** (no block-level markup such as `<p>`, `<h1>`–`<h6>`, `<ul>`, `<blockquote>`, …), preserve the paragraph's existing style across the replacement. Content that genuinely carries block markup still applies that markup, as before.

### Test
`tests/writer/test_apply_document_content_heading_rewrite_uno.py` — rewrites the text of a `Heading 3` paragraph inline and asserts the paragraph is still `Heading 3` afterwards. Fails on the current code (demoted to body); passes with the fix.
