### PR TITLE
fix(mcp): serialize mutating long-running tools per document

### DIFF
--- a/plugin/doc/specialized_base.py
+++ b/plugin/doc/specialized_base.py
@@ -86,6 +86,28 @@ class DelegateToSpecializedBase(ToolBase):
         """Run in a background thread so the main-thread queue/drain loop isn't blocked."""
         return True
 
+    # Domains whose work is read-only -> a long-running delegation to them must NOT
+    # take the per-document mutation lock (it would needlessly serialize research on
+    # the same doc). The gateway itself is is_mutation=True for the mutating domains.
+    _READ_ONLY_DOMAINS = frozenset({"document_research", "web_research"})
+
+    def requires_document_lock(self, arguments=None):
+        domain = None
+        if isinstance(arguments, dict):
+            domain = arguments.get("domain")
+        elif isinstance(arguments, str):
+            try:
+                from plugin.framework.errors import safe_json_loads
+
+                data = safe_json_loads(arguments)
+                if isinstance(data, dict):
+                    domain = data.get("domain")
+            except Exception:
+                domain = None
+        if domain in self._READ_ONLY_DOMAINS:
+            return False
+        return super().requires_document_lock(arguments)
+
     def execute(self, ctx, **kwargs):
         domain = kwargs.get("domain")
         python_tool_domain = kwargs.get("python_tool_domain")

--- a/plugin/framework/tool.py
+++ b/plugin/framework/tool.py
@@ -253,6 +253,15 @@ class ToolBase(ABC):
             return not self.name.startswith(_READ_PREFIXES)
         return True
 
+    def requires_document_lock(self, arguments=None):
+        """Whether a long-running run of this tool must hold the per-document
+        mutation lock (see plugin/mcp/mcp_protocol.py _execute_long_running).
+
+        Defaults to :meth:`detects_mutation`. Tools that only *sometimes* mutate —
+        e.g. a delegate gateway that routes to a read-only domain depending on
+        ``arguments`` — can override this so read-only runs are not serialized."""
+        return self.detects_mutation()
+
     def _tool_error(self, message, code="TOOL_EXECUTION_ERROR", **details):
         """Standardized JSON payload for tool errors.
 

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -71,6 +71,26 @@ _tool_semaphore = threading.Semaphore(1)
 _WAIT_TIMEOUT = 5.0
 _PROCESS_TIMEOUT = 60.0
 
+# Per-document locks for MUTATING long-running tools. Long-running tools run their
+# body off the main thread and without the backpressure semaphore (so minutes-long
+# work like image generation or sub-agent research does not block every other tool).
+# That left a hole: two mutating long-running tools could touch the SAME document
+# concurrently. These locks serialize mutating long-running tools per document —
+# different documents and read-only long-running tools stay fully concurrent. This
+# complements (does not replace) the main-thread marshalling well-behaved tools do.
+_doc_locks: "dict[str, threading.Lock]" = {}
+_doc_locks_guard = threading.Lock()
+
+
+def _get_document_lock(doc_key):
+    """Return the (shared) lock for *doc_key*, creating it on first use."""
+    with _doc_locks_guard:
+        lock = _doc_locks.get(doc_key)
+        if lock is None:
+            lock = threading.Lock()
+            _doc_locks[doc_key] = lock
+        return lock
+
 
 class BusyError(WriterAgentException):
     """The VCL main thread is already processing another tool call."""
@@ -512,7 +532,12 @@ class MCPProtocolHandler:
     def _execute_long_running(self, tool_name, arguments, document_url=None):
         """Execute a long-running tool on the current background HTTP thread.
         Context resolution (finding the active doc) is strictly done on the main thread
-        to ensure thread safety with LibreOffice UNO."""
+        to ensure thread safety with LibreOffice UNO.
+
+        Mutating long-running tools additionally hold a per-document lock for the
+        duration of the call, so two of them cannot mutate the SAME document at once.
+        Read-only long-running tools and tools targeting different documents are not
+        affected and still run fully concurrently."""
 
         def _get_context():
             doc_svc = self.services.document
@@ -527,9 +552,18 @@ class MCPProtocolHandler:
             import uno
 
             ctx = uno.getComponentContext()
-            return doc, doc_type, ctx
+            # Stable per-document key for the mutation lock (resolved on the main
+            # thread alongside the doc). Falls back to a shared sentinel.
+            doc_key = document_url
+            if not doc_key and doc is not None:
+                try:
+                    doc_key = doc.getURL() or getattr(doc, "RuntimeUID", None)
+                except Exception:
+                    log.debug("Could not resolve document key for the mutation lock", exc_info=True)
+                    doc_key = None
+            return doc, doc_type, ctx, doc_key
 
-        doc, doc_type, ctx = self.queue_executor.execute(_get_context, timeout=10.0)
+        doc, doc_type, ctx, doc_key = self.queue_executor.execute(_get_context, timeout=10.0)
 
         if doc is None and not document_url:
             return {"status": "error", "code": "NO_DOCUMENT_OPEN", "message": "No document open in LibreOffice."}
@@ -548,10 +582,27 @@ class MCPProtocolHandler:
 
         context = ToolContext(doc=doc, ctx=ctx, doc_type=doc_type, services=self.services, caller="mcp", active_page_index=active_page_idx)
 
-
-        t0 = time.perf_counter()
-        result = self.tool_registry.execute(tool_name, context, **arguments)
-        elapsed = time.perf_counter() - t0
+        # Mutating long-running tools serialize per document (see _doc_locks above).
+        # Sub-tools invoked by a delegating tool run in-process (not via this method),
+        # so the lock is not re-entered on the same thread -> no self-deadlock.
+        tool = self.tool_registry.get(tool_name)
+        if tool is not None:
+            try:
+                needs_doc_lock = bool(tool.requires_document_lock(arguments))
+            except Exception:
+                needs_doc_lock = bool(tool.detects_mutation())
+        else:
+            needs_doc_lock = True  # unknown tool -> be safe
+        doc_lock = _get_document_lock(doc_key or "__active_document__") if needs_doc_lock else None
+        if doc_lock is not None:
+            doc_lock.acquire()
+        try:
+            t0 = time.perf_counter()
+            result = self.tool_registry.execute(tool_name, context, **arguments)
+            elapsed = time.perf_counter() - t0
+        finally:
+            if doc_lock is not None:
+                doc_lock.release()
 
         if isinstance(result, dict):
             result["_elapsed_ms"] = round(elapsed * 1000, 1)

--- a/tests/mcp/test_long_running_concurrency.py
+++ b/tests/mcp/test_long_running_concurrency.py
@@ -1,0 +1,192 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Concurrency of mutating long-running MCP tools.
+#
+# _execute_with_backpressure acquires threading.Semaphore(1) AND marshals the whole
+# tool body to the main thread, so those tools are serialized (add_comment goes
+# through here, not long_running). _execute_long_running runs the tool body on the
+# HTTP worker thread, off the semaphore, so two long-running tools could mutate the
+# same document concurrently. The fix holds a PER-DOCUMENT lock for the duration of
+# MUTATING long-running tools. So:
+#   - backpressure path                         -> serialized (max concurrency 1)
+#   - long-running MUTATING, same document      -> serialized (max concurrency 1)
+#   - long-running MUTATING, different documents -> concurrent (max concurrency 2)
+#   - long-running READ-ONLY, same document     -> concurrent (max concurrency 2)
+# This guarantees no concurrent UNO mutation of the same document without blocking
+# read-only work or work on other documents.
+import threading
+import time
+
+from plugin.mcp.mcp_protocol import MCPProtocolHandler
+
+
+class _FakeMainThread:
+    """Simulates the real single main-thread QueueExecutor: everything marshalled
+    here runs serialized."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+
+    def execute(self, fn, *args, **kwargs):  # ignores timeout=
+        with self._lock:
+            return fn(*args)
+
+
+class _Doc:
+    def __init__(self, url=""):
+        self._url = url
+
+    def getURL(self):
+        return self._url
+
+
+class _FakeDocSvc:
+    def resolve_document_by_url(self, url):
+        return (_Doc(url), "writer")
+
+    def get_active_document(self):
+        return _Doc("")
+
+    def detect_doc_type(self, doc):
+        return "writer"
+
+
+class _ToolInfo:
+    """Mimics the relevant ToolBase contract used by the handler."""
+
+    def __init__(self, is_mutation, lock_required=None):
+        self.is_mutation = is_mutation
+        self._lock_required = lock_required
+
+    def detects_mutation(self):
+        return bool(self.is_mutation)
+
+    def requires_document_lock(self, arguments=None):
+        if self._lock_required is not None:
+            return self._lock_required
+        return self.detects_mutation()
+
+
+class _Registry:
+    """Stub tool_registry: .get(name) reports the lock contract; .execute is
+    instrumented to measure the max concurrency observed inside the tool body
+    (where a real UNO mutation would happen)."""
+
+    def __init__(self, is_mutation=True, hold=0.4, lock_required=None):
+        self._is_mutation = is_mutation
+        self._lock_required = lock_required
+        self._hold = hold
+        self._active = 0
+        self.max_concurrency = 0
+        self._lock = threading.Lock()
+
+    def get(self, name):
+        return _ToolInfo(self._is_mutation, self._lock_required)
+
+    def execute(self, name, context, **kwargs):
+        with self._lock:
+            self._active += 1
+            self.max_concurrency = max(self.max_concurrency, self._active)
+        time.sleep(self._hold)
+        with self._lock:
+            self._active -= 1
+        return {"status": "ok"}
+
+
+class _FakeServices:
+    def __init__(self, tools):
+        self.tools = tools
+        self.document = _FakeDocSvc()
+
+    def get(self, key):
+        return _FakeMainThread() if key == "main_thread" else None
+
+
+def _run_concurrent(method, doc_urls):
+    errors = []
+
+    def worker(url):
+        try:
+            method("any_tool", {}, document_url=url)
+        except Exception as e:  # noqa: BLE001
+            errors.append("%s: %s" % (type(e).__name__, e))
+
+    threads = [threading.Thread(target=worker, args=(u,)) for u in doc_urls]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return errors
+
+
+def test_backpressure_path_serializes_via_semaphore():
+    """Non-long-running tools (add_comment & co.) go through _execute_with_backpressure,
+    which serializes via Semaphore(1) + main thread. Max concurrency == 1."""
+    reg = _Registry(is_mutation=True)
+    handler = MCPProtocolHandler(_FakeServices(reg))
+
+    errors = _run_concurrent(handler._execute_with_backpressure, ["file:///x.odt"] * 2)
+
+    assert not errors, "backpressure should not error: %s" % errors
+    assert reg.max_concurrency == 1, "expected SERIALIZED (1), got %d" % reg.max_concurrency
+
+
+def test_long_running_mutating_same_document_serializes():
+    """FIX: two MUTATING long-running tools on the SAME document must not overlap."""
+    reg = _Registry(is_mutation=True)
+    handler = MCPProtocolHandler(_FakeServices(reg))
+
+    errors = _run_concurrent(handler._execute_long_running, ["file:///same.odt"] * 2)
+
+    assert not errors, "long_running should not error: %s" % errors
+    assert reg.max_concurrency == 1, (
+        "expected SERIALIZED (1) for same-doc mutation, got %d" % reg.max_concurrency
+    )
+
+
+def test_long_running_mutating_different_documents_run_concurrently():
+    """Mutating long-running tools on DIFFERENT documents are not over-serialized."""
+    reg = _Registry(is_mutation=True)
+    handler = MCPProtocolHandler(_FakeServices(reg))
+
+    errors = _run_concurrent(handler._execute_long_running, ["file:///a.odt", "file:///b.odt"])
+
+    assert not errors, "long_running should not error: %s" % errors
+    assert reg.max_concurrency == 2, (
+        "expected CONCURRENT (2) across different docs, got %d" % reg.max_concurrency
+    )
+
+
+def test_long_running_readonly_same_document_runs_concurrently():
+    """READ-ONLY long-running tools (e.g. document_research) are never blocked by the
+    per-document mutation lock, even on the same document."""
+    reg = _Registry(is_mutation=False)
+    handler = MCPProtocolHandler(_FakeServices(reg))
+
+    errors = _run_concurrent(handler._execute_long_running, ["file:///same.odt"] * 2)
+
+    assert not errors, "long_running read-only should not error: %s" % errors
+    assert reg.max_concurrency == 2, (
+        "expected CONCURRENT (2) for read-only, got %d" % reg.max_concurrency
+    )
+
+
+def test_long_running_tool_can_opt_out_of_document_lock():
+    """A tool flagged is_mutation=True but whose requires_document_lock() returns
+    False (e.g. the delegate gateway routing to a read-only domain like
+    document_research) must NOT be serialized — it runs concurrently on the same doc."""
+    reg = _Registry(is_mutation=True, lock_required=False)
+    handler = MCPProtocolHandler(_FakeServices(reg))
+
+    errors = _run_concurrent(handler._execute_long_running, ["file:///same.odt"] * 2)
+
+    assert not errors, "long_running should not error: %s" % errors
+    assert reg.max_concurrency == 2, (
+        "expected CONCURRENT (2) when the tool opts out of the lock, got %d" % reg.max_concurrency
+    )


### PR DESCRIPTION
### Problem
Two **mutating long-running tools** can act on the **same document concurrently**, risking corrupted edits. Long-running tools run their body off the main thread and without the backpressure semaphore (so minutes-long work such as image generation or sub-agent research does not block every other tool) — but that left a hole where two of them could mutate the same document at once.

### Cause
The long-running execution path had no per-document serialization. Well-behaved tools marshal their work onto the main thread, but long-running tools deliberately do not, so nothing serialized two concurrent mutations of one document.

### Fix
Serialize **mutating** long-running tools **per document**: each document gets a lock that a mutating long-running tool holds for the duration of its call. Read-only long-running tools, and tools targeting **different** documents, stay fully concurrent. A `requires_document_lock(arguments)` hook (default: `detects_mutation()`) lets a delegating gateway opt read-only domains out (e.g. `document_research`, `web_research`), so research on a document is not needlessly serialized. Sub-tools invoked in-process by a delegating tool do not re-enter the lock on the same thread, so there is no self-deadlock.

### Test
`tests/mcp/test_long_running_concurrency.py` — drives two concurrent mutating long-running calls on one document and asserts they are serialized, while read-only and different-document cases stay concurrent. Fails on the current code (observes concurrent execution); passes with the fix.
