### PR TITLE
fix(writer): preserve direct character formatting across the paragraph on apply_style

### DIFF
--- a/plugin/writer/styles.py
+++ b/plugin/writer/styles.py
@@ -270,6 +270,135 @@ class GetStyleInfo(ToolWriterStyleBase):
         return {"status": "ok", **info}
 
 
+def _capture_direct_char_overrides(doc, cursor):
+    """Capture DIRECT character formatting in *cursor*'s range so it can survive a
+    paragraph-style change.
+
+    LibreOffice resets direct character formatting to the paragraph style's
+    defaults when ParaStyleName is set.
+    ``getPropertyState`` is unreliable at the text-portion level (it reports
+    DEFAULT_VALUE even for hard-set values), so we detect overrides by VALUE:
+    a Char* property whose value differs from the paragraph's *current* style
+    default is a direct override worth preserving.
+
+    KNOWN LIMITATION: because detection is value-vs-style-default (not a true
+    "was set directly" check), a direct override whose value *equals* the current
+    style's default is NOT captured. So applying a new style whose default differs
+    can make that property visibly change (e.g. text directly set to normal weight,
+    equal to Standard's default, becomes bold when Heading 1 is applied). This is a
+    rare edge; the common case (override visibly differs from the style) is covered.
+
+    Returns a list of ``(text_cursor, {prop_name: value})`` for
+    :func:`_restore_char_overrides`.
+    """
+    overrides = []
+    try:
+        para_styles = doc.getStyleFamilies().getByName("ParagraphStyles")
+    except Exception:
+        para_styles = None
+    try:
+        READONLY = uno.getConstantByName("com.sun.star.beans.PropertyAttribute.READONLY")
+    except Exception:
+        READONLY = 0
+    try:
+        para_enum = cursor.createEnumeration()
+    except Exception:
+        return overrides
+    # `is True` (not mere truthiness): real PyUNO returns a Python bool, so this
+    # iterates correctly while exiting immediately for mocked / non-UNO objects
+    # (whose hasMoreElements() returns a truthy stub) instead of looping forever.
+    # The counters also cap pathological documents.
+    _paras = 0
+    while para_enum.hasMoreElements() is True and _paras < 200000:
+        _paras += 1
+        try:
+            para = para_enum.nextElement()
+        except Exception:
+            break
+        if not (hasattr(para, "supportsService") and para.supportsService("com.sun.star.text.Paragraph")):
+            continue
+        old_style = None
+        if para_styles is not None:
+            try:
+                old_style = para_styles.getByName(para.getPropertyValue("ParaStyleName"))
+            except Exception:
+                old_style = None
+        try:
+            portion_enum = para.createEnumeration()
+        except Exception:
+            continue
+        _portions = 0
+        while portion_enum.hasMoreElements() is True and _portions < 50000:
+            _portions += 1
+            try:
+                portion = portion_enum.nextElement()
+                if portion.getPropertyValue("TextPortionType") != "Text":
+                    continue
+                portion_props = portion.getPropertySetInfo().getProperties()
+            except Exception:
+                continue
+            props = {}
+            for p in portion_props:
+                name = p.Name
+                if not name.startswith("Char"):
+                    continue
+                if READONLY and (p.Attributes & READONLY):
+                    continue
+                try:
+                    val = portion.getPropertyValue(name)
+                except Exception:
+                    continue
+                if old_style is not None:
+                    try:
+                        if val == old_style.getPropertyValue(name):
+                            continue  # equals style default -> inherited, not a direct override
+                    except Exception:
+                        continue  # style lacks this property -> cannot classify, skip
+                props[name] = val
+            if props:
+                try:
+                    pc = portion.getText().createTextCursorByRange(portion.getStart())
+                    pc.gotoRange(portion.getEnd(), True)
+                except Exception:
+                    continue
+                overrides.append((pc, props))
+    return overrides
+
+
+def _restore_char_overrides(overrides):
+    """Reapply captured direct character overrides (see :func:`_capture_direct_char_overrides`)."""
+    for pc, props in overrides:
+        for name, val in props.items():
+            try:
+                pc.setPropertyValue(name, val)
+            except Exception:
+                pass
+
+
+def _expand_to_full_paragraphs(cursor):
+    """Return a cursor spanning the FULL paragraph(s) that *cursor* touches.
+
+    A paragraph style resets DIRECT character formatting across the FULL
+    paragraph, but a ``target='search'`` cursor may cover only a sub-range of it
+    (the matched substring). Capturing over the expanded span keeps direct
+    formatting that lives OUTSIDE the match in the same paragraph. Returns None
+    if the text does not support paragraph cursors (caller falls back to the
+    original cursor).
+    """
+    try:
+        text = cursor.getText()
+        start = text.createTextCursorByRange(cursor.getStart())
+        end = text.createTextCursorByRange(cursor.getEnd())
+        # XParagraphCursor: snap to the enclosing paragraph boundaries.
+        start.gotoStartOfParagraph(False)
+        end.gotoEndOfParagraph(True)
+        expanded = text.createTextCursorByRange(start.getStart())
+        expanded.gotoRange(end.getEnd(), True)
+        return expanded
+    except Exception:
+        return None
+
+
 class ApplyStyle(FrameworkToolBase):
     """Apply a paragraph or character style."""
 
@@ -325,7 +454,18 @@ class ApplyStyle(FrameworkToolBase):
             return self._tool_error("Failed to resolve target location.")
 
         try:
-            cursor.setPropertyValue(uno_prop, uno_value)
+            if family == "ParagraphStyles":
+                # Applying a paragraph style wipes DIRECT character formatting; capture
+                # it first and restore it after, so e.g. a hard-set color/bold survives.
+                # The reset affects the WHOLE paragraph, so capture over the full
+                # paragraph span (not just a sub-range search match) — otherwise direct
+                # formatting outside the matched text would be lost.
+                capture_cursor = _expand_to_full_paragraphs(cursor) or cursor
+                overrides = _capture_direct_char_overrides(ctx.doc, capture_cursor)
+                cursor.setPropertyValue(uno_prop, uno_value)
+                _restore_char_overrides(overrides)
+            else:
+                cursor.setPropertyValue(uno_prop, uno_value)
         except Exception as e:
             return self._tool_error("Could not apply style: %s" % e)
         return {"status": "ok", "style_name": style_name, "family": family}

--- a/tests/writer/test_apply_style_preserve_inline_uno.py
+++ b/tests/writer/test_apply_style_preserve_inline_uno.py
@@ -1,0 +1,143 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Regression test: applying a paragraph style via apply_style must not wipe DIRECT
+# character formatting (color/bold/highlight) already set on the target text. The fix
+# captures the direct char overrides (values that differ from the old style's defaults)
+# and restores them after setting ParaStyleName.
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.writer.styles import ApplyStyle
+from plugin.tests.testing_utils import TestingFactory
+
+_test_doc = None
+_test_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+    _test_doc = TestingFactory.create_native_doc(ctx, doc_type="writer")
+
+
+@teardown
+def my_teardown(ctx):
+    global _test_doc
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+
+
+@native_test
+def test_apply_paragraph_style_preserves_direct_char_format_uno():
+    """Applying a PARAGRAPH style must not wipe DIRECT character formatting
+    (color/bold) already set on the text."""
+    doc = _test_doc
+    text = doc.getText()
+
+    # 1) insert text
+    insert_cur = text.createTextCursor()
+    text.insertString(insert_cur, "Important contract clause.", False)
+
+    # 2) apply DIRECT character formatting over the whole text
+    fmt = text.createTextCursorByRange(text.getStart())
+    fmt.gotoEnd(True)
+    fmt.setPropertyValue("CharColor", 0xFF0000)   # red
+    fmt.setPropertyValue("CharWeight", 150.0)     # com.sun.star.awt.FontWeight.BOLD
+
+    # sanity: the direct formatting was actually applied
+    assert int(fmt.getPropertyValue("CharColor")) == 0xFF0000
+    assert fmt.getPropertyValue("CharWeight") == 150.0
+
+    # 3) apply a PARAGRAPH style via the tool (target = whole document)
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    res = ApplyStyle().execute(
+        tool_ctx, style_name="Standard", family="ParagraphStyles", target="full_document"
+    )
+    assert res.get("status") == "ok", f"apply_style failed: {res}"
+
+    # 4) EXPECTED: the direct character formatting survives the paragraph style
+    chk = text.createTextCursorByRange(text.getStart())
+    chk.gotoEnd(True)
+    assert int(chk.getPropertyValue("CharColor")) == 0xFF0000, \
+        "apply_style wiped the direct character COLOR"
+    assert chk.getPropertyValue("CharWeight") == 150.0, \
+        "apply_style wiped the direct character BOLD"
+
+
+@native_test
+def test_apply_paragraph_style_via_search_preserves_whole_paragraph_uno():
+    """Regression (found via live MCP testing 2026-06-01): when a PARAGRAPH style is
+    applied with target='search' matching only a SUBSTRING, the style still resets the
+    WHOLE paragraph's direct char formatting. The capture must therefore cover the
+    whole paragraph, not just the matched range, so direct formatting OUTSIDE the
+    match survives too."""
+    doc = _test_doc
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    text.insertString(cur, "Result figures by a judge final.", False)
+
+    # whole paragraph red + bold (direct)
+    fmt = text.createTextCursorByRange(text.getStart())
+    fmt.gotoEnd(True)
+    fmt.setPropertyValue("CharColor", 0xFF0000)
+    fmt.setPropertyValue("CharWeight", 150.0)
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    # search matches ONLY a substring in the middle of the paragraph
+    res = ApplyStyle().execute(
+        tool_ctx, style_name="Quotations", family="ParagraphStyles",
+        target="search", old_content="by a judge",
+    )
+    assert res.get("status") == "ok", f"apply_style failed: {res}"
+
+    # check a portion OUTSIDE the matched range ("Result", the first word): it must
+    # keep red+bold. Before the fix, only "by a judge" was preserved.
+    lead = text.createTextCursorByRange(text.getStart())
+    lead.goRight(6, True)  # "Result"
+    assert int(lead.getPropertyValue("CharColor")) == 0xFF0000, \
+        "direct COLOR lost outside the matched range"
+    assert lead.getPropertyValue("CharWeight") == 150.0, \
+        "direct BOLD lost outside the matched range"
+
+
+@native_test
+def test_apply_style_known_limitation_direct_equals_old_default_uno():
+    """Characterizes a KNOWN LIMITATION: detection is
+    'differs from the style default', not 'was set directly'. So a DIRECT override
+    whose value EQUALS the old style's default is NOT preserved, and can become
+    visible when a style with a different default is applied.
+
+    Scenario: a Standard paragraph (default CharWeight=100) with CharWeight=100 set
+    DIRECTLY; apply Heading 1 (default bold=150). The ideal would be to stay 100, but
+    today it becomes 150. This test PINS the current behavior; if we ever improve the
+    origin detection, it fails and reminds us to update."""
+    doc = _test_doc
+    text = doc.getText()
+    insert_cur = text.createTextCursor()
+    text.insertString(insert_cur, "Directly-normal text.", False)
+
+    fmt = text.createTextCursorByRange(text.getStart())
+    fmt.gotoEnd(True)
+    fmt.setPropertyValue("CharWeight", 100.0)  # NORMAL, set directly = Standard's default
+    assert fmt.getPropertyValue("CharWeight") == 100.0
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    res = ApplyStyle().execute(
+        tool_ctx, style_name="Heading 1", family="ParagraphStyles", target="full_document"
+    )
+    assert res.get("status") == "ok", f"apply_style failed: {res}"
+
+    chk = text.createTextCursorByRange(text.getStart())
+    chk.gotoEnd(True)
+    # LIMITATION: the 'normal' override (= Standard's default) was not preserved -> Heading 1 bold.
+    assert chk.getPropertyValue("CharWeight") == 150.0, \
+        "if this fails, origin detection improved — update the doc/limitation"


### PR DESCRIPTION
### Problem
Applying a paragraph style with `apply_style` **wipes direct character formatting** (color, bold, highlight) already present on the text. For example, a red + bold paragraph turns black + regular after a paragraph style is applied.

### Cause
Setting `ParaStyleName` resets direct character properties on the paragraph, so direct formatting the user applied on top of the previous style is lost.

### Fix
Before applying the style, capture the direct character overrides (the character properties whose values differ from the *old* style's defaults) across the **whole paragraph**, then restore them after setting the new style. Read-only properties are skipped. The paragraph adopts the new style but keeps the user's direct color/bold/etc.

### Test
`tests/writer/test_apply_style_preserve_inline_uno.py` — applies a paragraph style to red + bold text (both whole-document and search-targeted) and asserts the direct color/weight survive, including outside the matched substring. Fails on the current code (formatting wiped); passes with the fix.

### Known limitation
A direct override whose value *equals* the old style's default is not detected as "direct" and can change when a style with a different default is applied. This is pinned by a characterization test, so any future improvement to the origin detection is noticed.
