### PR TITLE
fix(writer): preserve direct character formatting when restoring heading style

### DIFF
--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -592,7 +592,7 @@ def replace_single_range_with_content(model, text_range, content, ctx, config_sv
         try:
             restore = text_obj.createTextCursorByRange(anchor.getStart())
             restore.gotoRange(cursor.getEnd(), True)
-            restore.setPropertyValue("ParaStyleName", saved_style)
+            apply_paragraph_style_preserving_direct_char(model, restore, saved_style)
         except Exception:
             log.debug("replace_single_range_with_content: could not restore ParaStyleName", exc_info=True)
     else:

--- a/tests/writer/test_apply_document_content_heading_rewrite_uno.py
+++ b/tests/writer/test_apply_document_content_heading_rewrite_uno.py
@@ -60,6 +60,12 @@ def _para_style_at_start(text):
     return chk.getPropertyValue("ParaStyleName")
 
 
+def _char_prop_over_paragraph(text, name):
+    cur = text.createTextCursorByRange(text.getStart())
+    cur.gotoEnd(True)
+    return int(cur.getPropertyValue(name))
+
+
 @native_test
 def test_apply_document_content_preserves_heading_level_span_uno():
     """Replacing heading text with inline <span> must not demote the paragraph."""
@@ -107,3 +113,45 @@ def test_apply_document_content_block_markup_changes_heading_level_uno():
     para_style = _para_style_at_start(text)
     assert para_style == "Heading 2", \
         "block markup should set Heading 2, got '%s'" % para_style
+
+
+@native_test
+def test_apply_document_content_preserves_inline_color_on_heading_uno():
+    """Inline content with DIRECT character formatting (a red <span>) replacing a heading
+    must keep both the heading level AND the direct color. The StarWriter HTML import
+    applies the color, but restoring the heading paragraph style used to wipe it; the
+    restore must preserve direct Char* formatting."""
+    doc, text = _doc_with_heading3()
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    res = ApplyDocumentContent().execute(
+        tool_ctx,
+        content=['<span style="color: #ff0000">%s</span>' % _HEADING_TEXT],
+        old_content=_HEADING_TEXT,
+        target="search",
+    )
+    assert res.get("status") == "ok", f"apply_document_content failed: {res}"
+    assert _para_style_at_start(text) == "Heading 3", \
+        "demoted the heading to '%s'" % _para_style_at_start(text)
+    color = _char_prop_over_paragraph(text, "CharColor")
+    assert color == 0xFF0000, \
+        "restoring the heading style wiped the direct red color (CharColor=0x%06x)" % (color & 0xFFFFFF)
+
+
+@native_test
+def test_apply_document_content_preserves_inline_highlight_on_heading_uno():
+    """A direct character highlight (background) on inline content replacing a heading
+    must survive the paragraph-style restore, just like the colour."""
+    doc, text = _doc_with_heading3()
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    res = ApplyDocumentContent().execute(
+        tool_ctx,
+        content=['<span style="background: #ffff00">%s</span>' % _HEADING_TEXT],
+        old_content=_HEADING_TEXT,
+        target="search",
+    )
+    assert res.get("status") == "ok", f"apply_document_content failed: {res}"
+    assert _para_style_at_start(text) == "Heading 3", \
+        "demoted the heading to '%s'" % _para_style_at_start(text)
+    back = _char_prop_over_paragraph(text, "CharBackColor")
+    assert back == 0xFFFF00, \
+        "restoring the heading style wiped the direct highlight (CharBackColor=0x%06x)" % (back & 0xFFFFFF)


### PR DESCRIPTION
### Problem
Replacing the text of a heading with inline-only content that carries direct character formatting (e.g. a coloured or highlighted `<span>`) via `apply_document_content` keeps the heading level but silently drops the inline formatting — the colour/highlight is lost.

### Cause
`replace_single_range_with_content` preserves the heading paragraph style for inline content by saving it, inserting the fragment, then restoring it with a raw `setPropertyValue("ParaStyleName", ...)`. Setting a paragraph style resets the paragraph's direct `Char*` properties to the style's defaults, so the colour/highlight the StarWriter HTML import applied is wiped by the restore.

### Fix
Route that restore through `apply_paragraph_style_preserving_direct_char` (the helper already used by `apply_style`), so the paragraph style is restored without wiping the direct character overrides.

### Test
`tests/writer/test_apply_document_content_heading_rewrite_uno.py` — adds UNO regression tests asserting that a direct colour and a direct highlight on inline content survive the heading-style restore (the heading level is still preserved). Both fail on the current code (formatting wiped) and pass with the fix.
