### PR TITLE
feat(writer): structured machine-readable returns for the edit tools (anti silent-failure)

### DIFF
--- a/docs/mcp-protocol.md
+++ b/docs/mcp-protocol.md
@@ -662,6 +662,22 @@ No tool schema changes; targeting is at the transport layer. Optional per-call `
 
 ---
 
+## Edit Tool Result Fields (structured returns)
+
+The mutating edit tools return **structured, machine-readable fields** alongside the human `message`, so a client (MCP host or the in-app agent) can tell what actually happened instead of assuming `status: "ok"` means success.
+
+**`apply_document_content`** (search path)
+- `replaced_count` — how many occurrences were actually replaced. **`replaced_count: 0` returns `status: "error"`** (a search that matched nothing is no longer a silent "ok"); `> 0` returns `status: "ok"`.
+- If a replacement raises mid-`all_matches`, the existing abort behavior stands (no partial-replace handling — the call surfaces the error).
+
+**`apply_style`** — `applied` (bool), `target`, and `matched` (only when `target="search"`; a search miss returns `status:"error"`, `applied:false`, `matched:false`).
+
+**`add_comment`** — `matched` (anchor found) and `comment_added`; an anchor miss returns `status:"error"`. `anchor_text` is echoed on success.
+
+These fields are intended for clients to avoid parsing message strings; branch on `replaced_count` / `applied` / `comment_added`. Search no-ops now return `status:"error"` so clients do not treat missed edits as successful mutations.
+
+---
+
 ## Security Notes
 
 - Bind to `localhost` only. Never expose to external interfaces by default.

--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -406,7 +406,12 @@ def next_state(state: ToolLoopState, event: ToolLoopEvent) -> FsmTransition[Tool
                 else:
                     effects.append(ToolLoopUIEffect(kind="append", text=f"[{func_name}: {note}]\n"))
 
-            if func_name == "apply_document_content" and isinstance(note, str) and note.strip().startswith("Replaced 0 occurrence"):
+            # Prefer the structured replaced_count (cleaner than parsing the message);
+            # fall back to the legacy string check for results that predate the field.
+            replaced_zero = result_data.get("replaced_count") == 0
+            if not replaced_zero and isinstance(note, str):
+                replaced_zero = note.strip().startswith("Replaced 0 occurrence")
+            if func_name == "apply_document_content" and replaced_zero:
                 params_display = func_args_str if len(func_args_str) <= 800 else func_args_str[:800] + "..."
                 effects.append(ToolLoopUIEffect(kind="append", text=f"[Debug: params {params_display}]\n"))
 

--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -228,6 +228,7 @@ TRANSLATION_RULES = "TRANSLATION: get_document_content(scope=full) -> translate 
 
 # Tool-usage workflow patterns (no repeat of apply_document_content targets; see WRITER_APPLY_DOCUMENT_HTML_RULES).
 TOOL_USAGE_PATTERNS = """TOOL USAGE PATTERNS:
+- After an edit tool, confirm it landed via that tool's own structured field — not the message wording: apply_document_content -> replaced_count > 0; apply_style -> applied is true; add_comment -> comment_added is true. A no-op (e.g. text not found) returns status="error"; do not assume success.
 - search_in_document (with return_offsets if needed) is for inspection/navigation; use apply_document_content with old_content for replacements.
 - If a tool call fails, verify content and target are provided (use target='beginning' / 'end' / 'selection' for insert-only).
 - When asked to review or give feedback or suggestions on a document, use the add_comment method to add your input to specific places in the document. Use for both positive and negative feedback.

--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -507,8 +507,13 @@ class ApplyDocumentContent(ToolBase):
         # Collapse exotic horizontal whitespace; preserve newlines for paragraph-aware search.
         search_string = _normalize_search_string_for_find(search_string)
         if not search_string:
+            # Parameter error (like old_content=None), not a search no-op: the search never ran,
+            # so there's no replaced_count to report — use the standard tool error shape.
             return self._tool_error("old_content is empty after normalization.")
         doc = ctx.doc
+        # replaced_count is the machine-readable success signal: 0 -> status "error" (a silent
+        # no-op surfaced as a failure), N>0 -> "ok". No matched_count/warning/partial-replace:
+        # if a replace raises mid-all_matches the existing abort behavior stands.
         all_matches = kwargs.get("all_matches", False)
         if all_matches:
             ranges = _find_all_ranges(doc, search_string)
@@ -520,20 +525,26 @@ class ApplyDocumentContent(ToolBase):
                 else:
                     format_support.replace_single_range_with_content(doc, found, content, ctx.ctx, config_svc)
                 count += 1
-            msg = "Replaced %d occurrence(s)." % count
-            if use_preserve and count > 0:
-                msg += " (formatting preserved)"
             if count == 0:
-                msg += " No matches found. Try a shorter substring."
-            return {"status": "ok", "message": msg}
+                return {"status": "error",
+                        "message": "Replaced 0 occurrence(s). No matches found. Try a shorter substring.",
+                        "replaced_count": 0}
+            msg = "Replaced %d occurrence(s)." % count
+            if use_preserve:
+                msg += " (formatting preserved)"
+            return {"status": "ok", "message": msg, "replaced_count": count}
         found = _find_first_range(doc, search_string)
         if found is None:
-            return {"status": "error", "message": "old_content not found in document. Try a shorter, unique substring."}
+            return {"status": "error", "message": "old_content not found in document. Try a shorter, unique substring.",
+                    "replaced_count": 0}
         if use_preserve:
             format_support.replace_preserving_format(doc, found, raw_content, ctx.ctx)
-            return {"status": "ok", "message": "Replaced 1 occurrence (by old_content). (formatting preserved)"}
-        format_support.replace_single_range_with_content(doc, found, content, ctx.ctx, config_svc)
-        return {"status": "ok", "message": "Replaced 1 occurrence (by old_content)."}
+        else:
+            format_support.replace_single_range_with_content(doc, found, content, ctx.ctx, config_svc)
+        msg = "Replaced 1 occurrence (by old_content)."
+        if use_preserve:
+            msg += " (formatting preserved)"
+        return {"status": "ok", "message": msg, "replaced_count": 1}
 
 
 # ------------------------------------------------------------------

--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -93,7 +93,9 @@ class AddComment(ToolBase):
         sd.SearchRegularExpression = False
         found = doc.findFirst(sd)
         if found is None:
-            return {"status": "not_found", "message": "Text '%s' not found." % search_text}
+            # status="error" (not "not_found"): an anchor miss is a failure, so the chat FSM and
+            # MCP host don't treat a no-op as success. anchor_text is returned on success only.
+            return {"status": "error", "message": "Text '%s' not found." % search_text, "matched": False, "comment_added": False}
         anchor_range = found.getStart()
 
         annotation = doc.createInstance("com.sun.star.text.textfield.Annotation")
@@ -103,7 +105,7 @@ class AddComment(ToolBase):
         cursor = doc_text.createTextCursorByRange(anchor_range)
         doc_text.insertTextContent(cursor, annotation, False)
 
-        return {"status": "ok", "message": "Comment added.", "author": author}
+        return {"status": "ok", "message": "Comment added.", "author": author, "matched": True, "comment_added": True, "anchor_text": search_text}
 
 
 class DeleteComment(ToolWriterCommentBase):

--- a/plugin/writer/styles.py
+++ b/plugin/writer/styles.py
@@ -320,6 +320,10 @@ class ApplyStyle(FrameworkToolBase):
         try:
             cursor = resolve_target_cursor(ctx, target, old_content)
         except ValueError as ve:
+            if target == "search":
+                # Surface the search-miss as a structured (top-level) failure, like
+                # apply_document_content, so a client can branch on matched/applied.
+                return {"status": "error", "message": str(ve), "target": "search", "applied": False, "matched": False}
             return self._tool_error(str(ve))
 
         if not cursor:
@@ -332,7 +336,11 @@ class ApplyStyle(FrameworkToolBase):
                 cursor.setPropertyValue(uno_prop, uno_value)
         except Exception as e:
             return self._tool_error("Could not apply style: %s" % e)
-        return {"status": "ok", "style_name": style_name, "family": family}
+        result = {"status": "ok", "message": "Applied style '%s' (%s) to %s." % (style_name, family, target),
+                  "style_name": style_name, "family": family, "target": target, "applied": True}
+        if target == "search":
+            result["matched"] = True  # a search miss would have errored earlier in resolve_target_cursor
+        return result
 
 
 class UpdateStyle(ToolWriterStyleBase):

--- a/scripts/prompt_optimization/string_eval_tools.py
+++ b/scripts/prompt_optimization/string_eval_tools.py
@@ -88,6 +88,8 @@ class StringDocState:
         content = _normalize_apply_content(content)
         all_matches = bool(kwargs.get("all_matches", False))
 
+        # Mirror production's structured returns (content.py): on the search path use
+        # replaced_count as the success signal (0 -> status "error", N>0 -> "ok").
         if target == "full_document":
             self._html = content
             return {"status": "ok", "message": "Replaced entire document."}
@@ -101,14 +103,22 @@ class StringDocState:
             self._html = self._html + content
             return {"status": "ok", "message": "Inserted content (simulated selection)."}
         if target == "search":
-            old = str(old_content)
+            # Mirror production: old_content empty after stripping is a parameter error (no
+            # replaced_count — the search never ran), not a match-everything no-op.
+            old = str(old_content).strip()
+            if not old:
+                return {"status": "error", "message": "old_content is empty after normalization."}
             if old not in self._html:
-                return {"status": "error", "message": "old_content not found in document."}
+                return {"status": "error", "message": "old_content not found in document.",
+                        "replaced_count": 0}
             if all_matches:
+                count = self._html.count(old)
                 self._html = self._html.replace(old, content)
-                return {"status": "ok", "message": "Replaced all matches."}
+                return {"status": "ok", "message": "Replaced %d occurrence(s)." % count,
+                        "replaced_count": count}
             self._html = self._html.replace(old, content, 1)
-            return {"status": "ok", "message": "Replaced first match."}
+            return {"status": "ok", "message": "Replaced 1 occurrence (by old_content).",
+                    "replaced_count": 1}
         return {"status": "error", "message": f"Unknown target: {target!r}"}
 
     def find_text(

--- a/tests/chatbot/test_tool_loop_state.py
+++ b/tests/chatbot/test_tool_loop_state.py
@@ -288,6 +288,43 @@ def test_tool_result_delegate_gateway_error():
     assert "No specialized tools found" in append_eff.text
 
 
+def test_apply_document_content_debug_uses_structured_replaced_count():
+    # replaced_count == 0 but the message does NOT start with "Replaced 0 occurrence";
+    # only the structured field should trigger the debug-params line (proves the consumer
+    # reads replaced_count, not the message string).
+    state = create_base_state()
+    event = create_event(
+        EventKind.TOOL_RESULT,
+        call_id="c1",
+        func_name="apply_document_content",
+        func_args_str='{"target": "search", "old_content": "zzz"}',
+        result='{"status": "error", "message": "old_content not found in document.", "replaced_count": 0}',
+        mutates_document=True,
+    )
+    tr = next_state(state, event)
+    assert any(
+        isinstance(e, ToolLoopUIEffect) and e.kind == "append" and e.text.startswith("[Debug: params")
+        for e in tr.effects
+    )
+
+
+def test_apply_document_content_no_debug_when_replaced():
+    state = create_base_state()
+    event = create_event(
+        EventKind.TOOL_RESULT,
+        call_id="c2",
+        func_name="apply_document_content",
+        func_args_str='{"target": "search", "old_content": "foo"}',
+        result='{"status": "ok", "message": "Replaced 2 occurrence(s).", "replaced_count": 2}',
+        mutates_document=True,
+    )
+    tr = next_state(state, event)
+    assert not any(
+        isinstance(e, ToolLoopUIEffect) and e.kind == "append" and e.text.startswith("[Debug: params")
+        for e in tr.effects
+    )
+
+
 def test_next_tool_when_stopped():
     # If is_stopped=True but empty pending_tools, it shouldn't update status
     state = create_base_state(is_stopped=True)

--- a/tests/writer/test_add_comment_uno.py
+++ b/tests/writer/test_add_comment_uno.py
@@ -1,0 +1,69 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# add_comment returns structured fields (matched, comment_added, anchor_text) so the agent
+# can tell whether the anchor was found and the comment actually inserted, instead of having
+# to parse the message string.
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.writer.specialized.comments import AddComment
+from plugin.tests.testing_utils import TestingFactory
+
+_test_doc = None
+_test_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+    _test_doc = TestingFactory.create_native_doc(ctx, doc_type="writer", hidden=True)
+
+
+@teardown
+def my_teardown(ctx):
+    global _test_doc
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+
+
+def _set_body(text_value):
+    text = _test_doc.getText()
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEnd(True)
+    cur.setString("")
+    cur.gotoStart(False)
+    text.insertString(cur, text_value, False)
+
+
+def _ctx():
+    return TestingFactory.create_context(doc=_test_doc, ctx=_test_ctx, env="native")
+
+
+@native_test
+def test_add_comment_reports_anchor_found_uno():
+    _set_body("Anchor here please")
+    res = AddComment().execute(_ctx(), content="a note", search_text="Anchor")
+    assert res.get("status") == "ok", res
+    assert res.get("matched") is True, res
+    assert res.get("comment_added") is True, res
+    assert res.get("anchor_text") == "Anchor", res
+
+
+@native_test
+def test_add_comment_reports_anchor_not_found_uno():
+    _set_body("nothing relevant here")
+    res = AddComment().execute(_ctx(), content="a note", search_text="DOES_NOT_EXIST_XYZ")
+    # An anchor miss is a failure (status="error"), not a silent "not_found" the MCP host /
+    # chat FSM would treat as success. anchor_text is returned on success only.
+    assert res.get("status") == "error", res
+    assert res.get("matched") is False, res
+    assert res.get("comment_added") is False, res

--- a/tests/writer/test_apply_document_content_structured_return.py
+++ b/tests/writer/test_apply_document_content_structured_return.py
@@ -1,0 +1,65 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pure pytest (no LibreOffice): the structured-return logic of apply_document_content.
+# We mock the range finders + the replace helpers so only the replaced_count / status logic
+# is exercised: replaced_count == 0 -> status "error", N > 0 -> "ok".
+import types
+
+import pytest
+
+import plugin.writer.content as content_mod
+import plugin.writer.format as format_mod
+from plugin.writer.content import ApplyDocumentContent
+
+
+def _ctx():
+    return types.SimpleNamespace(
+        doc=object(), ctx=object(),
+        services=types.SimpleNamespace(get=lambda key, default=None: None),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_libreoffice(monkeypatch):
+    # Keep everything in-memory: plain-text content (use_preserve path) and no real replace.
+    monkeypatch.setattr(format_mod, "content_has_markup", lambda *a, **k: False)
+    monkeypatch.setattr(content_mod, "_normalize_search_string_for_find", lambda s: s)
+    monkeypatch.setattr(format_mod, "replace_preserving_format", lambda *a, **k: None)
+    monkeypatch.setattr(format_mod, "replace_single_range_with_content", lambda *a, **k: None)
+
+
+def test_search_no_match_returns_error_zero(monkeypatch):
+    monkeypatch.setattr(content_mod, "_find_first_range", lambda doc, s: None)
+    res = ApplyDocumentContent().execute(_ctx(), target="search", old_content="zzz", content="BAR")
+    assert res["status"] == "error", res
+    assert res["replaced_count"] == 0, res
+
+
+def test_search_single_success(monkeypatch):
+    monkeypatch.setattr(content_mod, "_find_first_range", lambda doc, s: object())
+    res = ApplyDocumentContent().execute(_ctx(), target="search", old_content="foo", content="BAR")
+    assert res["status"] == "ok", res
+    assert res["replaced_count"] == 1, res
+
+
+def test_search_all_matches_reports_count(monkeypatch):
+    monkeypatch.setattr(content_mod, "_find_all_ranges", lambda doc, s: [object(), object(), object()])
+    res = ApplyDocumentContent().execute(
+        _ctx(), target="search", old_content="foo", content="BAR", all_matches=True)
+    assert res["status"] == "ok", res
+    assert res["replaced_count"] == 3, res
+
+
+def test_search_all_matches_no_match_errors(monkeypatch):
+    monkeypatch.setattr(content_mod, "_find_all_ranges", lambda doc, s: [])
+    res = ApplyDocumentContent().execute(
+        _ctx(), target="search", old_content="zzz", content="BAR", all_matches=True)
+    assert res["status"] == "error", res
+    assert res["replaced_count"] == 0, res
+    assert res["message"].startswith("Replaced 0 occurrence"), res

--- a/tests/writer/test_apply_document_content_structured_return_uno.py
+++ b/tests/writer/test_apply_document_content_structured_return_uno.py
@@ -1,0 +1,101 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# apply_document_content returns a machine-readable replaced_count so the agent can tell whether
+# an edit actually landed instead of always seeing status="ok": replaced_count == 0 -> status
+# "error" (a silent no-op surfaced), N > 0 -> "ok". (No target/formatting_preserved/matched_count/
+# warning/partial-replace — minimal per maintainer request; a replace that raises mid-all_matches
+# keeps the existing abort behavior.) These tests cover single-match, all_matches, and no-match.
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.writer.content import ApplyDocumentContent
+from plugin.tests.testing_utils import TestingFactory
+
+_test_doc = None
+_test_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _test_doc, _test_ctx
+    _test_ctx = ctx
+    _test_doc = TestingFactory.create_native_doc(ctx, doc_type="writer", hidden=True)
+
+
+@teardown
+def my_teardown(ctx):
+    global _test_doc
+    if _test_doc:
+        _test_doc.close(True)
+    _test_doc = None
+
+
+def _set_body(text_value):
+    text = _test_doc.getText()
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEnd(True)
+    cur.setString("")
+    cur.gotoStart(False)
+    text.insertString(cur, text_value, False)
+
+
+def _ctx():
+    return TestingFactory.create_context(doc=_test_doc, ctx=_test_ctx, env="native")
+
+
+@native_test
+def test_single_match_reports_replaced_count_uno():
+    _set_body("alpha foo beta")
+    res = ApplyDocumentContent().execute(_ctx(), target="search", old_content="foo", content="BAR")
+    assert res.get("status") == "ok", res
+    assert res.get("replaced_count") == 1, res
+
+
+@native_test
+def test_no_match_reports_zero_and_errors_uno():
+    """The anti silent-failure case: a search that matches nothing must report status=error."""
+    _set_body("nothing relevant here")
+    res = ApplyDocumentContent().execute(_ctx(), target="search", old_content="zzz-not-present", content="BAR")
+    assert res.get("status") == "error", res
+    assert res.get("replaced_count") == 0, res
+
+
+@native_test
+def test_all_matches_reports_total_count_uno():
+    _set_body("x foo y foo z foo w")
+    res = ApplyDocumentContent().execute(_ctx(), target="search", old_content="foo", content="BAR", all_matches=True)
+    assert res.get("status") == "ok", res
+    assert res.get("replaced_count") == 3, res
+
+
+@native_test
+def test_all_matches_no_match_errors_uno():
+    _set_body("nothing here")
+    res = ApplyDocumentContent().execute(_ctx(), target="search", old_content="zzz", content="BAR", all_matches=True)
+    assert res.get("status") == "error", res
+    assert res.get("replaced_count") == 0, res
+    # The consumer's legacy string fallback relies on this exact prefix.
+    assert res.get("message", "").startswith("Replaced 0 occurrence"), res
+
+
+@native_test
+def test_insert_branch_succeeds_uno():
+    _set_body("seed")
+    res = ApplyDocumentContent().execute(_ctx(), target="end", content="more")
+    assert res.get("status") == "ok", res
+
+
+@native_test
+def test_empty_old_content_is_a_parameter_error_uno():
+    """old_content that normalizes to empty is a parameter error (like old_content=None), not a
+    search no-op: status="error" and the search never ran (no replaced_count)."""
+    _set_body("some content here")
+    res = ApplyDocumentContent().execute(_ctx(), target="search", old_content="   ", content="BAR")
+    assert res.get("status") == "error", res

--- a/tests/writer/test_apply_style_preserve_inline_uno.py
+++ b/tests/writer/test_apply_style_preserve_inline_uno.py
@@ -234,3 +234,44 @@ def test_apply_paragraph_style_multi_paragraph_selection_uno():
     p2.goRight(len("First paragraph here.") + 1 + 6, True)
     assert int(p2.getPropertyValue("CharColor")) == 0xFF0000, \
         "direct COLOR lost in second paragraph"
+
+
+@native_test
+def test_apply_style_returns_structured_fields_uno():
+    """apply_style returns target/applied; matched=True only when target='search'."""
+    doc = _test_doc
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    text.insertString(cur, "Mark this clause.", False)
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+
+    res = ApplyStyle().execute(tool_ctx, style_name="Standard", family="ParagraphStyles", target="full_document")
+    assert res.get("status") == "ok", res
+    assert res.get("applied") is True, res
+    assert res.get("target") == "full_document", res
+    assert "matched" not in res, res  # full_document is not a search
+
+    res2 = ApplyStyle().execute(tool_ctx, style_name="Standard", family="ParagraphStyles", target="search", old_content="Mark this clause.")
+    assert res2.get("status") == "ok", res2
+    assert res2.get("target") == "search", res2
+    assert res2.get("matched") is True, res2
+
+
+@native_test
+def test_apply_style_search_miss_reports_not_matched_uno():
+    """A target='search' miss returns an error carrying matched=False / applied!=True
+    (no silent ok), consistent with apply_document_content's no-match."""
+    doc = _test_doc
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    text.insertString(cur, "Some clause text.", False)
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=_test_ctx, env="native")
+    res = ApplyStyle().execute(
+        tool_ctx, style_name="Standard", family="ParagraphStyles",
+        target="search", old_content="NOT-PRESENT-XYZ",
+    )
+    assert res.get("status") == "error", res
+    assert res.get("matched") is False, res
+    assert res.get("applied") is not True, res


### PR DESCRIPTION
## Problem

The mutating edit tools returned basically `{"status": "ok", "message": ...}`, so a caller (the in-app agent or an MCP host) couldn't tell whether an edit actually landed — a `target="search"` that matched nothing, or an `add_comment` whose anchor wasn't found, looked identical to a real success. Silent failure.

Implements the structured-returns proposal we discussed, with your "just simplify to `replaced_count`" steer.

## Change (minimal)

- **`apply_document_content`**: adds `replaced_count`. `replaced_count == 0` → `status: "error"` (the silent no-op surfaced) on **both** the single-match and `all_matches` paths; `> 0` → `"ok"`. Nothing else added — no `matched_count` / `warning` / partial-replace handling; if a replace raises mid-`all_matches`, the existing abort behavior stands.
- **`apply_style`**: adds `target`, `applied`, `matched` (for `target="search"`); a search miss returns a structured error with `applied: false` / `matched: false`.
- **`add_comment`**: adds `matched`, `comment_added`; an anchor miss now returns `status: "error"` (was `"not_found"`, which the chat FSM and MCP `mcp_state.py` treated as success); `anchor_text` echoed on success.
- **`tool_loop_state`** (chat consumer): reads `replaced_count` instead of string-parsing the message (legacy string fallback kept).

## Behavior change

A search/anchor **miss is now `status: "error"`** (was a silent `"ok"` / `"not_found"`), so consumers stop treating no-ops as success. Successful calls are unchanged.

## Also

- One-line writer tool-usage nudge (check `replaced_count` / `applied` / `comment_added`, not the message wording).
- Updated the prompt-eval mock (`scripts/prompt_optimization/string_eval_tools.py`) to match production semantics.
- Documented the contract in `docs/mcp-protocol.md`.

## Tests

- **pytest (no LibreOffice):** `apply_document_content` structured-return logic (mocked finders: no-match / single / all_matches) + `tool_loop_state`.
- **UNO:** `apply_document_content` (single, all_matches, no-match, empty old_content), `add_comment` (hit/miss), `apply_style` (preserve inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
