### PR TITLE
feat(writer): reviewable agent edits — tracked changes with inline review

### DIFF
--- a/docs/reviewable-agent-edits.md
+++ b/docs/reviewable-agent-edits.md
@@ -1,0 +1,118 @@
+# Reviewable Agent Edits
+
+When review mode is on, every edit the agent makes lands as a **native LibreOffice tracked
+change (redline)** the user can accept or reject, and the agent learns the per-change outcome.
+Review is Writer-only.
+
+## Configuration
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `writer.require_edit_review` | `false` | Master switch. When on, agent edits are recorded as tracked changes **and** the edit call blocks until the user has reviewed them. |
+| `writer.track_changes_reviewable` | `false` | Records agent edits as tracked changes without the block-and-wait. `require_edit_review` implies this. |
+| `writer.edit_review_timeout` | `900` (seconds) | Max time an edit call blocks waiting for review. `0` disables waiting (record only). |
+
+`review_recording_enabled(ctx)` is the single helper every edit path checks — it returns true
+when **either** flag is set.
+
+## How a change is tracked
+
+`plugin/writer/edit_review.py` owns the whole story via `EditReviewSession`:
+
+* `record_mutation()` snapshots the document's redline identifiers, runs the edit, and tags every
+  **new** redline's `RedlineComment` with a per-change token `wa-review:<session>:<n>`.
+* Completion is *"no redline carrying this session's token remains"* — **not** "zero redlines in
+  the document" — so the user's own pre-existing redlines never block or confuse it.
+* Each change is anchored with a `wa_review_<session>_<n>` bookmark spanning the affected range, so
+  it survives positions shifting as other changes are resolved. Bookmarks are always removed when
+  the review finishes (success, timeout, or error) — including when the edit raises part-way
+  through a multi-match replace.
+* Tracking is forced on for the duration even if the user didn't have it on, and their prior
+  `RecordChanges` state is restored afterward. Markup is forced **visible** (`ShowChanges = True`)
+  so a reviewable change is never left invisible.
+* Insertions are authored `WriterAgent` and deletions `WriterAgent (deletions)`, so LibreOffice's
+  by-author coloring renders new vs removed text in two distinct colors.
+
+## Outcomes
+
+After review (or timeout) each change reports one of:
+
+| `outcome` | Meaning |
+|-----------|---------|
+| `accepted` | The anchored text now matches the proposed form. |
+| `rejected` | The anchored text now matches the original form. |
+| `modified` | The user edited the area during review — the agent must not assume either text survived. |
+| `pending` | Still unresolved at timeout (`complete: false`). |
+
+A tracked change disappears on **both** accept and reject, so the outcome is derived by comparing
+the anchored paragraph against the pre-computed accept-form and reject-form, not by reading the
+redline afterward.
+
+## Tool response shape
+
+Mutating tools (chat sidebar and MCP) return the same schema:
+
+```json
+{
+  "status": "ok",
+  "review": {
+    "complete": true,
+    "timed_out": false,
+    "changes": [
+      { "id": "wa-review:ab12cd34:0", "outcome": "accepted",
+        "original_preview": "…", "proposed_preview": "…" }
+    ]
+  }
+}
+```
+
+On timeout: `"complete": false, "timed_out": true`, pending entries report `outcome: "pending"`,
+and the tool message asks the agent to have the user finish reviewing before continuing.
+
+## MCP vs sidebar
+
+Both shells run the same `EditReviewSession.wait_for_review()`:
+
+* **MCP** marks the mutating tool `long_running` so the call blocks on the HTTP thread (one
+  request, one response — the response comes back after review). The per-document mutation gate
+  stays held while waiting, so a concurrent mutating call on the same document queues behind it.
+* **Sidebar** sets `is_async()` on the mutating tool so the chat worker thread blocks without
+  freezing the drain loop; a `status_callback` shows "Review the agent's changes…".
+
+In both, every document read/cleanup during the wait is marshalled to the main thread, which stays
+free for the user's accept/reject clicks.
+
+### Toggling review on/off mid-run
+
+The chat loop snapshots the async-tool set once per round and MCP reads `long_running` per call, so
+`writer.require_edit_review` can change between that decision and execution. This is handled
+without error: a mutating tool already dispatched to a worker thread keeps `is_async() == True`
+there (so the main-thread guard doesn't reject it) and `execute()` marshals the now-wait-free edit
+to the main thread. Turning review **on** mid-round simply means the in-flight edit runs without a
+wait that round.
+
+## Inline review UI
+
+Reviewing through *Edit ▸ Track Changes ▸ Manage* is heavy, and the native UI exposes a replace's
+Delete and Insert as two independent rows. On top of the native redlines, a small inline surface
+(`plugin/writer/inline_review.py`, wired by `change_context_menu.py` / `review_click_popup.py`)
+resolves a whole agent change at the cursor as one unit (the Delete+Insert pair together), via
+left-click popup or right-click menu, plus accept/reject-all.
+
+It is strictly token-scoped — only `wa-review` changes are listed.
+
+### Limitations
+
+* **Style changes are not reviewable.** `apply_style`, `update_style`, `create_style` and
+  `import_styles` apply directly and return `style_unreviewed: true`; the agent is prompted to tell
+  the user it changed a style (styles don't produce redlines).
+* **Inline resolve refuses on a shared paragraph.** `.uno:Accept/RejectTrackedChange` resolves
+  every redline in the selection, and the selection is widened to whole paragraphs (the dispatch
+  won't fire on an exact-bounds selection). So when one of the **user's own** tracked changes or
+  another agent change shares a paragraph with the selected agent change, the inline single-change
+  resolve refuses rather than touch more than the requested change. Accept/reject-all can still
+  resolve all agent changes when no user redlines are present; otherwise shared paragraphs are left
+  for the native *Manage* dialog.
+* **Extend selection** records only the appended continuation as a single tracked **insertion**
+  (the original is never struck); it streams live with tracking off, then collapses to one redline
+  at the end.

--- a/plugin/chatbot/selection.py
+++ b/plugin/chatbot/selection.py
@@ -13,6 +13,7 @@ from plugin.framework.uno_context import get_ctx
 from plugin.framework.async_stream import run_stream_async
 from plugin.framework.config import get_api_config, set_config, get_current_endpoint
 from plugin.framework.client.llm_client import LlmClient
+from plugin.writer.edit_review import review_recording_enabled
 from plugin.doc.document_helpers import (
     WriterCompoundUndo,
     get_string_without_tracked_deletions,
@@ -251,7 +252,10 @@ def _edit_writer(services, ctx, doc):
 
     max_tokens = len(original_text) + max_new_tokens
 
-    session = WriterStreamedRewriteSession(doc, text_range, original_text)
+    session = WriterStreamedRewriteSession(
+        doc, text_range, original_text,
+        track_reviewable=review_recording_enabled(ctx),
+    )
 
     def apply_chunk(text, is_thinking=False):
         if not is_thinking:

--- a/plugin/chatbot/selection.py
+++ b/plugin/chatbot/selection.py
@@ -15,7 +15,7 @@ from plugin.framework.config import get_api_config, set_config, get_current_endp
 from plugin.framework.client.llm_client import LlmClient
 from plugin.writer.edit_review import review_recording_enabled
 from plugin.doc.document_helpers import (
-    WriterCompoundUndo,
+    WriterStreamedAppendSession,
     get_string_without_tracked_deletions,
     build_writer_rewrite_prompt,
     WriterStreamedRewriteSession,
@@ -79,27 +79,24 @@ def _extend_writer(services, ctx, doc):
         messages.append({"role": "system", "content": system_prompt})
     messages.append({"role": "user", "content": selected_text})
 
-    compound_undo = WriterCompoundUndo(doc, "WriterAgent: Extend selection")
+    session = WriterStreamedAppendSession(
+        doc, text_range, selected_text,
+        track_reviewable=review_recording_enabled(ctx),
+    )
 
     def apply_chunk(text, is_thinking=False):
         if not is_thinking:
-            try:
-                text_range.setString(text_range.getString() + text)
-            except Exception as e:
-                if isinstance(e, UNO_DISPOSED_EXCEPTIONS):
-                    log.debug("Failed to append text to Writer selection (likely disposed): %s", e)
-                else:
-                    log.exception("Failed to append text")
+            session.append_chunk(text)
 
     def on_done():
-        compound_undo.close()
+        warning = session.finish()
+        if warning:
+            msgbox(ctx, _("WriterAgent: Extend Selection"), warning)
 
     def on_error(e):
-        try:
-            log.exception("Extend selection failed")
-            msgbox(ctx, _("WriterAgent: Extend Selection"), str(e))
-        finally:
-            compound_undo.close()
+        session.abort_and_restore()
+        log.exception("Extend selection failed")
+        msgbox(ctx, _("WriterAgent: Extend Selection"), str(e))
 
     api_config = get_api_config(ctx)
     client = LlmClient(api_config, ctx)

--- a/plugin/doc/document_helpers.py
+++ b/plugin/doc/document_helpers.py
@@ -274,6 +274,14 @@ class WriterStreamedRewriteSession:
 
                         before_ids = snapshot_redline_ids(self.doc)
                         prior_author = review_authors.begin(get_ctx())
+                        # Make the markup visible so a reviewable change isn't left invisible
+                        # when the user has Track Changes display off (matches
+                        # EditReviewSession.__enter__). Review mode only -- never when the user
+                        # merely has their own Track Changes on (we respect their view setting).
+                        try:
+                            self.doc.setPropertyValue("ShowChanges", True)
+                        except Exception:
+                            logging.getLogger(__name__).debug("streamed rewrite: could not force ShowChanges", exc_info=True)
                     except Exception:
                         logging.getLogger(__name__).debug("streamed rewrite: review tagging setup failed", exc_info=True)
                 try:
@@ -343,6 +351,144 @@ class WriterStreamedRewriteSession:
                     self.doc.setPropertyValue("RecordChanges", True)
                 except Exception:
                     pass
+            self._compound_undo.close()
+
+
+class WriterStreamedAppendSession:
+    """Manage a streamed Writer APPEND (extend-selection) that collapses to one tracked insertion.
+
+    Unlike :class:`WriterStreamedRewriteSession` (which REPLACES the range), extend-selection
+    keeps the user's original text and streams the agent's continuation AFTER it. Streaming runs
+    with tracking OFF (the user sees the text appear without a redline per chunk); ``finish()``
+    then converts ONLY the appended continuation into a single tracked INSERTION -- the original
+    is never struck through -- authored as the agent and tagged for the inline review UI.
+    """
+
+    _UNDO_CONTEXT_TITLE = "WriterAgent: Extend selection"
+
+    def __init__(self, doc, text_range, original_text: str, track_reviewable: bool = False):
+        self.doc = doc
+        self.text_range = text_range
+        self.original_text = original_text
+        self.appended_text = ""
+        self.track_reviewable = track_reviewable
+        self._compound_undo = WriterCompoundUndo(doc, self._UNDO_CONTEXT_TITLE)
+
+        try:
+            self.was_recording = bool(self.doc.getPropertyValue("RecordChanges"))
+        except Exception:
+            self.was_recording = False
+        # Stream with tracking OFF so the live continuation isn't recorded as a redline per
+        # chunk; finish() re-records the whole appended run as one tracked insertion.
+        try:
+            if self.was_recording:
+                self.doc.setPropertyValue("RecordChanges", False)
+        except Exception:
+            pass
+
+    def append_chunk(self, chunk: str) -> None:
+        """Append streamed text after the original (tracking off; one redline created at finish)."""
+        if not chunk:
+            return
+        self.appended_text += chunk
+        try:
+            self.text_range.setString(self.original_text + self.appended_text)
+        except Exception:
+            logging.getLogger(__name__).debug("streamed append: chunk apply failed", exc_info=True)
+
+    def finish(self) -> str | None:
+        """Collapse the appended continuation into one tracked insertion. Returns a warning on degraded success."""
+        try:
+            if not self.appended_text:
+                # We may have turned off the user's own Record Changes in __init__ to avoid a
+                # redline per streamed chunk. If the model produced nothing, there is no edit to
+                # collapse, but the user's prior tracking state still must be restored.
+                if self.was_recording:
+                    try:
+                        self.doc.setPropertyValue("RecordChanges", True)
+                    except Exception:
+                        pass
+                return None
+            if not (self.was_recording or self.track_reviewable):
+                return None
+
+            before_ids = None
+            prior_author = None
+            if self.track_reviewable:
+                try:
+                    from plugin.framework.uno_context import get_ctx
+                    from plugin.writer import review_authors
+                    from plugin.writer.edit_review import snapshot_redline_ids
+
+                    before_ids = snapshot_redline_ids(self.doc)
+                    prior_author = review_authors.begin(get_ctx())
+                    # Make the markup visible so a reviewable change isn't invisible when the
+                    # user has Track Changes display off (matches EditReviewSession.__enter__).
+                    try:
+                        self.doc.setPropertyValue("ShowChanges", True)
+                    except Exception:
+                        logging.getLogger(__name__).debug("streamed append: could not force ShowChanges", exc_info=True)
+                except Exception:
+                    logging.getLogger(__name__).debug("streamed append: review tagging setup failed", exc_info=True)
+            try:
+                # Drop the untracked appended run (back to just the original), then re-insert ONLY
+                # that run as a tracked insertion at the end -- so the original carries no redline.
+                self.text_range.setString(self.original_text)
+                self.doc.setPropertyValue("RecordChanges", True)
+                text = self.text_range.getText()
+                end_cursor = text.createTextCursorByRange(self.text_range.getEnd())
+                text.insertString(end_cursor, self.appended_text, False)
+            finally:
+                if prior_author is not None:
+                    try:
+                        from plugin.framework.uno_context import get_ctx
+                        from plugin.writer import review_authors
+
+                        review_authors.end(get_ctx(), prior_author)
+                    except Exception:
+                        logging.getLogger(__name__).warning("streamed append: author restore failed", exc_info=True)
+            # Restore the user's prior recording state (existing redlines persist regardless).
+            if not self.was_recording:
+                try:
+                    self.doc.setPropertyValue("RecordChanges", False)
+                except Exception:
+                    pass
+            if before_ids is not None:
+                try:
+                    from plugin.writer.edit_review import tag_agent_redlines
+
+                    tag_agent_redlines(self.doc, before_ids)
+                except Exception:
+                    logging.getLogger(__name__).debug("streamed append: redline tagging failed", exc_info=True)
+            return None
+        except Exception:
+            logging.getLogger(__name__).exception("Failed to collapse streamed append into one tracked change")
+            # Degrade: keep the user's continuation (untracked) rather than losing it.
+            try:
+                self.doc.setPropertyValue("RecordChanges", False)
+            except Exception:
+                pass
+            try:
+                self.text_range.setString(self.original_text + self.appended_text)
+            except Exception:
+                pass
+            try:
+                self.doc.setPropertyValue("RecordChanges", self.was_recording)
+            except Exception:
+                pass
+            return "Failed to collapse the streamed continuation into a single tracked change. The text was kept, but may not be reviewable."
+        finally:
+            self._compound_undo.close()
+
+    def abort_and_restore(self) -> None:
+        """After a streaming error, restore the recording state and close the undo group.
+
+        The partial continuation is left in place, matching the prior extend-selection behavior."""
+        try:
+            self.doc.setPropertyValue("RecordChanges", bool(self.was_recording))
+        except Exception:
+            pass
+        finally:
             self._compound_undo.close()
 
 

--- a/plugin/doc/document_helpers.py
+++ b/plugin/doc/document_helpers.py
@@ -216,12 +216,15 @@ class WriterStreamedRewriteSession:
 
     _UNDO_CONTEXT_TITLE = "WriterAgent: Edit selection"
 
-    def __init__(self, doc, text_range, original_text: str):
+    def __init__(self, doc, text_range, original_text: str, track_reviewable: bool = False):
         self.doc = doc
         self.text_range = text_range
         self.original_text = original_text
         self.generated_text = ""
         self.was_recording = False
+        # When True (opt-in flag), the agent's edit is collapsed into one tracked
+        # change for the user to review even if they did not have Track Changes on.
+        self.track_reviewable = track_reviewable
         self._compound_undo = WriterCompoundUndo(doc, self._UNDO_CONTEXT_TITLE)
 
         try:
@@ -254,13 +257,53 @@ class WriterStreamedRewriteSession:
     def finish(self) -> str | None:
         """Finalize the rewrite. Returns a warning message on degraded success."""
         try:
-            if not self.was_recording:
+            if not (self.was_recording or self.track_reviewable):
                 return None
 
             try:
-                self.text_range.setString(self.original_text)
-                self.doc.setPropertyValue("RecordChanges", True)
-                self.text_range.setString(self.generated_text)
+                # Review mode only (NOT when the user merely has their own Track Changes on):
+                # snapshot the redlines so the collapsed change can be tagged as an agent change
+                # afterward, and author it as the agent for the by-author coloring.
+                before_ids = None
+                prior_author = None
+                if self.track_reviewable:
+                    try:
+                        from plugin.framework.uno_context import get_ctx
+                        from plugin.writer import review_authors
+                        from plugin.writer.edit_review import snapshot_redline_ids
+
+                        before_ids = snapshot_redline_ids(self.doc)
+                        prior_author = review_authors.begin(get_ctx())
+                    except Exception:
+                        logging.getLogger(__name__).debug("streamed rewrite: review tagging setup failed", exc_info=True)
+                try:
+                    self.text_range.setString(self.original_text)
+                    self.doc.setPropertyValue("RecordChanges", True)
+                    self.text_range.setString(self.generated_text)
+                finally:
+                    if prior_author is not None:
+                        try:
+                            from plugin.framework.uno_context import get_ctx
+                            from plugin.writer import review_authors
+
+                            review_authors.end(get_ctx(), prior_author)
+                        except Exception:
+                            logging.getLogger(__name__).warning("streamed rewrite: author restore failed", exc_info=True)
+                # Restore the user's prior recording state. If they had Track Changes
+                # OFF and we only turned it ON to capture this edit as one reviewable
+                # redline (track_reviewable flag), turn it back OFF so their later
+                # manual typing is not tracked. Existing redlines persist regardless.
+                if not self.was_recording:
+                    self.doc.setPropertyValue("RecordChanges", False)
+                # Tag the collapsed redline(s) with a session token so the inline review UI
+                # (click popup / context menu) treats this streamed edit as an agent change.
+                if before_ids is not None:
+                    try:
+                        from plugin.writer.edit_review import tag_agent_redlines
+
+                        tag_agent_redlines(self.doc, before_ids)
+                    except Exception:
+                        logging.getLogger(__name__).debug("streamed rewrite: redline tagging failed", exc_info=True)
                 return None
             except Exception:
                 logging.getLogger(__name__).exception("Failed to collapse streamed edit into one tracked change")
@@ -275,9 +318,9 @@ class WriterStreamedRewriteSession:
                 except Exception as e:
                     fallback_errors.append(f"restore generated text failed: {e}")
                 try:
-                    self.doc.setPropertyValue("RecordChanges", True)
+                    self.doc.setPropertyValue("RecordChanges", self.was_recording)
                 except Exception as e:
-                    fallback_errors.append(f"re-enable tracking failed: {e}")
+                    fallback_errors.append(f"restore recording state failed: {e}")
 
                 if fallback_errors:
                     return "Failed to finalize the tracked edit and preserve the generated text: " + "; ".join(fallback_errors)

--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -280,6 +280,7 @@ TRANSLATION_RULES = "TRANSLATION: get_document_content(scope=full) -> translate 
 # Tool-usage workflow patterns (no repeat of apply_document_content targets; see WRITER_APPLY_DOCUMENT_HTML_RULES).
 TOOL_USAGE_PATTERNS = """TOOL USAGE PATTERNS:
 - After an edit tool, confirm it landed via that tool's own structured field — not the message wording: apply_document_content -> replaced_count > 0; apply_style -> applied is true; add_comment -> comment_added is true. A no-op (e.g. text not found) returns status="error"; do not assume success.
+- apply_style applies formatting directly and is NOT recorded as a tracked change. When its result has style_unreviewed=true (review mode is on), briefly tell the user you changed a style, since they cannot accept or reject it the way they review your text edits.
 - search_in_document (with return_offsets if needed) is for inspection/navigation; use apply_document_content with old_content for replacements.
 - If a tool call fails, verify content and target are provided (use target='beginning' / 'end' / 'selection' for insert-only).
 - When asked to review or give feedback or suggestions on a document, use the add_comment method to add your input to specific places in the document. Use for both positive and negative feedback.

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -317,13 +317,15 @@ def _register_core_handlers():
 
     def _resolve_change_at_cursor(accept):
         from plugin.framework.uno_context import get_desktop
-        from plugin.writer.inline_review import resolve_change_at_cursor
+        from plugin.writer.inline_review import resolve_change_at_cursor, show_review_message
 
         c = get_ctx()
         model = get_desktop(c).getCurrentComponent()
         if model is not None:
             ok, msg = resolve_change_at_cursor(model, c, accept)
             logging.getLogger("writeragent.main").debug("inline review: accept=%s -> ok=%s msg=%s", accept, ok, msg)
+            if not ok:
+                show_review_message(c, msg)
         else:
             logging.getLogger("writeragent.main").debug("inline review: no current component")
 
@@ -332,13 +334,14 @@ def _register_core_handlers():
 
     def _resolve_all_agent(accept):
         from plugin.framework.uno_context import get_desktop
-        from plugin.writer.inline_review import resolve_all_agent_changes
+        from plugin.writer.inline_review import resolve_all_with_feedback, show_review_message
 
         c = get_ctx()
         model = get_desktop(c).getCurrentComponent()
         if model is not None:
-            n = resolve_all_agent_changes(model, c, accept)
+            n, msg = resolve_all_with_feedback(model, c, accept)
             logging.getLogger("writeragent.main").debug("inline review: resolve-all accept=%s -> %d changes", accept, n)
+            show_review_message(c, msg)
 
     register_action_handler("writer", "review_accept_all", lambda: _resolve_all_agent(True))
     register_action_handler("writer", "review_reject_all", lambda: _resolve_all_agent(False))

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -315,6 +315,42 @@ def _register_core_handlers():
 
     register_action_handler("embeddings", "search_dialog", _open_search_dialog)
 
+    def _resolve_change_at_cursor(accept):
+        from plugin.framework.uno_context import get_desktop
+        from plugin.writer.inline_review import resolve_change_at_cursor
+
+        c = get_ctx()
+        model = get_desktop(c).getCurrentComponent()
+        if model is not None:
+            ok, msg = resolve_change_at_cursor(model, c, accept)
+            logging.getLogger("writeragent.main").debug("inline review: accept=%s -> ok=%s msg=%s", accept, ok, msg)
+        else:
+            logging.getLogger("writeragent.main").debug("inline review: no current component")
+
+    register_action_handler("writer", "accept_change", lambda: _resolve_change_at_cursor(True))
+    register_action_handler("writer", "reject_change", lambda: _resolve_change_at_cursor(False))
+
+    def _resolve_all_agent(accept):
+        from plugin.framework.uno_context import get_desktop
+        from plugin.writer.inline_review import resolve_all_agent_changes
+
+        c = get_ctx()
+        model = get_desktop(c).getCurrentComponent()
+        if model is not None:
+            n = resolve_all_agent_changes(model, c, accept)
+            logging.getLogger("writeragent.main").debug("inline review: resolve-all accept=%s -> %d changes", accept, n)
+
+    register_action_handler("writer", "review_accept_all", lambda: _resolve_all_agent(True))
+    register_action_handler("writer", "review_reject_all", lambda: _resolve_all_agent(False))
+
+    try:
+        from plugin.writer.change_context_menu import install_writer_change_context_menu
+
+        install_writer_change_context_menu(get_ctx())
+    except Exception:
+        # WARNING, not debug: a silent install failure looks identical to "menu ignored".
+        log.warning("Writer change context menu install failed", exc_info=True)
+
 
 
 # ── Dynamic menu text infrastructure ─────────────────────────────────

--- a/plugin/scripting/python_runner.py
+++ b/plugin/scripting/python_runner.py
@@ -465,6 +465,8 @@ def execute_and_insert_result(
             return {"ok": False, "message": f"{message} (took {formatted_time})"}
 
         try:
+            # Reviewable-edit recording for the Writer path lives inside
+            # insert_vision_result_into_writer (vision_egress).
             insert_vision_result(ctx, doc, result, params=vision_meta.params)
         except Exception as e:
             elapsed_total = time.perf_counter() - t0
@@ -942,7 +944,15 @@ def execute_and_insert_result(
             elif is_writer(doc):
                 formatted = format_result_for_writer(result_data)
                 if formatted:
-                    insert_content_at_position(doc, ctx, formatted, "selection")
+                    # Review mode: record this agent-driven insertion as a reviewable tracked change.
+                    from plugin.writer.edit_review import EditReviewSession, review_recording_enabled
+
+                    review = EditReviewSession(doc, ctx, enabled=review_recording_enabled(ctx))
+                    try:
+                        with review:
+                            review.record_mutation(lambda: insert_content_at_position(doc, ctx, formatted, "selection"))
+                    finally:
+                        review.cleanup()
             elif is_draw(doc):
                 insert_result_into_draw(doc, ctx, result_data)
             else:

--- a/plugin/vision/vision_egress.py
+++ b/plugin/vision/vision_egress.py
@@ -73,7 +73,15 @@ def insert_vision_result_into_writer(ctx: Any, doc: Any, result: dict[str, Any])
         html.count("style="),
         html[:120],
     )
-    insert_content_at_position(doc, ctx, html, "selection")
+    # Review mode: record this agent-driven insertion as a reviewable tracked change.
+    from plugin.writer.edit_review import EditReviewSession, review_recording_enabled
+
+    review = EditReviewSession(doc, ctx, enabled=review_recording_enabled(ctx))
+    try:
+        with review:
+            review.record_mutation(lambda: insert_content_at_position(doc, ctx, html, "selection"))
+    finally:
+        review.cleanup()
 
 
 def insert_vision_result(

--- a/plugin/writer/change_context_menu.py
+++ b/plugin/writer/change_context_menu.py
@@ -1,0 +1,242 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Writer right-click review: accept/reject the agent's tracked changes, as whole units.
+
+Adds four entries to the Writer text context menu (only while the document holds pending AGENT
+changes -- wa-review session tokens): accept/reject the agent change under the cursor as one
+unit (a replace's strikethrough + underline resolve together, no Manage dialog), and
+accept/reject ALL agent changes at once. The user's own tracked changes are never touched.
+The entries dispatch ``org.extension.writeragent:writer.accept_change`` / ``writer.reject_change``
+/ ``writer.review_accept_all`` / ``writer.review_reject_all``, handled in ``main.py``.
+
+PyUNO pitfalls this file works around (each silently killed the menu when done wrong):
+- ``queryInterface(InterfaceClass)`` cannot convert an imported interface class to a UNO type;
+  call the interface's methods directly on the proxy object instead.
+- An exception escaping ``notifyContextMenuExecute`` makes the core permanently UNREGISTER the
+  interceptor (``catch (...) { removeInterface }`` in SfxViewShell::TryContextMenuInterception)
+  with no diagnostics -- so the entire body, imports included, lives inside try/except.
+- ``registerContextMenuInterceptor`` on a controller that is not (yet/anymore) attached to a
+  view shell succeeds and does nothing. Registration therefore prefers ``Event.ViewController``
+  from OnViewCreated (broadcast only after the view shell is attached) and re-registers per new
+  controller; interceptors do not survive a view recreation (reload, new window).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+import unohelper
+
+log = logging.getLogger(__name__)
+
+_ACCEPT_URL = "org.extension.writeragent:writer.accept_change"
+_REJECT_URL = "org.extension.writeragent:writer.reject_change"
+_ACCEPT_ALL_URL = "org.extension.writeragent:writer.review_accept_all"
+_REJECT_ALL_URL = "org.extension.writeragent:writer.review_reject_all"
+
+_lock = threading.RLock()
+# Registered controllers, deduplicated by UNO object identity: PyUNO hands out a NEW proxy
+# object per call/event for the same underlying controller, so dedup by Python id() fails
+# (OnViewCreated + OnLoad would register the same view twice -> duplicated menu entries).
+# PyUNO proxies implement == via UNO identity, so a list + `in` is the reliable test.
+# Strong refs are kept for the office session; releasing them when a view is disposed is
+# follow-up work (one controller+interceptor pair lingers per closed document).
+_registered_controllers: list[Any] = []
+_interceptors: list[Any] = []  # keep strong refs so the Python objects outlive the call
+_doc_listener: Any = None
+_interceptor_cls: Any = None
+
+
+def _is_writer(model: Any) -> bool:
+    try:
+        return bool(model is not None and model.supportsService("com.sun.star.text.TextDocument"))
+    except Exception:
+        return False
+
+
+def _build_menu(model: Any, event: Any) -> Any:
+    """Append the Accept/Reject entries when the doc has tracked changes.
+
+    EVERYTHING (imports included) stays inside the try: an exception escaping this callback
+    causes LibreOffice to silently unregister the interceptor forever.
+    """
+    try:
+        from com.sun.star.ui.ContextMenuInterceptorAction import CONTINUE_MODIFIED, IGNORED
+        from com.sun.star.ui import ActionTriggerSeparatorType
+
+        from plugin.framework.i18n import _
+        from plugin.writer.inline_review import has_agent_changes
+
+        has = has_agent_changes(model)
+        log.debug("change_context_menu: notifyContextMenuExecute (Writer), has_agent_changes=%s", has)
+        if not has:
+            return IGNORED
+        container = event.ActionTriggerContainer
+        # The container implements XMultiServiceFactory; call it directly on the proxy
+        # (queryInterface with an imported interface class does not work in PyUNO).
+        if container is None or not hasattr(container, "createInstance"):
+            return IGNORED
+
+        separator = container.createInstance("com.sun.star.ui.ActionTriggerSeparator")
+        separator.setPropertyValue("SeparatorType", ActionTriggerSeparatorType.LINE)
+        # Distinct wording from LibreOffice's native per-mark "Accept Change" / "Reject Change":
+        # ours resolves the WHOLE change at the cursor (a replace's delete + insert together).
+        accept = container.createInstance("com.sun.star.ui.ActionTrigger")
+        accept.setPropertyValue("Text", _("Accept whole change (agent)"))
+        accept.setPropertyValue("CommandURL", _ACCEPT_URL)
+        reject = container.createInstance("com.sun.star.ui.ActionTrigger")
+        reject.setPropertyValue("Text", _("Reject whole change (agent)"))
+        reject.setPropertyValue("CommandURL", _REJECT_URL)
+        # Bulk: resolve every agent change at once (token-filtered, so the user's own redlines
+        # are spared). Reachable from a right-click anywhere a change exists.
+        accept_all = container.createInstance("com.sun.star.ui.ActionTrigger")
+        accept_all.setPropertyValue("Text", _("Accept all agent changes"))
+        accept_all.setPropertyValue("CommandURL", _ACCEPT_ALL_URL)
+        reject_all = container.createInstance("com.sun.star.ui.ActionTrigger")
+        reject_all.setPropertyValue("Text", _("Reject all agent changes"))
+        reject_all.setPropertyValue("CommandURL", _REJECT_ALL_URL)
+
+        count = container.getCount()
+        container.insertByIndex(count, separator)
+        container.insertByIndex(count + 1, accept)
+        container.insertByIndex(count + 2, reject)
+        container.insertByIndex(count + 3, accept_all)
+        container.insertByIndex(count + 4, reject_all)
+        log.debug("change_context_menu: added review entries at index %d", count)
+        return CONTINUE_MODIFIED
+    except Exception:
+        log.exception("change_context_menu: building menu failed")
+        try:
+            from com.sun.star.ui.ContextMenuInterceptorAction import IGNORED
+
+            return IGNORED
+        except Exception:
+            return None
+
+
+def _make_interceptor(model: Any) -> Any:
+    global _interceptor_cls
+    if _interceptor_cls is None:
+        from com.sun.star.ui import XContextMenuInterceptor
+
+        class _ChangeContextMenuInterceptor(unohelper.Base, XContextMenuInterceptor):  # type: ignore[misc, valid-type]
+            def __init__(self, model: Any) -> None:
+                super().__init__()
+                self._model = model
+
+            def notifyContextMenuExecute(self, aEvent):  # noqa: N802, N803 -- UNO API
+                return _build_menu(self._model, aEvent)
+
+        _interceptor_cls = _ChangeContextMenuInterceptor
+    return _interceptor_cls(model)
+
+
+def _register_controller(controller: Any) -> None:
+    """Register the interceptor on one Writer view controller (idempotent per controller)."""
+    if controller is None:
+        return
+    try:
+        with _lock:
+            if controller in _registered_controllers:  # UNO-identity equality, see above
+                return
+        model = controller.getModel()
+        if not _is_writer(model):
+            return
+        # PyUNO exposes every supported interface's methods directly on the proxy; calling
+        # registerContextMenuInterceptor on the controller is the working form.
+        if not hasattr(controller, "registerContextMenuInterceptor"):
+            return
+        interceptor = _make_interceptor(model)
+        with _lock:
+            if controller in _registered_controllers:
+                return
+            controller.registerContextMenuInterceptor(interceptor)
+            _registered_controllers.append(controller)
+            _interceptors.append(interceptor)
+        log.debug("change_context_menu: registered on Writer controller")
+        # Same controller, same lifecycle: also attach the click-to-review popup handler.
+        try:
+            from plugin.writer.review_click_popup import register_click_review
+
+            register_click_review(controller)
+        except Exception:
+            log.warning("change_context_menu: click-review registration failed", exc_info=True)
+    except Exception:
+        # WARNING, not debug: a silent registration failure looks identical to "menu ignored".
+        log.warning("change_context_menu: register failed", exc_info=True)
+
+
+def _register_frame(frame: Any) -> None:
+    try:
+        controller = frame.getController() if frame is not None else None
+    except Exception:
+        return
+    _register_controller(controller)
+
+
+def _install_doc_event_listener(ctx: Any) -> None:
+    """Attach a global listener so documents/views opened AFTER bootstrap get the menu too."""
+    global _doc_listener
+    with _lock:
+        if _doc_listener is not None:
+            return
+    try:
+        from plugin.framework.uno_listeners import BaseDocumentEventListener
+
+        class _NewDocListener(BaseDocumentEventListener):  # type: ignore[misc, valid-type]
+            def on_document_event(self, Event: Any) -> None:  # noqa: N803 -- UNO signature
+                try:
+                    name = getattr(Event, "EventName", "") or ""
+                    if name not in ("OnViewCreated", "OnLoadFinished", "OnLoad", "OnNew"):
+                        return
+                    # Prefer the event's own controller: it is guaranteed attached to the view
+                    # shell (OnViewCreated is broadcast after attach), while getCurrentController
+                    # can race and yield a controller whose registration is a silent no-op.
+                    controller = getattr(Event, "ViewController", None)
+                    if controller is not None:
+                        _register_controller(controller)
+                        return
+                    source = getattr(Event, "Source", None)
+                    if source is not None and hasattr(source, "getCurrentController"):
+                        _register_controller(source.getCurrentController())
+                except Exception:
+                    log.warning("change_context_menu: doc-event handling failed", exc_info=True)
+
+        smgr = ctx.getServiceManager()
+        broadcaster = smgr.createInstanceWithContext("com.sun.star.frame.GlobalEventBroadcaster", ctx)
+        listener = _NewDocListener()
+        broadcaster.addDocumentEventListener(listener)
+        with _lock:
+            _doc_listener = listener
+        log.debug("change_context_menu: global doc-event listener attached")
+    except Exception:
+        log.warning("change_context_menu: doc-event listener install failed", exc_info=True)
+
+
+def install_writer_change_context_menu(ctx: Any) -> None:
+    """Register the Accept/Reject context menu on open Writer views and future ones."""
+    try:
+        from plugin.framework.uno_context import get_desktop
+
+        desktop = get_desktop(ctx)
+        if desktop is not None:
+            frames = desktop.getFrames()
+            if frames is not None:
+                for i in range(frames.getCount()):
+                    try:
+                        _register_frame(frames.getByIndex(i))
+                    except Exception:
+                        log.debug("change_context_menu: frame %s skipped", i, exc_info=True)
+            try:
+                current = desktop.getCurrentFrame()
+                if current is not None:
+                    _register_frame(current)
+            except Exception:
+                log.debug("change_context_menu: current frame skipped", exc_info=True)
+        _install_doc_event_listener(ctx)
+    except Exception:
+        log.warning("change_context_menu: install failed", exc_info=True)

--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -476,25 +476,50 @@ class ApplyDocumentContent(ToolBase):
         return self._wait_enabled_globally()
 
     def is_async(self):
-        # Mirrors long_running: when the call may block for review, the chat worker/HTTP
-        # thread hosts it (the main-thread guard in execute_safe is bypassed) and every
-        # document touch below is marshalled via execute_on_main_thread.
-        return self._wait_enabled_globally()
+        # When review-wait is on, the chat worker / MCP HTTP thread hosts this call (the
+        # main-thread guard in execute_safe is bypassed) and every document touch is
+        # marshalled via execute_on_main_thread.
+        if self._wait_enabled_globally():
+            return True
+        # Also stay "async" whenever we're ALREADY on a background thread: the chat loop
+        # snapshots the async-tool set once per round and MCP reads long_running per call, so
+        # review can be toggled OFF between that decision and now. If it was, we're running on a
+        # worker thread with the live flag False -- returning True keeps execute_safe's
+        # main-thread guard from rejecting us; execute() then runs the (now wait-free) edit on
+        # the main thread via marshalling, so the toggle is handled safely instead of erroring.
+        return threading.current_thread() is not threading.main_thread()
 
     def execute(self, ctx, **kwargs):
         wait_seconds = self._review_wait_seconds(ctx.ctx)
-        if wait_seconds <= 0 or threading.current_thread() is threading.main_thread():
-            # No review-wait (or we ARE the main thread, where blocking would freeze the
-            # UI and the user could never click accept/reject): edit directly, no wait.
-            session = None
+        on_main = threading.current_thread() is threading.main_thread()
+        if wait_seconds <= 0 or on_main:
+            # No review-wait: review is off, it was toggled off after this call was dispatched
+            # to a worker thread, or we ARE the main thread (where blocking would freeze the UI
+            # and the user could never click accept/reject). Edit once, don't wait -- but UNO is
+            # not thread-safe, so when we're on a worker thread (the toggled-off case) the edit
+            # and its cleanup run on the main thread via marshalling rather than here.
+            # The session is registered in session_box the instant _execute_edit creates it (via
+            # session_sink), so its anchor bookmarks are released in `finally` even if the edit
+            # raises mid-way (e.g. the 2nd of 3 replace-all matches fails after the 1st).
+            session_box = []
+
+            def _do_edit():
+                return self._execute_edit(ctx, session_sink=session_box, **kwargs)
+
             try:
-                result, session = self._execute_edit(ctx, **kwargs)
+                if on_main:
+                    result, _ = _do_edit()
+                else:
+                    from plugin.framework.queue_executor import execute_on_main_thread
+                    result, _ = execute_on_main_thread(_do_edit, timeout=60.0)
                 return result
             finally:
-                # Always release the session's anchor bookmarks, even when the edit raises
-                # mid-way (e.g. the 2nd of 3 replace-all matches fails after anchoring the 1st).
-                if session is not None:
-                    session.cleanup()
+                if session_box:
+                    if on_main:
+                        session_box[0].cleanup()
+                    else:
+                        from plugin.framework.queue_executor import execute_on_main_thread
+                        execute_on_main_thread(session_box[0].cleanup)
 
         # Review-wait path, on a background (MCP HTTP / chat worker) thread: run the edit
         # on the main thread, then block HERE until the user reviews the tracked changes.
@@ -506,10 +531,9 @@ class ApplyDocumentContent(ToolBase):
         session_box = []
 
         def _edit_on_main_thread():
-            edit_result, edit_session = self._execute_edit(ctx, **kwargs)
-            if edit_session is not None:
-                session_box.append(edit_session)
-            return edit_result, edit_session
+            # session_sink registers the session in session_box the instant it's created, so
+            # the `except` below can release its bookmarks even if the edit raises mid-way.
+            return self._execute_edit(ctx, session_sink=session_box, **kwargs)
 
         try:
             # 60s edit budget: matches the synchronous MCP path's processing timeout; the
@@ -560,7 +584,7 @@ class ApplyDocumentContent(ToolBase):
             )
         return result
 
-    def _execute_edit(self, ctx, **kwargs):
+    def _execute_edit(self, ctx, session_sink=None, **kwargs):
         """Apply the edit and return ``(result_dict, session_or_None)``.
 
         Runs on the MAIN thread always (directly on the sync path; marshalled via
@@ -622,6 +646,11 @@ class ApplyDocumentContent(ToolBase):
         # get_config_bool_safe tolerates the flag not being registered yet (returns False).
         track_reviewable = review_recording_enabled(ctx.ctx)
         session = EditReviewSession(ctx.doc, ctx.ctx, enabled=track_reviewable)
+        # Register with the caller's sink AS SOON AS the session exists, so its anchor
+        # bookmarks are released even if the edit below raises mid-way (a replace-all that
+        # anchors the 1st match then fails on the 2nd) -- before we ever return the session.
+        if session_sink is not None:
+            session_sink.append(session)
 
         def _plain_preview(value):
             s = str(value)

--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -17,10 +17,13 @@
 """Writer content tools — read, apply, find, and paragraph operations."""
 
 import logging
+import threading
 
 from plugin.framework.tool import ToolBase, ToolBaseDummy
 from plugin.framework.constants import APPLY_DOCUMENT_CONTENT_TOOL_RESEARCH_HINT
 from plugin.doc.document_helpers import normalize_linebreaks, get_string_without_tracked_deletions
+from plugin.writer.edit_review import EditReviewSession, review_recording_enabled
+from plugin.framework.config import get_config_bool_safe, get_config_int_safe
 from plugin.framework.errors import safe_json_loads
 import re as re_mod
 
@@ -446,7 +449,123 @@ class ApplyDocumentContent(ToolBase):
     tier = "core"
     is_mutation = True
 
+    def _review_wait_seconds(self, uno_ctx):
+        """Max seconds the edit call should block waiting for review; 0 = don't wait."""
+        try:
+            if not get_config_bool_safe(uno_ctx, "writer.require_edit_review"):
+                return 0
+            return max(0, get_config_int_safe(uno_ctx, "writer.edit_review_timeout"))
+        except Exception:
+            return 0
+
+    def _wait_enabled_globally(self):
+        """Config read without a tool context, for long_running/is_async (called by the
+        MCP/chat shells before execute). False whenever the context isn't available."""
+        try:
+            from plugin.framework.uno_context import get_ctx
+
+            return self._review_wait_seconds(get_ctx()) > 0
+        except Exception:
+            return False
+
+    @property
+    def long_running(self):
+        # With review-wait on, MCP must run this call on its HTTP thread so the wait can
+        # block there (one request, one response -- the response just comes back after the
+        # user reviews). With it off, stay a normal synchronous main-thread tool.
+        return self._wait_enabled_globally()
+
+    def is_async(self):
+        # Mirrors long_running: when the call may block for review, the chat worker/HTTP
+        # thread hosts it (the main-thread guard in execute_safe is bypassed) and every
+        # document touch below is marshalled via execute_on_main_thread.
+        return self._wait_enabled_globally()
+
     def execute(self, ctx, **kwargs):
+        wait_seconds = self._review_wait_seconds(ctx.ctx)
+        if wait_seconds <= 0 or threading.current_thread() is threading.main_thread():
+            # No review-wait (or we ARE the main thread, where blocking would freeze the
+            # UI and the user could never click accept/reject): edit directly, no wait.
+            session = None
+            try:
+                result, session = self._execute_edit(ctx, **kwargs)
+                return result
+            finally:
+                # Always release the session's anchor bookmarks, even when the edit raises
+                # mid-way (e.g. the 2nd of 3 replace-all matches fails after anchoring the 1st).
+                if session is not None:
+                    session.cleanup()
+
+        # Review-wait path, on a background (MCP HTTP / chat worker) thread: run the edit
+        # on the main thread, then block HERE until the user reviews the tracked changes.
+        from plugin.framework.queue_executor import execute_on_main_thread
+
+        # Capture the session as soon as _execute_edit creates it, so its anchor bookmarks can
+        # be released even when the edit raises mid-way. The cleanup is itself marshalled, and
+        # the queue executor serializes main-thread items, so it runs after the edit settles.
+        session_box = []
+
+        def _edit_on_main_thread():
+            edit_result, edit_session = self._execute_edit(ctx, **kwargs)
+            if edit_session is not None:
+                session_box.append(edit_session)
+            return edit_result, edit_session
+
+        try:
+            # 60s edit budget: matches the synchronous MCP path's processing timeout; the
+            # default 30s marshalling timeout would reject large full-document replaces that
+            # are fine without review mode.
+            result, session = execute_on_main_thread(_edit_on_main_thread, timeout=60.0)
+        except Exception:
+            if session_box:
+                execute_on_main_thread(session_box[0].cleanup)
+            raise
+        if session is None or not session.changes or result.get("status") != "ok":
+            if session is not None:
+                execute_on_main_thread(session.cleanup)
+            return result
+
+        # In-app chat: surface a sidebar status while we block (MCP has no sidebar -> None, no-op).
+        # The callback marshals onto the chat drain queue, so it is safe from this worker thread.
+        status_cb = getattr(ctx, "status_callback", None)
+        if callable(status_cb):
+            try:
+                status_cb("Review the agent's changes in the document — accept or reject the tracked changes.")
+            except Exception:
+                log.debug("apply_document_content: status_callback failed", exc_info=True)
+
+        # Stop waiting early when the review feature is toggled off mid-wait OR the user
+        # cancels the chat turn (Stop button); MCP has no stop predicate -> None.
+        user_stop = getattr(ctx, "stop_checker", None)
+
+        def _stop():
+            if self._review_wait_seconds(ctx.ctx) <= 0:
+                return True
+            try:
+                return bool(user_stop()) if callable(user_stop) else False
+            except Exception:
+                return False
+
+        review = session.wait_for_review(
+            timeout=wait_seconds,
+            stop_checker=_stop,
+            uno_runner=execute_on_main_thread,
+        )
+        result = dict(result)
+        result["review"] = review
+        if not review.get("complete"):
+            result["message"] = (result.get("message") or "") + (
+                " The user has not finished reviewing these tracked changes; ask them to"
+                " accept or reject the changes in the document, then continue."
+            )
+        return result
+
+    def _execute_edit(self, ctx, **kwargs):
+        """Apply the edit and return ``(result_dict, session_or_None)``.
+
+        Runs on the MAIN thread always (directly on the sync path; marshalled via
+        execute_on_main_thread on the review-wait path). The caller owns the session's
+        wait/cleanup."""
         from . import format as format_support
         content = kwargs.get("content", "")
         old_content = kwargs.get("old_content")
@@ -455,10 +574,10 @@ class ApplyDocumentContent(ToolBase):
         if not target and old_content is not None:
             target = "search"
         if not target:
-            return self._tool_error("Provide a target ('beginning', 'end', 'selection', 'full_document', 'search') or old_content for find-and-replace.")
+            return self._tool_error("Provide a target ('beginning', 'end', 'selection', 'full_document', 'search') or old_content for find-and-replace."), None
 
         if target == "search" and old_content is None:
-            return self._tool_error("target='search' requires old_content.")
+            return self._tool_error("target='search' requires old_content."), None
 
         # Normalize content:
         # - If the model (or caller) serialized a list as a JSON string,
@@ -496,19 +615,47 @@ class ApplyDocumentContent(ToolBase):
         raw_content = content
 
         config_svc = ctx.services.get("config")
+        # Opt-in review mode: when writer.track_changes_reviewable is on, the EditReviewSession records
+        # the agent's edits as native tracked changes (redlines) the user can accept/reject --
+        # tagging each logical change so its outcome can be reported -- and restores the prior
+        # recording state. Default off -> the session is inert and behavior is unchanged.
+        # get_config_bool_safe tolerates the flag not being registered yet (returns False).
+        track_reviewable = review_recording_enabled(ctx.ctx)
+        session = EditReviewSession(ctx.doc, ctx.ctx, enabled=track_reviewable)
+
+        def _plain_preview(value):
+            s = str(value)
+            if format_support.content_has_markup(s):
+                try:
+                    return format_support.html_to_plain_text(s, ctx.ctx, config_svc)
+                except Exception:
+                    return s
+            return s
 
         if target == "full_document":
-            format_support.replace_full_document(ctx.doc, ctx.ctx, content, config_svc=config_svc)
-            return {"status": "ok", "message": "Replaced entire document."}
+            with session:
+                session.record_mutation(
+                    lambda: format_support.replace_full_document(ctx.doc, ctx.ctx, content, config_svc=config_svc),
+                    proposed_preview=_plain_preview(content))
+            return {"status": "ok", "message": "Replaced entire document."}, session
         if target == "end":
-            format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "end", config_svc=config_svc)
-            return {"status": "ok", "message": "Inserted content at end."}
+            with session:
+                session.record_mutation(
+                    lambda: format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "end", config_svc=config_svc),
+                    proposed_preview=_plain_preview(content))
+            return {"status": "ok", "message": "Inserted content at end."}, session
         if target == "selection":
-            format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "selection", config_svc=config_svc)
-            return {"status": "ok", "message": "Inserted content at selection."}
+            with session:
+                session.record_mutation(
+                    lambda: format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "selection", config_svc=config_svc),
+                    proposed_preview=_plain_preview(content))
+            return {"status": "ok", "message": "Inserted content at selection."}, session
         if target == "beginning":
-            format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "beginning", config_svc=config_svc)
-            return {"status": "ok", "message": "Inserted content at beginning."}
+            with session:
+                session.record_mutation(
+                    lambda: format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "beginning", config_svc=config_svc),
+                    proposed_preview=_plain_preview(content))
+            return {"status": "ok", "message": "Inserted content at beginning."}, session
 
         # target == "search" from here on — old_content must be a findable substring, not the full body.
         # Whole-document replace: target='full_document' (no search, no old_content).
@@ -522,7 +669,7 @@ class ApplyDocumentContent(ToolBase):
         if not search_string:
             # Parameter error (like old_content=None), not a search no-op: the search never ran,
             # so there's no replaced_count to report — use the standard tool error shape.
-            return self._tool_error("old_content is empty after normalization.")
+            return self._tool_error("old_content is empty after normalization."), session
         doc = ctx.doc
         # replaced_count is the machine-readable success signal: 0 -> status "error" (a silent
         # no-op surfaced as a failure), N>0 -> "ok". No matched_count/warning/partial-replace:
@@ -533,32 +680,46 @@ class ApplyDocumentContent(ToolBase):
             ranges = _find_all_ranges(doc, search_string)
             count = 0
             # Replace from last to first so earlier character offsets stay valid after edits.
-            for found in reversed(ranges):
-                if use_preserve:
-                    format_support.replace_preserving_format(doc, found, raw_content, ctx.ctx)
-                else:
-                    format_support.replace_single_range_with_content(doc, found, content, ctx.ctx, config_svc)
-                count += 1
+            # One record_mutation per match: each replaced occurrence is its own reviewable
+            # change with its own accept/reject outcome.
+            with session:
+                for found in reversed(ranges):
+                    original = found.getString()
+                    if use_preserve:
+                        session.record_mutation(
+                            lambda f=found: format_support.replace_preserving_format(doc, f, raw_content, ctx.ctx),
+                            original_preview=original, proposed_preview=_plain_preview(raw_content))
+                    else:
+                        session.record_mutation(
+                            lambda f=found: format_support.replace_single_range_with_content(doc, f, content, ctx.ctx, config_svc),
+                            original_preview=original, proposed_preview=_plain_preview(content))
+                    count += 1
             if count == 0:
                 return {"status": "error",
                         "message": "Replaced 0 occurrence(s). No matches found. Try a shorter substring.",
-                        "replaced_count": 0}
+                        "replaced_count": 0}, session
             msg = "Replaced %d occurrence(s)." % count
             if use_preserve:
                 msg += " (formatting preserved)"
-            return {"status": "ok", "message": msg, "replaced_count": count}
+            return {"status": "ok", "message": msg, "replaced_count": count}, session
         found = _find_first_range(doc, search_string)
         if found is None:
             return {"status": "error", "message": "old_content not found in document. Try a shorter, unique substring.",
-                    "replaced_count": 0}
-        if use_preserve:
-            format_support.replace_preserving_format(doc, found, raw_content, ctx.ctx)
-        else:
-            format_support.replace_single_range_with_content(doc, found, content, ctx.ctx, config_svc)
+                    "replaced_count": 0}, session
+        original = found.getString()
+        with session:
+            if use_preserve:
+                session.record_mutation(
+                    lambda: format_support.replace_preserving_format(doc, found, raw_content, ctx.ctx),
+                    original_preview=original, proposed_preview=_plain_preview(raw_content))
+            else:
+                session.record_mutation(
+                    lambda: format_support.replace_single_range_with_content(doc, found, content, ctx.ctx, config_svc),
+                    original_preview=original, proposed_preview=_plain_preview(content))
         msg = "Replaced 1 occurrence (by old_content)."
         if use_preserve:
             msg += " (formatting preserved)"
-        return {"status": "ok", "message": msg, "replaced_count": 1}
+        return {"status": "ok", "message": msg, "replaced_count": 1}, session
 
 
 # ------------------------------------------------------------------

--- a/plugin/writer/edit_review.py
+++ b/plugin/writer/edit_review.py
@@ -1,0 +1,495 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Edit review session: agent edits land as reviewable tracked changes, and the agent
+learns the per-change outcome.
+
+One module owns the whole review story (recording state, author scoping, change tagging,
+anchoring, outcome detection, wait-for-review, cleanup), so entry points don't sprinkle
+``RecordChanges`` / author toggles around::
+
+    with EditReviewSession(doc, ctx, enabled=flag) as session:
+        session.record_mutation(apply_fn)      # one call per logical change
+    outcomes = session.wait_for_review(timeout=600)   # polls on the caller's thread
+
+How a change is tracked end to end:
+
+* ``record_mutation`` snapshots the document's redline identifiers, runs the edit, and tags
+  every NEW redline's ``RedlineComment`` with a per-change token (``wa-review:<session>:<n>``).
+  Completion is "no redline carrying this session's token remains" -- NOT "zero redlines in
+  the document" -- so the user's own pre-existing redlines never block or confuse it.
+* Each change is anchored with a bookmark (``wa_review_<session>_<n>``) spanning the affected
+  range, so it survives positions shifting as other changes are resolved. Bookmarks are
+  always removed when the review finishes (success, timeout, or error).
+* Outcome detection must survive the redline disappearing on BOTH accept and reject, and the
+  user editing the text during review. At record time we derive, from the tracked state, the
+  paragraph text as it would read after an accept (skip tracked deletions) and after a reject
+  (skip tracked insertions). At review end the anchored paragraph is compared against both:
+  equal to the accept form -> ``accepted``; the reject form -> ``rejected``; anything else ->
+  ``modified`` (the agent must not assume either text survived).
+
+The session is inert when ``enabled`` is False (edits apply directly, ``wait_for_review``
+returns an empty complete result), and degrades to inert if tracking cannot be enabled.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+import uuid
+from typing import Any, Callable
+
+log = logging.getLogger(__name__)
+
+# Public: every redline recorded by an EditReviewSession carries a RedlineComment starting
+# with this prefix (full form: "wa-review:<session>:<n>"). The review UIs key off it.
+TOKEN_PREFIX = "wa-review:"
+_BOOKMARK_PREFIX = "wa_review_"
+_PREVIEW_MAX_CHARS = 300
+
+
+def _preview(text: str) -> str:
+    """Bound a preview string (a full-document replace would otherwise ship megabytes)."""
+    text = text or ""
+    if len(text) <= _PREVIEW_MAX_CHARS:
+        return text
+    return text[: _PREVIEW_MAX_CHARS - 1] + "…"
+
+
+def review_recording_enabled(ctx: Any) -> bool:
+    """True when agent edits must be recorded as reviewable tracked changes.
+
+    writer.require_edit_review implies recording, so EVERY agent edit path must check both
+    flags through this helper -- not just writer.track_changes_reviewable.
+    """
+    from plugin.framework.config import get_config_bool_safe
+
+    return (get_config_bool_safe(ctx, "writer.track_changes_reviewable")
+            or get_config_bool_safe(ctx, "writer.require_edit_review"))
+
+
+def snapshot_redline_ids(doc: Any) -> set:
+    """Set of current RedlineIdentifiers -- snapshot before an edit to find the ones it adds."""
+    ids = set()
+    try:
+        enum = doc.getRedlines().createEnumeration()
+        while enum.hasMoreElements():
+            rl = enum.nextElement()
+            try:
+                ids.add(rl.getPropertyValue("RedlineIdentifier"))
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return ids
+
+
+def tag_agent_redlines(doc: Any, before_ids: set, change_index: int = 0) -> str | None:
+    """Stamp a fresh ``wa-review:<session>:<n>`` token on every redline created since
+    *before_ids*, marking them as ONE agent change so the inline review UI recognizes them.
+
+    For edit paths that produce their own redlines and only need them reviewable (e.g. the
+    streamed extend-selection rewrite, which already collapses to a single tracked change) --
+    no anchor/outcome/wait, which the streamed chat path doesn't use. Returns the token, or
+    None if nothing new was tagged.
+    """
+    token = "%s%s:%d" % (TOKEN_PREFIX, uuid.uuid4().hex[:8], change_index)
+    tagged = 0
+    try:
+        enum = doc.getRedlines().createEnumeration()
+        while enum.hasMoreElements():
+            rl = enum.nextElement()
+            try:
+                if rl.getPropertyValue("RedlineIdentifier") not in before_ids:
+                    rl.setPropertyValue("RedlineComment", token)
+                    tagged += 1
+            except Exception:
+                continue
+    except Exception:
+        log.debug("tag_agent_redlines: failed", exc_info=True)
+        return None
+    return token if tagged else None
+
+
+def _paragraph_cursor_for_range(text_range: Any) -> Any:
+    """A text cursor expanded to whole paragraphs around *text_range*."""
+    text = text_range.getText()
+    cur = text.createTextCursorByRange(text_range.getStart())
+    cur.gotoStartOfParagraph(False)
+    end = text.createTextCursorByRange(text_range.getEnd())
+    end.gotoEndOfParagraph(True)
+    cur.gotoRange(end.getEnd(), True)
+    return cur
+
+
+def _string_skipping_redline(text_range: Any, skip_type: str) -> str:
+    """Text of *text_range* with portions inside tracked *skip_type* redlines removed.
+
+    ``skip_type="Delete"`` yields the text as it would read if everything were ACCEPTED;
+    ``skip_type="Insert"`` yields the text as if everything were REJECTED. Mirrors
+    ``document_helpers.get_string_without_tracked_deletions`` but parameterized.
+    """
+    try:
+        para_enum = text_range.createEnumeration()
+    except Exception:
+        return text_range.getString()
+
+    parts: list[str] = []
+    try:
+        first = True
+        while para_enum.hasMoreElements():
+            para = para_enum.nextElement()
+            if not first:
+                parts.append("\n")
+            first = False
+            try:
+                portion_enum = para.createEnumeration()
+            except Exception:
+                parts.append(para.getString())
+                continue
+            skipping = False
+            while portion_enum.hasMoreElements():
+                portion = portion_enum.nextElement()
+                try:
+                    portion_type = portion.getPropertyValue("TextPortionType")
+                except Exception:
+                    continue
+                if portion_type == "Redline":
+                    try:
+                        if str(portion.getPropertyValue("RedlineType")) == skip_type:
+                            skipping = not skipping
+                    except Exception:
+                        pass
+                    continue
+                if skipping:
+                    continue
+                try:
+                    chunk = portion.getString()
+                except Exception:
+                    continue
+                if chunk:
+                    parts.append(chunk)
+    except Exception:
+        return text_range.getString()
+    return "".join(parts)
+
+
+class ChangeRecord:
+    """One reviewable change: its token, anchor, and the two expected end states."""
+
+    def __init__(self, token: str, bookmark: str, accepted_text: str, rejected_text: str,
+                 original_preview: str, proposed_preview: str) -> None:
+        self.token = token
+        self.bookmark = bookmark
+        self.accepted_text = accepted_text
+        self.rejected_text = rejected_text
+        self.original_preview = original_preview
+        self.proposed_preview = proposed_preview
+
+
+class EditReviewSession:
+    """Record agent edits as tagged tracked changes and report per-change outcomes."""
+
+    def __init__(self, doc: Any, ctx: Any, enabled: bool) -> None:
+        self.doc = doc
+        self.ctx = ctx
+        self.enabled = bool(enabled)
+        self.session_id = uuid.uuid4().hex[:8]
+        self.changes: list[ChangeRecord] = []
+        self._active = False
+        self._was_recording = False
+        self._prior_author: tuple[str, str] | None = None
+        self._cleaned = False
+
+    # -- session token helpers -------------------------------------------------------------
+
+    def _token(self, n: int) -> str:
+        return "%s%s:%d" % (TOKEN_PREFIX, self.session_id, n)
+
+    def _session_token_prefix(self) -> str:
+        return "%s%s:" % (TOKEN_PREFIX, self.session_id)
+
+    # -- author scoping --------------------------------------------------------------------
+    #
+    # Redlines record the author at creation time (read-only afterward). Split authoring
+    # (review_authors) sets the INSERT author as the default and lets the replace primitives
+    # author their setString("") deletion as the DELETE author -- two authors so LibreOffice's
+    # by-author coloring shows insertions and deletions in two distinct colors.
+
+    def _swap_author(self) -> None:
+        from plugin.writer import review_authors
+
+        self._prior_author = review_authors.begin(self.ctx)
+
+    def _restore_author(self) -> None:
+        from plugin.writer import review_authors
+
+        review_authors.end(self.ctx, self._prior_author)
+        self._prior_author = None
+
+    # -- context manager --------------------------------------------------------------------
+
+    def __enter__(self) -> "EditReviewSession":
+        if not self.enabled:
+            return self
+        try:
+            self._was_recording = bool(self.doc.getPropertyValue("RecordChanges"))
+        except Exception:
+            self._was_recording = False
+        if not self._was_recording:
+            try:
+                self.doc.setPropertyValue("RecordChanges", True)
+            except Exception:
+                # Cannot track: degrade to a direct (unreviewed) edit rather than failing.
+                log.warning("EditReviewSession: could not enable RecordChanges; edits will be unreviewed")
+                return self
+        self._active = True
+        self._swap_author()
+        # Make the markup visible so the user actually sees what to review.
+        try:
+            self.doc.setPropertyValue("ShowChanges", True)
+        except Exception:
+            log.debug("EditReviewSession: could not force ShowChanges", exc_info=True)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if not self._active:
+            return
+        self._restore_author()
+        if not self._was_recording:
+            try:
+                self.doc.setPropertyValue("RecordChanges", False)
+            except Exception:
+                log.warning(
+                    "EditReviewSession: failed to restore RecordChanges=False; "
+                    "user may be left with Track Changes ON", exc_info=True)
+        # Bookmarks stay until wait_for_review/cleanup: outcomes are read after this block.
+
+    # -- recording ---------------------------------------------------------------------------
+
+    def _redline_idents(self) -> set:
+        idents = set()
+        enum = self.doc.getRedlines().createEnumeration()
+        while enum.hasMoreElements():
+            rl = enum.nextElement()
+            try:
+                idents.add(rl.getPropertyValue("RedlineIdentifier"))
+            except Exception:
+                continue
+        return idents
+
+    def record_mutation(self, apply_fn: Callable[[], Any],
+                        original_preview: str = "", proposed_preview: str = "") -> Any:
+        """Run one logical edit and register it as a reviewable change.
+
+        Call once per logical change (per replaced match, per inserted block) so each gets
+        its own accept/reject outcome. Returns ``apply_fn``'s return value.
+        """
+        if not self._active:
+            return apply_fn()
+
+        before = self._redline_idents()
+        result = apply_fn()
+
+        new_redlines = []
+        enum = self.doc.getRedlines().createEnumeration()
+        while enum.hasMoreElements():
+            rl = enum.nextElement()
+            try:
+                if rl.getPropertyValue("RedlineIdentifier") not in before:
+                    new_redlines.append(rl)
+            except Exception:
+                continue
+        if not new_redlines:
+            return result
+
+        n = len(self.changes)
+        token = self._token(n)
+        with self._undo_lock():
+            for rl in new_redlines:
+                try:
+                    rl.setPropertyValue("RedlineComment", token)
+                except Exception:
+                    log.debug("EditReviewSession: could not tag a redline", exc_info=True)
+
+        # Bounding span across the new redlines -> anchor bookmark + expected end states.
+        # Built with cursor.gotoRange(range, expand=True): XTextRangeCompare is unreliable on
+        # redline ranges (a tracked DELETE's text sits outside the normal flow), so comparing
+        # starts/ends can collapse the span for replace changes.
+        ranges = []
+        for rl in new_redlines:
+            try:
+                s = rl.getPropertyValue("RedlineStart")
+                e = rl.getPropertyValue("RedlineEnd")
+            except Exception:
+                continue
+            if s is not None and e is not None:
+                ranges.append((s, e))
+        bookmark_name = ""
+        accepted_text = rejected_text = ""
+        if ranges:
+            try:
+                span = ranges[0][0].getText().createTextCursorByRange(ranges[0][0])
+                for s, e in ranges:
+                    span.gotoRange(s, True)  # expand=True grows the span in either direction
+                    span.gotoRange(e, True)
+                para = _paragraph_cursor_for_range(span)
+                accepted_text = _string_skipping_redline(para, "Delete")
+                rejected_text = _string_skipping_redline(para, "Insert")
+                bookmark_name = "%s%s_%d" % (_BOOKMARK_PREFIX, self.session_id, n)
+                bm = self.doc.createInstance("com.sun.star.text.Bookmark")
+                bm.setName(bookmark_name)
+                with self._undo_lock():
+                    para.getText().insertTextContent(para, bm, True)
+            except Exception:
+                bookmark_name = ""
+                log.debug("EditReviewSession: anchoring failed for change %d", n, exc_info=True)
+
+        self.changes.append(ChangeRecord(
+            token, bookmark_name, accepted_text, rejected_text,
+            original_preview or rejected_text, proposed_preview or accepted_text))
+        return result
+
+    # -- review ------------------------------------------------------------------------------
+
+    def _pending_tokens(self) -> set:
+        """Tokens of this session's changes that still have an unresolved redline."""
+        prefix = self._session_token_prefix()
+        pending = set()
+        try:
+            enum = self.doc.getRedlines().createEnumeration()
+            while enum.hasMoreElements():
+                rl = enum.nextElement()
+                try:
+                    comment = str(rl.getPropertyValue("RedlineComment"))
+                except Exception:
+                    continue
+                if comment.startswith(prefix):
+                    pending.add(comment)
+        except Exception:
+            log.debug("EditReviewSession: pending check failed", exc_info=True)
+        return pending
+
+    def _paragraph_text_at_anchor(self, record: ChangeRecord) -> str | None:
+        """Current whole-paragraph text at the change's bookmark, or None if the anchor is gone."""
+        if not record.bookmark:
+            return None
+        try:
+            bookmarks = self.doc.getBookmarks()
+            if not bookmarks.hasByName(record.bookmark):
+                return None
+            anchor = bookmarks.getByName(record.bookmark).getAnchor()
+            return _paragraph_cursor_for_range(anchor).getString()
+        except Exception:
+            log.debug("EditReviewSession: anchor read failed for %s", record.bookmark, exc_info=True)
+            return None
+
+    def _outcome(self, record: ChangeRecord, pending_tokens: set) -> str:
+        if record.token in pending_tokens:
+            return "pending"
+        current = self._paragraph_text_at_anchor(record)
+        if current is None:
+            # Anchor paragraph gone: a rejected pure insertion removes the paragraph (and
+            # the bookmark with it); anything else means the user reworked the area.
+            return "rejected" if record.rejected_text == "" else "modified"
+        if current == record.accepted_text:
+            return "accepted"
+        if current == record.rejected_text:
+            return "rejected"
+        return "modified"
+
+    @contextlib.contextmanager
+    def _undo_lock(self):
+        """Keep our internal bookkeeping (redline tagging, anchor bookmarks) OFF the user's
+        undo stack. Without this, the first one or two Ctrl+Z presses after an agent edit only
+        toggle our invisible wa_review bookmarks instead of undoing the visible change. Locking
+        the document undo manager around those writes is a no-op if the manager is unavailable."""
+        manager = None
+        try:
+            manager = self.doc.getUndoManager()
+            manager.lock()
+        except Exception:
+            manager = None
+        try:
+            yield
+        finally:
+            if manager is not None:
+                try:
+                    manager.unlock()
+                except Exception:
+                    log.debug("EditReviewSession: undo manager unlock failed", exc_info=True)
+
+    def cleanup(self) -> None:
+        """Remove this session's anchor bookmarks. Safe to call more than once."""
+        if self._cleaned:
+            return
+        self._cleaned = True
+        try:
+            bookmarks = self.doc.getBookmarks()
+            with self._undo_lock():
+                for record in self.changes:
+                    if not record.bookmark:
+                        continue
+                    try:
+                        if bookmarks.hasByName(record.bookmark):
+                            bm = bookmarks.getByName(record.bookmark)
+                            bm.getAnchor().getText().removeTextContent(bm)
+                    except Exception:
+                        log.debug("EditReviewSession: bookmark cleanup failed for %s", record.bookmark, exc_info=True)
+        except Exception:
+            log.debug("EditReviewSession: bookmark cleanup failed", exc_info=True)
+
+    def _review_payload(self, complete: bool, timed_out: bool) -> dict:
+        pending = self._pending_tokens()
+        return {
+            "complete": complete,
+            "timed_out": timed_out,
+            "changes": [
+                {
+                    "id": record.token,
+                    # Three-state outcome (accepted/rejected/modified, or pending on timeout):
+                    # a boolean can't express "the user edited this area during review".
+                    "outcome": self._outcome(record, pending),
+                    "original_preview": _preview(record.original_preview),
+                    "proposed_preview": _preview(record.proposed_preview),
+                }
+                for record in self.changes
+            ],
+        }
+
+    def wait_for_review(self, timeout: float, poll: float = 0.3,
+                        stop_checker: Callable[[], bool] | None = None,
+                        uno_runner: Callable[[Callable[[], Any]], Any] | None = None) -> dict:
+        """Block (on the caller's thread) until every change is resolved, then report outcomes.
+
+        Returns ``{"complete", "timed_out", "changes": [{"id", "outcome", ...}]}``. On timeout
+        the still-open entries report ``"pending"`` and ``complete`` is False -- the agent must
+        not assume the text's state. *stop_checker* lets the caller abort early (e.g. the
+        review feature was toggled off mid-wait); that also returns ``complete=False``.
+
+        Thread placement: poll from a background/HTTP thread so the main thread stays free for
+        the user's accept/reject clicks. UNO is not thread-safe, so callers off the main thread
+        pass ``uno_runner`` (e.g. ``execute_on_main_thread``) and every document read/cleanup in
+        the loop is marshalled through it; the sleep itself stays on the calling thread.
+        """
+        run = uno_runner if uno_runner is not None else (lambda fn: fn())
+        if not self._active or not self.changes:
+            try:
+                return {"complete": True, "timed_out": False, "changes": []}
+            finally:
+                run(self.cleanup)
+        try:
+            deadline = time.monotonic() + max(0.0, timeout)
+            timed_out = False
+            while run(self._pending_tokens):
+                if stop_checker is not None and stop_checker():
+                    return run(lambda: self._review_payload(complete=False, timed_out=False))
+                if time.monotonic() >= deadline:
+                    timed_out = True
+                    break
+                time.sleep(poll)
+            return run(lambda: self._review_payload(complete=not timed_out, timed_out=timed_out))
+        finally:
+            run(self.cleanup)

--- a/plugin/writer/editselection.py
+++ b/plugin/writer/editselection.py
@@ -25,7 +25,7 @@ from plugin.chatbot.dialogs import msgbox
 from plugin.framework.i18n import _
 from plugin.framework.config import set_config
 from plugin.framework.client.llm_client import LlmClient
-from plugin.doc.document_helpers import WriterCompoundUndo, WriterStreamedRewriteSession, build_writer_rewrite_prompt, get_string_without_tracked_deletions
+from plugin.doc.document_helpers import WriterStreamedAppendSession, WriterStreamedRewriteSession, build_writer_rewrite_prompt, get_string_without_tracked_deletions
 from plugin.writer.edit_review import review_recording_enabled
 
 
@@ -53,20 +53,23 @@ def do_extend_selection(ctx, model, input_box_fn):
 
     client = LlmClient(api_config, ctx)
 
-    compound_undo = WriterCompoundUndo(model, "WriterAgent: Extend selection")
+    session = WriterStreamedAppendSession(
+        model, text_range, original_text,
+        track_reviewable=review_recording_enabled(ctx),
+    )
 
     def apply_chunk(chunk_text, is_thinking=False):
         if not is_thinking:
-            text_range.setString(text_range.getString() + chunk_text)
+            session.append_chunk(chunk_text)
 
     def on_done():
-        compound_undo.close()
+        warning = session.finish()
+        if warning:
+            msgbox(ctx, _("WriterAgent: Extend Selection"), warning)
 
     def on_error(e):
-        try:
-            msgbox(ctx, _("WriterAgent: Extend Selection"), _(format_error_message(e)))
-        finally:
-            compound_undo.close()
+        session.abort_and_restore()
+        msgbox(ctx, _("WriterAgent: Extend Selection"), _(format_error_message(e)))
 
     try:
         run_stream_completion_async(ctx, client, prompt, system_prompt, max_tokens, apply_chunk, on_done, on_error)

--- a/plugin/writer/editselection.py
+++ b/plugin/writer/editselection.py
@@ -26,6 +26,7 @@ from plugin.framework.i18n import _
 from plugin.framework.config import set_config
 from plugin.framework.client.llm_client import LlmClient
 from plugin.doc.document_helpers import WriterCompoundUndo, WriterStreamedRewriteSession, build_writer_rewrite_prompt, get_string_without_tracked_deletions
+from plugin.writer.edit_review import review_recording_enabled
 
 
 def do_extend_selection(ctx, model, input_box_fn):
@@ -100,7 +101,10 @@ def do_edit_selection(ctx, model, input_box_fn):
         return
 
     client = LlmClient(api_config, ctx)
-    session = WriterStreamedRewriteSession(model, text_range, original_text)
+    session = WriterStreamedRewriteSession(
+        model, text_range, original_text,
+        track_reviewable=review_recording_enabled(ctx),
+    )
 
     def apply_chunk(chunk_text, is_thinking=False):
         if not is_thinking:

--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -35,6 +35,7 @@ from plugin.doc.document_helpers import normalize_linebreaks as _normalize, get_
 from .math.html_math_segment import html_fragment_contains_mixed_math, segment_html_with_mixed_math
 from .math.math_mml_convert import convert_latex_to_starmath, convert_mathml_to_starmath, insert_writer_math_formula
 from .ops import get_selection_range
+from .review_authors import deletion_author
 from . import xhtml_style_postprocess as xhtml_post
 
 log = logging.getLogger("writeragent.writer")
@@ -884,9 +885,25 @@ def replace_full_document(model, ctx, content, config_svc=None):
     cursor = text.createTextCursor()
     cursor.gotoStart(False)
     cursor.gotoEnd(True)
-    cursor.setString("")
+    with deletion_author():  # author the deletion distinctly (split by-author coloring)
+        cursor.setString("")
     cursor.gotoStart(False)
     _insert_mixed_or_plain_html(model, ctx, cursor, content, config_svc=config_svc)
+
+
+def _is_recording_changes(model):
+    """True if *model* is currently recording Track Changes (redlines).
+
+    Agent edits made while recording must land as a clean tracked Delete + Insert so the
+    user can accept (-> new text) or reject (-> old text) each one. The format-preserving
+    replace paths (the char-by-char diff in ``replace_preserving_format`` and the
+    paragraph-style restore below) corrupt that into a per-character mess or a FORMAT
+    redline that keeps the old text on Accept -- so those steps are skipped while recording.
+    """
+    try:
+        return bool(model.getPropertyValue("RecordChanges"))
+    except Exception:
+        return False
 
 
 def replace_single_range_with_content(model, text_range, content, ctx, config_svc=None):
@@ -915,7 +932,8 @@ def replace_single_range_with_content(model, text_range, content, ctx, config_sv
             saved_style = None
 
     cursor = text_obj.createTextCursorByRange(text_range)
-    cursor.setString("")
+    with deletion_author():  # author the deletion distinctly (split by-author coloring)
+        cursor.setString("")
 
     if saved_style is not None:
         anchor = text_obj.createTextCursorByRange(cursor.getStart())
@@ -925,12 +943,19 @@ def replace_single_range_with_content(model, text_range, content, ctx, config_sv
         # INSERTED content (not the document end), so [anchor, cursor] bounds it.
         inline_html = prepared.replace("\\n", "\n").replace("\\t", "\t")
         insert_html_fragment_at_cursor(cursor, inline_html, wrap=False, config_svc=config_svc, model=None)
-        try:
-            restore = text_obj.createTextCursorByRange(anchor.getStart())
-            restore.gotoRange(cursor.getEnd(), True)
-            apply_paragraph_style_preserving_direct_char(model, restore, saved_style)
-        except Exception:
-            log.debug("replace_single_range_with_content: could not restore ParaStyleName", exc_info=True)
+        # Re-apply the saved paragraph style (the HTML import can demote Heading -> body).
+        # Skip it while Track Changes is recording: setString("") above leaves the old text in
+        # place as a tracked DELETE, and re-applying a paragraph style across [anchor, cursor]
+        # spans that struck text, converting its DELETE redline into a FORMAT redline -- so
+        # accepting the change would keep BOTH the old and new text. The inline import does not
+        # demote the style here, so skipping the restore keeps a clean Delete + Insert pair.
+        if not _is_recording_changes(model):
+            try:
+                restore = text_obj.createTextCursorByRange(anchor.getStart())
+                restore.gotoRange(cursor.getEnd(), True)
+                apply_paragraph_style_preserving_direct_char(model, restore, saved_style)
+            except Exception:
+                log.debug("replace_single_range_with_content: could not restore ParaStyleName", exc_info=True)
     else:
         # apply_styles=False: a search/replace splits the matched paragraph, so applying a
         # data-lo-style here would restyle the surrounding text. Styled writes use full_document.
@@ -1192,6 +1217,19 @@ def replace_preserving_format(model, target_range, new_text, ctx=None):
     text = target_range.getText()
     old_text = _normalize(target_range.getString())
     new_text = _normalize(new_text)
+
+    # Track Changes: the char-by-char diff below records a separate redline for EACH changed
+    # character, which renders as a scrambled, un-reviewable mess (old and new text interleaved).
+    # When recording, replace the whole range in one shot so the edit is a single tracked
+    # Delete + Insert the user can accept (-> new text) or reject (-> old text) cleanly.
+    if _is_recording_changes(model):
+        cursor = text.createTextCursorByRange(target_range)
+        with deletion_author():  # author the deletion distinctly (split by-author coloring)
+            cursor.setString("")
+        if new_text:
+            text.insertString(cursor, new_text, False)
+        return
+
     old_len = len(old_text)
     new_len = len(new_text)
 

--- a/plugin/writer/inline_review.py
+++ b/plugin/writer/inline_review.py
@@ -1,0 +1,271 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Inline review of tracked changes.
+
+Accept or reject the tracked change the cursor sits on as ONE unit. A text replace records two
+redlines -- a Delete (struck old text) and an Insert (new text) -- which LibreOffice's native UI
+lets you resolve independently, so accepting one and rejecting the other yields an incoherent
+result. Here we resolve every tracked change in the cursor's paragraph together (a replace's
+delete+insert live in the same paragraph), driving the native ``.uno:AcceptTrackedChange`` /
+``.uno:RejectTrackedChange`` on a paragraph-wide selection.
+
+Selecting a RANGE and dispatching (rather than selecting a single redline's anchor) is deliberate:
+a pure Delete redline has an empty anchor, so the per-redline ``select(anchor)`` path in
+``tracking.py`` cannot target it; a range selection covers both marks of the pair.
+
+This is the model layer; the right-click context menu in ``change_context_menu.py`` calls it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def _redline_count(model: Any) -> int:
+    """Number of tracked changes (redlines) currently in the document."""
+    n = 0
+    try:
+        enum = model.getRedlines().createEnumeration()
+        while enum.hasMoreElements():
+            enum.nextElement()
+            n += 1
+    except Exception:
+        log.debug("inline_review: could not enumerate redlines", exc_info=True)
+    return n
+
+
+def has_agent_changes(model: Any) -> bool:
+    """True if the document holds any pending AGENT change (gates the review UI entries)."""
+    return bool(_agent_redlines(model))
+
+
+def resolve_change_at_cursor(model: Any, ctx: Any, accept: bool) -> tuple[bool, str]:
+    """Accept (``accept=True``) or reject the AGENT change under the view cursor, as one unit
+    (the whole Delete+Insert pair of a replace).
+
+    Only agent changes (wa-review session tokens) are eligible -- the user's own tracked
+    changes are left to LibreOffice's native review UI. Returns ``(ok, message)``; ``ok`` is
+    False with a friendly message when the cursor is not on an agent change.
+    """
+    token = cursor_in_agent_change(model)
+    if token is None:
+        if not _agent_redlines(model):
+            return False, "No agent changes to review in this document."
+        return False, "Put the cursor on a highlighted agent change first."
+    if not resolve_agent_change(model, ctx, token, accept):
+        return False, "Could not resolve the agent change at the cursor."
+    return True, "Change accepted." if accept else "Change rejected."
+
+
+# --- agent-change helpers (used by the click popup and the context menu) -------------------
+#
+# Every redline an EditReviewSession records carries a RedlineComment "wa-review:<session>:<n>"
+# (see edit_review.TOKEN_PREFIX); one token = one logical change (a replace's Delete+Insert
+# pair shares it). These helpers see the document purely through those tokens, so the user's
+# own tracked changes are never listed or resolved.
+
+
+def _agent_redlines(model: Any) -> list:
+    """[(token, redline)] for every redline tagged by an EditReviewSession."""
+    from plugin.writer.edit_review import TOKEN_PREFIX
+
+    out = []
+    try:
+        enum = model.getRedlines().createEnumeration()
+        while enum.hasMoreElements():
+            rl = enum.nextElement()
+            try:
+                comment = str(rl.getPropertyValue("RedlineComment"))
+            except Exception:
+                continue
+            if comment.startswith(TOKEN_PREFIX):
+                out.append((comment, rl))
+    except Exception:
+        log.debug("inline_review: agent redline scan failed", exc_info=True)
+    return out
+
+
+def agent_changes(model: Any) -> list[dict]:
+    """Pending agent changes, one entry per logical change (grouped by token), in document
+    order of first appearance: ``{"token", "old", "new"}``. The old/new preview texts are what
+    a review surface needs to present a change; the tests also use them to pin the grouping of
+    a change's Delete+Insert pair under one token."""
+    grouped: dict[str, dict] = {}
+    for token, rl in _agent_redlines(model):
+        entry = grouped.setdefault(token, {"token": token, "old": "", "new": ""})
+        try:
+            kind = str(rl.getPropertyValue("RedlineType"))
+            start = rl.getPropertyValue("RedlineStart")
+            end = rl.getPropertyValue("RedlineEnd")
+            if start is None or end is None:
+                continue
+            span = start.getText().createTextCursorByRange(start)
+            span.gotoRange(end, True)
+            text = span.getString()
+            if kind == "Delete":
+                entry["old"] += text
+            elif kind == "Insert":
+                entry["new"] += text
+        except Exception:
+            continue
+    return list(grouped.values())
+
+
+def _change_bounds(model: Any, token: str):
+    """Bounding (start, end) text ranges spanning all redlines of one change, or (None, None).
+
+    Builds the union with ``cursor.gotoRange(..., expand=True)`` rather than
+    ``compareRegionStarts``: the latter is unreliable on redline ranges (a tracked DELETE's text
+    is not in the normal flow), which collapsed the selection for replace changes (Insert+Delete).
+    """
+    ranges = []
+    for comment, rl in _agent_redlines(model):
+        if comment != token:
+            continue
+        try:
+            s = rl.getPropertyValue("RedlineStart")
+            e = rl.getPropertyValue("RedlineEnd")
+        except Exception:
+            continue
+        if s is not None and e is not None:
+            ranges.append((s, e))
+    if not ranges:
+        return None, None
+    try:
+        text = ranges[0][0].getText()
+        cursor = text.createTextCursorByRange(ranges[0][0])
+        for s, e in ranges:
+            cursor.gotoRange(s, True)  # expand=True grows the selection in either direction
+            cursor.gotoRange(e, True)
+        return cursor.getStart(), cursor.getEnd()
+    except Exception:
+        log.debug("inline_review: _change_bounds union failed", exc_info=True)
+        return ranges[0]
+
+
+def goto_agent_change(model: Any, token: str) -> bool:
+    """Move the view cursor to (and select) the given change so the user sees it."""
+    left, right = _change_bounds(model, token)
+    if left is None:
+        return False
+    try:
+        view_cursor = model.getCurrentController().getViewCursor()
+        view_cursor.gotoRange(left, False)
+        view_cursor.gotoRange(right, True)
+        return True
+    except Exception:
+        log.debug("inline_review: goto_agent_change failed", exc_info=True)
+        return False
+
+
+def cursor_in_agent_change(model: Any) -> str | None:
+    """Token of the agent change the view cursor currently sits in, else None."""
+    try:
+        cursor = model.getCurrentController().getViewCursor()
+        text = cursor.getText()
+        # Compare via a model text cursor: view-cursor-owned ranges can fail XTextRangeCompare.
+        pos = text.createTextCursorByRange(cursor.getStart())
+    except Exception:
+        return None
+    for token, rl in _agent_redlines(model):
+        try:
+            s = rl.getPropertyValue("RedlineStart")
+            e = rl.getPropertyValue("RedlineEnd")
+            if s is None or e is None:
+                continue
+            # Compare cursor-to-cursor: XTextRangeCompare can refuse mixed range flavors
+            # (a plain text cursor vs a redline-owned range), so wrap the redline in a
+            # text-cursor span first.
+            span = text.createTextCursorByRange(s)
+            span.gotoRange(e, True)
+            if text.compareRegionStarts(pos, span) == 1:  # pos before the span starts
+                continue
+            if text.compareRegionEnds(pos, span) == -1:  # pos after the span ends
+                continue
+            return token
+        except Exception:
+            continue
+    return None
+
+
+def resolve_agent_change(model: Any, ctx: Any, token: str, accept: bool) -> bool:
+    """Accept/reject ONE agent change (both marks of its pair) by token.
+
+    The dispatch selection is expanded to whole PARAGRAPHS around the change: empirically,
+    .uno:Accept/RejectTrackedChange does not resolve redlines when the selection matches the
+    redline bounds exactly, but does on a paragraph-wide selection. Limitation: another
+    tracked change sharing the same paragraph resolves along with it.
+    """
+    before = len(_agent_redlines(model))
+    left, right = _change_bounds(model, token)
+    if left is None:
+        return False
+    try:
+        text = left.getText()
+        start = text.createTextCursorByRange(left)
+        start.gotoStartOfParagraph(False)
+        end = text.createTextCursorByRange(right)
+        end.gotoEndOfParagraph(True)
+        view_cursor = model.getCurrentController().getViewCursor()
+        view_cursor.gotoRange(start.getStart(), False)
+        view_cursor.gotoRange(end.getEnd(), True)
+        controller = model.getCurrentController()
+        smgr = ctx.getServiceManager()
+        dispatcher = smgr.createInstanceWithContext("com.sun.star.frame.DispatchHelper", ctx)
+        command = ".uno:AcceptTrackedChange" if accept else ".uno:RejectTrackedChange"
+        dispatcher.executeDispatch(controller.getFrame(), command, "", 0, ())
+    except Exception:
+        log.exception("inline_review: resolve_agent_change dispatch failed")
+        return False
+    return len(_agent_redlines(model)) < before
+
+
+def resolve_all_agent_changes(model: Any, ctx: Any, accept: bool) -> int:
+    """Accept/reject every pending agent change (the user's own redlines stay untouched).
+    Returns how many changes were resolved."""
+    changes = agent_changes(model)
+    if not changes:
+        return 0
+
+    # Common case -- the document holds ONLY the agent's redlines: a single global
+    # AcceptAll/RejectAll dispatch is reliable. (A per-change dispatch loop only resolves
+    # the FIRST change per call in the live view: the second .uno:AcceptTrackedChange needs
+    # the event loop to cycle, which it cannot inside one synchronous handler.)
+    if len(_agent_redlines(model)) == _redline_count(model):
+        try:
+            controller = model.getCurrentController()
+            smgr = ctx.getServiceManager()
+            dispatcher = smgr.createInstanceWithContext("com.sun.star.frame.DispatchHelper", ctx)
+            command = ".uno:AcceptAllTrackedChanges" if accept else ".uno:RejectAllTrackedChanges"
+            dispatcher.executeDispatch(controller.getFrame(), command, "", 0, ())
+            return len(changes) if not agent_changes(model) else 0
+        except Exception:
+            log.exception("inline_review: resolve-all global dispatch failed")
+            return 0
+
+    # User redlines are mixed in: resolve agent changes one per pass, flushing pending VCL
+    # events between dispatches so each one actually takes effect in the live view.
+    resolved = 0
+    try:
+        toolkit = ctx.getServiceManager().createInstanceWithContext("com.sun.star.awt.Toolkit", ctx)
+    except Exception:
+        toolkit = None
+    for _ in range(200):  # generous upper bound; each pass resolves one change
+        changes = agent_changes(model)
+        if not changes:
+            break
+        if not resolve_agent_change(model, ctx, changes[0]["token"], accept):
+            log.warning("inline_review: could not resolve %s; stopping", changes[0]["token"])
+            break
+        resolved += 1
+        if toolkit is not None:
+            try:
+                toolkit.processEventsToIdle()
+            except Exception:
+                toolkit = None
+    return resolved

--- a/plugin/writer/inline_review.py
+++ b/plugin/writer/inline_review.py
@@ -25,6 +25,14 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
+# Shown when a conservative resolve refuses because the change shares a paragraph with the
+# user's own tracked change (or another agent change). Surfaced via show_review_message() so a
+# click that resolves nothing on purpose isn't silent.
+_RESOLVE_REFUSED_HINT = (
+    "Could not resolve this change here -- it may share a paragraph with one of"
+    " your tracked changes or another agent change. Resolve it from Edit > Track Changes > Manage."
+)
+
 
 def _redline_count(model: Any) -> int:
     """Number of tracked changes (redlines) currently in the document."""
@@ -58,9 +66,40 @@ def resolve_change_at_cursor(model: Any, ctx: Any, accept: bool) -> tuple[bool, 
             return False, "No agent changes to review in this document."
         return False, "Put the cursor on a highlighted agent change first."
     if not resolve_agent_change(model, ctx, token, accept):
-        return False, ("Could not resolve this change here -- it may share a paragraph with one of"
-                       " your tracked changes or another agent change. Resolve it from Edit > Track Changes > Manage.")
+        return False, _RESOLVE_REFUSED_HINT
     return True, "Change accepted." if accept else "Change rejected."
+
+
+def resolve_all_with_feedback(model: Any, ctx: Any, accept: bool) -> tuple[int, str]:
+    """Accept/reject all agent changes; return ``(count_resolved, message)``. The message is a
+    user-facing note when some or all changes were skipped -- they share a paragraph with one of
+    the user's own redlines, which resolve-all deliberately won't touch -- and empty when
+    everything resolved (or there was nothing to do)."""
+    total = len(agent_changes(model))
+    if total == 0:
+        return 0, "No agent changes to review in this document."
+    n = resolve_all_agent_changes(model, ctx, accept)
+    if n >= total:
+        return n, ""
+    if n == 0:
+        return 0, ("None could be resolved here -- each shares a paragraph with one of your own"
+                   " tracked changes. Resolve them from Edit > Track Changes > Manage.")
+    return n, ("Resolved %d of %d. The rest share a paragraph with your own tracked changes --"
+               " resolve those from Edit > Track Changes > Manage." % (n, total))
+
+
+def show_review_message(ctx: Any, message: str) -> None:
+    """Surface a review outcome (e.g. a conservative refusal) to the user so a click that
+    resolves nothing isn't silent. No-op on an empty message; best-effort -- UI feedback must
+    never break the resolve itself."""
+    if not message:
+        return
+    try:
+        from plugin.chatbot.dialogs import msgbox
+
+        msgbox(ctx, "Review agent changes", message)
+    except Exception:
+        log.debug("inline_review: could not show review message %r", message, exc_info=True)
 
 
 # --- agent-change helpers (used by the click popup and the context menu) -------------------

--- a/plugin/writer/inline_review.py
+++ b/plugin/writer/inline_review.py
@@ -58,7 +58,8 @@ def resolve_change_at_cursor(model: Any, ctx: Any, accept: bool) -> tuple[bool, 
             return False, "No agent changes to review in this document."
         return False, "Put the cursor on a highlighted agent change first."
     if not resolve_agent_change(model, ctx, token, accept):
-        return False, "Could not resolve the agent change at the cursor."
+        return False, ("Could not resolve this change here -- it may share a paragraph with one of"
+                       " your tracked changes or another agent change. Resolve it from Edit > Track Changes > Manage.")
     return True, "Change accepted." if accept else "Change rejected."
 
 
@@ -193,13 +194,100 @@ def cursor_in_agent_change(model: Any) -> str | None:
     return None
 
 
-def resolve_agent_change(model: Any, ctx: Any, token: str, accept: bool) -> bool:
+def _span_contains_point(text: Any, span: Any, point: Any) -> bool:
+    """True if collapsed range ``point`` lies within ``span``'s [start, end] (same ``text``)."""
+    try:
+        if text.compareRegionStarts(point, span) == 1:   # point starts before span -> left of it
+            return False
+        if text.compareRegionEnds(point, span) == -1:    # point ends after span -> right of it
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def _foreign_redline_in_span(model: Any, text: Any, span: Any) -> bool:
+    """True if any redline NOT tagged by an EditReviewSession overlaps ``span``.
+
+    The inline resolve drives a paragraph-wide ``.uno`` dispatch that resolves EVERY redline in
+    the range, so when a user-owned tracked change shares those paragraphs we refuse rather than
+    silently accept/reject it. Best-effort: a detection failure falls back to "no foreign
+    redline" so the common case (the user has none of their own) is never blocked.
+    """
+    from plugin.writer.edit_review import TOKEN_PREFIX
+
+    try:
+        enum = model.getRedlines().createEnumeration()
+    except Exception:
+        return False
+    while enum.hasMoreElements():
+        try:
+            rl = enum.nextElement()
+            if str(rl.getPropertyValue("RedlineComment")).startswith(TOKEN_PREFIX):
+                continue  # one of ours -- safe to resolve
+            s = rl.getPropertyValue("RedlineStart")
+            e = rl.getPropertyValue("RedlineEnd")
+            if s is None or e is None:
+                continue
+            rl_span = text.createTextCursorByRange(s)
+            rl_span.gotoRange(e, True)
+            # Overlap iff the foreign redline's start/end falls inside span, or span starts inside it.
+            if (_span_contains_point(text, span, rl_span.getStart())
+                    or _span_contains_point(text, span, rl_span.getEnd())
+                    or _span_contains_point(text, rl_span, span.getStart())):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _other_agent_redline_in_span(model: Any, text: Any, span: Any, token: str) -> bool:
+    """True if another agent change token overlaps ``span``.
+
+    The inline "this change" command is only truthful when the paragraph-wide dispatch contains
+    one logical agent change. If a second wa-review token shares the paragraph, LibreOffice would
+    resolve both, so we refuse and leave that dense case to the native Manage dialog.
+    """
+    from plugin.writer.edit_review import TOKEN_PREFIX
+
+    try:
+        enum = model.getRedlines().createEnumeration()
+    except Exception:
+        return False
+    while enum.hasMoreElements():
+        try:
+            rl = enum.nextElement()
+            comment = str(rl.getPropertyValue("RedlineComment"))
+            if not comment.startswith(TOKEN_PREFIX) or comment == token:
+                continue
+            s = rl.getPropertyValue("RedlineStart")
+            e = rl.getPropertyValue("RedlineEnd")
+            if s is None or e is None:
+                continue
+            rl_span = text.createTextCursorByRange(s)
+            rl_span.gotoRange(e, True)
+            if (_span_contains_point(text, span, rl_span.getStart())
+                    or _span_contains_point(text, span, rl_span.getEnd())
+                    or _span_contains_point(text, rl_span, span.getStart())):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def resolve_agent_change(model: Any, ctx: Any, token: str, accept: bool, refuse_sibling_agent: bool = True) -> bool:
     """Accept/reject ONE agent change (both marks of its pair) by token.
+
+    ``refuse_sibling_agent`` (default True) makes the single "resolve this change" command refuse
+    when ANOTHER agent change shares the paragraph, so it never silently resolves two. resolve-all
+    passes False -- there, resolving sibling agent changes together is the whole point; only a
+    USER redline in the paragraph still blocks it.
 
     The dispatch selection is expanded to whole PARAGRAPHS around the change: empirically,
     .uno:Accept/RejectTrackedChange does not resolve redlines when the selection matches the
-    redline bounds exactly, but does on a paragraph-wide selection. Limitation: another
-    tracked change sharing the same paragraph resolves along with it.
+    redline bounds exactly, but does on a paragraph-wide selection. Because that dispatch
+    resolves EVERY redline in the selection, we first refuse (return False) when a redline that
+    isn't ours shares those paragraphs -- the user's own tracked changes are never touched.
     """
     before = len(_agent_redlines(model))
     left, right = _change_bounds(model, token)
@@ -211,6 +299,16 @@ def resolve_agent_change(model: Any, ctx: Any, token: str, accept: bool) -> bool
         start.gotoStartOfParagraph(False)
         end = text.createTextCursorByRange(right)
         end.gotoEndOfParagraph(True)
+        # Never resolve a paragraph that also holds one of the user's own tracked changes:
+        # the dispatch below would accept/reject it too. Leave that case to the native review UI.
+        para_span = text.createTextCursorByRange(start.getStart())
+        para_span.gotoRange(end.getEnd(), True)
+        if _foreign_redline_in_span(model, text, para_span):
+            log.debug("inline_review: refusing inline resolve of %s -- a user redline shares its paragraph", token)
+            return False
+        if refuse_sibling_agent and _other_agent_redline_in_span(model, text, para_span, token):
+            log.debug("inline_review: refusing inline resolve of %s -- another agent change shares its paragraph", token)
+            return False
         view_cursor = model.getCurrentController().getViewCursor()
         view_cursor.gotoRange(start.getStart(), False)
         view_cursor.gotoRange(end.getEnd(), True)
@@ -251,17 +349,25 @@ def resolve_all_agent_changes(model: Any, ctx: Any, accept: bool) -> int:
     # User redlines are mixed in: resolve agent changes one per pass, flushing pending VCL
     # events between dispatches so each one actually takes effect in the live view.
     resolved = 0
+    skip: set[str] = set()  # changes that share a paragraph with a user redline (or failed)
     try:
         toolkit = ctx.getServiceManager().createInstanceWithContext("com.sun.star.awt.Toolkit", ctx)
     except Exception:
         toolkit = None
     for _ in range(200):  # generous upper bound; each pass resolves one change
-        changes = agent_changes(model)
-        if not changes:
+        pending = [c for c in agent_changes(model) if c["token"] not in skip]
+        if not pending:
             break
-        if not resolve_agent_change(model, ctx, changes[0]["token"], accept):
-            log.warning("inline_review: could not resolve %s; stopping", changes[0]["token"])
-            break
+        token = pending[0]["token"]
+        # resolve-all WANTS sibling agent changes in a paragraph resolved together -- only a USER
+        # redline there blocks it (checked inside via _foreign_redline_in_span). Single
+        # "resolve this change" keeps refuse_sibling_agent=True so it stays truthful.
+        if not resolve_agent_change(model, ctx, token, accept, refuse_sibling_agent=False):
+            # Refused (shares a paragraph with the user's own redline) or failed: skip it and keep
+            # resolving the rest -- the user handles the skipped one via the native review UI.
+            log.debug("inline_review: skipping %s in resolve-all (foreign redline or failure)", token)
+            skip.add(token)
+            continue
         resolved += 1
         if toolkit is not None:
             try:

--- a/plugin/writer/inline_review.py
+++ b/plugin/writer/inline_review.py
@@ -387,30 +387,34 @@ def resolve_all_agent_changes(model: Any, ctx: Any, accept: bool) -> int:
 
     # User redlines are mixed in: resolve agent changes one per pass, flushing pending VCL
     # events between dispatches so each one actually takes effect in the live view.
-    resolved = 0
+    initial = len(agent_changes(model))
     skip: set[str] = set()  # changes that share a paragraph with a user redline (or failed)
     try:
         toolkit = ctx.getServiceManager().createInstanceWithContext("com.sun.star.awt.Toolkit", ctx)
     except Exception:
         toolkit = None
-    for _ in range(200):  # generous upper bound; each pass resolves one change
+    for _ in range(200):  # generous upper bound; each pass clears at least one change (or skips)
         pending = [c for c in agent_changes(model) if c["token"] not in skip]
         if not pending:
             break
         token = pending[0]["token"]
+        before = len(agent_changes(model))
         # resolve-all WANTS sibling agent changes in a paragraph resolved together -- only a USER
         # redline there blocks it (checked inside via _foreign_redline_in_span). Single
         # "resolve this change" keeps refuse_sibling_agent=True so it stays truthful.
-        if not resolve_agent_change(model, ctx, token, accept, refuse_sibling_agent=False):
-            # Refused (shares a paragraph with the user's own redline) or failed: skip it and keep
-            # resolving the rest -- the user handles the skipped one via the native review UI.
-            log.debug("inline_review: skipping %s in resolve-all (foreign redline or failure)", token)
-            skip.add(token)
-            continue
-        resolved += 1
+        ok = resolve_agent_change(model, ctx, token, accept, refuse_sibling_agent=False)
         if toolkit is not None:
             try:
                 toolkit.processEventsToIdle()
             except Exception:
                 toolkit = None
-    return resolved
+        if not ok or len(agent_changes(model)) >= before:
+            # Refused (shares a paragraph with the user's own redline), failed, or cleared nothing:
+            # skip it so the rest still resolve and a stuck change can't spin the loop. The user
+            # handles the skipped one via the native review UI.
+            log.debug("inline_review: skipping %s in resolve-all (foreign redline or no change)", token)
+            skip.add(token)
+    # Count by how many agent changes actually disappeared, NOT a per-pass +1: one paragraph-wide
+    # dispatch can clear several sibling agent changes in the same clean paragraph at once, so +1
+    # would undercount and make resolve_all_with_feedback report a false "Resolved N of M".
+    return initial - len(agent_changes(model))

--- a/plugin/writer/module.yaml
+++ b/plugin/writer/module.yaml
@@ -3,4 +3,22 @@ title: Writer document tools (including navigation and search)
 requires: [document, config, format, events]
 provides_services: [writer_bookmarks, writer_tree, writer_proximity, writer_index]
 
-config: {}
+config:
+  track_changes_reviewable:
+    type: boolean
+    default: false
+    widget: checkbox
+    label: Review Agent Edits (Track Changes)
+    helper: "Record the agent's edits as tracked changes you can accept or reject"
+  require_edit_review:
+    type: boolean
+    default: false
+    widget: checkbox
+    label: Wait for Edit Review
+    helper: "The agent's edit call waits until you accept or reject its tracked changes (implies recording them)"
+  edit_review_timeout:
+    type: int
+    default: 900
+    widget: number
+    label: Edit Review Max Wait (seconds)
+    helper: "How long an edit call waits for review before returning with the changes still pending (0 disables waiting)"

--- a/plugin/writer/review_authors.py
+++ b/plugin/writer/review_authors.py
@@ -1,0 +1,112 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Split authoring for agent tracked changes: insertions and deletions get DIFFERENT authors
+so LibreOffice's "show changes by author" coloring shows them in two distinct colors.
+
+A redline's author is captured at creation time and is READ-ONLY afterward (setting
+RedlineAuthor on an existing redline is a silent no-op), so the only way to author a replace's
+Insert and Delete differently is to swap the office author BETWEEN the deletion and the
+insertion. EditReviewSession makes the INSERT author the default for the whole edit via
+``begin()``; each replace primitive wraps its ``setString("")`` deletion in ``deletion_author()``,
+which flips the office author to the DELETE author for that moment and back. All of this runs
+synchronously on the main thread, so the brief intermediate author state is never observed.
+
+The actual colors are LibreOffice's automatic per-author choice (we cannot pick them) -- the two
+authors just guarantee two distinct colors. Inert (no swaps) unless ``begin()`` armed this thread.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import threading
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Distinct authors -> distinct by-author colors. Both read as the agent in the Manage dialog.
+INSERT_AUTHOR = "WriterAgent"
+DELETE_AUTHOR = "WriterAgent (deletions)"
+
+_state = threading.local()
+
+
+def _author_access(ctx: Any) -> Any:
+    from com.sun.star.beans import NamedValue
+
+    smgr = ctx.getServiceManager()
+    provider = smgr.createInstanceWithContext("com.sun.star.configuration.ConfigurationProvider", ctx)
+    node = NamedValue()
+    node.Name = "nodepath"
+    node.Value = "/org.openoffice.UserProfile/Data"
+    return provider.createInstanceWithArguments(
+        "com.sun.star.configuration.ConfigurationUpdateAccess", (node,))
+
+
+def _set_office_author(ctx: Any, given: str) -> bool:
+    try:
+        access = _author_access(ctx)
+        access.setPropertyValue("givenname", given)
+        access.setPropertyValue("sn", "")
+        access.commitChanges()
+        return True
+    except Exception:
+        log.debug("review_authors: could not set office author", exc_info=True)
+        return False
+
+
+def begin(ctx: Any, insert_author: str = INSERT_AUTHOR, delete_author: str = DELETE_AUTHOR):
+    """Capture the prior office author, set the INSERT author as the default, and arm
+    ``deletion_author()`` on this thread. Returns the prior ``(given, sn)`` for ``end()``, or None.
+    """
+    prior = None
+    try:
+        access = _author_access(ctx)
+        prior = (str(access.getPropertyValue("givenname")), str(access.getPropertyValue("sn")))
+        access.setPropertyValue("givenname", insert_author)
+        access.setPropertyValue("sn", "")
+        access.commitChanges()
+    except Exception:
+        log.debug("review_authors.begin failed", exc_info=True)
+        prior = None
+    _state.ctx = ctx
+    _state.insert = insert_author
+    _state.delete = delete_author
+    return prior
+
+
+def end(ctx: Any, prior) -> None:
+    """Disarm split authoring and restore the prior office author."""
+    _state.ctx = None
+    _state.insert = None
+    _state.delete = None
+    if prior is None:
+        return
+    try:
+        access = _author_access(ctx)
+        access.setPropertyValue("givenname", prior[0])
+        access.setPropertyValue("sn", prior[1])
+        access.commitChanges()
+    except Exception:
+        log.warning("review_authors.end: failed to restore office author %r", prior, exc_info=True)
+
+
+@contextlib.contextmanager
+def deletion_author():
+    """Author the tracked deletion inside this block as the DELETE author, then restore the
+    INSERT author. A no-op unless ``begin()`` armed split authoring on this thread."""
+    ctx = getattr(_state, "ctx", None)
+    delete = getattr(_state, "delete", None)
+    insert = getattr(_state, "insert", None)
+    if ctx is None or not delete:
+        yield
+        return
+    if not _set_office_author(ctx, delete):
+        yield
+        return
+    try:
+        yield
+    finally:
+        _set_office_author(ctx, insert or "")

--- a/plugin/writer/review_authors.py
+++ b/plugin/writer/review_authors.py
@@ -60,20 +60,32 @@ def _set_office_author(ctx: Any, given: str) -> bool:
 def begin(ctx: Any, insert_author: str = INSERT_AUTHOR, delete_author: str = DELETE_AUTHOR):
     """Capture the prior office author, set the INSERT author as the default, and arm
     ``deletion_author()`` on this thread. Returns the prior ``(given, sn)`` for ``end()``, or None.
+
+    Split authoring is armed ONLY if the office author was actually switched. If that fails, the
+    thread-local is left disarmed -- so a failed begin() can never leave ``deletion_author()``
+    armed for a later, unrelated edit on this thread, even when the caller skips ``end()`` on a
+    None return.
     """
     prior = None
+    armed = False
     try:
         access = _author_access(ctx)
         prior = (str(access.getPropertyValue("givenname")), str(access.getPropertyValue("sn")))
         access.setPropertyValue("givenname", insert_author)
         access.setPropertyValue("sn", "")
         access.commitChanges()
+        armed = True
     except Exception:
         log.debug("review_authors.begin failed", exc_info=True)
         prior = None
-    _state.ctx = ctx
-    _state.insert = insert_author
-    _state.delete = delete_author
+    if armed:
+        _state.ctx = ctx
+        _state.insert = insert_author
+        _state.delete = delete_author
+    else:
+        _state.ctx = None
+        _state.insert = None
+        _state.delete = None
     return prior
 
 

--- a/plugin/writer/review_click_popup.py
+++ b/plugin/writer/review_click_popup.py
@@ -41,8 +41,9 @@ def _show_popup_and_resolve(model: Any, source_window: Any, x: int, y: int) -> N
             agent_changes,
             cursor_in_agent_change,
             goto_agent_change,
-            resolve_agent_change,
-            resolve_all_agent_changes,
+            resolve_all_with_feedback,
+            resolve_change_at_cursor,
+            show_review_message,
         )
 
         ctx = get_ctx()
@@ -72,13 +73,19 @@ def _show_popup_and_resolve(model: Any, source_window: Any, x: int, y: int) -> N
         rect.Height = 0
         choice = popup.execute(source_window, rect, 0)
         if choice == 1:
-            resolve_agent_change(model, ctx, token, True)
+            ok, msg = resolve_change_at_cursor(model, ctx, True)
+            if not ok:
+                show_review_message(ctx, msg)
         elif choice == 2:
-            resolve_agent_change(model, ctx, token, False)
+            ok, msg = resolve_change_at_cursor(model, ctx, False)
+            if not ok:
+                show_review_message(ctx, msg)
         elif choice == 3:
-            resolve_all_agent_changes(model, ctx, True)
+            _, msg = resolve_all_with_feedback(model, ctx, True)
+            show_review_message(ctx, msg)
         elif choice == 4:
-            resolve_all_agent_changes(model, ctx, False)
+            _, msg = resolve_all_with_feedback(model, ctx, False)
+            show_review_message(ctx, msg)
     except Exception:
         log.warning("review_click_popup: popup failed", exc_info=True)
 

--- a/plugin/writer/review_click_popup.py
+++ b/plugin/writer/review_click_popup.py
@@ -1,0 +1,140 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Click-to-review popup: left-click an agent change, get Accept/Reject right at the pointer.
+
+The closest a LibreOffice extension gets to Google-Docs-style inline review buttons (true
+floating hover widgets over the text canvas would require a core fork): an XMouseClickHandler
+on the Writer view watches single left-clicks; when the caret lands inside an AGENT change
+(identified by its wa-review session token -- the user's own redlines don't trigger it), a
+small popup menu opens at the click position with Accept / Reject for that whole change.
+
+The click itself is never consumed (the caret still moves normally), and the check runs as a
+posted main-thread follow-up so LibreOffice finishes its own click handling (caret placement)
+first. Registration mirrors change_context_menu: per controller, UNO-identity dedup.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+import unohelper
+
+log = logging.getLogger(__name__)
+
+_lock = threading.RLock()
+_registered_controllers: list[Any] = []  # UNO-identity dedup (PyUNO proxies: use ==, not id());
+# strong refs kept for the office session -- releasing on view dispose is follow-up work
+_handlers: list[Any] = []  # strong refs
+_handler_cls: Any = None
+
+
+def _show_popup_and_resolve(model: Any, source_window: Any, x: int, y: int) -> None:
+    """Runs on the main thread AFTER the click was processed by the view."""
+    try:
+        from plugin.framework.uno_context import get_ctx
+        from plugin.framework.i18n import _
+        from plugin.writer.inline_review import (
+            agent_changes,
+            cursor_in_agent_change,
+            goto_agent_change,
+            resolve_agent_change,
+            resolve_all_agent_changes,
+        )
+
+        ctx = get_ctx()
+        token = cursor_in_agent_change(model)
+        if token is None:
+            return
+
+        # Select the whole edited region so it's highlighted while the user decides -- mirrors
+        # the native Manage Changes dialog, where picking a change selects it in the document.
+        goto_agent_change(model, token)
+
+        from com.sun.star.awt import Rectangle
+
+        smgr = ctx.getServiceManager()
+        popup = smgr.createInstanceWithContext("com.sun.star.awt.PopupMenu", ctx)
+        popup.insertItem(1, "✓ " + _("Accept this change"), 0, 0)
+        popup.insertItem(2, "✗ " + _("Reject this change"), 0, 1)
+        total = len(agent_changes(model))
+        if total > 1:
+            popup.insertSeparator(2)
+            popup.insertItem(3, "✓ " + _("Accept all {0} changes").format(total), 0, 3)
+            popup.insertItem(4, "✗ " + _("Reject all {0} changes").format(total), 0, 4)
+        rect = Rectangle()
+        rect.X = int(x)
+        rect.Y = int(y)
+        rect.Width = 0
+        rect.Height = 0
+        choice = popup.execute(source_window, rect, 0)
+        if choice == 1:
+            resolve_agent_change(model, ctx, token, True)
+        elif choice == 2:
+            resolve_agent_change(model, ctx, token, False)
+        elif choice == 3:
+            resolve_all_agent_changes(model, ctx, True)
+        elif choice == 4:
+            resolve_all_agent_changes(model, ctx, False)
+    except Exception:
+        log.warning("review_click_popup: popup failed", exc_info=True)
+
+
+def _make_handler(model: Any) -> Any:
+    global _handler_cls
+    if _handler_cls is None:
+        from com.sun.star.awt import XMouseClickHandler
+
+        class _ClickReviewHandler(unohelper.Base, XMouseClickHandler):  # type: ignore[misc, valid-type]
+            def __init__(self, model: Any) -> None:
+                super().__init__()
+                self._model = model
+
+            def mousePressed(self, e):  # noqa: N802 -- UNO API
+                return False  # never consume
+
+            def mouseReleased(self, e):  # noqa: N802 -- UNO API
+                try:
+                    if e.ClickCount == 1 and e.Buttons == 1 and not e.PopupTrigger:  # plain left click
+                        source = e.Source
+                        x, y = e.X, e.Y
+                        model = self._model
+                        from plugin.framework.queue_executor import post_to_main_thread
+
+                        # Defer: let the view finish moving the caret to the click point first.
+                        post_to_main_thread(_show_popup_and_resolve, model, source, x, y)
+                except Exception:
+                    log.debug("review_click_popup: mouseReleased failed", exc_info=True)
+                return False  # never consume
+
+            def disposing(self, Source):  # noqa: N802, N803 -- UNO API
+                pass
+
+        _handler_cls = _ClickReviewHandler
+    return _handler_cls(model)
+
+
+def register_click_review(controller: Any) -> None:
+    """Attach the click handler to one Writer view controller (idempotent per controller)."""
+    if controller is None:
+        return
+    try:
+        with _lock:
+            if controller in _registered_controllers:
+                return
+        if not hasattr(controller, "addMouseClickHandler"):
+            return
+        model = controller.getModel()
+        handler = _make_handler(model)
+        with _lock:
+            if controller in _registered_controllers:
+                return
+            controller.addMouseClickHandler(handler)
+            _registered_controllers.append(controller)
+            _handlers.append(handler)
+        log.debug("review_click_popup: registered on Writer controller")
+    except Exception:
+        log.warning("review_click_popup: register failed", exc_info=True)

--- a/plugin/writer/styles.py
+++ b/plugin/writer/styles.py
@@ -434,6 +434,12 @@ class UpdateStyle(ToolWriterStyleBase):
                 result["status"] = "error"
                 result["message"] = "Failed to apply any updates."
 
+        # Style changes don't produce tracked changes, so the agent can't review them like a
+        # text edit -- flag it (matches ApplyStyle) so the agent tells the user it changed a style.
+        from plugin.writer.edit_review import review_recording_enabled
+
+        if result.get("status") != "error" and review_recording_enabled(ctx.ctx):
+            result["style_unreviewed"] = True
         return result
 
 
@@ -552,7 +558,13 @@ class CreateStyle(ToolWriterStyleBase):
             msg = getattr(e, "Message", str(e))
             return self._tool_error("Failed to create style: %s" % msg)
 
-        return {"status": "ok", "style_name": style_name, "family": family, "service": service}
+        result = {"status": "ok", "style_name": style_name, "family": family, "service": service}
+        # Style changes aren't reviewable as tracked changes -- flag it for the agent (matches ApplyStyle).
+        from plugin.writer.edit_review import review_recording_enabled
+
+        if review_recording_enabled(ctx.ctx):
+            result["style_unreviewed"] = True
+        return result
 
 
 class ImportStyles(ToolWriterStyleBase):
@@ -608,4 +620,10 @@ class ImportStyles(ToolWriterStyleBase):
         except Exception as e:
             return self._tool_error("Failed to import styles from %s: %s" % (file_path, e))
 
-        return {"status": "ok", "file_path": file_path, "overwrite": overwrite}
+        result = {"status": "ok", "file_path": file_path, "overwrite": overwrite}
+        # Imported styles aren't reviewable as tracked changes -- flag it for the agent (matches ApplyStyle).
+        from plugin.writer.edit_review import review_recording_enabled
+
+        if review_recording_enabled(ctx.ctx):
+            result["style_unreviewed"] = True
+        return result

--- a/plugin/writer/styles.py
+++ b/plugin/writer/styles.py
@@ -342,6 +342,14 @@ class ApplyStyle(FrameworkToolBase):
                   "style_name": style_name, "family": family, "target": target, "applied": True}
         if target == "search":
             result["matched"] = True  # a search miss would have errored earlier in resolve_target_cursor
+        # A style change is applied directly and does NOT become a tracked change (LibreOffice
+        # records text/char-format edits as redlines, but not a style swap). When review mode is on
+        # the agent expects its edits to be reviewable, so flag that this one was not -- the agent
+        # should tell the user it changed a style they cannot accept/reject like a text edit.
+        from plugin.writer.edit_review import review_recording_enabled
+
+        if review_recording_enabled(ctx.ctx):
+            result["style_unreviewed"] = True
         return result
 
 

--- a/tests/writer/test_edit_review_uno.py
+++ b/tests/writer/test_edit_review_uno.py
@@ -1,0 +1,277 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# EditReviewSession: the centralized review story for agent edits. Covers: inert when
+# disabled; recording + per-change RedlineComment tokens + author attribution + restore
+# semantics; completion keyed to THIS session's tokens (user redlines don't block);
+# per-change outcomes accepted/rejected/modified/pending; timeout; stop_checker;
+# bookmark cleanup; ShowChanges forced on.
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.tests.testing_utils import TestingFactory
+from plugin.writer.edit_review import EditReviewSession, _BOOKMARK_PREFIX
+
+_PARA_BREAK = uno.getConstantByName("com.sun.star.text.ControlCharacter.PARAGRAPH_BREAK")
+
+_doc = None
+_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _doc, _ctx
+    _ctx = ctx
+    _doc = TestingFactory.create_native_doc(ctx, doc_type="writer", hidden=True)
+
+
+@teardown
+def my_teardown(ctx):
+    global _doc
+    if _doc:
+        _doc.close(True)
+    _doc = None
+
+
+def _find(needle):
+    sd = _doc.createSearchDescriptor()
+    sd.setSearchString(needle)
+    return _doc.findFirst(sd)
+
+
+def _body(*paragraphs):
+    text = _doc.getText()
+    _doc.setPropertyValue("RecordChanges", False)
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEnd(True)
+    cur.setString("")
+    cur.gotoStart(False)
+    for i, para in enumerate(paragraphs):
+        if i:
+            text.insertControlCharacter(cur, _PARA_BREAK, False)
+        text.insertString(cur, para, False)
+    if _redlines():
+        helper = _ctx.getServiceManager().createInstanceWithContext("com.sun.star.frame.DispatchHelper", _ctx)
+        helper.executeDispatch(_doc.getCurrentController().getFrame(), ".uno:AcceptAllTrackedChanges", "", 0, ())
+
+
+def _redlines():
+    out = []
+    e = _doc.getRedlines().createEnumeration()
+    while e.hasMoreElements():
+        rl = e.nextElement()
+        entry = {"type": rl.getPropertyValue("RedlineType")}
+        for prop in ("RedlineComment", "RedlineAuthor"):
+            try:
+                entry[prop] = str(rl.getPropertyValue(prop))
+            except Exception:
+                entry[prop] = ""
+        out.append(entry)
+    return out
+
+
+def _replace_fn(old, new):
+    """A mutation callable: replace first occurrence of *old* with *new* (clean delete+insert)."""
+    def fn():
+        found = _find(old)
+        assert found is not None, "mutation target %r not found" % old
+        text = found.getText()
+        c = text.createTextCursorByRange(found)
+        c.setString("")
+        text.insertString(c, new, False)
+    return fn
+
+
+def _resolve_at(needle, accept):
+    """Resolve the tracked change in *needle*'s paragraph, as a user would (select + native
+    accept/reject dispatch). Local on purpose: this suite must not depend on the UI helpers."""
+    f = _find(needle)
+    assert f is not None, "resolve target %r not found" % needle
+    text = f.getText()
+    para = text.createTextCursorByRange(f.getStart())
+    para.gotoStartOfParagraph(False)
+    para.gotoEndOfParagraph(True)
+    view_cursor = _doc.getCurrentController().getViewCursor()
+    view_cursor.gotoRange(para.getStart(), False)
+    view_cursor.gotoRange(para.getEnd(), True)
+    helper = _ctx.getServiceManager().createInstanceWithContext("com.sun.star.frame.DispatchHelper", _ctx)
+    command = ".uno:AcceptTrackedChange" if accept else ".uno:RejectTrackedChange"
+    helper.executeDispatch(_doc.getCurrentController().getFrame(), command, "", 0, ())
+
+
+def _wa_bookmarks():
+    return [n for n in _doc.getBookmarks().getElementNames() if n.startswith(_BOOKMARK_PREFIX)]
+
+
+@native_test
+def test_disabled_session_is_inert_uno():
+    _body("Alpha paragraph.")
+    with EditReviewSession(_doc, _ctx, enabled=False) as session:
+        session.record_mutation(_replace_fn("Alpha paragraph.", "Alpha edited."))
+    assert _redlines() == [], "disabled session must not record redlines"
+    assert _find("Alpha edited.") is not None, "edit applied directly"
+    result = session.wait_for_review(timeout=0.1)
+    assert result == {"complete": True, "timed_out": False, "changes": []}, result
+
+
+@native_test
+def test_records_tags_author_and_restores_uno():
+    _body("Alpha paragraph.")
+    _doc.setPropertyValue("ShowChanges", False)
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        assert _doc.getPropertyValue("ShowChanges") is True, "session start must make markup visible"
+        session.record_mutation(_replace_fn("Alpha paragraph.", "Alpha edited."))
+    rls = _redlines()
+    assert len(rls) == 2, "a replace records a Delete+Insert pair, got %r" % rls
+    token = session.changes[0].token
+    assert token.startswith("wa-review:"), token
+    assert all(r["RedlineComment"] == token for r in rls), "BOTH redlines carry the change token: %r" % rls
+    assert all(r["RedlineAuthor"] == "WriterAgent" for r in rls), "agent attribution: %r" % rls
+    assert _doc.getPropertyValue("RecordChanges") is False, "prior OFF state restored"
+    session.cleanup()
+
+
+@native_test
+def test_bookkeeping_stays_off_the_undo_stack_uno():
+    """The user's first Ctrl+Z after an agent edit must undo the VISIBLE change, not toggle our
+    invisible wa_review anchor bookmarks. Recording + cleanup lock the document undo manager
+    around the tag/bookmark bookkeeping, so the user's undo stack only holds the real edit."""
+    _body("This clause is important.")
+    _doc.setPropertyValue("RecordChanges", False)
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(_replace_fn("This clause is important.", "This clause is essential."))
+    session.cleanup()
+    assert _wa_bookmarks() == [], "cleanup must leave no anchor bookmarks behind"
+    um = _doc.getUndoManager()
+    assert um.isUndoPossible(), "the agent edit must be undoable"
+    title = um.getCurrentUndoActionTitle()
+    assert "bookmark" not in title.lower() and _BOOKMARK_PREFIX not in title, \
+        "internal bookkeeping leaked onto the user's undo stack: top=%r" % title
+    # One undo must revert the edit (drop a redline), not no-op on an invisible bookmark.
+    before = len(_redlines())
+    helper = _ctx.getServiceManager().createInstanceWithContext("com.sun.star.frame.DispatchHelper", _ctx)
+    helper.executeDispatch(_doc.getCurrentController().getFrame(), ".uno:Undo", "", 0, ())
+    assert len(_redlines()) < before, \
+        "the first undo must revert the agent edit, not toggle an invisible bookmark (had %d redlines)" % before
+
+
+@native_test
+def test_user_redlines_do_not_block_completion_uno():
+    _body("User paragraph.", "Agent paragraph.")
+    # the USER has their own pending tracked change before the agent edits
+    _doc.setPropertyValue("RecordChanges", True)
+    _replace_fn("User paragraph.", "User edited paragraph.")()
+    _doc.setPropertyValue("RecordChanges", False)
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(_replace_fn("Agent paragraph.", "Agent edited paragraph."))
+    untagged = [r for r in _redlines() if not r["RedlineComment"].startswith("wa-review:")]
+    assert len(untagged) == 2, "the user's own redlines must NOT get the session token: %r" % _redlines()
+    _resolve_at("Agent edited", True)  # resolve only the agent's change
+    result = session.wait_for_review(timeout=2, poll=0.05)
+    assert result["complete"] is True, "user's pending redline must not block completion: %r" % result
+    assert [r for r in _redlines() if not r["RedlineComment"].startswith("wa-review:")], \
+        "the user's redline must still be pending (untouched)"
+    _body("reset")  # clear the leftover user redline for the next test
+
+
+@native_test
+def test_outcomes_accept_and_reject_per_change_uno():
+    _body("First clause here.", "Second clause here.")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(_replace_fn("First clause here.", "First clause EDITED."),
+                                original_preview="First clause here.", proposed_preview="First clause EDITED.")
+        session.record_mutation(_replace_fn("Second clause here.", "Second clause EDITED."))
+    _resolve_at("First clause EDITED", True)    # accept change #1
+    _resolve_at("Second clause EDITED", False)  # reject change #2
+    result = session.wait_for_review(timeout=2, poll=0.05)
+    assert result["complete"] is True and result["timed_out"] is False, result
+    outcomes = [c["outcome"] for c in result["changes"]]
+    assert outcomes == ["accepted", "rejected"], "per-change outcomes: %r" % result
+    assert result["changes"][0]["original_preview"] == "First clause here."
+    assert result["changes"][0]["proposed_preview"] == "First clause EDITED."
+    assert _wa_bookmarks() == [], "anchor bookmarks must be cleaned after review"
+
+
+@native_test
+def test_outcome_modified_when_user_edits_during_review_uno():
+    _body("Stable clause here.")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(_replace_fn("Stable clause here.", "Stable clause EDITED."))
+    _resolve_at("Stable clause EDITED", True)
+    # the user reworks the paragraph after resolving (tracking off = silent manual edit)
+    f = _find("Stable clause EDITED.")
+    c = f.getText().createTextCursorByRange(f)
+    c.setString("Something else entirely.")
+    result = session.wait_for_review(timeout=2, poll=0.05)
+    assert result["changes"][0]["outcome"] == "modified", \
+        "user edit during review must report modified, got %r" % result
+
+
+@native_test
+def test_timeout_reports_pending_uno():
+    _body("Waiting clause here.")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(_replace_fn("Waiting clause here.", "Waiting clause EDITED."))
+    result = session.wait_for_review(timeout=0.3, poll=0.05)  # nobody reviews
+    assert result["complete"] is False and result["timed_out"] is True, result
+    assert result["changes"][0]["outcome"] == "pending", result
+    assert _wa_bookmarks() == [], "bookmarks cleaned even on timeout"
+    _body("reset")  # clear the unresolved change
+
+
+@native_test
+def test_stop_checker_aborts_wait_uno():
+    _body("Abort clause here.")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(_replace_fn("Abort clause here.", "Abort clause EDITED."))
+    result = session.wait_for_review(timeout=30, poll=0.05, stop_checker=lambda: True)
+    assert result["complete"] is False and result["timed_out"] is False, \
+        "stop_checker abort is not a timeout: %r" % result
+    _body("reset")
+
+
+@native_test
+def test_wait_for_review_routes_uno_via_runner_uno():
+    """Off-main-thread callers (MCP HTTP / chat worker) pass uno_runner=execute_on_main_thread;
+    every document touch in the wait loop must flow through it."""
+    _body("Runner clause here.")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(_replace_fn("Runner clause here.", "Runner clause EDITED."))
+    _resolve_at("Runner clause EDITED", True)
+    calls = {"n": 0}
+
+    def runner(fn):
+        calls["n"] += 1
+        return fn()
+
+    result = session.wait_for_review(timeout=2, poll=0.05, uno_runner=runner)
+    assert result["complete"] is True and result["changes"][0]["outcome"] == "accepted", result
+    assert calls["n"] >= 3, "pending check, payload, and cleanup must go through the runner, got %d" % calls["n"]
+
+
+@native_test
+def test_prior_recording_on_is_preserved_uno():
+    _body("Tracked clause here.")
+    _doc.setPropertyValue("RecordChanges", True)
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(_replace_fn("Tracked clause here.", "Tracked clause EDITED."))
+    assert _doc.getPropertyValue("RecordChanges") is True, "user's ON state must be preserved"
+    _doc.setPropertyValue("RecordChanges", False)
+    assert session.changes, "change recorded under user tracking too"
+    session.cleanup()
+    _body("reset")
+
+
+@native_test
+def test_exception_restores_recording_and_author_uno():
+    _body("Crash clause here.")
+    try:
+        with EditReviewSession(_doc, _ctx, enabled=True):
+            assert _doc.getPropertyValue("RecordChanges") is True
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert _doc.getPropertyValue("RecordChanges") is False, "recording restored on exception"

--- a/tests/writer/test_inline_review_uno.py
+++ b/tests/writer/test_inline_review_uno.py
@@ -332,3 +332,21 @@ def test_resolve_all_with_feedback_reports_skipped_then_silent_when_clean_uno():
     n2, msg2 = resolve_all_with_feedback(_doc, _ctx, True)
     assert n2 == 2 and msg2 == "", "all-clean resolve-all returns no message, got n=%d msg=%r" % (n2, msg2)
     _body("reset")
+
+
+@native_test
+def test_resolve_all_counts_siblings_cleared_by_one_dispatch_uno():
+    """Two agent changes in the SAME clean paragraph resolve together under one paragraph-wide
+    dispatch -- the count must reflect BOTH, not +1 per loop pass. Otherwise resolve_all_with_
+    feedback reports a false 'Resolved 1 of 2' with nothing actually left. A user redline in
+    ANOTHER paragraph forces the mixed (per-change) path."""
+    _body("User clause here.", "Alpha beta gamma.")
+    _tracked_replace("User clause here.", "User edited.")   # user redline -> mixed path
+    _agent_edit(("Alpha", "One"), ("gamma", "three"))       # two agent changes, SAME paragraph
+    assert len(agent_changes(_doc)) == 2, agent_changes(_doc)
+    n, msg = resolve_all_with_feedback(_doc, _ctx, True)
+    assert n == 2, "both same-paragraph agent changes must count as resolved, got %d" % n
+    assert agent_changes(_doc) == [], "no agent change should remain"
+    assert msg == "", "no false 'Resolved 1 of 2' when everything resolved: %r" % msg
+    assert _redline_count() > 0, "the user's own redline in the other paragraph stays pending"
+    _body("reset")

--- a/tests/writer/test_inline_review_uno.py
+++ b/tests/writer/test_inline_review_uno.py
@@ -17,6 +17,7 @@ from plugin.writer.inline_review import (
     has_agent_changes,
     resolve_agent_change,
     resolve_all_agent_changes,
+    resolve_all_with_feedback,
     resolve_change_at_cursor,
 )
 
@@ -270,6 +271,7 @@ def test_resolve_refuses_when_user_redline_shares_paragraph_uno():
     before = _redline_count()
     ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
     assert ok is False, "must refuse when a user redline shares the paragraph: %r" % msg
+    assert msg and "Manage" in msg, "refusal must carry a user-facing hint (shown in the UI): %r" % msg
     assert _redline_count() == before, "neither the agent change nor the user's redline may be touched"
     assert has_agent_changes(_doc), "the agent change stays pending for the native UI"
     _body("reset")
@@ -308,4 +310,25 @@ def test_resolve_all_skips_change_sharing_paragraph_with_user_redline_uno():
     assert resolved == 1, "only the clean-paragraph agent change resolves, got %d" % resolved
     assert has_agent_changes(_doc), "the shared-paragraph agent change is left pending"
     assert _redline_count() < user_and_agent_before, "the clean agent change was resolved"
+    _body("reset")
+
+
+@native_test
+def test_resolve_all_with_feedback_reports_skipped_then_silent_when_clean_uno():
+    """resolve_all_with_feedback must surface a user-facing note when some changes are skipped
+    (they share a paragraph with the user's own redline) -- otherwise the menu/popup click looks
+    like it did nothing. A fully clean resolve-all returns an empty message (no nag)."""
+    # Mixed: one agent change shares paragraph 1 with a user redline (skipped), one is clean.
+    _body("The quick brown fox jumps.", "Lonely agent clause here.")
+    _tracked_replace("quick", "fast")
+    _agent_edit(("fox", "dog"), ("Lonely agent clause here.", "Lonely agent clause EDITED."))
+    n, msg = resolve_all_with_feedback(_doc, _ctx, True)
+    assert n == 1, "only the clean-paragraph agent change resolves, got %d" % n
+    assert msg and "Manage" in msg, "a skipped change must produce a user-facing message: %r" % msg
+
+    # All-clean run -> no message.
+    _body("Clean one.", "Clean two.")
+    _agent_edit(("Clean one.", "Clean one EDITED."), ("Clean two.", "Clean two EDITED."))
+    n2, msg2 = resolve_all_with_feedback(_doc, _ctx, True)
+    assert n2 == 2 and msg2 == "", "all-clean resolve-all returns no message, got n=%d msg=%r" % (n2, msg2)
     _body("reset")

--- a/tests/writer/test_inline_review_uno.py
+++ b/tests/writer/test_inline_review_uno.py
@@ -1,0 +1,256 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Inline review (model layer): accept/reject the tracked change under the cursor as one unit,
+# resolving a replace's delete+insert pair together. Drives native .uno:Accept/RejectTrackedChange
+# on a paragraph-wide selection via the view cursor.
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.tests.testing_utils import TestingFactory
+from plugin.writer.edit_review import EditReviewSession
+from plugin.writer.inline_review import (
+    agent_changes,
+    cursor_in_agent_change,
+    has_agent_changes,
+    resolve_agent_change,
+    resolve_all_agent_changes,
+    resolve_change_at_cursor,
+)
+
+_PARA_BREAK = uno.getConstantByName("com.sun.star.text.ControlCharacter.PARAGRAPH_BREAK")
+
+_doc = None
+_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _doc, _ctx
+    _ctx = ctx
+    _doc = TestingFactory.create_native_doc(ctx, doc_type="writer", hidden=True)
+
+
+@teardown
+def my_teardown(ctx):
+    global _doc
+    if _doc:
+        _doc.close(True)
+    _doc = None
+
+
+def _find(needle):
+    sd = _doc.createSearchDescriptor()
+    sd.setSearchString(needle)
+    return _doc.findFirst(sd)
+
+
+def _body(*paragraphs):
+    """Reset the document body to the given paragraphs (no tracking)."""
+    text = _doc.getText()
+    _doc.setPropertyValue("RecordChanges", False)
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEnd(True)
+    cur.setString("")
+    cur.gotoStart(False)
+    for i, para in enumerate(paragraphs):
+        if i:
+            text.insertControlCharacter(cur, _PARA_BREAK, False)
+        text.insertString(cur, para, False)
+    if len(_doc.getRedlines()):
+        _accept_all()
+
+
+def _accept_all():
+    helper = _ctx.getServiceManager().createInstanceWithContext("com.sun.star.frame.DispatchHelper", _ctx)
+    helper.executeDispatch(_doc.getCurrentController().getFrame(), ".uno:AcceptAllTrackedChanges", "", 0, ())
+
+
+def _tracked_replace(old, new):
+    """Replace the first occurrence of *old* with *new* as a tracked Delete+Insert."""
+    text = _doc.getText()
+    found = _find(old)
+    assert found is not None, "setup: %r not found" % old
+    _doc.setPropertyValue("RecordChanges", True)
+    c = text.createTextCursorByRange(found)
+    c.setString("")
+    text.insertString(c, new, False)
+    _doc.setPropertyValue("RecordChanges", False)
+
+
+def _caret_in(needle):
+    f = _find(needle)
+    assert f is not None, "caret target %r not found" % needle
+    _doc.getCurrentController().getViewCursor().gotoRange(f.getStart(), False)
+
+
+def _para_with(needle):
+    f = _find(needle)
+    if f is None:
+        return None
+    t = f.getText().createTextCursorByRange(f.getStart())
+    t.gotoStartOfParagraph(False)
+    t.gotoEndOfParagraph(True)
+    return t.getString()
+
+
+def _redline_count():
+    n = 0
+    e = _doc.getRedlines().createEnumeration()
+    while e.hasMoreElements():
+        e.nextElement()
+        n += 1
+    return n
+
+
+@native_test
+def test_has_agent_changes_gates_on_agent_tokens_uno():
+    _body("Plain paragraph.")
+    assert has_agent_changes(_doc) is False, "clean doc has no agent changes"
+    _tracked_replace("Plain paragraph.", "Edited paragraph.")  # user-style redline, no token
+    assert has_agent_changes(_doc) is False, "the user's own redline must not count as an agent change"
+    _agent_edit(("Edited paragraph.", "Agent edited paragraph."))
+    assert has_agent_changes(_doc) is True, "an agent (tokened) change must be detected"
+    _body("reset")
+
+
+@native_test
+def test_resolve_accept_keeps_new_and_clears_pair_uno():
+    _body("This clause is important.")
+    _agent_edit(("This clause is important.", "This clause is essential."))
+    _caret_in("essential")
+    ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
+    assert ok, msg
+    assert _para_with("clause") == "This clause is essential.", "accept keeps only the new text, got %r" % _para_with("clause")
+    assert _redline_count() == 0, "the whole pair (delete+insert) must be resolved, got %d left" % _redline_count()
+
+
+@native_test
+def test_resolve_reject_restores_old_and_clears_pair_uno():
+    _body("This clause is important.")
+    _agent_edit(("This clause is important.", "This clause is essential."))
+    _caret_in("essential")
+    ok, msg = resolve_change_at_cursor(_doc, _ctx, False)
+    assert ok, msg
+    assert _para_with("clause") == "This clause is important.", "reject restores the old text, got %r" % _para_with("clause")
+    assert _redline_count() == 0, "reject must clear the pair, got %d left" % _redline_count()
+
+
+@native_test
+def test_resolve_does_nothing_when_cursor_off_change_uno():
+    # change in paragraph A, cursor parked in a DIFFERENT paragraph B -> no-op, friendly message
+    _body("First paragraph here.", "Second paragraph here.")
+    _agent_edit(("First paragraph here.", "First paragraph edited."))
+    _caret_in("Second paragraph")
+    before = _redline_count()
+    ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
+    assert ok is False, "cursor not on the change -> should not resolve, msg=%r" % msg
+    assert _redline_count() == before, "a no-op must not touch the other paragraph's change"
+
+
+@native_test
+def test_resolve_reports_when_no_changes_uno():
+    _body("Nothing tracked here.")
+    ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
+    assert ok is False and "No agent changes" in msg, msg
+
+
+@native_test
+def test_resolve_ignores_user_own_redline_uno():
+    """The user's own tracked change (no session token) is not the agent UI's business."""
+    _body("User paragraph here.")
+    _tracked_replace("User paragraph here.", "User edited paragraph.")  # untokened
+    _caret_in("User edited")
+    before = _redline_count()
+    ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
+    assert ok is False, "a user redline must not be resolved via the agent UI: %r" % msg
+    assert _redline_count() == before, "the user's redline must remain pending"
+    _body("reset")
+
+
+# --- token-based agent-change helpers (used by the click popup and the context menu) ------
+
+def _agent_edit(*pairs):
+    """Record each (old, new) replace as ONE tagged agent change via EditReviewSession."""
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        for old, new in pairs:
+            session.record_mutation(_tracked_replace_fn(old, new))
+    session.cleanup()
+    return session
+
+
+def _tracked_replace_fn(old, new):
+    def fn():
+        found = _find(old)
+        assert found is not None, "agent edit target %r not found" % old
+        text = found.getText()
+        c = text.createTextCursorByRange(found)
+        c.setString("")
+        text.insertString(c, new, False)
+    return fn
+
+
+@native_test
+def test_agent_changes_lists_per_change_previews_uno():
+    _body("Alpha clause one.", "Beta clause two.")
+    _agent_edit(("Alpha clause one.", "Alpha EDITED one."), ("Beta clause two.", "Beta EDITED two."))
+    changes = agent_changes(_doc)
+    assert len(changes) == 2, changes
+    assert changes[0]["old"] == "Alpha clause one." and changes[0]["new"] == "Alpha EDITED one.", changes[0]
+    assert changes[1]["old"] == "Beta clause two." and changes[1]["new"] == "Beta EDITED two.", changes[1]
+
+
+@native_test
+def test_agent_changes_ignores_user_redlines_uno():
+    _body("User paragraph.", "Agent paragraph.")
+    _doc.setPropertyValue("RecordChanges", True)
+    _tracked_replace_fn("User paragraph.", "User edited.")()
+    _doc.setPropertyValue("RecordChanges", False)
+    _agent_edit(("Agent paragraph.", "Agent edited."))
+    changes = agent_changes(_doc)
+    assert len(changes) == 1 and changes[0]["new"] == "Agent edited.", \
+        "only the agent's tagged change is listed: %r" % changes
+    _body("reset")
+
+
+@native_test
+def test_resolve_agent_change_by_token_resolves_only_that_pair_uno():
+    _body("First clause here.", "Second clause here.")
+    _agent_edit(("First clause here.", "First EDITED."), ("Second clause here.", "Second EDITED."))
+    changes = agent_changes(_doc)
+    assert resolve_agent_change(_doc, _ctx, changes[0]["token"], True) is True
+    left = agent_changes(_doc)
+    assert len(left) == 1 and left[0]["token"] == changes[1]["token"], \
+        "only the targeted change resolves: %r" % left
+    assert _para_with("First") == "First EDITED.", _para_with("First")
+    _body("reset")
+
+
+@native_test
+def test_resolve_all_agent_changes_spares_user_redlines_uno():
+    _body("User paragraph.", "Agent one.", "Agent two.")
+    _doc.setPropertyValue("RecordChanges", True)
+    _tracked_replace_fn("User paragraph.", "User edited.")()
+    _doc.setPropertyValue("RecordChanges", False)
+    _agent_edit(("Agent one.", "Agent one EDITED."), ("Agent two.", "Agent two EDITED."))
+    n = resolve_all_agent_changes(_doc, _ctx, True)
+    assert n == 2, "both agent changes resolved, got %d" % n
+    assert agent_changes(_doc) == [], "no agent changes left"
+    assert _redline_count() > 0, "the user's own redline must remain pending"
+    _body("reset")
+
+
+@native_test
+def test_cursor_in_agent_change_detects_token_uno():
+    _body("Plain paragraph.", "Target clause here.")
+    session = _agent_edit(("Target clause here.", "Target EDITED here."))
+    _caret_in("Target EDITED")
+    got = cursor_in_agent_change(_doc)
+    assert got == session.changes[0].token, \
+        "got=%r want=%r changes=%r" % (got, session.changes[0].token, agent_changes(_doc))
+    _caret_in("Plain paragraph")
+    assert cursor_in_agent_change(_doc) is None, "caret outside the change -> None"
+    _body("reset")

--- a/tests/writer/test_inline_review_uno.py
+++ b/tests/writer/test_inline_review_uno.py
@@ -254,3 +254,58 @@ def test_cursor_in_agent_change_detects_token_uno():
     _caret_in("Plain paragraph")
     assert cursor_in_agent_change(_doc) is None, "caret outside the change -> None"
     _body("reset")
+
+
+@native_test
+def test_resolve_refuses_when_user_redline_shares_paragraph_uno():
+    """Token-scoping guarantee for the SAME-paragraph case: the paragraph-wide dispatch resolves
+    every redline in the selection, so when one of the user's OWN tracked changes shares a
+    paragraph with an agent change the inline resolve refuses and touches NOTHING -- the user
+    resolves that one via the native UI. (Existing user-redline tests put them in separate
+    paragraphs, where the dispatch never reached them.)"""
+    _body("The quick brown fox jumps.")
+    _tracked_replace("quick", "fast")     # the user's own (untokened) redline ...
+    _agent_edit(("fox", "dog"))           # ... and an agent change in the SAME paragraph
+    _caret_in("dog")
+    before = _redline_count()
+    ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
+    assert ok is False, "must refuse when a user redline shares the paragraph: %r" % msg
+    assert _redline_count() == before, "neither the agent change nor the user's redline may be touched"
+    assert has_agent_changes(_doc), "the agent change stays pending for the native UI"
+    _body("reset")
+
+
+@native_test
+def test_resolve_refuses_when_another_agent_change_shares_paragraph_uno():
+    """Inline "this change" also refuses when another agent token is in the same paragraph.
+
+    The dispatch selection is paragraph-wide, so accepting one token here would accept the other
+    token too and misrepresent the command as a single-change action.
+    """
+    _body("Alpha beta gamma.")
+    _agent_edit(("Alpha", "One"), ("gamma", "three"))
+    changes = agent_changes(_doc)
+    assert len(changes) == 2, changes
+    _caret_in("One")
+    before = _redline_count()
+    ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
+    assert ok is False, "must refuse when another agent change shares the paragraph: %r" % msg
+    assert _redline_count() == before, "no same-paragraph agent change should be resolved by the single-change UI"
+    assert len(agent_changes(_doc)) == 2, "both agent changes stay pending"
+    _body("reset")
+
+
+@native_test
+def test_resolve_all_skips_change_sharing_paragraph_with_user_redline_uno():
+    """resolve-all must spare a user redline even when it shares a paragraph with an agent change:
+    that change is skipped (left for the native UI) while agent changes in clean paragraphs still
+    resolve."""
+    _body("The quick brown fox jumps.", "Lonely agent clause here.")
+    _tracked_replace("quick", "fast")                         # user redline in paragraph 1
+    _agent_edit(("fox", "dog"), ("Lonely agent clause here.", "Lonely agent clause EDITED."))
+    user_and_agent_before = _redline_count()
+    resolved = resolve_all_agent_changes(_doc, _ctx, True)
+    assert resolved == 1, "only the clean-paragraph agent change resolves, got %d" % resolved
+    assert has_agent_changes(_doc), "the shared-paragraph agent change is left pending"
+    assert _redline_count() < user_and_agent_before, "the clean agent change was resolved"
+    _body("reset")

--- a/tests/writer/test_track_changes_reviewable_uno.py
+++ b/tests/writer/test_track_changes_reviewable_uno.py
@@ -536,3 +536,23 @@ def test_bookmarks_cleaned_when_edit_raises_midway_uno():
         set_config(_ctx, _FLAG, prev)
         if len(_doc.getRedlines()):
             _reject_all()
+
+
+@native_test
+def test_review_authors_failed_begin_leaves_split_authoring_disarmed_uno():
+    """A failed begin() (office-author access unavailable) must NOT arm the thread-local; otherwise
+    deletion_author() would stay armed for a later, unrelated edit on this thread. The streamed
+    sessions skip end() on a None return, so the safety has to live in begin() itself."""
+    from plugin.writer import review_authors
+
+    class _BadCtx:
+        def getServiceManager(self):  # _author_access() calls this; raising makes begin() fail
+            raise RuntimeError("no service manager")
+
+    prior = review_authors.begin(_BadCtx())
+    try:
+        assert prior is None, "begin() on a broken ctx must return None"
+        assert getattr(review_authors._state, "ctx", None) is None, \
+            "a failed begin() must leave split authoring disarmed (deletion_author stays inert)"
+    finally:
+        review_authors.end(_ctx, None)  # keep the thread-local clean for later tests

--- a/tests/writer/test_track_changes_reviewable_uno.py
+++ b/tests/writer/test_track_changes_reviewable_uno.py
@@ -1,0 +1,394 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Reviewable agent edits — recording coverage. With writer.track_changes_reviewable on, agent
+# edits land as native tracked changes (redlines) the user can accept/reject, tagged with
+# per-change session tokens; the user's prior RecordChanges state is restored afterward. Flag
+# off = today's behavior, byte for byte. Covers: the replace primitives staying Track-Changes-
+# safe under recording (a clean Delete+Insert per change, never a per-character mess or a
+# Format redline that keeps old text on Accept), the streamed rewrite session, attribution
+# (insertions and deletions authored distinctly for by-author coloring), the style_unreviewed
+# flag, and the apply_document_content tool wiring end to end (incl. never block-waiting on the
+# main thread). The EditReviewSession itself is covered in test_edit_review_uno.py; the inline
+# review UI helpers in test_inline_review_uno.py.
+import contextlib
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.tests.testing_utils import TestingFactory
+from plugin.doc.document_helpers import WriterStreamedRewriteSession
+from plugin.writer.content import ApplyDocumentContent
+from plugin.writer.edit_review import EditReviewSession
+from plugin.framework.config import set_config, get_config_bool_safe
+import plugin.writer.format as fmt
+
+_FLAG = "writer.track_changes_reviewable"
+
+_doc = None
+_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _doc, _ctx
+    _ctx = ctx
+    _doc = TestingFactory.create_native_doc(ctx, doc_type="writer", hidden=True)
+
+
+@teardown
+def my_teardown(ctx):
+    global _doc
+    if _doc:
+        _doc.close(True)
+    _doc = None
+
+
+def _reset(text_str="Original body text."):
+    text = _doc.getText()
+    _doc.setPropertyValue("RecordChanges", False)
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEnd(True)
+    cur.setString("")
+    cur.gotoStart(False)
+    cur.setPropertyValue("ParaStyleName", "Standard")
+    text.insertString(cur, text_str, False)
+    # Clear any redlines accumulated by a prior test (accept-all leaves a clean doc).
+    if len(_doc.getRedlines()):
+        _accept_all()
+
+
+@contextlib.contextmanager
+def _recording():
+    """Record the wrapped edit as tracked changes (the primitive the session builds on)."""
+    _doc.setPropertyValue("RecordChanges", True)
+    try:
+        yield
+    finally:
+        _doc.setPropertyValue("RecordChanges", False)
+
+
+def _redlines():
+    out = []
+    e = _doc.getRedlines().createEnumeration()
+    while e.hasMoreElements():
+        rl = e.nextElement()
+        entry = {"type": str(rl.getPropertyValue("RedlineType"))}
+        for prop in ("RedlineComment", "RedlineAuthor"):
+            try:
+                entry[prop] = str(rl.getPropertyValue(prop))
+            except Exception:
+                entry[prop] = ""
+        out.append(entry)
+    return out
+
+
+def _redline_types():
+    return [r["type"] for r in _redlines()]
+
+
+def _accept_all():
+    helper = _ctx.getServiceManager().createInstanceWithContext("com.sun.star.frame.DispatchHelper", _ctx)
+    frame = _doc.getCurrentController().getFrame()
+    helper.executeDispatch(frame, ".uno:AcceptAllTrackedChanges", "", 0, ())
+
+
+def _reject_all():
+    helper = _ctx.getServiceManager().createInstanceWithContext("com.sun.star.frame.DispatchHelper", _ctx)
+    frame = _doc.getCurrentController().getFrame()
+    helper.executeDispatch(frame, ".uno:RejectAllTrackedChanges", "", 0, ())
+
+
+def _para_text():
+    cur = _doc.getText().createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEndOfParagraph(True)
+    return cur.getString()
+
+
+def _para_range():
+    text = _doc.getText()
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEndOfParagraph(True)
+    return cur
+
+
+def _tool_ctx():
+    return TestingFactory.create_context(doc=_doc, ctx=_ctx, env="native")
+
+
+# --- replace primitives must be Track-Changes-safe: a clean Delete+Insert, not a char-by-char
+# --- mess (plain text) nor a Format redline that keeps the old text on Accept (inline markup) ---
+
+@native_test
+def test_search_replace_plain_text_clean_redline_uno():
+    """Plain-text replace_preserving_format under recording must NOT diff char-by-char (which
+    records a redline per changed character -> a scrambled, un-reviewable redline). It must be a
+    single clean Delete+Insert, so reject restores the original exactly."""
+    _reset("This clause is important.")
+    with _recording():
+        fmt.replace_preserving_format(_doc, _para_range(), "This clause is critically important.", _ctx)
+    rl = _redline_types()
+    assert "Insert" in rl and "Delete" in rl, "plain replace under recording must yield Insert+Delete, got %r" % rl
+    _reject_all()
+    assert _para_text() == "This clause is important.", "reject must restore the original exactly, got %r" % _para_text()
+
+
+@native_test
+def test_search_replace_plain_text_accept_keeps_only_new_uno():
+    """Accept must leave ONLY the new text -- the old must be a real tracked deletion that gets removed."""
+    _reset("This clause is important.")
+    with _recording():
+        fmt.replace_preserving_format(_doc, _para_range(), "This clause is critically important.", _ctx)
+    _accept_all()
+    assert _para_text() == "This clause is critically important.", "accept must keep only the new text, got %r" % _para_text()
+
+
+@native_test
+def test_search_replace_inline_markup_no_format_redline_uno():
+    """Inline markup replace must record a Delete (not a Format) for the old text. A Format redline
+    survives Accept, so the doc would keep BOTH the old and the new text."""
+    _reset("This clause is important.")
+    with _recording():
+        fmt.replace_single_range_with_content(
+            _doc, _para_range(), "<span>This clause is critically important.</span>", _ctx, None)
+    rl = _redline_types()
+    assert "Format" not in rl, "inline replace must not leave a Format redline (it keeps old text on accept), got %r" % rl
+    assert "Delete" in rl and "Insert" in rl, "inline replace must be a clean Delete+Insert, got %r" % rl
+    _accept_all()
+    assert _para_text() == "This clause is critically important.", "accept must keep ONLY the new text, got %r" % _para_text()
+
+
+@native_test
+def test_search_replace_inline_markup_heading_style_preserved_uno():
+    """Skipping the paragraph-style restore while recording must NOT demote a heading: the inline
+    HTML import keeps the style, and the edit stays a clean reviewable Delete+Insert."""
+    _reset("Engine selection")
+    _para_range().setPropertyValue("ParaStyleName", "Heading 3")
+    with _recording():
+        fmt.replace_single_range_with_content(
+            _doc, _para_range(), "<span>Powertrain selection</span>", _ctx, None)
+    _accept_all()
+    assert _para_text() == "Powertrain selection", "accept must keep only the new heading text, got %r" % _para_text()
+    assert _para_range().getPropertyValue("ParaStyleName") == "Heading 3", \
+        "heading style must be preserved, got %r" % _para_range().getPropertyValue("ParaStyleName")
+
+
+@native_test
+def test_full_replace_tracked_and_reject_restores_uno():
+    """replace_full_document under recording -> reviewable redlines; reject restores the body."""
+    _reset("Old document body.")
+    with _recording():
+        fmt.replace_full_document(_doc, _ctx, "<p>Brand new body.</p>")
+    rl = _redline_types()
+    assert "Insert" in rl and "Delete" in rl, "full replace under recording must yield Insert+Delete redlines, got %r" % rl
+    _reject_all()
+    assert "Old document body." in _para_text(), "reject must restore the original body, got %r" % _para_text()
+
+
+# --- streamed rewrite session (edit-selection path) --------------------------------------
+
+def _session_run(track_reviewable, prior_recording):
+    _reset("Sentence to rewrite.")
+    _doc.setPropertyValue("RecordChanges", prior_recording)
+    text = _doc.getText()
+    rng = text.createTextCursor()
+    rng.gotoStart(False)
+    rng.gotoEndOfParagraph(True)
+    session = WriterStreamedRewriteSession(_doc, rng, "Sentence to rewrite.", track_reviewable=track_reviewable)
+    session.append_chunk("Rewritten sentence.")
+    session.finish()
+
+
+@native_test
+def test_session_flag_on_user_off_creates_redline_restores_off_uno():
+    _session_run(track_reviewable=True, prior_recording=False)
+    assert _redline_types(), "flag on must collapse the streamed edit into a redline"
+    assert _doc.getPropertyValue("RecordChanges") is False, "recording restored to OFF"
+    _reject_all()
+    assert _para_text() == "Sentence to rewrite.", "reject restores the original sentence"
+
+
+@native_test
+def test_session_flag_off_user_off_no_redline_uno():
+    _session_run(track_reviewable=False, prior_recording=False)
+    assert _redline_types() == [], "flag off + user off must not create a redline"
+    assert _para_text() == "Rewritten sentence.", "edit applied directly"
+
+
+@native_test
+def test_session_prior_recording_on_preserved_uno():
+    _session_run(track_reviewable=False, prior_recording=True)
+    assert _redline_types(), "user-on tracking must still collapse to a redline"
+    assert _doc.getPropertyValue("RecordChanges") is True, "prior ON state preserved"
+    _doc.setPropertyValue("RecordChanges", False)
+
+
+@native_test
+def test_streamed_edit_tagged_as_agent_change_uno():
+    """The streamed rewrite collapses to one tracked change; it must also be TAGGED with a
+    session token so the review tooling recognizes it as an agent change."""
+    _session_run(track_reviewable=True, prior_recording=False)
+    comments = [r["RedlineComment"] for r in _redlines()]
+    assert comments and all(c.startswith("wa-review:") for c in comments), \
+        "streamed edit redlines must carry a session token, got %r" % comments
+    assert len(set(comments)) == 1, "the streamed edit is ONE agent change (one token), got %r" % comments
+    authors = {r["RedlineAuthor"] for r in _redlines()}
+    assert authors == {"WriterAgent"}, "the streamed change is authored as the agent, got %r" % authors
+    _reject_all()
+
+
+# --- attribution: insertions vs deletions get different authors (-> 2 by-author colors) ---
+
+@native_test
+def test_split_authors_insert_vs_delete_uno():
+    """A replace records its Insert and Delete under DIFFERENT authors, so LibreOffice's
+    by-author redline coloring shows new vs removed text in two distinct colors."""
+    _reset("Old clause body here.")
+    prev = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, True)
+    try:
+        res = ApplyDocumentContent().execute(
+            _tool_ctx(), target="search", old_content="Old clause body here.", content=["New clause body here."])
+        assert res.get("status") == "ok", res
+        by_type = {r["type"]: r["RedlineAuthor"] for r in _redlines()}
+        assert by_type.get("Insert") == "WriterAgent", "insertions authored WriterAgent: %r" % by_type
+        assert by_type.get("Delete") == "WriterAgent (deletions)", "deletions authored distinctly: %r" % by_type
+    finally:
+        set_config(_ctx, _FLAG, prev)
+        _reject_all()
+
+
+# --- the apply_document_content tool end to end (config read + session wiring) -----------
+
+@native_test
+def test_apply_document_content_tool_tracks_when_config_on_uno():
+    """Real tool path: content.py reads writer.track_changes_reviewable=True and records the
+    edit as reviewable redlines; reject restores. (Exercises the config read, which the
+    primitive-level tests above do not.)"""
+    _reset("Old tool body.")
+    prev = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, True)
+    try:
+        assert get_config_bool_safe(_ctx, _FLAG) is True, "flag should read True (test-infra sanity)"
+        res = ApplyDocumentContent().execute(_tool_ctx(), target="full_document", content=["<p>Tool new body.</p>"])
+        assert res.get("status") == "ok", res
+        rl = _redline_types()
+        assert "Insert" in rl and "Delete" in rl, "tool path with flag on must create redlines, got %r" % rl
+        _reject_all()
+        assert "Old tool body." in _para_text(), "reject must restore the original, got %r" % _para_text()
+    finally:
+        set_config(_ctx, _FLAG, prev)  # restore the dev's prior value, not a hardcoded False
+
+
+@native_test
+def test_apply_document_content_tool_untracked_when_config_off_uno():
+    """Flag off (the default): the tool applies directly, no redline."""
+    _reset("Old tool body.")
+    prev = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, False)
+    try:
+        assert get_config_bool_safe(_ctx, _FLAG) is False
+        res = ApplyDocumentContent().execute(_tool_ctx(), target="full_document", content=["<p>Tool new body.</p>"])
+        assert res.get("status") == "ok", res
+        assert _redline_types() == [], "flag off must not create redlines"
+        assert "Tool new body." in _para_text()
+    finally:
+        set_config(_ctx, _FLAG, prev)
+
+
+@native_test
+def test_apply_document_content_tool_tags_changes_with_session_tokens_uno():
+    """Every redline of a flag-on edit carries a wa-review:<session>:<n> token (so completion
+    and outcome detection key on this session only), and a replace-all yields one tagged change
+    PER MATCH."""
+    _reset("Tag alpha here. Tag alpha there.")
+    prev = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, True)
+    try:
+        res = ApplyDocumentContent().execute(
+            _tool_ctx(), target="search", old_content="Tag alpha", content=["Tag beta"], all_matches=True)
+        assert res.get("status") == "ok", res
+        assert res.get("replaced_count") == 2, res
+        comments = [r["RedlineComment"] for r in _redlines()]
+        assert comments and all(c.startswith("wa-review:") for c in comments), \
+            "all redlines must carry session tokens, got %r" % comments
+        assert len(set(comments)) == 2, "two matches -> two distinct per-change tokens, got %r" % comments
+    finally:
+        set_config(_ctx, _FLAG, prev)
+        _reject_all()
+
+
+@native_test
+def test_tool_never_blocks_on_main_thread_even_with_wait_flag_uno():
+    """writer.require_edit_review on: from the MAIN thread the tool must NOT block-wait (the
+    user could never click accept/reject if the UI thread were parked) -- it edits, records
+    (wait implies recording), and returns without a review payload. The blocking wait only
+    happens on a background MCP/chat thread."""
+    _reset("Guard body text.")
+    prev_wait = get_config_bool_safe(_ctx, "writer.require_edit_review")
+    prev_rec = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, "writer.require_edit_review", True)
+    set_config(_ctx, _FLAG, False)
+    try:
+        res = ApplyDocumentContent().execute(_tool_ctx(), target="end", content=["<p>Guard addition.</p>"])
+        assert res.get("status") == "ok", res
+        assert "review" not in res, "main-thread call must not block-wait: %r" % res
+        assert _redline_types(), "the wait flag must imply recording (redlines expected)"
+    finally:
+        set_config(_ctx, "writer.require_edit_review", prev_wait)
+        set_config(_ctx, _FLAG, prev_rec)
+        _reject_all()
+
+
+# --- style changes are not redline-trackable; the tool says so under review mode ---------
+
+@native_test
+def test_apply_style_flags_unreviewed_when_review_on_uno():
+    from plugin.writer.styles import ApplyStyle
+
+    _reset("Heading target text.")
+    prev = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, True)
+    try:
+        res = ApplyStyle().execute(_tool_ctx(), style_name="Heading 2", family="ParagraphStyles", target="full_document")
+        assert res.get("status") == "ok", res
+        assert res.get("style_unreviewed") is True, "style edit must flag unreviewed under review mode: %r" % res
+        assert _redline_types() == [], "a paragraph-style change creates no redline"
+    finally:
+        set_config(_ctx, _FLAG, prev)
+
+
+@native_test
+def test_apply_style_no_unreviewed_flag_when_review_off_uno():
+    from plugin.writer.styles import ApplyStyle
+
+    _reset("Heading target text.")
+    prev = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, False)
+    try:
+        res = ApplyStyle().execute(_tool_ctx(), style_name="Heading 2", family="ParagraphStyles", target="full_document")
+        assert res.get("status") == "ok", res
+        assert "style_unreviewed" not in res, "no unreviewed flag when review mode off: %r" % res
+    finally:
+        set_config(_ctx, _FLAG, prev)
+
+
+# --- script/vision result insertions record through the session too ----------------------
+
+@native_test
+def test_insert_content_at_position_recorded_by_session_uno():
+    """The mechanism the script/vision result insertions rely on: insert_content_at_position
+    inside an enabled EditReviewSession lands as a tagged Insert redline, and the prior
+    recording state is restored."""
+    _reset("Existing body.")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        session.record_mutation(lambda: fmt.insert_content_at_position(_doc, _ctx, "<p>Inserted result.</p>", "end"))
+    session.cleanup()
+    rls = _redlines()
+    assert any(r["type"] == "Insert" for r in rls), "insert must create an Insert redline, got %r" % rls
+    assert all(r["RedlineComment"].startswith("wa-review:") for r in rls), "tagged: %r" % rls
+    assert _doc.getPropertyValue("RecordChanges") is False, "recording restored to OFF"
+    _reject_all()

--- a/tests/writer/test_track_changes_reviewable_uno.py
+++ b/tests/writer/test_track_changes_reviewable_uno.py
@@ -17,7 +17,7 @@ import contextlib
 
 from plugin.testing_runner import native_test, setup, teardown
 from plugin.tests.testing_utils import TestingFactory
-from plugin.doc.document_helpers import WriterStreamedRewriteSession
+from plugin.doc.document_helpers import WriterStreamedRewriteSession, WriterStreamedAppendSession
 from plugin.writer.content import ApplyDocumentContent
 from plugin.writer.edit_review import EditReviewSession
 from plugin.framework.config import set_config, get_config_bool_safe
@@ -392,3 +392,147 @@ def test_insert_content_at_position_recorded_by_session_uno():
     assert all(r["RedlineComment"].startswith("wa-review:") for r in rls), "tagged: %r" % rls
     assert _doc.getPropertyValue("RecordChanges") is False, "recording restored to OFF"
     _reject_all()
+
+
+# --- extend-selection: append the continuation as ONE tracked INSERTION (the original is never
+# --- struck), tagged as an agent change -- via WriterStreamedAppendSession --------------------
+
+def _append_run(track_reviewable, prior_recording):
+    _reset("Original sentence.")
+    _doc.setPropertyValue("RecordChanges", prior_recording)
+    rng = _doc.getText().createTextCursor()
+    rng.gotoStart(False)
+    rng.gotoEndOfParagraph(True)
+    session = WriterStreamedAppendSession(_doc, rng, "Original sentence.", track_reviewable=track_reviewable)
+    session.append_chunk(" Added continuation.")
+    session.finish()
+
+
+@native_test
+def test_streamed_append_tracks_only_appended_text_uno():
+    """Extend collapses to ONE tracked INSERTION of just the appended text -- the original keeps
+    no Delete redline -- tagged as an agent change. Reject removes only the appended text."""
+    _doc.setPropertyValue("ShowChanges", False)
+    _append_run(track_reviewable=True, prior_recording=False)
+    rls = _redlines()
+    assert rls, "review mode must collapse the appended continuation into a redline"
+    assert all(r["type"] == "Insert" for r in rls), \
+        "extend appends -> Insert only, the original keeps no Delete redline, got %r" % [r["type"] for r in rls]
+    comments = [r["RedlineComment"] for r in rls]
+    assert comments and all(c.startswith("wa-review:") for c in comments), \
+        "appended redline must carry a session token, got %r" % comments
+    assert len(set(comments)) == 1, "the append is ONE agent change (one token), got %r" % comments
+    assert _doc.getPropertyValue("ShowChanges") is True, "review mode forces markup visible"
+    assert _doc.getPropertyValue("RecordChanges") is False, "recording restored to OFF"
+    _reject_all()
+    assert _para_text() == "Original sentence.", "reject removes only the appended continuation"
+
+
+@native_test
+def test_streamed_append_flag_off_no_redline_uno():
+    """Flag off + user not recording: extend appends directly, no redline (today's behavior)."""
+    _append_run(track_reviewable=False, prior_recording=False)
+    assert _redline_types() == [], "flag off + user off must not create a redline"
+    assert _para_text() == "Original sentence. Added continuation.", "the continuation is appended in full"
+
+
+@native_test
+def test_streamed_append_no_output_restores_prior_recording_uno():
+    """A no-op streamed extend still restores the user's RecordChanges state.
+
+    WriterStreamedAppendSession turns recording off while chunks stream, so an empty model result
+    must not leave the user's own tracking disabled just because there was no edit to collapse.
+    """
+    _reset("Original sentence.")
+    _doc.setPropertyValue("RecordChanges", True)
+    rng = _doc.getText().createTextCursor()
+    rng.gotoStart(False)
+    rng.gotoEndOfParagraph(True)
+    session = WriterStreamedAppendSession(_doc, rng, "Original sentence.", track_reviewable=False)
+    warning = session.finish()
+    assert warning is None
+    assert _doc.getPropertyValue("RecordChanges") is True, "no-output append must restore the user's RecordChanges ON state"
+    _doc.setPropertyValue("RecordChanges", False)
+
+
+@native_test
+def test_update_style_flags_unreviewed_when_review_on_uno():
+    """Like apply_style, update_style is a style mutation -> not reviewable -> must flag the agent."""
+    from plugin.writer.styles import UpdateStyle
+
+    _reset("Body text for style update.")
+    prev = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, True)
+    try:
+        res = UpdateStyle().execute(
+            _tool_ctx(), style_name="Standard", family="ParagraphStyles",
+            property_updates={"CharWeight": 150.0})  # 150.0 == BOLD
+        assert res.get("status") == "ok", res
+        assert res.get("style_unreviewed") is True, "update_style must flag unreviewed under review mode: %r" % res
+        assert _redline_types() == [], "a style change creates no redline"
+    finally:
+        set_config(_ctx, _FLAG, prev)
+
+
+@native_test
+def test_is_async_true_on_background_thread_when_review_toggled_off_uno():
+    """If review is toggled OFF after the async snapshot dispatched the tool to a worker thread,
+    is_async() must still report True there so execute_safe's main-thread guard won't reject it
+    (execute() then marshals the wait-free edit to the main thread)."""
+    import threading
+
+    prev = get_config_bool_safe(_ctx, "writer.require_edit_review")
+    set_config(_ctx, "writer.require_edit_review", False)
+    try:
+        tool = ApplyDocumentContent()
+        assert tool.is_async() is False, "main thread + review off -> synchronous (no spurious async)"
+        seen = {}
+
+        def _check():
+            seen["v"] = tool.is_async()
+
+        t = threading.Thread(target=_check)
+        t.start()
+        t.join()
+        assert seen.get("v") is True, "on a worker thread is_async must stay True so execute_safe won't reject"
+    finally:
+        set_config(_ctx, "writer.require_edit_review", prev)
+
+
+@native_test
+def test_bookmarks_cleaned_when_edit_raises_midway_uno():
+    """#4: if _execute_edit raises AFTER a change was anchored (a replace-all that fails on a later
+    match, having anchored the first), execute() must still release the session's wa_review_*
+    anchor bookmarks via the session_sink -- none may leak in the document."""
+    from plugin.writer.content import ApplyDocumentContent
+    from plugin.writer.edit_review import EditReviewSession
+
+    _reset("Anchor target paragraph.")
+    prev = get_config_bool_safe(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, True)
+
+    class _BoomTool(ApplyDocumentContent):
+        def _execute_edit(self, ctx, session_sink=None, **kwargs):
+            # Mirror the real path: create the session, register it in the sink, anchor ONE change
+            # (creating a wa_review_* bookmark), then fail before returning.
+            session = EditReviewSession(ctx.doc, ctx.ctx, enabled=True)
+            if session_sink is not None:
+                session_sink.append(session)
+            with session:
+                session.record_mutation(
+                    lambda: fmt.insert_content_at_position(ctx.doc, ctx.ctx, "<p>Inserted.</p>", "end"))
+            raise RuntimeError("boom after anchoring the first change")
+
+    try:
+        raised = False
+        try:
+            _BoomTool().execute(_tool_ctx())
+        except RuntimeError:
+            raised = True
+        assert raised, "the mid-edit failure must propagate to the caller"
+        leaked = [n for n in _doc.getBookmarks().getElementNames() if n.startswith("wa_review_")]
+        assert leaked == [], "anchor bookmarks must be cleaned up on a mid-edit failure, leaked: %r" % leaked
+    finally:
+        set_config(_ctx, _FLAG, prev)
+        if len(_doc.getRedlines()):
+            _reject_all()


### PR DESCRIPTION
Implements the reviewable-agent-edits feature from the proposal in [#326](https://github.com/KeithCu/writeragent/discussions/326). Writer-only; all flags default off (off = current behavior, byte for byte).

**Core (as discussed):** one `EditReviewSession` (`plugin/writer/edit_review.py`) owns recording, session-token tagging, anchoring, attribution, the wait loop, and cleanup — every edit path goes through it. Completion is keyed to this session's `wa-review:<id>:<n>` tokens (not "zero redlines"), so the user's pre-existing redlines or edits-while-waiting never block it. Review forces `RecordChanges` on and restores the prior state. Same core for the sidebar (`is_async`) and MCP (`long_running`); every document touch during the wait is marshalled to the main thread, which stays free for accept/reject.

**Deliberate deviations from the sketch (all flagged in the discussion):**
- **Outcome is an enum** — `accepted | rejected | modified | pending` — a bool can't carry "user edited during review" (modified).
- **Granularity B** (one change per match/block), tested over MCP. Known edge: two matches in one paragraph share the paragraph snapshot, so mixed resolutions there can degrade to `modified`.
- **`ShowChanges` property** forced on, not `.uno:ShowTrackedChanges` (a toggle would hide markup for someone already showing it).
- **Two-color attribution** — insertions authored `WriterAgent`, deletions `WriterAgent (deletions)`, so by-author coloring shows new vs removed.
- **Recording-only replace fixes** — `replace_preserving_format`'s char-by-char diff and the inline-markup style re-apply don't compose with recording (per-character redlines; a Format redline that keeps both texts on Accept). Under recording the replace becomes one whole-range delete+insert and skips the style re-apply; review-off is unchanged (pinned by a flag-off regression test).
- **Undo hygiene** — the anchor bookmarks + redline tagging are locked off the user's undo stack, so the first Ctrl+Z reverts the visible edit.

**Inline review surface (separable):** on top of the native redlines, a left-click popup + right-click menu resolve a whole agent change (the Delete+Insert pair) as one unit, plus accept/reject-all. Strictly token-scoped — it never lists or touches the user's own tracked changes.

**Settings:** `writer.require_edit_review`, `writer.track_changes_reviewable`, `writer.edit_review_timeout` (defaults: off / off / 900s).

Design + limitations in `docs/reviewable-agent-edits.md`; covered by in-process UNO suites.

Kept separate as discussed: the Calc context-menu `queryInterface` fix.
