### PR TITLE
Style model: FODT autostyle recovery + collision-safe compact tokens

### DIFF
--- a/docs/html_style_model_plan.md
+++ b/docs/html_style_model_plan.md
@@ -18,7 +18,7 @@ While the original proposal to add a `get_paragraph_metadata` tool provides accu
 Instead of a separate diagnostic tool, we will **embed the LibreOffice style model directly into the HTML representation**.
 
 We will achieve **Read/Write Symmetry**:
-- **Read:** Paragraphs will include their named style as a custom data attribute (e.g., `<p data-lo-style="Caption">`). Values are **compact tokens with no spaces** (`Heading1`, `TextBody`, `Standard`) so models do not have to juggle LibreOffice spacing quirks. Inline `style="..."` attributes will be reserved *exclusively* for direct formatting overrides.
+- **Read:** Paragraphs will include their named style as a custom data attribute (e.g., `<p data-lo-style="Caption">`). Values are **compact tokens with no spaces** (`Heading1`, `Textbody`, `Standard`) so models do not have to juggle LibreOffice spacing quirks. Inline `style="..."` attributes will be reserved *exclusively* for direct formatting overrides.
 - **Write:** When the agent generates HTML, it uses the same compact tokens in `data-lo-style`. The extension resolves them back to real UNO `ParaStyleName` values (e.g. `Heading1` → `Heading 1`) before `setPropertyValue`, then applies any inline CSS as direct overrides on top.
 
 **Benefits:**
@@ -51,7 +51,7 @@ A contributor explored reading `ParaStyleName` from the UNO model in lockstep wi
 - It duplicates work that `_range_to_content_via_temp_doc` already does when building temp docs for selection/range export.
 - It conflicts with the core bet: one fast `XHTML Writer File` export + string post-process.
 
-**String massaging is the read path:** decode ODF-encoded class suffixes for named styles, strip spaces for agent-facing `data-lo-style`, resolve autostyle `P*` classes from the same export's `<style>` block when needed; omit `data-lo-style` when unresolvable. Write path maps compact tokens back to UNO via the document style list.
+**String massaging is the read path:** decode ODF-encoded class suffixes for named styles, strip spaces for agent-facing `data-lo-style`, resolve autostyle `P*` classes via the paired flat-ODF parent map (`style:parent-style-name`, see the autostyle-name-recovery note above) with the XHTML `<style>` block CSS fingerprint as fallback; omit `data-lo-style` only when still unresolvable. Write path maps compact tokens back to UNO via the document style list.
 
 We trust LibreOffice's XHTML export and UNO style APIs — no parallel model-walk, no alternate read path.
 
@@ -82,12 +82,14 @@ Probe harness: [`tests/writer/test_xhtml_export_uno.py`](../tests/writer/test_xh
 |------|--------------------------|-----------------|----------------------|
 | Default body (`Standard`) | `paragraph-Standard` **or** `paragraph-P1` (LO/version dependent) | Named and/or autostyle rules | Decode → compact → `data-lo-style="Standard"`, or fingerprint/omit for `P1` |
 | `Heading 1` | `paragraph-Heading_20_1` | Named rule present | Decode → compact → `data-lo-style="Heading1"` |
-| `Text Body`, `Caption` | `paragraph-Text_20_Body`, `paragraph-Caption`, etc. | Named rule present | Decode suffix → compact → `data-lo-style` (e.g. `TextBody`, `Caption`) |
+| `Text body`, `Caption` | `paragraph-Text_20_body`, `paragraph-Caption`, etc. | Named rule present | Decode suffix → compact → `data-lo-style` (e.g. `Textbody`, `Caption`) |
 | Char override (e.g. bold word) | `text-T1` on `<span>` | `.text-T1 { font-weight: bold; }` | Inline `style="font-weight: bold"` on span |
 | Mixed doc | Mix of above per paragraph | Both `paragraph-*` and `text-*` rules | Per-paragraph rules below |
 | Trailing empty paragraph | Extra `<p class="paragraph-Standard">&nbsp;</p>` | — | Filter empty/`&nbsp;`-only `<p>` from agent-facing output (optional but recommended) |
 
 **Important:** Contributor probe saw `paragraph-P1` for `Standard`; WriterAgent dev LO export saw `paragraph-Standard` directly. **Implementation must handle both** — do not assume one LO behavior.
+
+**Autostyle name recovery via flat ODF (implemented).** After an edit, the StarWriter HTML import bakes extra direct char props into the paragraph, so on re-export it is an autostyle (`paragraph-Pn`) whose CSS matches no named rule — the XHTML fingerprint then can't recover the name (the write→read round-trip would drop the token). Fix (two filters): export the document ALSO as flat ODF (`OpenDocument Text Flat XML`), which keeps `<style:style style:name="Pn" style:parent-style-name="...">`; the automatic style name `Pn` is identical to the XHTML `paragraph-Pn` class suffix, so a string-only `Pn → parent` map recovers the real style name (no model walk, no order alignment). The CSS fingerprint stays as a fallback when no FODT map is available.
 
 ### Autostyle decision table (locked from probe)
 
@@ -131,11 +133,11 @@ Probe harness: [`tests/writer/test_xhtml_export_uno.py`](../tests/writer/test_xh
    |--------------------|---------------------|-----------------|
    | `Standard` | `Standard` | `Standard` |
    | `Heading_20_1` | `Heading 1` | `Heading1` |
-   | `Text_20_Body` | `Text Body` | `TextBody` |
+   | `Text_20_body` | `Text body` | `Textbody` |
    | `Caption` | `Caption` | `Caption` |
    | `P1` | — | See [Autostyle decision table](#autostyle-decision-table-locked-from-probe) |
 
-5. **Transform paragraph tags:** For each block `<p>`, `<div>`, `<h1>`–`<h6>`, etc. with `class="paragraph-…"`: emit `data-lo-style="…"`, strip `paragraph-*` from `class`, drop empty `class`.
+5. **Transform paragraph tags:** For each paragraph block (`<p>`, `<h1>`–`<h6>`, `<li>`, `<blockquote>`, `<pre>`) with `class="paragraph-…"`: emit `data-lo-style="…"`, strip `paragraph-*` from `class`, drop empty `class`. NOTE: `<div>` is treated as a **transparent container** (not a styleable block) on both read and write — LibreOffice does not put a paragraph style on a `<div>`, and on write a `<div>` is not its own paragraph, so counting it as a style slot desyncs the positional apply.
 
 6. **Strip boilerplate:** Existing `_strip_html_boilerplate()` returns `<body>` inner HTML only.
 
@@ -161,7 +163,7 @@ StarWriter HTML import does not understand `data-lo-style`. Write path:
 
 6. **Fallback:** Unknown style name → `Standard` (or skip apply and log).
 
-**Hook points:** `replace_full_document`, `insert_content_at_position`, `replace_single_range_with_content` (when block markup present). Count paragraphs before insert to compute the correct offset for partial edits.
+**Hook points:** Named-style application runs on `replace_full_document` only. Targeted inserts/replaces (`insert_content_at_position`, `replace_single_range_with_content`) still insert the content but **skip** style application: the first imported block merges into the cursor's existing paragraph, so applying its `data-lo-style` would restyle the adjacent (pre-existing) text. For styling existing text use `apply_style`. (Applying styles only to genuinely-new paragraphs on partial edits is a follow-up — see the checklist.)
 
 ---
 
@@ -169,7 +171,7 @@ StarWriter HTML import does not understand `data-lo-style`. Write path:
 
 1. **Unit tests (pytest):** `decode_lo_css_class_suffix`, CSS map extraction, char inline transform, paragraph transform, autostyle fingerprint — no LibreOffice.
 2. **UNO tests:** [`tests/writer/test_xhtml_export_uno.py`](../tests/writer/test_xhtml_export_uno.py) documents export shapes; add round-trip test: read emits `data-lo-style="Heading1"`, agent writes it back, verify UNO `ParaStyleName == "Heading 1"` and bold override.
-3. **Prompts:** `WRITER_APPLY_DOCUMENT_HTML_RULES` in [`plugin/framework/constants.py`](../plugin/framework/constants.py) — agent reads/writes compact `data-lo-style` tokens (no spaces: `Heading1`, `TextBody`); inline `style` for overrides only.
+3. **Prompts:** `WRITER_APPLY_DOCUMENT_HTML_RULES` in [`plugin/framework/constants.py`](../plugin/framework/constants.py) — agent reads/writes compact `data-lo-style` tokens (no spaces: `Heading1`, `Textbody`); inline `style` for overrides only.
 4. **Docs:** [`docs/llm-styles.md`](llm-styles.md) — `data-lo-style` is the agent-facing convention; legacy `class="Style Name"` via StarWriter remains for non-agent HTML.
 5. **`get_paragraph_metadata`:** Keep as optional `specialized` tier only if needed for debugging; not required for core read/write.
 
@@ -199,11 +201,11 @@ One `storeToURL` export + in-memory string/CSS parsing on the read path; UNO `se
 
 ## Design Approval Checklist
 
-Before implementation PR:
+Status (implemented in this PR):
 
-- [ ] Read path: XHTML export + string pipeline only
-- [ ] Autostyle: decode named classes + CSS fingerprint + omit (no `P1` passed to LLM as a style name)
-- [ ] Write path: strip `data-lo-style`, import HTML, apply styles via `apply_paragraph_style_preserving_direct_char`
-- [ ] Agent prompt documents compact `data-lo-style` tokens (no spaces) vs inline `style`
-- [ ] Write path resolves compact tokens → UNO `ParaStyleName` via style list lookup
-- [ ] Unit + UNO round-trip tests included
+- [x] Read path: XHTML export (+ paired flat-ODF parent map) + string pipeline only
+- [x] Autostyle: flat-ODF `parent-style-name` recovery (primary) + CSS fingerprint (fallback) + omit/collision-safe (no `P1` passed to the LLM as a style name)
+- [x] Write path: strip `data-lo-style`, import HTML, apply styles via `apply_paragraph_style_preserving_direct_char` (applied on `full_document`; targeted inserts/replaces skip apply to avoid restyling adjacent text — follow-up)
+- [x] Agent prompt documents compact `data-lo-style` tokens (no spaces) vs inline `style`
+- [x] Write path resolves compact tokens → UNO `ParaStyleName` via style list lookup (collision → fail-safe `Standard`)
+- [x] Unit + UNO round-trip tests included (incl. the write→read FODT recovery)

--- a/docs/llm-styles.md
+++ b/docs/llm-styles.md
@@ -10,7 +10,7 @@ You can have the LLM map directly to your existing styles using the standard HTM
 
 ### Paragraph Styles
 
-Instruct the LLM to output a `<p>` or `<div>` tag with the class name matching the exact name of the LibreOffice paragraph style.
+Instruct the LLM to output a `<p>` tag with the class name matching the exact name of the LibreOffice paragraph style.
 
 ```html
 <p class="My Custom Theme">This paragraph will take on the 'My Custom Theme' style.</p>
@@ -31,6 +31,23 @@ Standard HTML tags are also automatically mapped to their LibreOffice equivalent
 * `<h1>`, `<h2>`, `<h3>` → **Heading 1**, **Heading 2**, **Heading 3**
 * `<blockquote>` → **Quotations**
 * `<ul>/<li>` → Standard List formatting
+
+## The `data-lo-style` Convention (Agent Read/Write)
+
+The `class="Style Name"` mapping above is the **legacy** path: it relies on LibreOffice's `HTML (StarWriter)` import and is still honored for hand-written or non-agent HTML.
+
+For the agent, WriterAgent uses a tighter, symmetric convention so reads and writes speak the same language:
+
+- **Read:** `get_document_content` exports via the `XHTML Writer File` filter and post-processes it. Each block carries its named paragraph style as a **compact `data-lo-style` token = the LibreOffice style name with spaces removed** (`Heading 1` → `Heading1`, `Text body` → `Textbody`, `Caption` → `Caption`, `Standard` → `Standard`). Use the tokens exactly as returned. Inline `style="..."` is reserved *exclusively* for direct character overrides. Synthetic autostyle paragraphs (e.g. after an edit, where the StarWriter import bakes extra direct char props into the paragraph) have their real base style name recovered from a paired flat-ODF (`.fodt`) export (the autostyle's `style:parent-style-name`, which the XHTML export flattens away); only a genuinely unresolvable autostyle is emitted without a token.
+- **Write:** `apply_document_content` reads `data-lo-style` back, resolves the compact token to the real LibreOffice `ParaStyleName` (`Heading1` → `Heading 1`), applies the named style first, then layers any inline `style="..."` on top as direct overrides. An unknown token falls back to `Standard`. **Named-style application happens when you rewrite the whole document (`target="full_document"`).** For targeted inserts/replaces (`end`/`beginning`/`selection`/`search`) the content is inserted but the named style is **not** applied — the first imported block merges into the cursor's existing paragraph, so applying its style would restyle the adjacent pre-existing text. To style text that already exists, use `apply_style`. Inline `style="..."` character overrides are honored on all targets.
+
+```html
+<!-- What get_document_content returns, and what the agent should write back: -->
+<p data-lo-style="Heading1">Section title</p>
+<p data-lo-style="Standard">A normal paragraph with a <span style="font-weight: bold">bold</span> word.</p>
+```
+
+Use the tokens exactly as returned by `get_document_content` (no spaces). This keeps documents using named styles instead of accreting raw inline formatting.
 
 ## Strategies for Prompting
 

--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -132,10 +132,12 @@ APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL):
 - `content` must be a JSON array of HTML strings (one fragment per heading/paragraph). We wrap in <html>/<body>.
 {HTML_FRAGMENT_RULES}
 - Math: Always use inline delimiters \\(...\\) for every equation—in running text or in its own <p>. No $...$, $$...$$, \\[...\\], HTML-escaped math, equation images, or plain-text formulas like x².
+- Named paragraph styles: get_document_content marks each block's LibreOffice paragraph style as a `data-lo-style` token = the style name with spaces removed (e.g. `Heading 1`->`Heading1`, `Text body`->`Textbody`, `Caption`->`Caption`); use the tokens EXACTLY as returned. It reserves inline style="..." for direct character overrides. PRESERVE and USE it — emit `<p data-lo-style="Heading1">...</p>` to apply a named style, using the tokens exactly as returned (the named style is applied first, then any inline style="" is layered on top as a direct override). Prefer named styles over hardcoded inline formatting; an unknown token falls back to 'Standard'. data-lo-style is applied when you rewrite with target='full_document'; for targeted inserts/replaces (end/beginning/selection/search) the named style is NOT applied (it would restyle adjacent text) — rewrite via full_document for styling, or use apply_style to (re)style existing text.
 
 EXAMPLES:
 - Good: ["<h1>Title</h1>", "<p>Paragraph with <strong>bold</strong> text and \\"quotes\\".</p>"]
 - Good math: ["<p>The identity \\(a^2+b^2=c^2\\) holds.</p>"]
+- Good styles: ["<p data-lo-style=\\"Heading1\\">Section title</p>", "<p data-lo-style=\\"Quotations\\">A quoted clause.</p>"]
 - Bad: <h1>Title</h1><p>Paragraph</p> (must be a list of strings)
 - Bad: ["&lt;h1&gt;Title&lt;/h1&gt;"] (escaped entities)
 - Bad: ["&lt;math&gt;x^2&lt;/math&gt;"] (HTML-escaped math; use LaTeX delimiters)

--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -24,6 +24,7 @@ import re
 import tempfile
 import urllib.parse
 import urllib.request
+from html.parser import HTMLParser
 from typing import Any, cast
 
 import uno
@@ -34,6 +35,7 @@ from plugin.doc.document_helpers import normalize_linebreaks as _normalize
 from .math.html_math_segment import html_fragment_contains_mixed_math, segment_html_with_mixed_math
 from .math.math_mml_convert import convert_latex_to_starmath, convert_mathml_to_starmath, insert_writer_math_formula
 from .ops import get_selection_range
+from . import xhtml_style_postprocess as xhtml_post
 
 log = logging.getLogger("writeragent.writer")
 
@@ -44,6 +46,18 @@ log = logging.getLogger("writeragent.writer")
 
 HTML_FILTER = "HTML (StarWriter)"
 HTML_EXTENSION = ".html"
+
+# Read-path export filter. The XHTML filter preserves the paragraph style model as CSS
+# classes + a <style> block (vs HTML (StarWriter), which flattens everything to inline
+# CSS). We post-process it into semantic data-lo-style attributes. The WRITE/import path
+# keeps HTML (StarWriter).
+XHTML_FILTER = "XHTML Writer File"
+XHTML_EXTENSION = ".xhtml"
+# Flat ODF: keeps each autostyle's parent named style (style:parent-style-name), which the
+# XHTML export flattens away — so autostyle paragraphs (common after a StarWriter import) can
+# recover their real style name. Paired with the XHTML export on the read path.
+FLAT_ODF_FILTER = "OpenDocument Text Flat XML"
+FODT_EXTENSION = ".fodt"
 
 # System temp directory (cross-platform).
 TEMP_DIR = tempfile.gettempdir()
@@ -161,14 +175,16 @@ def _create_property_value(name, value):
 
 
 @contextlib.contextmanager
-def _with_temp_buffer(content=None, config_svc=None):
+def _with_temp_buffer(content=None, config_svc=None, ext=None):
     """Context manager that yields ``(path, file_url)`` for a temp file
     with the correct format extension.
 
     If *content* is not ``None`` it is written to the file.
+    *ext* overrides the file extension (e.g. ``".xhtml"`` for the read filter).
     The file is deleted on exit.
     """
-    _, ext = _get_format_props(config_svc)
+    if ext is None:
+        _, ext = _get_format_props(config_svc)
     fd, path = tempfile.mkstemp(suffix=ext, dir=TEMP_DIR)
     try:
         if content is not None:
@@ -199,6 +215,227 @@ def _strip_html_boilerplate(html_string):
     if match:
         return match.group(1).strip()
     return html_string
+
+
+# ---------------------------------------------------------------------------
+# Semantic style model (read path): XHTML filter -> semantic data-lo-style HTML.
+# The pure string/CSS pipeline lives in xhtml_style_postprocess (no UNO); this module
+# only owns the UNO export. See docs/html_style_model_plan.md.
+# ---------------------------------------------------------------------------
+
+
+def _export_xhtml(doc, config_svc):
+    """Export *doc* via the XHTML Writer File filter; return the raw XHTML string."""
+    with _with_temp_buffer(None, config_svc, ext=XHTML_EXTENSION) as (path, file_url):
+        props = (_create_property_value("FilterName", XHTML_FILTER),)
+        doc.storeToURL(file_url, props)
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+
+
+def _autostyle_parents(doc, config_svc):
+    """Export *doc* as flat ODF and return the autostyle -> parent-style map (Pn -> base name).
+
+    Lets the read path recover an autostyle paragraph's real style name when the XHTML CSS
+    fingerprint matches nothing. Returns ``{}`` on any failure (the read still works, just
+    without the autostyle-name recovery)."""
+    try:
+        with _with_temp_buffer(None, config_svc, ext=FODT_EXTENSION) as (path, file_url):
+            props = (_create_property_value("FilterName", FLAT_ODF_FILTER),)
+            doc.storeToURL(file_url, props)
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                fodt = f.read()
+        return xhtml_post.extract_autostyle_parents_from_fodt(fodt)
+    except Exception:
+        log.debug("_autostyle_parents: flat-ODF export failed", exc_info=True)
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Semantic style model (write path): honor data-lo-style on incoming HTML
+# ---------------------------------------------------------------------------
+
+
+def _strip_data_lo_style(start_tag):
+    """Remove any data-lo-style attribute from a single start-tag string."""
+    start_tag = re.sub(r'\s+data-lo-style="[^"]*"', "", start_tag)
+    return re.sub(r"\s+data-lo-style='[^']*'", "", start_tag)
+
+
+class _BlockLoStyleExtractor(HTMLParser):
+    """Collect data-lo-style per TOP-LEVEL block (document order) and strip the attribute
+    from the HTML, so the StarWriter import sees clean markup and we apply the named styles
+    ourselves afterwards. Content inside <table> is left to the import (avoids order desync)."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=False)
+        self._table_depth = 0
+        self.styles = []
+        self._out = []
+
+    def _emit(self, raw, attrs, is_block):
+        if is_block and self._table_depth == 0:
+            val = None
+            for k, v in attrs:
+                if k == "data-lo-style":
+                    val = v
+            self.styles.append(val)
+            self._out.append(_strip_data_lo_style(raw))
+        else:
+            # Non-top-level / non-block: leave verbatim. In particular, a table-cell block's
+            # data-lo-style is left for the import to ignore (v1 doesn't apply cell styles),
+            # rather than silently stripped without being applied.
+            self._out.append(raw)
+
+    def handle_starttag(self, tag, attrs):
+        raw = self.get_starttag_text() or ("<%s>" % tag)
+        if tag.lower() == "table":
+            self._table_depth += 1
+            self._out.append(raw)
+            return
+        # BLOCK_TAGS excludes <div> (transparent container), so a wrapper does not consume a
+        # positional style slot — keeps read and write symmetric on <div>.
+        self._emit(raw, attrs, tag.lower() in xhtml_post.BLOCK_TAGS)
+
+    def handle_startendtag(self, tag, attrs):
+        raw = self.get_starttag_text() or ("<%s/>" % tag)
+        self._emit(raw, attrs, tag.lower() in xhtml_post.BLOCK_TAGS)
+
+    def handle_endtag(self, tag):
+        if tag.lower() == "table" and self._table_depth > 0:
+            self._table_depth -= 1
+        self._out.append("</%s>" % tag)
+
+    def handle_data(self, data):
+        self._out.append(data)
+
+    def handle_entityref(self, name):
+        self._out.append("&%s;" % name)
+
+    def handle_charref(self, name):
+        self._out.append("&#%s;" % name)
+
+    def handle_comment(self, data):
+        self._out.append("<!--%s-->" % data)
+
+    def result(self):
+        return "".join(self._out), self.styles
+
+
+def _extract_block_lo_styles(html):
+    """Return ``(clean_html, [data_lo_style_or_None per top-level block])``.
+
+    Short-circuits (returns the html unchanged, no styles) when there is no data-lo-style,
+    so existing callers are completely unaffected."""
+    if not html or "data-lo-style" not in html:
+        return html, []
+    ex = _BlockLoStyleExtractor()
+    ex.feed(html)
+    ex.close()
+    return ex.result()
+
+
+def _count_preceding_paras(text_obj, target):
+    """Number of paragraphs in *text_obj* whose start is before *target* (insertion point).
+
+    Computed BEFORE the import so we know where the inserted block paragraphs begin (a saved
+    cursor would drift to the end of the inserted content)."""
+    idx = 0
+    try:
+        e = text_obj.createEnumeration()
+    except Exception:
+        return 0
+    guard = 0
+    while e.hasMoreElements() and guard < 200000:
+        guard += 1
+        try:
+            el = e.nextElement()
+        except Exception:
+            break
+        if not (hasattr(el, "supportsService") and el.supportsService("com.sun.star.text.Paragraph")):
+            continue
+        try:
+            if text_obj.compareRegionStarts(el.getStart(), target) == 1:
+                idx += 1
+            else:
+                break
+        except Exception:
+            break
+    return idx
+
+
+def _resolve_paragraph_style_token(model, fam, token):
+    """Resolve an agent-facing compact ``data-lo-style`` token to a real UNO ParaStyleName.
+
+    A candidate is any paragraph style whose name equals the token (covers space-free names
+    and an agent that passed the exact spaced form) OR whose space-free form equals the token
+    (``Heading1`` -> ``Heading 1``). Exactly one candidate -> use it. **More than one ->
+    ambiguous** (e.g. a literal ``Heading1`` coexisting with built-in ``Heading 1``); fail safe
+    to ``Standard`` instead of silently picking one. No candidate -> case-insensitive resolve,
+    then ``Standard``. The ambiguity gate runs BEFORE any exact-name shortcut so a colliding
+    token can never silently land on the wrong style (per docs/html_style_model_plan.md)."""
+    from plugin.writer.content import _resolve_style_name
+
+    if fam is not None:
+        candidates = []
+        try:
+            for name in fam.getElementNames():
+                if name == token or xhtml_post.compact_lo_style_name(name) == token:
+                    if name not in candidates:
+                        candidates.append(name)
+        except Exception:
+            candidates = []
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            log.debug("data-lo-style: token %r is ambiguous across %r; falling back to Standard",
+                      token, candidates)
+            return "Standard"
+    resolved = _resolve_style_name(model, token)
+    if fam is None or fam.hasByName(resolved):
+        return resolved
+    return "Standard"
+
+
+def _apply_block_lo_styles(model, text_obj, start_idx, styles):
+    """Apply each block's data-lo-style to the inserted paragraphs (positionally), starting at
+    paragraph index *start_idx*. Reuses apply_paragraph_style_preserving_direct_char so the
+    named style is applied first and the import's inline char overrides survive on top.
+    Compact tokens (``Heading1``) are resolved to UNO names; unknown styles fall back to
+    'Standard' (per the style-model plan)."""
+    try:
+        fam = model.getStyleFamilies().getByName("ParagraphStyles")
+    except Exception:
+        fam = None
+    # Collect the target paragraphs (from start_idx, at most len(styles)) before mutating.
+    paras = []
+    try:
+        e = text_obj.createEnumeration()
+    except Exception:
+        return
+    i = 0
+    guard = 0
+    while e.hasMoreElements() and guard < 200000 and len(paras) < len(styles):
+        guard += 1
+        try:
+            el = e.nextElement()
+        except Exception:
+            break
+        if not (hasattr(el, "supportsService") and el.supportsService("com.sun.star.text.Paragraph")):
+            continue
+        if i >= start_idx:
+            paras.append(el)
+        i += 1
+    for para_el, style in zip(paras, styles):
+        if not style:
+            continue
+        resolved = _resolve_paragraph_style_token(model, fam, style)
+        try:
+            cur = text_obj.createTextCursorByRange(para_el.getStart())
+            cur.gotoEndOfParagraph(True)
+            apply_paragraph_style_preserving_direct_char(model, cur, resolved)
+        except Exception:
+            log.debug("data-lo-style: failed to apply %r", style, exc_info=True)
 
 
 def _wrap_html_fragment(html_content, extra_css=None):
@@ -341,13 +578,19 @@ def _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc
         if not added_any:
             return ""
 
-        filter_name, _ = _get_format_props(config_svc)
-        with _with_temp_buffer(None, config_svc) as (path, file_url):
-            props = (_create_property_value("FilterName", filter_name),)
-            temp_doc.storeToURL(file_url, props)
-            with open(path, "r", encoding="utf-8", errors="replace") as f:
-                content = f.read()
-        content = _strip_html_boilerplate(content)
+        try:
+            xhtml = _export_xhtml(temp_doc, config_svc)
+            parents = _autostyle_parents(temp_doc, config_svc)
+            content = xhtml_post.xhtml_to_semantic_html(xhtml, parents)
+        except Exception:
+            log.exception("_range_to_content_via_temp_doc (XHTML) failed; falling back to StarWriter")
+            filter_name, _ = _get_format_props(config_svc)
+            with _with_temp_buffer(None, config_svc) as (path, file_url):
+                props = (_create_property_value("FilterName", filter_name),)
+                temp_doc.storeToURL(file_url, props)
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    content = f.read()
+            content = _strip_html_boilerplate(content)
         if max_chars and len(content) > max_chars:
             content = content[:max_chars] + "\n\n[... truncated ...]"
         return content
@@ -391,7 +634,18 @@ def document_to_content(model, ctx, services, max_chars=None, scope="full", rang
         end = min(end, doc_len)
         return _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc)
 
-    # scope == "full"
+    # scope == "full" — preferred: XHTML (+ flat-ODF parent map) -> semantic data-lo-style.
+    try:
+        xhtml = _export_xhtml(model, config_svc)
+        parents = _autostyle_parents(model, config_svc)
+        content = xhtml_post.xhtml_to_semantic_html(xhtml, parents)
+        if max_chars and len(content) > max_chars:
+            content = content[:max_chars] + "\n\n[... truncated ...]"
+        return content
+    except Exception:
+        log.exception("document_to_content (full, XHTML) failed; falling back to StarWriter")
+
+    # Fallback: legacy StarWriter export (so reads never hard-fail).
     try:
         filter_name, _ = _get_format_props(config_svc)
         with _with_temp_buffer(None, config_svc) as (path, file_url):
@@ -496,16 +750,55 @@ def _insert_mixed_html_and_math_at_cursor(model, ctx, cursor, unescaped: str, co
             log.debug("math import failed: %s snippet=%r", res.error_message, snippet)
 
 
-def _insert_mixed_or_plain_html(model, ctx, cursor, unescaped_content, config_svc=None):
-    """HTML import, with an optional MathML + TeX preprocessing layer."""
-    if html_fragment_contains_mixed_math(unescaped_content):
-        _insert_mixed_html_and_math_at_cursor(model, ctx, cursor, unescaped_content, config_svc=config_svc)
+def _insert_mixed_or_plain_html(model, ctx, cursor, unescaped_content, config_svc=None, apply_styles=True):
+    """HTML import (optional MathML + TeX layer).
+
+    data-lo-style paragraph styling is applied via UNO after the import only when *apply_styles*
+    is True (target=full_document). For insert/replace targets it is False: the StarWriter import
+    merges the first inserted block into the cursor's EXISTING paragraph, so applying the named
+    style there would restyle the pre-existing text (corruption). On those paths we still strip
+    data-lo-style (clean import) but do not apply it — styled writes go through full_document, or
+    use apply_style to (re)style existing text. (Targeted styled inserts are a future follow-up.)
+    """
+    # Strip data-lo-style so the StarWriter import sees clean markup (it drops unknown attributes
+    # anyway); we re-apply the named styles via UNO afterwards only when apply_styles is True.
+    clean, block_styles = _extract_block_lo_styles(unescaped_content)
+    styled = apply_styles and any(block_styles)
+    text_obj = cursor.getText()
+    # Index of the paragraph where the inserted block content begins (computed pre-import).
+    # The first imported block MERGES into the paragraph that contains the cursor when the
+    # cursor is not at a paragraph boundary (target=end/search/selection). So count paragraphs
+    # strictly before the cursor's *paragraph* (not the cursor position) — otherwise the applied
+    # styles shift by one. (For full_document the cursor is already at the paragraph start.)
+    start_idx = 0
+    if styled:
+        ref = cursor.getStart()
+        try:
+            para_cur = text_obj.createTextCursorByRange(cursor.getStart())
+            para_cur.gotoStartOfParagraph(False)
+            ref = para_cur.getStart()
+        except Exception:
+            pass
+        start_idx = _count_preceding_paras(text_obj, ref)
+
+    if html_fragment_contains_mixed_math(clean):
+        _insert_mixed_html_and_math_at_cursor(model, ctx, cursor, clean, config_svc=config_svc)
     else:
         # Expand literal \n and \t for plain HTML without math
-        unescaped_content = unescaped_content.replace("\\n", "\n").replace("\\t", "\t")
+        expanded = clean.replace("\\n", "\n").replace("\\t", "\t")
+        single = _ensure_html_linebreaks(expanded)
+        if not styled:
+            _insert_starwriter_html_at_cursor(model, cursor, single, config_svc=config_svc)
+            return
+        # model=None: keep the cursor at the end of the inserted content.
+        insert_html_fragment_at_cursor(cursor, single, wrap=False, config_svc=config_svc, model=None)
 
-        single = _ensure_html_linebreaks(unescaped_content)
-        _insert_starwriter_html_at_cursor(model, cursor, single, config_svc=config_svc)
+    if styled:
+        try:
+            _apply_block_lo_styles(model, text_obj, start_idx, block_styles)
+        except Exception:
+            log.debug("data-lo-style application failed", exc_info=True)
+        _cursor_goto_document_end(model, cursor)
 
 
 def insert_content_at_position(model, ctx, content, position, config_svc=None):
@@ -537,7 +830,9 @@ def insert_content_at_position(model, ctx, content, position, config_svc=None):
     else:
         raise ToolExecutionError("Unknown position: %s" % position)
 
-    _insert_mixed_or_plain_html(model, ctx, cursor, content, config_svc=config_svc)
+    # apply_styles=False: inserting next to existing text merges the first block into it, so the
+    # named style would restyle that text. Styled paragraph writes go through full_document.
+    _insert_mixed_or_plain_html(model, ctx, cursor, content, config_svc=config_svc, apply_styles=False)
 
 
 def replace_full_document(model, ctx, content, config_svc=None):
@@ -596,7 +891,9 @@ def replace_single_range_with_content(model, text_range, content, ctx, config_sv
         except Exception:
             log.debug("replace_single_range_with_content: could not restore ParaStyleName", exc_info=True)
     else:
-        _insert_mixed_or_plain_html(model, ctx, cursor, prepared, config_svc=config_svc)
+        # apply_styles=False: a search/replace splits the matched paragraph, so applying a
+        # data-lo-style here would restyle the surrounding text. Styled writes use full_document.
+        _insert_mixed_or_plain_html(model, ctx, cursor, prepared, config_svc=config_svc, apply_styles=False)
 
 
 # ---------------------------------------------------------------------------

--- a/plugin/writer/xhtml_style_postprocess.py
+++ b/plugin/writer/xhtml_style_postprocess.py
@@ -1,278 +1,295 @@
 # WriterAgent - AI Writing Assistant for LibreOffice
-# Copyright (c) 2024 John Balis
-# Copyright (c) 2026 KeithCu (modifications and relicensing)
+# Copyright (c) 2026 KeithCu
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-"""Pure-string post-processing for XHTML Writer File export (semantic style model)."""
-
-from __future__ import annotations
-
-import html as html_mod
-import logging
+#
+# Pure string/CSS post-processing of LibreOffice "XHTML Writer File" output into the
+# agent-facing semantic HTML described in docs/html_style_model_plan.md (read path):
+#   - named paragraph styles  -> data-lo-style="<compact token>" (no spaces: "Heading1")
+#   - direct character overrides (text-* synthetic classes) -> inline style="..."
+#   - synthetic paragraph-* autostyle classes (P1, P2, ...) -> resolved by CSS fingerprint
+#     against the named paragraph rules, or omitted when not uniquely resolvable.
+# No UNO / no model access — this is the string pipeline the plan mandates over a model walk.
+import html as _html
 import re
-from typing import Any
+from html.parser import HTMLParser
 
-log = logging.getLogger("writeragent.writer")
+# Block tags that carry a paragraph style (read) and that produce exactly one paragraph on
+# import (write, where each consumes one positional data-lo-style slot). NOTE: <div> is
+# deliberately EXCLUDED — LibreOffice never emits a paragraph style on a <div>, and on write a
+# <div> is a transparent container (not its own paragraph). Treating it as a styleable block
+# desynced styles (read/write asymmetry); keeping it out makes both paths agree.
+BLOCK_TAGS = {"p", "h1", "h2", "h3", "h4", "h5", "h6", "li", "blockquote", "pre"}
 
-_AUTOSTYLE_PARA_RE = re.compile(r"^P\d+$", re.IGNORECASE)
-_CSS_RULE_RE = re.compile(
-    r"\.(paragraph-[A-Za-z0-9_]+|text-[A-Za-z0-9_]+)\s*\{([^}]*)\}",
-    re.IGNORECASE,
+_AUTOSTYLE_RE = re.compile(r"^P\d+$")
+_STYLE_BLOCK_RE = re.compile(r"<style[^>]*>(.*?)</style>", re.DOTALL | re.IGNORECASE)
+_RULE_RE = re.compile(r"\.([A-Za-z0-9_\-]+)\s*\{([^}]*)\}")
+_BODY_RE = re.compile(r"<body[^>]*>(.*)</body>", re.DOTALL | re.IGNORECASE)
+_PARA_CLASS_RE = re.compile(r"\bparagraph-[A-Za-z0-9_\-]+")
+_TRAILING_EMPTY_P_RE = re.compile(
+    r"\s*<p\b[^>]*>(?:\s|&nbsp;|&#160;|&#xa0;| )*</p>\s*$", re.IGNORECASE
 )
-_CLASS_ATTR_RE = re.compile(r'\bclass=(["\'])(.*?)\1', re.IGNORECASE)
-_DATA_LO_STYLE_RE = re.compile(
-    r'\bdata-lo-style=(["\'])(.*?)\1',
-    re.IGNORECASE,
-)
-_BLOCK_WITH_DATA_LO_STYLE_RE = re.compile(
-    r"<(p|div|h[1-6]|blockquote|li)\b([^>]*)\bdata-lo-style=(['\"])(.*?)\3",
-    re.IGNORECASE,
-)
-_STYLE_BLOCK_RE = re.compile(r"<style\b[^>]*>(.*?)</style>", re.IGNORECASE | re.DOTALL)
 
 
-def decode_lo_css_class_suffix(suffix: str) -> str:
-    """Reverse ODF URL encoding in CSS class suffixes (_20_ → space, etc.)."""
-    if not suffix:
-        return suffix
-    return re.sub(
-        r"_([0-9a-fA-F]{2})_",
-        lambda m: chr(int(m.group(1), 16)),
-        suffix,
-    )
+def decode_lo_css_class_suffix(suffix):
+    """Reverse ODF URL-style encoding in a CSS class suffix (``Heading_20_1`` -> ``Heading 1``)."""
+    return re.sub(r"_([0-9a-fA-F]{2})_", lambda m: chr(int(m.group(1), 16)), suffix)
 
 
-def _normalize_css_decl(decl: str) -> str:
-    return re.sub(r"\s+", " ", (decl or "").strip())
+def compact_lo_style_name(uno_name):
+    """Agent-facing token: drop spaces (``Heading 1`` -> ``Heading1``)."""
+    return uno_name.replace(" ", "")
 
 
-def extract_css_rule_map(xhtml: str) -> dict[str, str]:
-    """Map CSS class name (without dot) to normalized declaration text."""
-    rules: dict[str, str] = {}
-    for m in _CSS_RULE_RE.finditer(xhtml or ""):
-        rules[m.group(1)] = _normalize_css_decl(m.group(2))
-    return rules
+_FODT_STYLE_RE = re.compile(r"<style:style\b([^>]*?)/?>", re.IGNORECASE)
 
 
-def _paragraph_class_token(class_token: str) -> str | None:
-    if class_token.startswith("paragraph-"):
-        return class_token
-    return None
-
-
-def _is_autostyle_paragraph_class(class_token: str) -> bool:
-    suffix = class_token[len("paragraph-") :]
-    return bool(_AUTOSTYLE_PARA_RE.match(suffix))
-
-
-def resolve_paragraph_style_from_class(
-    class_token: str,
-    css_rules: dict[str, str],
-) -> str | None:
-    """Map a paragraph-* export class to a UNO ParaStyleName, or None to omit."""
-    if not class_token or not class_token.startswith("paragraph-"):
-        return None
-    suffix = class_token[len("paragraph-") :]
-    if not _AUTOSTYLE_PARA_RE.match(suffix):
-        return decode_lo_css_class_suffix(suffix)
-
-    auto_decl = css_rules.get(class_token)
-    if not auto_decl:
-        return None
-
-    named_matches: list[str] = []
-    for cls, decl in css_rules.items():
-        if not cls.startswith("paragraph-") or _is_autostyle_paragraph_class(cls):
+def extract_autostyle_parents_from_fodt(fodt):
+    """Map automatic paragraph style name (``P1``, ``P2``, ...) -> its parent named style, from a
+    flat ODF (.fodt) export. The XHTML export flattens this parent away, so an autostyle's CSS
+    often matches no named rule (the common case after a StarWriter HTML import); the flat ODF
+    keeps ``style:parent-style-name``, and the automatic style name (``Pn``) is identical to the
+    XHTML ``paragraph-Pn`` class suffix — a reliable, order-independent join. Parent values may
+    still be ODF-encoded (``Text_20_body``); decode at use via ``decode_lo_css_class_suffix``.
+    """
+    out = {}
+    for m in _FODT_STYLE_RE.finditer(fodt or ""):
+        attrs = m.group(1)
+        fam = re.search(r'style:family="([^"]*)"', attrs)
+        if not fam or fam.group(1) != "paragraph":
             continue
-        if decl == auto_decl:
-            named_matches.append(decode_lo_css_class_suffix(cls[len("paragraph-") :]))
-
-    if len(named_matches) == 1:
-        return named_matches[0]
-    if len(named_matches) > 1:
-        log.debug(
-            "resolve_paragraph_style_from_class: ambiguous fingerprint for %s matches %s",
-            class_token,
-            named_matches,
-        )
-    return None
+        name = re.search(r'style:name="([^"]*)"', attrs)
+        parent = re.search(r'style:parent-style-name="([^"]*)"', attrs)
+        if name and parent and _AUTOSTYLE_RE.match(name.group(1)):
+            # XML attribute values are entity-escaped (a style named "A & B" -> "A &amp; B").
+            out[name.group(1)] = _html.unescape(parent.group(1))
+    return out
 
 
-def _merge_inline_style(existing: str | None, added: str) -> str:
-    existing = (existing or "").strip()
-    added = added.strip().rstrip(";")
-    if not existing:
-        return added + ";" if added else ""
-    if not added:
-        return existing if existing.endswith(";") else existing + ";"
-    base = existing.rstrip(";")
-    return base + "; " + added + ";"
+def _clean_decl_ordered(decl):
+    """Cleaned declaration, original order preserved, no trailing ``;`` (for inlining)."""
+    parts = [p.strip() for p in decl.split(";") if p.strip()]
+    return "; ".join(parts)
 
 
-def _inline_text_autostyle_classes(html_fragment: str, css_rules: dict[str, str]) -> str:
-    """Replace text-* classes with inline style from the export stylesheet."""
+def _normalize_decl(decl):
+    """Order-independent fingerprint of a declaration set (for autostyle matching)."""
+    parts = [p.strip() for p in decl.split(";") if p.strip()]
+    return ";".join(sorted(parts))
 
-    def _replace_tag(match: re.Match[str]) -> str:
-        tag = match.group(1)
-        before = match.group(2)
-        quote = match.group(3)
-        class_val = match.group(4)
-        after = match.group(5)
-        tokens = class_val.split()
-        kept: list[str] = []
-        inline = ""
-        for token in tokens:
-            if token.startswith("text-") and token in css_rules:
-                inline = _merge_inline_style(inline, css_rules[token])
-            else:
-                kept.append(token)
-        attrs = before + after
-        if kept:
-            attrs = _CLASS_ATTR_RE.sub("", attrs, count=1)
-            attrs = attrs.strip()
-            class_attr = ' class="%s"' % " ".join(kept)
+
+def parse_style_block(xhtml):
+    """Return ``(raw_map, norm_map)`` for every class rule in the ``<style>`` block(s).
+
+    ``raw_map[class] = "decl; decl"`` (order preserved) is used to inline char overrides;
+    ``norm_map[class] = "decl;decl"`` (sorted) is used to fingerprint autostyles.
+    """
+    raw_map = {}
+    norm_map = {}
+    for block in _STYLE_BLOCK_RE.findall(xhtml or ""):
+        for name, decl in _RULE_RE.findall(block):
+            raw_map[name] = _clean_decl_ordered(decl)
+            norm_map[name] = _normalize_decl(decl)
+    return raw_map, norm_map
+
+
+def _strip_body(xhtml):
+    """Return the inner HTML of ``<body>`` (or the input unchanged if there is no body)."""
+    m = _BODY_RE.search(xhtml or "")
+    return m.group(1).strip() if m else (xhtml or "")
+
+
+def _drop_trailing_empty_paragraphs(html):
+    """Drop whitespace/``&nbsp;``-only ``<p>`` blocks at the very end (LO export ghost paras)."""
+    while True:
+        new = _TRAILING_EMPTY_P_RE.sub("", html)
+        if new == html:
+            return html
+        html = new
+
+
+def _inject_attr(start_tag, attr):
+    """Insert *attr* (e.g. ``' data-lo-style="X"'``) just before the closing ``>`` of a tag."""
+    if start_tag.endswith("/>"):
+        return start_tag[:-2].rstrip() + attr + "/>"
+    if start_tag.endswith(">"):
+        return start_tag[:-1].rstrip() + attr + ">"
+    return start_tag + attr
+
+
+def _attr_value(attrs, key):
+    for k, v in attrs:
+        if k == key:
+            return v or ""
+    return ""
+
+
+class _SemanticTransformer(HTMLParser):
+    """Rewrite LO XHTML body into the agent-facing semantic HTML.
+
+    Top-level paragraph blocks get ``data-lo-style="<compact token>"`` (named styles only;
+    autostyles resolved by CSS fingerprint or omitted). Char overrides (``text-*`` classes)
+    are inlined as ``style="..."``. Inside ``<table>`` the synthetic ``paragraph-*`` class is
+    stripped (no leak) but no ``data-lo-style`` is emitted — cell styles are out of scope for
+    v1 round-trip. Tags are re-emitted verbatim via ``get_starttag_text()``; only the
+    attributes we change are rewritten with string ops.
+    """
+
+    def __init__(self, raw_map, norm_map, autostyle_parents=None):
+        super().__init__(convert_charrefs=False)
+        self._raw = raw_map
+        self._autostyle_parents = autostyle_parents or {}
+        # Map a named paragraph rule's fingerprint -> list of its compact tokens.
+        self._named_fingerprint = {}
+        # Map a compact token -> set of distinct UNO names that compact to it. When more than
+        # one named style produces the same token (e.g. "Heading 1" and a literal "Heading1"),
+        # the token is AMBIGUOUS and must not be emitted — see _colliding_tokens below.
+        token_names = {}
+        for cls, norm in norm_map.items():
+            if not cls.startswith("paragraph-"):
+                continue
+            suffix = cls[len("paragraph-"):]
+            if _AUTOSTYLE_RE.match(suffix):
+                continue
+            name = decode_lo_css_class_suffix(suffix)
+            token = compact_lo_style_name(name)
+            self._named_fingerprint.setdefault(norm, []).append(token)
+            token_names.setdefault(token, set()).add(name)
+        # Tokens produced by >1 distinct named style collide: the write path could not tell
+        # them apart, so we omit (write treats a missing token as the default body style)
+        # rather than emit a token that would silently resolve to the wrong style.
+        self._colliding_tokens = {t for t, names in token_names.items() if len(names) > 1}
+        self._norm = norm_map
+        self._table_depth = 0
+        self._out = []
+
+    def _paragraph_token(self, suffix):
+        """Compact ``data-lo-style`` token for a ``paragraph-<suffix>`` class, or ``None``.
+
+        For autostyles (``paragraph-Pn``) the flat-ODF parent map (when supplied) is
+        authoritative: the XHTML export flattens the parent away, so the autostyle CSS often
+        matches no named rule (the common case after a StarWriter HTML import), but the .fodt
+        export keeps the parent and ``Pn`` is the same name in both exports — so the real style
+        name is recovered. CSS fingerprint is the fallback when there is no FODT map.
+
+        KNOWN LIMITATION (v1): the whole-paragraph DIRECT *overrides* themselves (alignment,
+        margins, whole-paragraph colour baked into the autostyle CSS) are still dropped — only
+        the style NAME is recovered, and character-level overrides survive via inline ``text-*``
+        spans. Whole-paragraph Para* overrides do not round-trip (the write path cannot restore
+        Para* when applying a named style).
+        """
+        if _AUTOSTYLE_RE.match(suffix):
+            # Authoritative: the flat-ODF parent of this autostyle (Pn -> named base).
+            parent = self._autostyle_parents.get(suffix)
+            if parent:
+                token = compact_lo_style_name(decode_lo_css_class_suffix(parent))
+                if token not in self._colliding_tokens:
+                    return token
+            # Fallback: resolve by CSS fingerprint against named rules.
+            norm = self._norm.get("paragraph-" + suffix)
+            matches = self._named_fingerprint.get(norm) if norm else None
+            if matches and len(matches) == 1 and matches[0] not in self._colliding_tokens:
+                return matches[0]
+            return None  # not uniquely resolvable -> omit (write treats absence as body)
+        token = compact_lo_style_name(decode_lo_css_class_suffix(suffix))
+        if token in self._colliding_tokens:
+            return None  # ambiguous compact token -> omit (Issue 2)
+        return token
+
+    def _rewrite_block(self, raw, attrs):
+        classes = _attr_value(attrs, "class")
+        para_classes = _PARA_CLASS_RE.findall(classes)
+        token = None
+        if para_classes and self._table_depth == 0:
+            suffix = para_classes[0][len("paragraph-"):]
+            token = self._paragraph_token(suffix)
+        # Strip every paragraph-* class (top-level or cell) so it never leaks to the agent.
+        raw = _strip_class_names(raw, _PARA_CLASS_RE)
+        if token:
+            raw = _inject_attr(raw, ' data-lo-style="%s"' % token)
+        return raw
+
+    def _rewrite_span(self, raw, attrs):
+        classes = _attr_value(attrs, "class")
+        names = classes.split()
+        text_names = [c for c in names if c.startswith("text-")]
+        if not text_names:
+            return raw
+        css_parts = [self._raw[c] for c in text_names if c in self._raw]
+        remaining = [c for c in names if not c.startswith("text-")]
+        raw = re.sub(r'\s+class="[^"]*"', "", raw)
+        raw = re.sub(r"\s+class='[^']*'", "", raw)
+        ins = ""
+        if css_parts:
+            ins += ' style="%s"' % "; ".join(css_parts)
+        if remaining:
+            ins += ' class="%s"' % " ".join(remaining)
+        return _inject_attr(raw, ins) if ins else raw
+
+    def handle_starttag(self, tag, attrs):
+        raw = self.get_starttag_text() or ("<%s>" % tag)
+        t = tag.lower()
+        if t == "table":
+            self._table_depth += 1
+            self._out.append(raw)
+        elif t in BLOCK_TAGS:
+            self._out.append(self._rewrite_block(raw, attrs))
+        elif t == "span":
+            self._out.append(self._rewrite_span(raw, attrs))
         else:
-            attrs = _CLASS_ATTR_RE.sub("", attrs, count=1).strip()
-            class_attr = ""
-        style_match = _DATA_LO_STYLE_RE  # noqa: F841 — placeholder to avoid shadow; use inline style re
-        style_re = re.compile(r'\bstyle=(["\'])(.*?)\1', re.IGNORECASE)
-        sm = style_re.search(attrs)
-        if inline:
-            if sm:
-                merged = _merge_inline_style(sm.group(2), inline.rstrip(";"))
-                attrs = style_re.sub('style=%s%s%s' % (sm.group(1), merged, sm.group(1)), attrs, count=1)
-            else:
-                attrs = (attrs + ' style="%s"' % html_mod.escape(inline, quote=True)).strip()
-        attrs = re.sub(r"\s+", " ", attrs).strip()
-        if attrs:
-            return "<%s %s%s>%s" % (tag, attrs, class_attr, match.group(6))
-        if class_attr:
-            return "<%s%s>%s" % (tag, class_attr, match.group(6))
-        return "<%s>%s" % (tag, match.group(6))
+            self._out.append(raw)
 
-    tag_re = re.compile(
-        r"<(span|font)\b([^>]*)\bclass=(['\"])(.*?)\3([^>]*)>(.*?)</\1>",
-        re.IGNORECASE | re.DOTALL,
-    )
-    return tag_re.sub(_replace_tag, html_fragment)
+    def handle_startendtag(self, tag, attrs):
+        self._out.append(self.get_starttag_text() or ("<%s/>" % tag))
 
+    def handle_endtag(self, tag):
+        if tag.lower() == "table" and self._table_depth > 0:
+            self._table_depth -= 1
+        self._out.append("</%s>" % tag)
 
-def _transform_paragraph_tag(match: re.Match[str], css_rules: dict[str, str]) -> str:
-    tag = match.group(1)
-    attrs = match.group(2)
-    cm = _CLASS_ATTR_RE.search(attrs)
-    if not cm:
-        return match.group(0)
-    tokens = cm.group(2).split()
-    para_tokens = [t for t in tokens if t.startswith("paragraph-")]
-    other_tokens = [t for t in tokens if not t.startswith("paragraph-")]
-    style_name = None
-    for pt in para_tokens:
-        resolved = resolve_paragraph_style_from_class(pt, css_rules)
-        if resolved:
-            style_name = resolved
-            break
-    new_attrs = _CLASS_ATTR_RE.sub("", attrs, count=1).strip()
-    if style_name:
-        if _DATA_LO_STYLE_RE.search(new_attrs):
-            new_attrs = _DATA_LO_STYLE_RE.sub("", new_attrs).strip()
-        new_attrs = (new_attrs + ' data-lo-style="%s"' % html_mod.escape(style_name, quote=True)).strip()
-    if other_tokens:
-        new_attrs = (new_attrs + ' class="%s"' % " ".join(other_tokens)).strip()
-    new_attrs = re.sub(r"\s+", " ", new_attrs).strip()
-    if new_attrs:
-        return "<%s %s>%s" % (tag, new_attrs, match.group(3))
-    return "<%s>%s" % (tag, match.group(3))
+    def handle_data(self, data):
+        self._out.append(data)
+
+    def handle_entityref(self, name):
+        self._out.append("&%s;" % name)
+
+    def handle_charref(self, name):
+        self._out.append("&#%s;" % name)
+
+    def handle_comment(self, data):
+        self._out.append("<!--%s-->" % data)
+
+    def result(self):
+        return "".join(self._out)
 
 
-def transform_paragraph_tags(html_fragment: str, css_rules: dict[str, str]) -> str:
-    para_re = re.compile(r"<(p|div|h[1-6]|blockquote|li)\b([^>]*)>(.*?)</\1>", re.IGNORECASE | re.DOTALL)
+def _strip_class_names(start_tag, name_re):
+    """Remove class names matching *name_re* from a start tag; drop the attr if it empties."""
+    def _sub(m):
+        kept = [c for c in m.group(2).split() if not name_re.fullmatch(c)]
+        return (" class=%s%s%s" % (m.group(1), " ".join(kept), m.group(1))) if kept else ""
 
-    def _sub(m: re.Match[str]) -> str:
-        return _transform_paragraph_tag(m, css_rules)
-
-    return para_re.sub(_sub, html_fragment)
-
-
-def postprocess_xhtml_export(xhtml: str) -> str:
-    """Convert XHTML Writer File export to agent-facing HTML with data-lo-style."""
-    if not xhtml or not isinstance(xhtml, str):
-        return xhtml
-    css_rules = extract_css_rule_map(xhtml)
-    body_match = re.search(r"<body[^>]*>(.*?)</body>", xhtml, re.DOTALL | re.IGNORECASE)
-    if not body_match:
-        return xhtml
-    body = body_match.group(1)
-    body = _inline_text_autostyle_classes(body, css_rules)
-    body = transform_paragraph_tags(body, css_rules)
-    return body.strip()
+    return re.sub(r'\s+class=(["\'])(.*?)\1', _sub, start_tag)
 
 
-def collect_data_lo_styles(html: str) -> tuple[str, list[str | None]]:
-    """Strip data-lo-style from block tags; return cleaned HTML and styles in document order."""
-    styles: list[str | None] = []
+def xhtml_to_semantic_html(full_xhtml, autostyle_parents=None):
+    """Convert raw LO ``XHTML Writer File`` output to the agent-facing semantic HTML.
 
-    def _repl(m: re.Match[str]) -> str:
-        styles.append(m.group(4))
-        attrs = m.group(2)
-        attrs = _DATA_LO_STYLE_RE.sub("", attrs)
-        attrs = re.sub(r"\s+", " ", attrs).strip()
-        if attrs:
-            return "<%s %s>" % (m.group(1), attrs)
-        return "<%s>" % m.group(1)
+    Single entry point: parse the ``<style>`` block, extract the body, inline char overrides,
+    emit ``data-lo-style`` compact tokens for named paragraph styles, drop trailing ghost
+    paragraphs. Pure string work — fully unit-testable without LibreOffice.
 
-    cleaned = _BLOCK_WITH_DATA_LO_STYLE_RE.sub(_repl, html or "")
-    return cleaned, styles
-
-
-def count_body_paragraphs(doc) -> int:
-    """Count paragraph elements in the document body text."""
-    count = 0
-    enum = doc.getText().createEnumeration()
-    while enum.hasMoreElements():
-        el = enum.nextElement()
-        if hasattr(el, "getString"):
-            count += 1
-    return count
-
-
-def apply_paragraph_styles_in_order(doc, style_names: list[str | None], skip: int = 0) -> None:
-    """Apply collected data-lo-style names to body paragraphs in order."""
-    from .format import apply_paragraph_style_preserving_direct_char
-
-    if not style_names:
-        return
-    text = doc.getText()
-    enum = text.createEnumeration()
-    style_idx = 0
-    skipped = 0
-    while enum.hasMoreElements() and style_idx < len(style_names):
-        el = enum.nextElement()
-        if not hasattr(el, "getString"):
-            continue
-        if skipped < skip:
-            skipped += 1
-            continue
-        name = style_names[style_idx]
-        style_idx += 1
-        if not name:
-            continue
-        try:
-            cursor = text.createTextCursorByRange(el.getStart())
-            apply_paragraph_style_preserving_direct_char(doc, cursor, name)
-        except Exception:
-            log.debug("apply_paragraph_styles_in_order: could not apply %r", name, exc_info=True)
-
-
-def preprocess_html_for_import(html: str) -> tuple[str, list[str | None]]:
-    """Prepare agent HTML for StarWriter import; return HTML and paragraph styles to apply after."""
-    cleaned, styles = collect_data_lo_styles(html)
-    return cleaned, styles
-
-
-def apply_data_lo_styles_after_import(doc, styles: list[str | None], paragraph_offset: int = 0) -> None:
-    """Apply paragraph styles collected from data-lo-style attributes."""
-    apply_paragraph_styles_in_order(doc, styles, skip=paragraph_offset)
+    *autostyle_parents* (from ``extract_autostyle_parents_from_fodt`` on a paired flat-ODF
+    export) lets autostyle paragraphs recover their real style name even when the XHTML CSS
+    fingerprint matches nothing — the common case after a StarWriter HTML import (write→read).
+    """
+    raw_map, norm_map = parse_style_block(full_xhtml)
+    body = _strip_body(full_xhtml)
+    tr = _SemanticTransformer(raw_map, norm_map, autostyle_parents)
+    tr.feed(body)
+    tr.close()
+    out = _drop_trailing_empty_paragraphs(tr.result())
+    return out.strip()

--- a/tests/writer/test_content_style_model_uno.py
+++ b/tests/writer/test_content_style_model_uno.py
@@ -1,0 +1,355 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# get_document_content embeds the paragraph style model in the HTML: each named-style block
+# carries a COMPACT data-lo-style token (no spaces: "Heading1"), direct char overrides are
+# inlined as style="..." (no synthetic classes leak), and synthetic autostyle paragraphs are
+# omitted (write treats a missing token as the default body style). Read path = XHTML Writer
+# File filter + pure string post-process; write path resolves compact tokens -> UNO names.
+# See docs/html_style_model_plan.md.
+import uno  # noqa: F401
+from com.sun.star.text.ControlCharacter import PARAGRAPH_BREAK
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.tests.testing_utils import TestingFactory
+from plugin.writer.content import ApplyDocumentContent
+import plugin.writer.format as fmt
+
+_doc = None
+_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _doc, _ctx
+    _ctx = ctx
+    _doc = TestingFactory.create_native_doc(ctx, doc_type="writer", hidden=True)
+
+
+@teardown
+def my_teardown(ctx):
+    global _doc
+    if _doc:
+        _doc.close(True)
+    _doc = None
+
+
+def _tool_ctx():
+    return TestingFactory.create_context(doc=_doc, ctx=_ctx, env="native")
+
+
+def _para_style_names():
+    text = _doc.getText()
+    out = []
+    e = text.createEnumeration()
+    while e.hasMoreElements():
+        el = e.nextElement()
+        if hasattr(el, "supportsService") and el.supportsService("com.sun.star.text.Paragraph"):
+            out.append(el.getPropertyValue("ParaStyleName"))
+    return out
+
+
+# --- Read path: named styles -> compact data-lo-style tokens ---------------
+
+@native_test
+def test_read_named_styles_emit_compact_tokens_uno():
+    doc = _doc
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.setPropertyValue("ParaStyleName", "Heading 1")
+    text.insertString(cur, "Big Title", False)
+    text.insertControlCharacter(cur, PARAGRAPH_BREAK, False)
+    cur.setPropertyValue("ParaStyleName", "Caption")
+    text.insertString(cur, "Figure 1 caption", False)
+    text.insertControlCharacter(cur, PARAGRAPH_BREAK, False)
+    cur.setPropertyValue("ParaStyleName", "Standard")
+    cur.setPropertyValue("CharColor", -1)
+    text.insertString(cur, "normal ", False)
+    cur.setPropertyValue("CharColor", 0xFF0000)
+    text.insertString(cur, "RED", False)
+    cur.setPropertyValue("CharColor", -1)
+    text.insertString(cur, " end", False)
+
+    content = fmt.document_to_content(doc, _ctx, None, scope="full")
+
+    # Named styles surfaced as COMPACT (space-free) tokens.
+    assert 'data-lo-style="Heading1"' in content, content
+    assert 'data-lo-style="Caption"' in content, content
+    # Direct char override inlined; no synthetic classes leak.
+    assert "ff0000" in content.lower(), content
+    assert "text-T" not in content, content
+    assert "paragraph-" not in content, content
+
+
+@native_test
+def test_read_order_survives_table_uno():
+    """A table between two paragraphs must not desync style assignment, and cells must not leak."""
+    doc = _doc
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.setPropertyValue("ParaStyleName", "Heading 2")
+    text.insertString(cur, "Before table", False)
+    text.insertControlCharacter(cur, PARAGRAPH_BREAK, False)
+
+    table = doc.createInstance("com.sun.star.text.TextTable")
+    table.initialize(2, 2)
+    text.insertTextContent(cur, table, False)
+
+    cur.gotoEnd(False)
+    cur.setPropertyValue("ParaStyleName", "Caption")
+    text.insertString(cur, "After table", False)
+
+    content = fmt.document_to_content(doc, _ctx, None, scope="full")
+
+    assert 'data-lo-style="Heading2"' in content, content
+    assert 'data-lo-style="Caption"' in content, content
+    i_before = content.index('data-lo-style="Heading2"')
+    i_table = content.lower().index("<table")
+    i_after = content.index('data-lo-style="Caption"')
+    assert i_before < i_table < i_after, "table desynced data-lo-style ordering: %s" % content
+    assert "paragraph-" not in content, content
+
+
+# --- Write path: apply_document_content honors compact data-lo-style -------
+
+@native_test
+def test_write_compact_token_applies_uno():
+    """Compact tokens drive the paragraph style; 'Heading2' resolves to UNO 'Heading 2'."""
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<p data-lo-style="Caption">cap</p>\n<p data-lo-style="Heading2">head</p>')
+    assert res.get("status") == "ok", res
+    names = _para_style_names()
+    assert "Caption" in names, names
+    assert "Heading 2" in names, names
+
+
+@native_test
+def test_write_compact_heading1_resolves_to_spaced_uno():
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<p data-lo-style="Heading1">title</p>')
+    assert res.get("status") == "ok", res
+    text = _doc.getText()
+    assert text.createTextCursorByRange(text.getStart()).getPropertyValue("ParaStyleName") == "Heading 1", \
+        _para_style_names()
+
+
+@native_test
+def test_write_compact_textbody_resolves_to_spaced_uno():
+    """Regression: the compact token 'Textbody' (LO name 'Text body', lowercase b) must resolve
+    to the real UNO 'Text body' — NOT fall back to Standard. Guards the prompt/code contract."""
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<p data-lo-style="Textbody">body text</p>')
+    assert res.get("status") == "ok", res
+    text = _doc.getText()
+    assert text.createTextCursorByRange(text.getStart()).getPropertyValue("ParaStyleName") == "Text body", \
+        _para_style_names()
+
+
+@native_test
+def test_write_spaced_form_still_works_uno():
+    """Back-compat: an agent that passes the spaced UNO name still resolves correctly."""
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<p data-lo-style="Heading 1">title</p>')
+    assert res.get("status") == "ok", res
+    text = _doc.getText()
+    assert text.createTextCursorByRange(text.getStart()).getPropertyValue("ParaStyleName") == "Heading 1", \
+        _para_style_names()
+
+
+@native_test
+def test_write_preserves_inline_override_uno():
+    """Applying the named style must not wipe the inline char override the import laid down."""
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<p data-lo-style="Heading1">title <span style="color: #ff0000">red</span></p>')
+    assert res.get("status") == "ok", res
+    text = _doc.getText()
+    assert text.createTextCursorByRange(text.getStart()).getPropertyValue("ParaStyleName") == "Heading 1", \
+        _para_style_names()
+    found_red = False
+    enum = text.createEnumeration()
+    while enum.hasMoreElements():
+        para = enum.nextElement()
+        if not (hasattr(para, "supportsService") and para.supportsService("com.sun.star.text.Paragraph")):
+            continue
+        pe = para.createEnumeration()
+        while pe.hasMoreElements():
+            portion = pe.nextElement()
+            try:
+                if int(portion.getPropertyValue("CharColor")) == 0xFF0000:
+                    found_red = True
+            except Exception:
+                pass
+    assert found_red, "inline red override was lost after applying data-lo-style"
+
+
+@native_test
+def test_write_unknown_token_falls_back_to_standard_uno():
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<p data-lo-style="NoSuchStyleXYZ">x</p>')
+    assert res.get("status") == "ok", res
+    assert "Standard" in _para_style_names(), _para_style_names()
+
+
+@native_test
+def test_read_write_round_trip_uno():
+    """Read a styled doc -> semantic content (compact tokens) -> write it back -> styles preserved."""
+    text = _doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.setPropertyValue("ParaStyleName", "Heading 1")
+    text.insertString(cur, "Title", False)
+    text.insertControlCharacter(cur, PARAGRAPH_BREAK, False)
+    cur.setPropertyValue("ParaStyleName", "Caption")
+    text.insertString(cur, "Cap", False)
+
+    content = fmt.document_to_content(_doc, _ctx, None, scope="full")
+    assert 'data-lo-style="Heading1"' in content, content  # compact token round-trips
+    res = ApplyDocumentContent().execute(_tool_ctx(), target="full_document", content=content)
+    assert res.get("status") == "ok", res
+    names = _para_style_names()
+    assert "Heading 1" in names, names
+    assert "Caption" in names, names
+
+
+@native_test
+def test_write_div_wrapper_does_not_desync_styles_uno():
+    """A <div> is a transparent container: it must not consume a positional style slot, so an
+    off-contract wrapper does not shift styles onto the wrong paragraphs."""
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<div><p data-lo-style="Heading1">first</p><p data-lo-style="Caption">second</p></div>')
+    assert res.get("status") == "ok", res
+    text = _doc.getText()
+    pairs = []
+    e = text.createEnumeration()
+    while e.hasMoreElements():
+        el = e.nextElement()
+        if hasattr(el, "supportsService") and el.supportsService("com.sun.star.text.Paragraph"):
+            pairs.append((el.getPropertyValue("ParaStyleName"), el.getString()))
+    by_text = {t: s for s, t in pairs}
+    assert by_text.get("first") == "Heading 1", pairs
+    assert by_text.get("second") == "Caption", pairs
+
+
+@native_test
+def test_write_ambiguous_token_falls_back_to_standard_uno():
+    """Issue 2: a literal style named 'Heading1' coexisting with built-in 'Heading 1' makes the
+    token 'Heading1' ambiguous; the resolver must fail safe to 'Standard', never silently pick
+    one of them."""
+    fam = _doc.getStyleFamilies().getByName("ParagraphStyles")
+    created = False
+    if not fam.hasByName("Heading1"):
+        st = _doc.createInstance("com.sun.star.style.ParagraphStyle")
+        fam.insertByName("Heading1", st)
+        created = True
+    try:
+        res = ApplyDocumentContent().execute(
+            _tool_ctx(), target="full_document",
+            content='<p data-lo-style="Heading1">x</p>')
+        assert res.get("status") == "ok", res
+        text = _doc.getText()
+        applied = text.createTextCursorByRange(text.getStart()).getPropertyValue("ParaStyleName")
+        assert applied == "Standard", "ambiguous token resolved to %r instead of Standard" % applied
+    finally:
+        # Restore the shared document's style set (setup/teardown are per-module).
+        if created and fam.hasByName("Heading1"):
+            fam.removeByName("Heading1")
+
+
+@native_test
+def test_write_data_lo_style_with_math_uno():
+    """A compact token must apply even when the paragraph contains math (math import branch)."""
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<p data-lo-style="Heading1">Equation \\(x^2\\) here</p>')
+    assert res.get("status") == "ok", res
+    text = _doc.getText()
+    assert text.createTextCursorByRange(text.getStart()).getPropertyValue("ParaStyleName") == "Heading 1", \
+        _para_style_names()
+
+
+@native_test
+def test_write_then_read_recovers_token_via_fodt_uno():
+    """THE round-trip proof: writing a paragraph makes the StarWriter import stamp direct char
+    props, so on re-export the paragraph is an autostyle whose XHTML CSS matches no named rule
+    (the wall). The flat-ODF parent map recovers the real style name on re-read."""
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="full_document",
+        content='<p data-lo-style="Caption">just a caption</p>')
+    assert res.get("status") == "ok", res
+    content = fmt.document_to_content(_doc, _ctx, None, scope="full")
+    # Before the FODT fix this dropped the token; now it round-trips.
+    assert 'data-lo-style="Caption"' in content, content
+    assert "paragraph-" not in content, content
+
+
+def _para_pairs():
+    text = _doc.getText()
+    out = []
+    e = text.createEnumeration()
+    while e.hasMoreElements():
+        el = e.nextElement()
+        if hasattr(el, "supportsService") and el.supportsService("com.sun.star.text.Paragraph"):
+            out.append((el.getPropertyValue("ParaStyleName"), el.getString()))
+    return out
+
+
+@native_test
+def test_write_end_does_not_restyle_existing_text_uno():
+    """data-lo-style is applied only on full_document. For target=end the first block merges into
+    the existing paragraph, so we DON'T apply the named style (it would restyle the existing
+    text). The pre-existing paragraph must stay Standard; the content is still inserted."""
+    text = _doc.getText()
+    text.setString("Existing line")
+    _baseline = text.createTextCursor()
+    _baseline.gotoStart(False)
+    _baseline.gotoEnd(True)
+    _baseline.setPropertyValue("ParaStyleName", "Standard")  # shared _doc: clear prior-test style
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="end",
+        content=['<p data-lo-style="Caption">CAPX para</p>', '<p data-lo-style="Heading2">HEADX para</p>'])
+    assert res.get("status") == "ok", res
+    pairs = _para_pairs()
+    # The pre-existing text must NOT be restyled to Caption (no corruption).
+    existing = next(s for s, t in pairs if t.startswith("Existing line"))
+    assert existing == "Standard", pairs
+    # The content was still inserted.
+    assert any("CAPX" in t for _, t in pairs), pairs
+    assert any("HEADX" in t for _, t in pairs), pairs
+
+
+@native_test
+def test_write_search_does_not_restyle_surrounding_text_uno():
+    """target=search: a replace splits the matched paragraph, so applying data-lo-style would
+    restyle the surrounding text. We don't apply on search; the surrounding text stays Standard."""
+    text = _doc.getText()
+    text.setString("MARKER tail")
+    _baseline = text.createTextCursor()
+    _baseline.gotoStart(False)
+    _baseline.gotoEnd(True)
+    _baseline.setPropertyValue("ParaStyleName", "Standard")  # shared _doc: clear prior-test style
+    res = ApplyDocumentContent().execute(
+        _tool_ctx(), target="search", old_content="MARKER",
+        content=['<p data-lo-style="Caption">CAPX</p>', '<p data-lo-style="Heading2">HEADX</p>'])
+    assert res.get("status") == "ok", res
+    pairs = _para_pairs()
+    # Nothing got restyled to Caption/Heading 2 (styles are not applied on search).
+    assert all(s not in ("Caption", "Heading 2") for s, _ in pairs), pairs
+    # The content was still inserted.
+    assert any("CAPX" in t for _, t in pairs), pairs

--- a/tests/writer/test_xhtml_style_postprocess.py
+++ b/tests/writer/test_xhtml_style_postprocess.py
@@ -1,0 +1,241 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pure pytest unit tests (no LibreOffice) for the XHTML style post-process pipeline.
+# Fixtures mirror the real "XHTML Writer File" output captured from LibreOffice.
+from plugin.writer.xhtml_style_postprocess import (
+    compact_lo_style_name,
+    decode_lo_css_class_suffix,
+    extract_autostyle_parents_from_fodt,
+    parse_style_block,
+    xhtml_to_semantic_html,
+)
+
+# Faithful slice of real LO XHTML export (see docs/html_style_model_plan.md, Phase 0).
+# P1 = Standard + a bold child span; P2 = Standard + whole-paragraph center+red overrides.
+REFERENCE_XHTML = """<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
+<head>
+<style>
+    table { border-collapse:collapse; }
+    h1, h2, h3, h4, h5, h6 { clear:both;}
+    .paragraph-Caption{ font-size:12pt; font-family:'Liberation Serif'; writing-mode:horizontal-tb; direction:ltr;margin-top:0.0835in; margin-bottom:0.0835in; font-style:italic; }
+    .paragraph-Heading_20_1{ font-size:18pt; margin-bottom:0.0835in; margin-top:0.1665in; font-family:'Liberation Sans'; writing-mode:horizontal-tb; direction:ltr;font-weight:bold; }
+    .paragraph-P1{ font-size:12pt; font-family:'Liberation Serif'; writing-mode:horizontal-tb; direction:ltr;font-weight:normal; }
+    .paragraph-P2{ font-size:12pt; font-family:'Liberation Serif'; writing-mode:horizontal-tb; direction:ltr;text-align:center ! important; color:#ff0000; }
+    .paragraph-Standard{ font-size:12pt; font-family:'Liberation Serif'; writing-mode:horizontal-tb; direction:ltr;}
+    .paragraph-Table_20_Contents{ font-size:12pt; font-family:'Liberation Serif'; writing-mode:horizontal-tb; direction:ltr;}
+    .paragraph-Text_20_body{ font-size:12pt; font-family:'Liberation Serif'; writing-mode:horizontal-tb; direction:ltr;margin-top:0in; margin-bottom:0.0972in; line-height:115%; }
+    .text-T1{ font-weight:bold; }
+</style>
+</head>
+<body dir="ltr" style="max-width:8.2681in;">
+<h1 class="paragraph-Heading_20_1"><a id="a__Big_Title"><span/></a>Big Title</h1>
+<p class="paragraph-Caption">Figure 1 caption</p>
+<p class="paragraph-Text_20_body">A normal text body paragraph.</p>
+<p class="paragraph-P1">normal <span class="text-T1">BOLD</span> end</p>
+<p class="paragraph-P2">centered red whole paragraph</p>
+<p class="paragraph-Standard">plain standard tail</p>
+<table border="0" class="table-Table1"><tr><td class="cell-Table1_A1">
+<p class="paragraph-Table_20_Contents">MinerU</p>
+</td><td class="cell-Table1_B1"><p class="paragraph-Table_20_Contents"> </p></td></tr></table>
+<p class="paragraph-Standard"> </p></body>
+</html>"""
+
+
+# --- small helpers ---------------------------------------------------------
+
+def test_decode_lo_css_class_suffix():
+    assert decode_lo_css_class_suffix("Heading_20_1") == "Heading 1"
+    assert decode_lo_css_class_suffix("Text_20_body") == "Text body"
+    assert decode_lo_css_class_suffix("Table_20_Contents") == "Table Contents"
+    assert decode_lo_css_class_suffix("Caption") == "Caption"
+    assert decode_lo_css_class_suffix("Standard") == "Standard"
+
+
+def test_compact_lo_style_name():
+    assert compact_lo_style_name("Heading 1") == "Heading1"
+    assert compact_lo_style_name("Text body") == "Textbody"
+    assert compact_lo_style_name("Standard") == "Standard"
+
+
+def test_parse_style_block_extracts_class_declarations():
+    raw, norm = parse_style_block(REFERENCE_XHTML)
+    assert raw["text-T1"] == "font-weight:bold"
+    assert "font-style:italic" in raw["paragraph-Caption"]
+    # Fingerprint is order-independent; P1 (Standard + font-weight:normal) != Standard.
+    assert norm["paragraph-P1"] != norm["paragraph-Standard"]
+
+
+# --- full pipeline ---------------------------------------------------------
+
+def test_named_styles_become_compact_data_lo_style():
+    out = xhtml_to_semantic_html(REFERENCE_XHTML)
+    assert 'data-lo-style="Heading1"' in out, out
+    assert 'data-lo-style="Caption"' in out, out
+    assert 'data-lo-style="Textbody"' in out, out
+    assert 'data-lo-style="Standard"' in out, out
+
+
+def test_char_override_inlined_no_synthetic_classes_leak():
+    out = xhtml_to_semantic_html(REFERENCE_XHTML)
+    assert "font-weight:bold" in out, out
+    assert "paragraph-" not in out, out
+    assert "text-T" not in out, out
+
+
+def test_autostyle_paragraphs_omit_data_lo_style():
+    """P1/P2 (Standard + direct overrides) don't fingerprint-match a named rule -> omitted.
+
+    The write path treats a missing data-lo-style as the default body style, so this still
+    round-trips for Standard. The char override (bold) survives via the inline span."""
+    out = xhtml_to_semantic_html(REFERENCE_XHTML)
+    # The "normal BOLD end" paragraph (P1) must carry no data-lo-style but keep the bold span.
+    line = next(ln for ln in out.splitlines() if "BOLD" in ln)
+    assert "data-lo-style" not in line, line
+    assert "font-weight:bold" in line, line
+
+
+def test_trailing_empty_paragraph_dropped():
+    import re
+    out = xhtml_to_semantic_html(REFERENCE_XHTML)
+    # The trailing ghost <p ...> </p> LO appends is gone; the last real block is the table.
+    assert out.rstrip().endswith("</table>"), out
+    assert re.search(r"<p\b[^>]*>(?:\s|&nbsp;)*</p>\s*$", out) is None, out
+    # The empty cell paragraph INSIDE the table is structural and legitimately kept.
+    assert "MinerU" in out, out
+
+
+def test_table_preserved_cell_classes_stripped():
+    out = xhtml_to_semantic_html(REFERENCE_XHTML)
+    assert "<table" in out, out
+    assert "MinerU" in out, out
+    # Order: heading before the table, the table, the standard tail before it.
+    i_head = out.index('data-lo-style="Heading1"')
+    i_table = out.lower().index("<table")
+    assert i_head < i_table, out
+    # No paragraph-* leaks from cells either.
+    assert "paragraph-" not in out, out
+
+
+# --- autostyle fingerprint resolution (positive + ambiguous) ---------------
+
+_FINGERPRINT_XHTML = """<html><head><style>
+.paragraph-Quotations{ margin-left:0.5in; font-style:italic; }
+.paragraph-P7{ font-style:italic; margin-left:0.5in; }
+</style></head><body>
+<p class="paragraph-P7">quoted clause</p>
+</body></html>"""
+
+
+def test_autostyle_uniquely_matching_named_rule_resolves():
+    """P7's CSS equals Quotations' (order-independent) -> resolve to that named token."""
+    out = xhtml_to_semantic_html(_FINGERPRINT_XHTML)
+    assert 'data-lo-style="Quotations"' in out, out
+
+
+_AMBIGUOUS_XHTML = """<html><head><style>
+.paragraph-Foo{ font-style:italic; }
+.paragraph-Bar{ font-style:italic; }
+.paragraph-P9{ font-style:italic; }
+</style></head><body>
+<p class="paragraph-P9">ambiguous</p>
+</body></html>"""
+
+
+def test_autostyle_ambiguous_match_omitted():
+    """Two named rules share the autostyle's CSS -> omit (do not guess)."""
+    out = xhtml_to_semantic_html(_AMBIGUOUS_XHTML)
+    assert "data-lo-style" not in out, out
+    assert "paragraph-" not in out, out
+
+
+# --- Issue 1 characterization: whole-paragraph direct overrides are dropped ---
+
+def test_whole_paragraph_direct_override_is_dropped():
+    """KNOWN LIMITATION: a Standard paragraph with whole-paragraph center+colour (autostyle P2,
+    a superset of the body style) is emitted WITHOUT a token and WITHOUT the override CSS.
+    Alignment/whole-paragraph colour do not round-trip in v1 (documented for the maintainer)."""
+    out = xhtml_to_semantic_html(REFERENCE_XHTML)
+    line = next(ln for ln in out.splitlines() if "centered red whole paragraph" in ln)
+    assert "data-lo-style" not in line, line          # base style not recoverable -> omitted
+    assert "text-align" not in line and "center" not in line.replace("centered", ""), line
+    assert "ff0000" not in line.lower() and "color" not in line, line  # the override is dropped
+
+
+# --- Issue 2: token collision (two styles compacting to the same token) -------
+
+_COLLISION_XHTML = """<html><head><style>
+.paragraph-Heading_20_1{ font-size:18pt; font-weight:bold; }
+.paragraph-Heading1{ font-size:14pt; color:#0000ff; }
+</style></head><body>
+<p class="paragraph-Heading_20_1">spaced heading</p>
+<p class="paragraph-Heading1">literal heading</p>
+</body></html>"""
+
+
+def test_div_is_a_transparent_container_on_read():
+    """`<div>` is not a styleable block (symmetric with the write path): a wrapper passes
+    through and the inner <p> still gets its token. Guards the read/write div symmetry."""
+    from plugin.writer.xhtml_style_postprocess import BLOCK_TAGS
+    assert "div" not in BLOCK_TAGS
+    xhtml = ('<html><head><style>.paragraph-Caption{ font-style:italic; }</style></head>'
+             '<body><div><p class="paragraph-Caption">x</p></div></body></html>')
+    out = xhtml_to_semantic_html(xhtml)
+    assert '<div>' in out, out                       # wrapper preserved verbatim
+    assert 'data-lo-style="Caption"' in out, out      # token landed on the <p>, not the <div>
+    assert "data-lo-style" not in out.split("<p", 1)[0], out  # nothing on the <div> itself
+    assert "paragraph-" not in out, out
+
+
+def test_colliding_tokens_are_omitted_on_read():
+    """`Heading 1` and a literal `Heading1` both compact to `Heading1` -> ambiguous -> omit both
+    (the write path could not tell them apart). Issue 2 read side."""
+    out = xhtml_to_semantic_html(_COLLISION_XHTML)
+    assert "data-lo-style" not in out, out
+    assert "paragraph-" not in out, out
+    assert "spaced heading" in out and "literal heading" in out, out
+
+
+# --- FODT autostyle-parent recovery (fixes the write->read round-trip wall) -----
+
+_FODT = (
+    "<office:automatic-styles>"
+    '<style:style style:name="P1" style:family="paragraph" style:parent-style-name="Caption"/>'
+    '<style:style style:name="P2" style:family="paragraph" style:parent-style-name="Text_20_body"/>'
+    '<style:style style:name="T1" style:family="text"/>'
+    "</office:automatic-styles>"
+)
+
+
+def test_extract_autostyle_parents_from_fodt():
+    assert extract_autostyle_parents_from_fodt(_FODT) == {"P1": "Caption", "P2": "Text_20_body"}
+
+
+# XHTML where P1 (a Caption-derived autostyle, as produced after a StarWriter import) carries
+# extra direct char props, so its CSS matches NO named rule -> fingerprint fails (the wall).
+_AUTOSTYLE_NO_NAMED_MATCH_XHTML = """<html><head><style>
+.paragraph-P1{ font-size:12pt; background-color:transparent; text-decoration:none ! important; }
+.paragraph-Standard{ font-size:12pt; }
+</style></head><body>
+<p class="paragraph-P1">just a caption</p>
+</body></html>"""
+
+
+def test_fodt_parent_recovers_name_when_fingerprint_fails():
+    # Without the FODT map: the autostyle resolves to nothing (the round-trip wall).
+    assert "data-lo-style" not in xhtml_to_semantic_html(_AUTOSTYLE_NO_NAMED_MATCH_XHTML)
+    # With the FODT parent map: the real name is recovered as a compact token.
+    out = xhtml_to_semantic_html(_AUTOSTYLE_NO_NAMED_MATCH_XHTML, {"P1": "Caption"})
+    assert 'data-lo-style="Caption"' in out, out
+    assert "paragraph-P1" not in out, out
+
+
+def test_fodt_parent_encoded_name_is_decoded_and_compacted():
+    out = xhtml_to_semantic_html(_AUTOSTYLE_NO_NAMED_MATCH_XHTML, {"P1": "Text_20_body"})
+    assert 'data-lo-style="Textbody"' in out, out  # decode _20_ -> space, then compact


### PR DESCRIPTION
## What

Builds the `data-lo-style` read/write style model on top of the existing XHTML
pipeline so the agent reads and writes named paragraph styles symmetrically.

This **reworks `plugin/writer/xhtml_style_postprocess.py`** (your module) per the
direction we discussed: **compact tokens** (style name minus spaces) and the
**flat-ODF (`.fodt`) autostyle recovery** you approved. It is a fairly large diff
to that file because the token shape and the autostyle path changed; happy to
split or adjust to taste.

## Why

After a StarWriter HTML import, edited paragraphs carry redundant direct
paragraph-level char props, so the XHTML export emits them as autostyles
(`paragraph-Pn`) with no named CSS rule — the style token was dropped on the
write→read round-trip. The XHTML export flattens `style:parent-style-name` away,
but the paired `.fodt` export keeps it, and `Pn` is identical in both, so we
recover the real base style by name (no model walk, no order alignment).

## How

- **Read:** compact `data-lo-style` tokens (`"Heading 1"` → `"Heading1"`).
  Synthetic autostyle paragraphs recover their base style from a paired `.fodt`
  export via `style:parent-style-name`. Collisions fall back to a CSS
  fingerprint, then `Standard`; a synthetic `Pn` is never leaked to the LLM.
- **Write:** resolve compact tokens to UNO `ParaStyleName`, apply the named
  style, layer inline `style=""` as direct char overrides.

## Scope / known limitation

Named-style application runs on **`target="full_document"` only**. Targeted
inserts/replaces (`end`/`beginning`/`selection`/`search`) insert the content but
**skip** style application: the first imported block merges into the cursor's
existing paragraph, so applying its style would restyle the adjacent pre-existing
text. For styling existing text, `apply_style` is the path. Applying styles only
to genuinely-new paragraphs on partial edits is a clean follow-up. This is
documented in the prompt and `docs/llm-styles.md`.

## Tests

- **16 pure** (`tests/writer/test_xhtml_style_postprocess.py`): string pipeline,
  compact tokens, collision fingerprint, `.fodt` parent extraction.
- **15 UNO** (`tests/writer/test_content_style_model_uno.py`): compact resolve,
  spaced fallback, unknown→`Standard`, read/write round-trip, `.fodt` recovery
  after a write, and `end`/`search` not restyling adjacent text.
- **Live (MCP):** read shows compact tokens; `full_document` write→read recovers
  tokens via `.fodt`; `search` insert leaves the neighbor's style intact;
  `apply_style` restyles an existing paragraph.

ty / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
