### PR TITLE
fix(calc): guard host-side numpy import in finalize_python_return

### DIFF
--- a/plugin/calc/python_function.py
+++ b/plugin/calc/python_function.py
@@ -175,8 +175,15 @@ def finalize_python_return(
     worker_data: Any = None,
 ) -> float | str | bool | tuple:
     """Map worker result to a single value Calc's add-in bridge accepts."""
-    import numpy as np
-    if isinstance(result, np.ndarray):
+    # numpy lives in the venv worker, NOT the LibreOffice host interpreter (import_policy:
+    # "the LibreOffice host environment does not [have NumPy]"). The worker already serializes
+    # arrays to plain lists before returning, so guard this import: on macOS the bundled host
+    # Python has no numpy, and an unguarded import discarded otherwise-successful results.
+    try:
+        import numpy as np
+    except ImportError:
+        np = None
+    if np is not None and isinstance(result, np.ndarray):
         res_list = result.tolist()
         if result.ndim == 1:
             result = [[x] for x in res_list]


### PR DESCRIPTION
Fixes #344.

`finalize_python_return()` did an unconditional `import numpy` in the LibreOffice **host** interpreter, which has no numpy by design. On macOS (the isolated bundled `LibreOfficePython.framework`) this always raised, so every `=PYTHON()` call — and the analysis / viz / symbolic / units Calc tools that finalize through it — returned `Error: No module named 'numpy'` **even though the venv worker computed the result correctly**.

The import is only used to coerce an `ndarray` result, and the worker already serializes numpy arrays to plain lists before returning, so the host path never actually sees an `ndarray`. This guards the import (no-op when numpy is absent in the host).

Full trace and root-cause in #344.
