### PR TITLE
Agent edit review mode: tracked changes you accept/reject

### DIFF
--- a/extension/Addons.xcu
+++ b/extension/Addons.xcu
@@ -251,6 +251,83 @@
         </node>
       </node>
     </node>
+    <node oor:name="OfficeToolBar">
+      <node oor:name="org.extension.writeragent.toolbar" oor:op="replace">
+        <node oor:name="t1" oor:op="replace">
+          <prop oor:name="URL">
+            <value>org.extension.writeragent:writer.review_prev</value>
+          </prop>
+          <prop oor:name="Title">
+            <value xml:lang="en-US">◀ Prev</value>
+          </prop>
+          <prop oor:name="Context" oor:type="xs:string">
+            <value>com.sun.star.text.TextDocument</value>
+          </prop>
+          <prop oor:name="Target" oor:type="xs:string">
+            <value>_self</value>
+          </prop>
+          <prop oor:name="ImageIdentifier" oor:type="xs:string">
+            <value />
+          </prop>
+        </node>
+        <node oor:name="t2" oor:op="replace">
+          <prop oor:name="URL">
+            <value>org.extension.writeragent:writer.review_next</value>
+          </prop>
+          <prop oor:name="Title">
+            <value xml:lang="en-US">Next ▶</value>
+          </prop>
+          <prop oor:name="Context" oor:type="xs:string">
+            <value>com.sun.star.text.TextDocument</value>
+          </prop>
+          <prop oor:name="Target" oor:type="xs:string">
+            <value>_self</value>
+          </prop>
+          <prop oor:name="ImageIdentifier" oor:type="xs:string">
+            <value />
+          </prop>
+        </node>
+        <node oor:name="sep1" oor:op="replace">
+          <prop oor:name="URL">
+            <value>private:separator</value>
+          </prop>
+        </node>
+        <node oor:name="t3" oor:op="replace">
+          <prop oor:name="URL">
+            <value>org.extension.writeragent:writer.review_accept_all</value>
+          </prop>
+          <prop oor:name="Title">
+            <value xml:lang="en-US">Accept all</value>
+          </prop>
+          <prop oor:name="Context" oor:type="xs:string">
+            <value>com.sun.star.text.TextDocument</value>
+          </prop>
+          <prop oor:name="Target" oor:type="xs:string">
+            <value>_self</value>
+          </prop>
+          <prop oor:name="ImageIdentifier" oor:type="xs:string">
+            <value />
+          </prop>
+        </node>
+        <node oor:name="t4" oor:op="replace">
+          <prop oor:name="URL">
+            <value>org.extension.writeragent:writer.review_reject_all</value>
+          </prop>
+          <prop oor:name="Title">
+            <value xml:lang="en-US">Reject all</value>
+          </prop>
+          <prop oor:name="Context" oor:type="xs:string">
+            <value>com.sun.star.text.TextDocument</value>
+          </prop>
+          <prop oor:name="Target" oor:type="xs:string">
+            <value>_self</value>
+          </prop>
+          <prop oor:name="ImageIdentifier" oor:type="xs:string">
+            <value />
+          </prop>
+        </node>
+      </node>
+    </node>
   </node>
 </oor:component-data>
 

--- a/extension/registry/org/openoffice/Office/UI/WriterWindowState.xcu
+++ b/extension/registry/org/openoffice/Office/UI/WriterWindowState.xcu
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Names the WriterAgent review fast-travel toolbar (else LibreOffice labels it the generic
+     "Add-On N") and starts it HIDDEN. The toolbar is declared in Addons.xcu under
+     OfficeToolBar / org.extension.writeragent.toolbar, so LO derives the resource URL
+     "private:resource/toolbar/addon_org.extension.writeragent.toolbar". It is shown/hidden at
+     runtime by plugin/writer/review_toolbar.py based on the count of pending agent changes. -->
+<oor:component-data xmlns:oor="http://openoffice.org/2001/registry"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    oor:name="WriterWindowState" oor:package="org.openoffice.Office.UI">
+  <node oor:name="UIElements">
+    <node oor:name="States">
+      <node oor:name="private:resource/toolbar/addon_org.extension.writeragent.toolbar" oor:op="replace">
+        <prop oor:name="UIName" oor:type="xs:string">
+          <value xml:lang="en-US">WriterAgent Review</value>
+        </prop>
+        <prop oor:name="Visible" oor:type="xs:boolean">
+          <value>false</value>
+        </prop>
+      </node>
+    </node>
+  </node>
+</oor:component-data>

--- a/plugin/doc/document_helpers.py
+++ b/plugin/doc/document_helpers.py
@@ -267,6 +267,7 @@ class WriterStreamedRewriteSession:
                 # snapshot the redlines so the collapsed change can be tagged as an agent change
                 # afterward, and author it as the agent for the by-author coloring.
                 before_ids = None
+                before_ids_ok = False
                 prior_author = None
                 if self.track_reviewable:
                     try:
@@ -274,7 +275,7 @@ class WriterStreamedRewriteSession:
                         from plugin.writer import review_authors
                         from plugin.writer.edit_review import snapshot_redline_ids
 
-                        before_ids = snapshot_redline_ids(self.doc)
+                        before_ids, before_ids_ok = snapshot_redline_ids(self.doc)
                         prior_author = review_authors.begin(get_ctx())
                         # Make the markup visible so a reviewable change isn't left invisible
                         # when the user has Track Changes display off (matches
@@ -311,7 +312,7 @@ class WriterStreamedRewriteSession:
                     try:
                         from plugin.writer.edit_review import tag_agent_redlines
 
-                        tag_agent_redlines(self.doc, before_ids)
+                        tag_agent_redlines(self.doc, before_ids, before_reliable=before_ids_ok)
                     except Exception:
                         logging.getLogger(__name__).debug("streamed rewrite: redline tagging failed", exc_info=True)
                 return None
@@ -415,6 +416,7 @@ class WriterStreamedAppendSession:
                 return None
 
             before_ids = None
+            before_ids_ok = False
             prior_author = None
             if self.track_reviewable:
                 try:
@@ -422,7 +424,7 @@ class WriterStreamedAppendSession:
                     from plugin.writer import review_authors
                     from plugin.writer.edit_review import snapshot_redline_ids
 
-                    before_ids = snapshot_redline_ids(self.doc)
+                    before_ids, before_ids_ok = snapshot_redline_ids(self.doc)
                     prior_author = review_authors.begin(get_ctx())
                     # Make the markup visible so a reviewable change isn't invisible when the
                     # user has Track Changes display off (matches EditReviewSession.__enter__).
@@ -459,7 +461,7 @@ class WriterStreamedAppendSession:
                 try:
                     from plugin.writer.edit_review import tag_agent_redlines
 
-                    tag_agent_redlines(self.doc, before_ids)
+                    tag_agent_redlines(self.doc, before_ids, before_reliable=before_ids_ok)
                 except Exception:
                     logging.getLogger(__name__).debug("streamed append: redline tagging failed", exc_info=True)
             return None
@@ -593,9 +595,26 @@ def _normalize_doc_url(url):
     return s
 
 
-def resolve_document_by_url(ctx, url):
-    """Resolve an open document by URL. Must be called on the UNO main thread.
+def get_runtime_uid(model):
+    """Stable per-session id for an open component.
 
+    Unlike the document URL, ``RuntimeUID`` exists even for unsaved/untitled
+    documents, so it can address a document that has no file on disk yet.
+    Returns "" if unavailable.
+    """
+    try:
+        uid = getattr(model, "RuntimeUID", None)
+        return str(uid) if uid else ""
+    except Exception:
+        return ""
+
+
+def resolve_document_by_url(ctx, url):
+    """Resolve an open document by URL or RuntimeUID. Must be called on the UNO main thread.
+
+    ``url`` may be a document URL or a ``RuntimeUID`` (as returned by
+    ``list_open_documents``); the RuntimeUID also matches unsaved/untitled
+    documents that have no URL yet.
     Returns (doc, doc_type) or (None, None) if not found.
     doc_type is one of 'writer', 'calc', 'draw'.
     """
@@ -621,9 +640,10 @@ def resolve_document_by_url(ctx, url):
                     model = elem
                 elif hasattr(elem, "getController") and elem.getController():
                     model = elem.getController().getModel()
-                if model and hasattr(model, "getURL"):
-                    doc_url = _normalize_doc_url(model.getURL())
-                    if doc_url and doc_url == target:
+                if model is not None:
+                    doc_url = _normalize_doc_url(model.getURL()) if hasattr(model, "getURL") else ""
+                    uid = get_runtime_uid(model)
+                    if (doc_url and doc_url == target) or (uid and uid == target):
                         doc_type_enum = get_document_type(model)
                         doc_type = "writer"
                         if doc_type_enum == DocumentType.CALC:

--- a/plugin/doc/document_research.py
+++ b/plugin/doc/document_research.py
@@ -598,7 +598,7 @@ def get_open_documents(uno_ctx: Any, active_model: Any = None) -> list[dict[str,
     """Retrieve all open documents from the desktop context with metadata."""
     from plugin.framework.thread_guard import assert_main_thread
     from plugin.framework.uno_context import get_desktop
-    from plugin.doc.document_helpers import get_document_type, DocumentType
+    from plugin.doc.document_helpers import get_document_type, DocumentType, get_runtime_uid
     import os
 
     assert_main_thread("document_research.get_open_documents")
@@ -617,6 +617,8 @@ def get_open_documents(uno_ctx: Any, active_model: Any = None) -> list[dict[str,
             continue
         url = model.getURL()
         if not url:
+            # An untitled doc has no URL, so its uid is the ONLY handle a caller can target it by.
+            # Never drop it on a type-lookup failure -- list it with doc_type "unknown" instead.
             try:
                 doc_type_enum = get_document_type(model)
                 doc_type = "writer"
@@ -624,15 +626,17 @@ def get_open_documents(uno_ctx: Any, active_model: Any = None) -> list[dict[str,
                     doc_type = "calc"
                 elif doc_type_enum in (DocumentType.DRAW, DocumentType.IMPRESS):
                     doc_type = "draw"
-                docs.append({
-                    "name": "Untitled",
-                    "url": "",
-                    "path": "",
-                    "doc_type": doc_type,
-                    "is_active": (active_model is not None and model == active_model)
-                })
             except Exception:
-                pass
+                doc_type = "unknown"
+                log.debug("get_open_documents: doc type lookup failed for an untitled doc", exc_info=True)
+            docs.append({
+                "name": "Untitled",
+                "url": "",
+                "uid": get_runtime_uid(model),
+                "path": "",
+                "doc_type": doc_type,
+                "is_active": (active_model is not None and model == active_model)
+            })
             continue
         
         path = _system_path_from_url(str(url)) or ""
@@ -653,6 +657,7 @@ def get_open_documents(uno_ctx: Any, active_model: Any = None) -> list[dict[str,
         docs.append({
             "name": name,
             "url": str(url),
+            "uid": get_runtime_uid(model),
             "path": path,
             "doc_type": doc_type_guess,
             "is_active": (active_model is not None and model == active_model)

--- a/plugin/doc/document_research_tools.py
+++ b/plugin/doc/document_research_tools.py
@@ -64,7 +64,8 @@ class ListOpenDocuments(ToolBase):
     name = "list_open_documents"
     description = (
         "List all currently open documents in LibreOffice. "
-        "Returns the path, name, URL, document type (writer, calc, draw), and if it is the currently active document."
+        "Returns the path, name, URL, a stable id (uid), document type (writer, calc, draw), and if it is the currently active document. "
+        "Pass a document's url OR uid as the document_url argument on any tool to target that document; the uid also works for unsaved/untitled documents that have no URL yet."
     )
     tier = "mcp"
     is_mutation = False

--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -161,6 +161,16 @@ RESEARCH_DELEGATE_TO_DOCUMENT = (
 )
 APPLY_DOCUMENT_CONTENT_TOOL_RESEARCH_HINT = "Required after web_research or document_research delegates return."
 
+# Canonical wording for tools that return a para_index / paragraph_index to the model. Those indexes
+# are internal addressing only; the user never sees them and they shift as the document changes, so
+# the model must refer to a place by quoting its text, not by number. Append to such tool
+# descriptions so the rule is stated uniformly wherever an index is exposed (#1).
+PARAGRAPH_INDEX_DIRECTIVE = (
+    "para_index / paragraph_index values are INTERNAL addressing only — NEVER cite paragraph numbers "
+    "to the user (they don't see them and they shift as the document changes); to point the user at a "
+    "place, quote the first few words of its text instead (e.g. \"the sentence starting 'The Amazon…'\")."
+)
+
 
 def delegation_math_to_python_hint(*, delegate_toolset: str) -> str:
     """Writer/Draw: route computational math to the python specialized sub-agent (fast local venv)."""

--- a/plugin/framework/tool.py
+++ b/plugin/framework/tool.py
@@ -121,7 +121,7 @@ def to_mcp_schema(tool, *, doc_type: str | None = None):
     if "document_url" not in input_schema["properties"]:
         input_schema["properties"]["document_url"] = {
             "type": "string",
-            "description": "Optional URL of the target document. If not provided, the active document is used."
+            "description": "Optional URL or RuntimeUID of the target document (both come from list_open_documents). If not provided, the active document is used. A RuntimeUID also targets unsaved/untitled documents that have no file URL yet."
         }
     desc = tool.get_description(doc_type)
 

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -321,6 +321,16 @@ def _register_core_handlers():
 
     register_action_handler("textanalytics", "open_dialog", _open_text_analytics)
 
+    def _refresh_review_toolbar(model):
+        """Re-evaluate the review toolbar's visibility (hide once nothing is left to review).
+        Also a catch-up point if changes were resolved via LibreOffice's native UI."""
+        try:
+            from plugin.writer.review_toolbar import refresh_review_toolbar
+
+            refresh_review_toolbar(model)
+        except Exception:
+            logging.getLogger("writeragent.main").debug("review toolbar refresh failed", exc_info=True)
+
     def _resolve_change_at_cursor(accept):
         from plugin.framework.uno_context import get_active_document
         from plugin.writer.inline_review import resolve_change_at_cursor, show_review_message
@@ -332,6 +342,7 @@ def _register_core_handlers():
             logging.getLogger("writeragent.main").debug("inline review: accept=%s -> ok=%s msg=%s", accept, ok, msg)
             if not ok:
                 show_review_message(c, msg)
+            _refresh_review_toolbar(model)
         else:
             logging.getLogger("writeragent.main").debug("inline review: no current component")
 
@@ -348,9 +359,27 @@ def _register_core_handlers():
             n, msg = resolve_all_with_feedback(model, c, accept)
             logging.getLogger("writeragent.main").debug("inline review: resolve-all accept=%s -> %d changes", accept, n)
             show_review_message(c, msg)
+            _refresh_review_toolbar(model)
 
     register_action_handler("writer", "review_accept_all", lambda: _resolve_all_agent(True))
     register_action_handler("writer", "review_reject_all", lambda: _resolve_all_agent(False))
+
+    def _goto_adjacent_change(forward):
+        """Fast-travel (#2): move the cursor to the next/previous pending agent change, in document
+        order, cycling. Drives the review toolbar's Next/Previous buttons (and any shortcut)."""
+        from plugin.framework.uno_context import get_active_document
+        from plugin.writer.inline_review import goto_adjacent_agent_change
+
+        c = get_ctx()
+        model = get_active_document(c)
+        if model is None:
+            return
+        token = goto_adjacent_agent_change(model, forward)
+        logging.getLogger("writeragent.main").debug("review nav: forward=%s -> token=%s", forward, token)
+        _refresh_review_toolbar(model)
+
+    register_action_handler("writer", "review_next", lambda: _goto_adjacent_change(True))
+    register_action_handler("writer", "review_prev", lambda: _goto_adjacent_change(False))
 
     try:
         from plugin.writer.change_context_menu import install_writer_change_context_menu
@@ -359,6 +388,13 @@ def _register_core_handlers():
     except Exception:
         # WARNING, not debug: a silent install failure looks identical to "menu ignored".
         log.warning("Writer change context menu install failed", exc_info=True)
+
+    try:
+        from plugin.writer.review_toolbar import install_review_toolbar
+
+        install_review_toolbar(get_ctx())
+    except Exception:
+        log.warning("Review toolbar visibility install failed", exc_info=True)
 
 
 
@@ -570,17 +606,29 @@ def notify_menu_update():
 
     Called by modules when state changes (e.g. server start/stop).
     """
+    # Snapshot the listeners under the lock, then fire OUTSIDE it. _fire_status_event ->
+    # listener.statusChanged is a UNO call to a UI control that marshals to the main thread, so
+    # holding _status_lock across it deadlocks: the main thread, while rebinding a toolbar
+    # controller (addStatusListener), waits for the same lock this background thread holds. (This is
+    # what froze LibreOffice on the toolbar's Accept all.) addStatusListener already fires outside
+    # the lock; this makes notify_menu_update consistent.
     with _status_lock:
-        alive = []
-        for listener, url in _status_listeners:
-            command = url.Path
-            text = get_menu_text(command)
-            try:
-                _fire_status_event(listener, url, text)
-                alive.append((listener, url))
-            except Exception as e:
-                log.warning("notify_menu_update: failed to fire status event for %s: %s", command, e)
-        _status_listeners[:] = alive
+        snapshot = list(_status_listeners)
+    failed = []
+    for listener, url in snapshot:
+        command = url.Path
+        text = get_menu_text(command)
+        try:
+            _fire_status_event(listener, url, text)
+        except Exception as e:
+            failed.append((listener, url))
+            log.warning("notify_menu_update: failed to fire status event for %s: %s", command, e)
+    if failed:
+        with _status_lock:
+            _status_listeners[:] = [
+                (lstnr, u) for (lstnr, u) in _status_listeners
+                if not any(lstnr is fl and u.Complete == fu.Complete for (fl, fu) in failed)
+            ]
     # Update icons in a background thread (avoids blocking UI)
     from plugin.framework.worker_pool import run_in_background
 

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -29,7 +29,7 @@ import time
 import uuid
 from contextlib import contextmanager
 
-from plugin.doc.document_helpers import _normalize_doc_url
+from plugin.doc.document_helpers import _normalize_doc_url, get_runtime_uid
 from plugin.framework.queue_executor import QueueExecutor
 from plugin.framework.errors import WriterAgentException, safe_json_loads
 from plugin.mcp.cors import send_cors_headers
@@ -82,26 +82,32 @@ _doc_gates_guard = threading.Lock()
 
 
 def _resolve_mcp_doc_key(document_url, doc):
-    """Stable per-document key for the mutation gate (resolve on main thread with *doc*).
+    """Stable per-document key for the mutation gate, derived from the RESOLVED document (``doc``).
 
-    Future: after Save As, callers may still use the old URL while doc.getURL() returns
-    the new one — two keys could exist briefly for the same logical document. Re-key or
-    prune gates on save events if that becomes a problem.
+    Keying off the resolved document — not the raw request handle — is what makes addressing the
+    SAME document by its file URL OR by its RuntimeUID map to ONE gate, so two concurrent mutating
+    calls on that document serialize instead of racing. RuntimeUID is preferred because it
+    is stable for the document's whole session (it survives Save As, where the URL changes).
 
-    When no X-Document-URL and the doc has no URL/RuntimeUID (unsaved active doc), falls
-    back to _ACTIVE_DOCUMENT_SENTINEL. Correct for "target the active document" today;
-    would over-serialize if LO ever allowed ambiguous active-doc targeting.
+    Falls back to the normalized request URL only when the document couldn't be resolved, and to
+    _ACTIVE_DOCUMENT_SENTINEL when there is neither — "target the active document" today.
     """
-    doc_key = _normalize_doc_url(document_url) if document_url else ""
-    if not doc_key and doc is not None:
+    if doc is not None:
         try:
-            url_part = _normalize_doc_url(doc.getURL())
-            uid_part = getattr(doc, "RuntimeUID", None)
-            doc_key = url_part or (str(uid_part) if uid_part is not None else "")
+            uid = get_runtime_uid(doc)
+            if uid:
+                return "uid:%s" % uid
+            url = _normalize_doc_url(doc.getURL())
+            if url:
+                return "url:%s" % url
         except Exception:
             log.debug("Could not resolve document key for the mutation gate", exc_info=True)
-            doc_key = ""
-    return doc_key or _ACTIVE_DOCUMENT_SENTINEL
+    # No resolved doc (or one with neither uid nor URL): best-effort key off the raw request URL,
+    # namespaced ("url:") so it can never collide with a resolved "uid:"/"url:" key; else the
+    # active-document sentinel.
+    if document_url:
+        return "url:%s" % _normalize_doc_url(document_url)
+    return _ACTIVE_DOCUMENT_SENTINEL
 
 
 def _get_document_mutation_gate(doc_key):

--- a/plugin/writer/change_context_menu.py
+++ b/plugin/writer/change_context_menu.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Writer right-click review: accept/reject the agent's tracked changes, as whole units.
 
-Adds four entries to the Writer text context menu (only while the document holds pending AGENT
+Adds two entries to the Writer text context menu (only while the document holds pending AGENT
 changes -- wa-review session tokens): accept/reject the agent change under the cursor as one
-unit (a replace's strikethrough + underline resolve together, no Manage dialog), and
-accept/reject ALL agent changes at once. The user's own tracked changes are never touched.
-The entries dispatch ``org.extension.writeragent:writer.accept_change`` / ``writer.reject_change``
-/ ``writer.review_accept_all`` / ``writer.review_reject_all``, handled in ``main.py``.
+unit (a replace's strikethrough + underline resolve together, no Manage dialog). The user's own
+tracked changes are never touched. Bulk accept/reject ALL agent changes lives on the review
+toolbar (#2), not in this menu. The entries dispatch
+``org.extension.writeragent:writer.accept_change`` / ``writer.reject_change``, handled in ``main.py``.
 
 PyUNO pitfalls this file works around (each silently killed the menu when done wrong):
 - ``queryInterface(InterfaceClass)`` cannot convert an imported interface class to a UNO type;
@@ -35,8 +35,6 @@ log = logging.getLogger(__name__)
 
 _ACCEPT_URL = "org.extension.writeragent:writer.accept_change"
 _REJECT_URL = "org.extension.writeragent:writer.reject_change"
-_ACCEPT_ALL_URL = "org.extension.writeragent:writer.review_accept_all"
-_REJECT_ALL_URL = "org.extension.writeragent:writer.review_reject_all"
 
 _lock = threading.RLock()
 # Registered controllers, deduplicated by UNO object identity: PyUNO hands out a NEW proxy
@@ -91,21 +89,13 @@ def _build_menu(model: Any, event: Any) -> Any:
         reject = container.createInstance("com.sun.star.ui.ActionTrigger")
         reject.setPropertyValue("Text", _("Reject whole change (agent)"))
         reject.setPropertyValue("CommandURL", _REJECT_URL)
-        # Bulk: resolve every agent change at once (token-filtered, so the user's own redlines
-        # are spared). Reachable from a right-click anywhere a change exists.
-        accept_all = container.createInstance("com.sun.star.ui.ActionTrigger")
-        accept_all.setPropertyValue("Text", _("Accept all agent changes"))
-        accept_all.setPropertyValue("CommandURL", _ACCEPT_ALL_URL)
-        reject_all = container.createInstance("com.sun.star.ui.ActionTrigger")
-        reject_all.setPropertyValue("Text", _("Reject all agent changes"))
-        reject_all.setPropertyValue("CommandURL", _REJECT_ALL_URL)
+        # Bulk accept/reject ALL is intentionally NOT here -- it lives on the review toolbar (#2).
+        # The right-click stays focused on the change under the cursor (the punctual action).
 
         count = container.getCount()
         container.insertByIndex(count, separator)
         container.insertByIndex(count + 1, accept)
         container.insertByIndex(count + 2, reject)
-        container.insertByIndex(count + 3, accept_all)
-        container.insertByIndex(count + 4, reject_all)
         log.debug("change_context_menu: added review entries at index %d", count)
         return CONTINUE_MODIFIED
     except Exception:

--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -16,14 +16,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Writer content tools — read, apply, find, and paragraph operations."""
 
+import itertools
 import logging
+import os
 import threading
 
 from plugin.framework.tool import ToolBase, ToolBaseDummy
 from plugin.framework.constants import APPLY_DOCUMENT_CONTENT_TOOL_RESEARCH_HINT
 from plugin.doc.document_helpers import normalize_linebreaks, get_string_without_tracked_deletions
 from plugin.writer.edit_review import EditReviewSession, edit_review_wait_seconds, review_recording_enabled, get_agent_edit_review_mode
-from plugin.framework.errors import safe_json_loads
+from plugin.framework.errors import safe_json_loads, ToolExecutionError
 import re as re_mod
 
 
@@ -326,6 +328,409 @@ def _all_start_indices(haystack, needle):
 def _find_all_ranges(doc, search_string):
     """All occurrences as TextRanges in document order (NBSP-aware native search with chaining)."""
     return _find_chained_range(doc, search_string, all_matches=True)
+
+
+# Agent-edit tuning knobs. These have sensible fixed defaults and are NOT settings-UI options (no
+# demonstrated need to tune them per document), so they are plain named constants -- not config keys.
+# A power user can still override any of them ONCE at startup via an environment variable: a named
+# constant with an escape hatch, read at import time.
+
+def _env_num(name, default, cast, ok):
+    """Read tuning knob *name* from the environment, *cast* it, and return it only if *ok(v)*;
+    otherwise the fixed *default*. Never raises -- a bad env value must never break an edit."""
+    try:
+        v = cast(os.environ[name])
+        return v if ok(v) else default
+    except (KeyError, ValueError, TypeError):
+        return default
+
+
+# Changed-word fraction at/under which a tracked replace is split into surgical sub-edits instead of
+# one whole-block Delete+Insert. > threshold -> one block change (today's behaviour); <= threshold ->
+# per-changed-run redlines. See plugin/writer/word_diff_split.py.
+_WORD_DIFF_THRESHOLD = _env_num(
+    "WRITERAGENT_AGENT_EDIT_DIFF_THRESHOLD", 0.6, float, lambda v: 0.0 <= v <= 1.0)
+
+# Max per-changed-run sub-edits before a surgical split falls back to ONE whole block. Bounds the
+# cost of recording a very scattered edit (each sub-edit re-enumerates redlines).
+_MAX_SURGICAL_RUNS = _env_num(
+    "WRITERAGENT_AGENT_EDIT_MAX_SURGICAL_RUNS", 40, int, lambda v: v >= 1)
+
+# Whether an agent edit's deletion and insertion are authored separately so LibreOffice's by-author
+# coloring renders removed vs new text in two distinct colors (on), or as one author / one color
+# (off). Off via the env var = any falsey token ("0", "false", "no", "off", "").
+_SPLIT_AUTHOR_COLORS = os.environ.get(
+    "WRITERAGENT_AGENT_EDIT_SPLIT_AUTHOR_COLORS", "1").strip().lower() not in ("0", "false", "no", "off", "")
+
+
+# goRight takes a C++ short (max 32767); chunk like the rest of the codebase (format.py, ops.py,
+# document_helpers.py) so a surgical sub-edit deep in a LONG block (the splitter's target case)
+# never overflows the count.
+_GO_RIGHT_CHUNK = 8192
+
+
+def _go_right(cursor, n, expand):
+    """Move (expand=False) or extend (expand=True) the cursor right by *n* chars, in chunks of
+    _GO_RIGHT_CHUNK (UNO caps the count at a C++ short). Returns True only if the FULL *n* was
+    consumed; False if goRight stopped early (end of text / an unexpected stop), so the caller can
+    refuse to edit at a wrong offset instead of silently landing short."""
+    while n > 0:
+        step = n if n < _GO_RIGHT_CHUNK else _GO_RIGHT_CHUNK
+        if not cursor.goRight(step, expand):
+            return False
+        n -= step
+    return True
+
+
+# Portion types whose presence keeps getString() char offsets aligned with the live cursor's
+# goRight stops, so surgical sub-edits still land correctly. "SoftPageBreak" is an automatic
+# (layout-only) page break: it contributes 0 chars to getString() and is not a goRight stop --
+# verified that navigating by getString offsets across one lands exactly right. Without it, any
+# paragraph that happens to straddle a page boundary was needlessly forced to whole-block. Real
+# content portions (fields, footnotes, ruby, redline marks, bookmarks, ...) DO shift offsets and
+# must keep returning False.
+_OFFSET_SAFE_PORTION_TYPES = frozenset({"Text", "SoftPageBreak"})
+
+
+def _block_safe_for_surgical(found):
+    """True only when *found* is a SINGLE paragraph whose portions are all offset-safe (plain text
+    or an automatic page break) and which has no tracked changes -- the case where getString() char
+    offsets line up with the live cursor's goRight stops. A multi-paragraph block, a struck
+    (tracked-deletion) run, or a real content portion (field/footnote/etc.) makes them diverge, so
+    the surgical sub-edits would land in the wrong place. Best-effort: any doubt -> False, and the
+    caller falls back to the whole-block replace (which handles every case).
+    """
+    from plugin.writer.edit_review import _string_skipping_redline
+    try:
+        # A tracked DELETION leaves struck text in getString() (the diff baseline) that the agent's
+        # old_content never matched -> the split would be computed against the wrong text.
+        if found.getString() != _string_skipping_redline(found, "Delete"):
+            return False
+        paras = found.createEnumeration()
+        seen = 0
+        while paras.hasMoreElements():
+            para = paras.nextElement()
+            seen += 1
+            if seen > 1 or not para.supportsService("com.sun.star.text.Paragraph"):
+                return False  # multi-paragraph or a table/other node
+            portions = para.createEnumeration()
+            while portions.hasMoreElements():
+                if str(portions.nextElement().TextPortionType) not in _OFFSET_SAFE_PORTION_TYPES:
+                    return False  # field / footnote / ruby / redline mark -> offsets diverge
+        return seen == 1
+    except Exception:
+        log.debug("content: _block_safe_for_surgical check failed; treating as unsafe", exc_info=True)
+        return False
+
+
+# Base title for the grouped undo action wrapping a surgical batch. Each batch gets a UNIQUE title
+# (base + a monotonic counter, see _next_surgical_undo_title) which both (a) collapses the batch into
+# ONE Ctrl+Z and (b) identifies OUR context on the undo stack before rolling it back on a mid-apply
+# failure. Uniqueness is load-bearing across the all_matches loop: an earlier match leaves its
+# COMPLETED context titled on top of the stack, so a later match whose EMPTY context is discarded on
+# leave must NOT mistake that earlier title for its own and undo a prior good edit (atomicity).
+_SURGICAL_UNDO_TITLE = "WriterAgent surgical edit"
+_surgical_batch_counter = itertools.count(1)
+
+
+def _next_surgical_undo_title() -> str:
+    """A process-unique grouped-undo title for one surgical batch (base + a monotonic counter)."""
+    return "%s#%d" % (_SURGICAL_UNDO_TITLE, next(_surgical_batch_counter))
+
+
+# Base title for the grouped-undo action wrapping a whole HTML/import edit (replace_full_document,
+# replace_single_range_with_content, selection insert). Shares the surgical counter so EVERY
+# WriterAgent context gets a globally-unique title -- load-bearing for the rollback identity check in
+# _close_surgical_context (it undoes a failed batch only when ITS unique title is on top of the stack).
+_AGENT_EDIT_UNDO_TITLE = "WriterAgent edit"
+
+
+def _next_agent_edit_undo_title() -> str:
+    """A process-unique grouped-undo title for one HTML/import edit (shares the monotonic counter)."""
+    return "%s#%d" % (_AGENT_EDIT_UNDO_TITLE, next(_surgical_batch_counter))
+
+
+def _close_surgical_context(undo_mgr, session, changes_before, applied_ok, undo_title):
+    """Close the surgical undo context -- pairing the earlier enterUndoContext exactly once -- and,
+    on failure, roll the partial batch back.
+
+    leaveUndoContext is ALWAYS attempted: the XUndoManager contract requires every enter to be matched
+    by a leave, and skipping it would leave the context open so later edits nest inside our group and
+    the undo stack drifts. A leave failure is logged at WARNING (it can leave the stack inconsistent),
+    not swallowed at debug. On the SUCCESS path nothing else is needed -- the edits are valid; the
+    worst a failed leave does is leave the grouping open, surfaced loudly rather than by undoing
+    good changes.
+
+    On the FAILURE path we additionally roll back: only if the leave succeeded AND the top of the undo
+    stack is THIS batch's unique ``undo_title`` do we undo it -- reverting even a half-applied
+    delete+insert -- then drop the partial change records + anchor bookmarks. The per-batch-unique
+    title is essential: when our context was empty (first sub-edit failed before mutating) it is
+    discarded on leave, exposing whatever was on top before -- which in an all_matches loop is an
+    EARLIER successful surgical batch; a constant title would match it and undo that good edit, so we
+    match the unique title and skip undo when it is not ours. Records are KEPT (not orphaned) when
+    undo() itself fails. Best-effort throughout; never masks the caller's original error."""
+    left = False
+    try:
+        undo_mgr.leaveUndoContext()
+        left = True
+    except Exception:
+        log.warning("content: leaveUndoContext failed; the undo stack may be inconsistent", exc_info=True)
+
+    if applied_ok:
+        return  # success: edits stand; a failed leave was already surfaced above
+
+    undone = False
+    if left:
+        try:
+            titles = undo_mgr.getAllUndoActionTitles()  # newest-first per XUndoManager
+            if titles and titles[0] == undo_title:
+                undo_mgr.undo()
+                undone = True
+        except Exception:
+            log.warning("content: undo of partial surgical batch failed; document may be partially "
+                        "edited", exc_info=True)
+    # Trim records when the document mutations were reverted, or when nothing was applied at all
+    # (empty context -> changes unchanged). Keep them when undo() demonstrably failed (or couldn't
+    # run because the context wouldn't close) so a live partial edit keeps a reviewable record.
+    kept = len(session.changes) - changes_before
+    if undone or kept == 0:
+        try:
+            session.discard_changes_since(changes_before)
+        except Exception:
+            log.debug("content: discarding partial surgical change records failed", exc_info=True)
+    else:
+        log.warning("content: surgical rollback could not undo a partial batch; keeping %d change "
+                    "record(s) so the partial edit stays reviewable", kept)
+
+
+def _apply_in_undo_context(doc, session, run):
+    """Run *run(in_undo_context)* -- which must perform exactly ONE session.record_mutation -- inside a
+    fresh grouped-undo context when one can be opened, so a split-author delete+insert stays atomic:
+    on failure the whole context is undone (reverting even a half-applied edit) and the partial record
+    dropped.
+
+    Mirrors the surgical batch's context handling: opens a PROCESS-UNIQUE context (so an earlier
+    batch's completed title on the undo stack is never mistaken for ours when rolling back) only when
+    the undo manager is usable and UNLOCKED (a locked manager silently ignores enterUndoContext, so we
+    would hold no real context and no rollback), calls ``run(True)``, and ALWAYS pairs
+    the enter with exactly one leave via _close_surgical_context. Without a usable, unlocked manager it
+    falls back to ``run(False)`` -- the single atomic setString, itself all-or-nothing (so the only
+    cost of the fallback is that the edit renders in one color instead of two)."""
+    undo_mgr = None
+    undo_title = _next_surgical_undo_title()
+    try:
+        mgr = doc.getUndoManager()
+        if mgr.isLocked():
+            raise RuntimeError("undo manager is locked; enterUndoContext would be a no-op")
+        mgr.enterUndoContext(undo_title)
+        undo_mgr = mgr
+    except Exception:
+        undo_mgr = None
+    if undo_mgr is None:
+        log.debug("content: no usable/unlocked undo manager; split-author whole-block edit falls back "
+                  "to the single atomic op (one color)")
+        run(False)
+        return
+
+    changes_before = len(session.changes)
+    applied_ok = False
+    try:
+        run(True)
+        applied_ok = True
+    finally:
+        # ALWAYS pair the enterUndoContext with exactly one leave (XUndoManager contract); on failure
+        # this also rolls the partial edit back. The original exception (if any) propagates after.
+        _close_surgical_context(undo_mgr, session, changes_before, applied_ok, undo_title)
+
+
+def _record_html_atomically(session, doc, mutate, track_reviewable, **record_kwargs):
+    """Record an HTML/import mutation that DELETES before it inserts -- replace_full_document,
+    replace_single_range_with_content, and the selection branch of insert_content_at_position all do
+    setString("") and THEN run a separate HTML import that can throw -- so it is ATOMIC: the delete
+    and the import either both land or neither does.
+
+    record_mutation() opens no undo context, so a throwing import would otherwise strand a bare
+    deletion (a half-applied edit) and register no reviewable change. Unlike the plain-text path there
+    is no atomic single-op variant of an HTML import, so when recording a reviewable change we wrap the
+    whole mutation in ONE grouped undo context and, on failure, undo it (reverting the partial
+    deletion) before re-raising. If no usable/unlocked undo manager is available we REFUSE before
+    mutating (fail closed) rather than risk a partial edit. When NOT recording (no review contract) the
+    mutation runs directly, exactly as before."""
+    if not track_reviewable:
+        return session.record_mutation(mutate, **record_kwargs)
+
+    undo_title = _next_agent_edit_undo_title()
+    try:
+        mgr = doc.getUndoManager()
+        if mgr.isLocked():
+            raise RuntimeError("undo manager is locked; enterUndoContext would be a no-op")
+        mgr.enterUndoContext(undo_title)
+    except Exception:
+        # No rollback available -> we cannot guarantee all-or-nothing, and an HTML import has no atomic
+        # single-op fallback. Refuse BEFORE any mutation so the document is never left half-edited.
+        raise ToolExecutionError(
+            "Cannot apply this content edit atomically in review mode (no usable undo context); "
+            "refusing rather than risk a half-applied edit.")
+
+    changes_before = len(session.changes)
+    applied_ok = False
+    try:
+        result = session.record_mutation(mutate, **record_kwargs)
+        applied_ok = True
+        return result
+    finally:
+        # Pair the enter with exactly one leave; on failure undo the partial edit and drop its record.
+        _close_surgical_context(mgr, session, changes_before, applied_ok, undo_title)
+
+
+def _record_preserve_replace(session, doc, found, new_text, uno_ctx, split):
+    """Record a format-preserving replace as ONE reviewable change, or -- when *split* (review
+    recording is on) and only PART of the block changed -- as several SURGICAL sub-changes,
+    each its own tracked Delete+Insert with its own accept/reject outcome.
+
+    Splitting keeps a one- or two-word tweak in a long paragraph from rendering (and having to be
+    accepted) as a whole-paragraph delete+insert. The agent still issues a single edit; it simply
+    gets one outcome per sub-change. A large change (> threshold of words changed) stays a single
+    clean block edit, matching today's behaviour.
+    """
+    from . import format as format_support
+
+    # Split-author coloring (deletion authored distinctly from insertion -> two by-author colors) is
+    # applied CONSISTENTLY to both the whole-block and surgical paths, so an agent edit looks the same
+    # however it lands. It is meaningful only when recording tracked changes, so it is scoped to
+    # *split* (review recording on) -- the non-review path is left exactly as before. Default on;
+    # override with WRITERAGENT_AGENT_EDIT_SPLIT_AUTHOR_COLORS.
+    split_author = split and _SPLIT_AUTHOR_COLORS
+
+    def _bound(s):  # this path is plain text (use_preserve); just cap the preview length
+        s = s or ""
+        return s if len(s) <= 300 else s[:299] + "…"
+
+    def _whole():
+        # The split-author two-step (delete authored distinctly, then insert) needs an open undo
+        # context to stay atomic, so when it's on we wrap the single record_mutation in one
+        # (_apply_in_undo_context; it falls back to the atomic single-op if no usable manager). When
+        # split-author is off, in_undo_context=False uses the single atomic setString directly (one UNO
+        # action, never a partial deletion) -- today's behaviour.
+        original = found.getString()
+
+        def _run(in_undo_context):
+            session.record_mutation(
+                lambda: format_support.replace_preserving_format(
+                    doc, found, new_text, uno_ctx,
+                    in_undo_context=in_undo_context, split_author=split_author),
+                original_preview=_bound(original), proposed_preview=_bound(new_text))
+
+        if split_author:
+            _apply_in_undo_context(doc, session, _run)
+        else:
+            _run(False)
+
+    if not split:
+        _whole()
+        return
+
+    from plugin.writer.word_diff_split import split_change
+
+    result = split_change(found.getString(), new_text, _WORD_DIFF_THRESHOLD)
+    if not result.is_surgical:
+        _whole()                       # big change -> single clean block (today's behaviour)
+        return
+    if not result.sub_edits:
+        return                         # old == new: nothing changed, record nothing
+    if len(result.sub_edits) > _MAX_SURGICAL_RUNS:
+        _whole()                       # too many scattered runs -> one block (bounded cost)
+        return
+    if not _block_safe_for_surgical(found):
+        _whole()                       # not plain single-paragraph text -> offsets unsafe; whole-block
+        return
+
+    text = found.getText()
+    anchor = found.getStart()
+
+    def _select(se):
+        """A fresh cursor selecting old[se.old_start:se.old_end] within the block, navigating from
+        the block start by char offset. Returns None if the cursor cannot be positioned EXACTLY
+        (goRight stopped early), so the caller never edits the wrong span."""
+        sub = text.createTextCursorByRange(anchor)
+        if se.old_start and not _go_right(sub, se.old_start, False):
+            return None
+        if se.old_end > se.old_start and not _go_right(sub, se.old_end - se.old_start, True):
+            return None
+        return sub
+
+    # Pre-flight: every sub-edit must select EXACTLY its expected old_text on the still-pristine
+    # block before we mutate anything. _block_safe_for_surgical already vets the block, but if an
+    # offset still doesn't line up (a stop it didn't catch), abort surgical and fall back to the
+    # whole-block replace -- never silently edit the wrong characters.
+    for se in result.sub_edits:
+        sub = _select(se)
+        if sub is None or sub.getString() != se.old_text:
+            log.debug("content: surgical pre-flight offset mismatch; falling back to whole-block")
+            _whole()
+            return
+
+    # Validated. Apply right-to-left so each sub-edit's char offsets into the ORIGINAL block stay
+    # valid (the text to its left is still pristine when we reach it). goRight is chunked.
+    #
+    # Atomicity: a sub-edit replace DELETES the old text before inserting the new, and the
+    # post-edit redline enumeration can also raise -- so a sub-edit CAN fail mid-apply, after earlier
+    # ones already landed. The pre-flight makes that rare, not impossible. To keep the batch
+    # all-or-nothing we group every sub-edit in ONE document undo context: on any failure we undo the
+    # whole context (reverting even a half-applied delete+insert) and drop the partial change records
+    # plus their anchor bookmarks, then re-raise so the tool reports an honest failure instead of a
+    # silently half-rewritten paragraph. Without a usable undo manager we can't group a multi-edit
+    # batch, so we fall back to the whole-block replace -- which is itself atomic (it passes
+    # in_undo_context=False, so format uses the single atomic setString, never a partial deletion).
+    undo_mgr = None
+    undo_title = _next_surgical_undo_title()
+    try:
+        mgr = doc.getUndoManager()
+        # A LOCKED undo manager silently IGNORES enterUndoContext (and would not record the
+        # mutations), so we'd hold no real context and have no rollback. Detect it and fall back
+        # rather than apply a multi-edit batch we cannot undo.
+        if mgr.isLocked():
+            raise RuntimeError("undo manager is locked; enterUndoContext would be a no-op")
+        mgr.enterUndoContext(undo_title)
+        undo_mgr = mgr
+    except Exception:
+        undo_mgr = None
+    if undo_mgr is None:
+        log.debug("content: no usable/unlocked undo manager; surgical edit falls back to whole-block "
+                  "for atomicity")
+        _whole()
+        return
+
+    changes_before = len(session.changes)
+    applied_ok = False
+    try:
+        for se in sorted(result.sub_edits, key=lambda e: e.old_start, reverse=True):
+            def apply_se(se=se):
+                sub = _select(se)
+                # Pre-flight proved these offsets on the pristine block and right-to-left order keeps
+                # the left pristine, so this should always match. If it ever doesn't, fail LOUD rather
+                # than corrupt the doc or ship a silent partial edit (tripwire).
+                if sub is None or sub.getString() != se.old_text:
+                    raise RuntimeError(
+                        "surgical sub-edit offset drifted at apply time; aborting to avoid corruption")
+                # in_undo_context=True: this runs inside the undo context opened below, so the
+                # split-author delete+insert is safe -- a failed insert is rolled back by the context
+                # (the explicit flag, NOT a guess from the manager state). split_author
+                # is threaded through so the surgical path honours the same coloring choice as the
+                # whole-block path (off -> the atomic single-op, still inside this context).
+                format_support.replace_preserving_format(doc, sub, se.new_text, uno_ctx,
+                                                         in_undo_context=True,
+                                                         split_author=split_author)
+
+            session.record_mutation(
+                apply_se,
+                original_preview=_bound(se.old_text),
+                proposed_preview=_bound(se.new_text))
+        applied_ok = True
+    finally:
+        # ALWAYS pair the enterUndoContext with exactly one leave (XUndoManager contract); on failure
+        # this also rolls the partial batch back. The original exception (if any) propagates after.
+        _close_surgical_context(undo_mgr, session, changes_before, applied_ok, undo_title)
 
 
 # ------------------------------------------------------------------
@@ -660,9 +1065,11 @@ class ApplyDocumentContent(ToolBase):
 
         if target == "full_document":
             with session:
-                session.record_mutation(
+                # Delete-then-import: make it atomic so a failed import can't strand a cleared document.
+                _record_html_atomically(
+                    session, ctx.doc,
                     lambda: format_support.replace_full_document(ctx.doc, ctx.ctx, content, config_svc=config_svc),
-                    proposed_preview=_plain_preview(content))
+                    track_reviewable, proposed_preview=_plain_preview(content))
             return {"status": "ok", "message": "Replaced entire document."}, session
         if target == "end":
             with session:
@@ -672,9 +1079,11 @@ class ApplyDocumentContent(ToolBase):
             return {"status": "ok", "message": "Inserted content at end."}, session
         if target == "selection":
             with session:
-                session.record_mutation(
+                # Selection insert clears the selection first, then imports -> atomic (full_document above).
+                _record_html_atomically(
+                    session, ctx.doc,
                     lambda: format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "selection", config_svc=config_svc),
-                    proposed_preview=_plain_preview(content))
+                    track_reviewable, proposed_preview=_plain_preview(content))
             return {"status": "ok", "message": "Inserted content at selection."}, session
         if target == "beginning":
             with session:
@@ -712,13 +1121,12 @@ class ApplyDocumentContent(ToolBase):
                 for found in reversed(ranges):
                     original = found.getString()
                     if use_preserve:
-                        session.record_mutation(
-                            lambda f=found: format_support.replace_preserving_format(doc, f, raw_content, ctx.ctx),
-                            original_preview=original, proposed_preview=_plain_preview(raw_content))
+                        _record_preserve_replace(session, doc, found, raw_content, ctx.ctx, track_reviewable)
                     else:
-                        session.record_mutation(
+                        _record_html_atomically(
+                            session, doc,
                             lambda f=found: format_support.replace_single_range_with_content(doc, f, content, ctx.ctx, config_svc),
-                            original_preview=original, proposed_preview=_plain_preview(content))
+                            track_reviewable, original_preview=original, proposed_preview=_plain_preview(content))
                     count += 1
             if count == 0:
                 return {"status": "error",
@@ -735,13 +1143,12 @@ class ApplyDocumentContent(ToolBase):
         original = found.getString()
         with session:
             if use_preserve:
-                session.record_mutation(
-                    lambda: format_support.replace_preserving_format(doc, found, raw_content, ctx.ctx),
-                    original_preview=original, proposed_preview=_plain_preview(raw_content))
+                _record_preserve_replace(session, doc, found, raw_content, ctx.ctx, track_reviewable)
             else:
-                session.record_mutation(
+                _record_html_atomically(
+                    session, doc,
                     lambda: format_support.replace_single_range_with_content(doc, found, content, ctx.ctx, config_svc),
-                    original_preview=original, proposed_preview=_plain_preview(content))
+                    track_reviewable, original_preview=original, proposed_preview=_plain_preview(content))
         msg = "Replaced 1 occurrence (by old_content)."
         if use_preserve:
             msg += " (formatting preserved)"

--- a/plugin/writer/edit_review.py
+++ b/plugin/writer/edit_review.py
@@ -91,23 +91,126 @@ def edit_review_wait_seconds(ctx: Any) -> int:
     return max(0, get_config_int_safe(ctx, "doc.edit_review_timeout"))
 
 
-def snapshot_redline_ids(doc: Any) -> set:
-    """Set of current RedlineIdentifiers -- snapshot before an edit to find the ones it adds."""
-    ids = set()
+def snapshot_redline_ids(doc: Any) -> tuple[set, bool]:
+    """``(set of current RedlineIdentifiers, reliable)`` -- snapshot BEFORE an edit so the edit's NEW
+    redlines can be found by difference (ids not in this set).
+
+    ``reliable`` is False when the snapshot is INCOMPLETE: the enumeration can't start/finish, stops
+    short of getCount() (yields fewer items than getCount() reports), or a redline's identifier can't
+    be read. A partial BEFORE snapshot is a data-loss hazard -- a pre-existing USER redline missing
+    from it would look "new" after the edit and be stamped with an agent token, after which
+    Accept/Reject All would resolve the user's own change. So callers MUST refuse to tag on an
+    unreliable snapshot.
+
+    On the count/enumeration mismatch (seen < getCount()): this is a DEFENSIVE INVARIANT, not an
+    observed bug. getRedlines() is one flat table and the mismatch has NOT been seen in real
+    LibreOffice (a native test confirms count == enumeration length, even across body and
+    table-cell containers). It is kept as cheap fail-closed insurance only because IF it ever
+    happened the cost would be the silent loss of a user's own redline. The same neutral
+    "fewer items than getCount() reports" framing is used by the sibling scan helpers below."""
+    ids: set = set()
     try:
-        enum = doc.getRedlines().createEnumeration()
-        while enum.hasMoreElements():
-            rl = enum.nextElement()
-            try:
-                ids.add(rl.getPropertyValue("RedlineIdentifier"))
-            except Exception:
-                continue
+        redlines = doc.getRedlines()
+        total = int(redlines.getCount())
+        enum = redlines.createEnumeration()
     except Exception:
-        pass
-    return ids
+        return ids, False  # can't enumerate/count -> can't tell new from pre-existing -> unreliable
+    reliable = True
+    seen = 0
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            rl = enum.nextElement()
+        except Exception:
+            return ids, False  # can't advance the enumeration -> incomplete -> unreliable
+        seen += 1
+        try:
+            ids.add(rl.getPropertyValue("RedlineIdentifier"))
+        except Exception:
+            reliable = False  # an existing redline we can't identify -> can't exclude it from "new"
+    if seen != total:
+        reliable = False  # enumeration shorter than getCount() -> a pre-existing redline may be unseen
+    return ids, reliable
 
 
-def tag_agent_redlines(doc: Any, before_ids: set, change_index: int = 0) -> str | None:
+def _new_redlines_complete(doc: Any, before_ids: set) -> tuple[list, bool]:
+    """``([redlines whose RedlineIdentifier is NOT in before_ids], reliable)`` -- the redlines an edit
+    just added. ``reliable`` is False when the post-edit scan is INCOMPLETE (enum/count error, a
+    count/enumeration mismatch, or an unreadable identifier), so a caller can refuse to tag a
+    HALF-found change rather than tag only part of a Delete/Insert pair."""
+    out: list = []
+    try:
+        redlines = doc.getRedlines()
+        total = int(redlines.getCount())
+        enum = redlines.createEnumeration()
+    except Exception:
+        return out, False
+    reliable = True
+    seen = 0
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            rl = enum.nextElement()
+        except Exception:
+            return out, False
+        seen += 1
+        try:
+            rid = rl.getPropertyValue("RedlineIdentifier")
+        except Exception:
+            reliable = False  # can't classify new-vs-pre-existing for this one -> incomplete
+            continue
+        if rid not in before_ids:
+            out.append(rl)
+    if seen != total:
+        reliable = False  # enumeration shorter than getCount() -> a new redline of this change may be unseen
+    return out, reliable
+
+
+def _tag_new_redlines(redlines: list, token: str) -> tuple[bool, int]:
+    """Stamp *token* (RedlineComment) on every redline -- ALL-OR-NOTHING. Returns
+    ``(success, orphans_remaining)`` as TWO separate values so success can never be confused with a
+    count (a single int made "n tagged ok" and "n orphans after a failure" collide
+    when n == len):
+
+      * ``(True, 0)``  -> every redline tagged (success);
+      * ``(False, 0)`` -> a failure that was FULLY reverted (NO redline left carrying the token);
+      * ``(False, n)`` -> a failure where ``n`` redlines still carry the token and could not be
+        cleared. Only reachable if setPropertyValue fails on a redline we just set (a broken UNO
+        state) -- the tag genuinely cannot be removed via the API then.
+
+    Any path through the ``except`` is a FAILURE (``success=False``), even if every redline happened
+    to end up tagged -- the caller must not register a change reached through the error path. On
+    failure the revert sweep includes the redline whose set JUST raised (setPropertyValue can mutate
+    the comment and THEN throw, so it may carry the token though it never entered ``applied``);
+    after attempting to clear each it READS the comment back and counts only those that
+    still carry the token (or can't be read) as orphans."""
+    applied: list = []
+    for rl in redlines:
+        try:
+            rl.setPropertyValue("RedlineComment", token)
+            applied.append(rl)
+        except Exception:
+            log.warning("EditReviewSession: tagging a redline failed; reverting the partial tag set",
+                        exc_info=True)
+            orphans = 0
+            for done in applied + [rl]:  # include the just-failed redline -- its set may have mutated
+                try:
+                    done.setPropertyValue("RedlineComment", "")
+                except Exception:
+                    log.warning("EditReviewSession: reverting a redline tag failed", exc_info=True)
+                try:
+                    if str(done.getPropertyValue("RedlineComment")) == token:
+                        orphans += 1  # still carries our token -> a real orphan we could not remove
+                except Exception:
+                    orphans += 1  # can't confirm it's clean -> count conservatively (fail closed)
+            return False, orphans  # FAILURE -- orphans>0 means tag(s) remain we could not remove
+    return True, 0
+
+
+def tag_agent_redlines(doc: Any, before_ids: set, change_index: int = 0,
+                       before_reliable: bool = False) -> str | None:
     """Stamp a fresh ``wa-review:<session>:<n>`` token on every redline created since
     *before_ids*, marking them as ONE agent change so the inline review UI recognizes them.
 
@@ -115,34 +218,45 @@ def tag_agent_redlines(doc: Any, before_ids: set, change_index: int = 0) -> str 
     streamed extend-selection rewrite, which already collapses to a single tracked change) --
     no anchor/outcome/wait, which the streamed chat path doesn't use. Returns the token, or
     None if nothing new was tagged.
-    """
-    token = "%s%s:%d" % (TOKEN_PREFIX, uuid.uuid4().hex[:8], change_index)
-    tagged = 0
-    try:
-        enum = doc.getRedlines().createEnumeration()
-        while enum.hasMoreElements():
-            rl = enum.nextElement()
-            try:
-                if rl.getPropertyValue("RedlineIdentifier") not in before_ids:
-                    rl.setPropertyValue("RedlineComment", token)
-                    tagged += 1
-            except Exception:
-                continue
-    except Exception:
-        log.debug("tag_agent_redlines: failed", exc_info=True)
+
+    Refuses (returns None) when *before_reliable* is False: a partial BEFORE snapshot could
+    misclassify a pre-existing USER redline as new and stamp it as an agent change, after which
+    Accept/Reject All would resolve the user's own change. The edit still stands;
+    its redlines just stay untagged -> treated as the user's -> never auto-resolved. *before_reliable*
+    defaults to False (fail closed): a caller must explicitly assert a verified-complete snapshot
+    (the boolean returned by ``snapshot_redline_ids``) to enable tagging."""
+    if not before_reliable:
+        log.warning("tag_agent_redlines: pre-edit snapshot unreliable; not tagging (avoids "
+                    "mis-tagging a user redline as an agent change)")
         return None
-    return token if tagged else None
+    # Find the new redlines with a COMPLETE post-edit scan; if it's incomplete we can't be sure we
+    # found the whole change, so refuse rather than tag a fragment.
+    new_redlines, after_ok = _new_redlines_complete(doc, before_ids)
+    if not after_ok:
+        log.warning("tag_agent_redlines: post-edit redline scan incomplete; not tagging (avoids a "
+                    "half-tagged change)")
+        return None
+    if not new_redlines:
+        return None
+    token = "%s%s:%d" % (TOKEN_PREFIX, uuid.uuid4().hex[:8], change_index)
+    success, orphans = _tag_new_redlines(new_redlines, token)  # all-or-nothing (reverts on failure)
+    if not success:
+        # Not a success path -- do NOT register. orphans == 0 -> clean revert; orphans > 0 -> the
+        # revert could not remove every tag, so surface the residual loudly.
+        if orphans:
+            log.warning("tag_agent_redlines: tagging failed and %d orphan tag(s) could not be "
+                        "reverted; not registering this change", orphans)
+        return None
+    # Full success. Streamed edit paths tag their redlines here instead of via record_mutation, so
+    # this is where they must reveal the review fast-travel toolbar (#2) -- otherwise it never appears
+    # for those edits. Best-effort/silent; runs on the edit's (main) thread.
+    try:
+        from plugin.writer.review_toolbar import refresh_review_toolbar
 
-
-def _paragraph_cursor_for_range(text_range: Any) -> Any:
-    """A text cursor expanded to whole paragraphs around *text_range*."""
-    text = text_range.getText()
-    cur = text.createTextCursorByRange(text_range.getStart())
-    cur.gotoStartOfParagraph(False)
-    end = text.createTextCursorByRange(text_range.getEnd())
-    end.gotoEndOfParagraph(True)
-    cur.gotoRange(end.getEnd(), True)
-    return cur
+        refresh_review_toolbar(doc)
+    except Exception:
+        log.debug("tag_agent_redlines: toolbar refresh failed", exc_info=True)
+    return token
 
 
 def _string_skipping_redline(text_range: Any, skip_type: str) -> str:
@@ -290,16 +404,10 @@ class EditReviewSession:
 
     # -- recording ---------------------------------------------------------------------------
 
-    def _redline_idents(self) -> set:
-        idents = set()
-        enum = self.doc.getRedlines().createEnumeration()
-        while enum.hasMoreElements():
-            rl = enum.nextElement()
-            try:
-                idents.add(rl.getPropertyValue("RedlineIdentifier"))
-            except Exception:
-                continue
-        return idents
+    def _redline_idents(self) -> tuple[set, bool]:
+        """``(current RedlineIdentifiers, reliable)`` -- see ``snapshot_redline_ids``. reliable=False
+        means the snapshot is incomplete and must NOT back a new-vs-pre-existing tagging decision."""
+        return snapshot_redline_ids(self.doc)
 
     def record_mutation(self, apply_fn: Callable[[], Any],
                         original_preview: str = "", proposed_preview: str = "") -> Any:
@@ -311,29 +419,44 @@ class EditReviewSession:
         if not self._active:
             return apply_fn()
 
-        before = self._redline_idents()
+        before, before_ok = self._redline_idents()
         result = apply_fn()
+        if not before_ok:
+            # The pre-edit redline snapshot was incomplete, so we can't reliably tell which redlines
+            # are NEW (ours) from pre-existing ones (the user's). Tagging now could stamp a user's
+            # redline as an agent change -> Accept/Reject All would later resolve it. Fail closed:
+            # the edit still applied, but we DON'T tag or register it -- its redlines stay untagged,
+            # so they read as the user's own and are never auto-resolved.
+            log.warning("EditReviewSession: pre-edit redline snapshot unreliable; leaving this edit "
+                        "untagged (not a reviewable agent change) to avoid mis-tagging user redlines")
+            return result
 
-        new_redlines = []
-        enum = self.doc.getRedlines().createEnumeration()
-        while enum.hasMoreElements():
-            rl = enum.nextElement()
-            try:
-                if rl.getPropertyValue("RedlineIdentifier") not in before:
-                    new_redlines.append(rl)
-            except Exception:
-                continue
+        # Find the new redlines with a COMPLETE post-edit scan. If incomplete we can't be sure we
+        # found the whole change (e.g. only one mark of a Delete/Insert pair), so fail closed: leave
+        # the edit untagged rather than register a fragment.
+        new_redlines, after_ok = _new_redlines_complete(self.doc, before)
+        if not after_ok:
+            log.warning("EditReviewSession: post-edit redline scan incomplete; leaving this edit "
+                        "untagged to avoid registering a half-tagged change")
+            return result
         if not new_redlines:
             return result
 
         n = len(self.changes)
         token = self._token(n)
         with self._undo_lock():
-            for rl in new_redlines:
-                try:
-                    rl.setPropertyValue("RedlineComment", token)
-                except Exception:
-                    log.debug("EditReviewSession: could not tag a redline", exc_info=True)
+            # All-or-nothing: register ONLY on full success. On any failure the partial set is
+            # reverted; orphans==0 is a clean revert, orphans>0 means a tag could not be removed
+            # (broken UNO state) -- surface it loudly. Either way leave the edit unregistered.
+            success, orphans = _tag_new_redlines(new_redlines, token)
+        if not success:
+            if orphans:
+                log.warning("EditReviewSession: tagging failed and %d orphan tag(s) could not be "
+                            "reverted; leaving this edit unregistered", orphans)
+            else:
+                log.warning("EditReviewSession: tagging failed and was reverted; leaving this edit "
+                            "untagged (not a reviewable agent change)")
+            return result
 
         # Bounding span across the new redlines -> anchor bookmark + expected end states.
         # Built with cursor.gotoRange(range, expand=True): XTextRangeCompare is unreliable on
@@ -356,14 +479,17 @@ class EditReviewSession:
                 for s, e in ranges:
                     span.gotoRange(s, True)  # expand=True grows the span in either direction
                     span.gotoRange(e, True)
-                para = _paragraph_cursor_for_range(span)
-                accepted_text = _string_skipping_redline(para, "Delete")
-                rejected_text = _string_skipping_redline(para, "Insert")
+                # Scope the captured states AND the anchor bookmark to the CHANGE's own redline
+                # span, not the whole paragraph -- so when several changes share a paragraph each
+                # one's outcome/final_text reflects only itself, and a change deep in a long
+                # paragraph is never truncated out of the preview.
+                accepted_text = _string_skipping_redline(span, "Delete")
+                rejected_text = _string_skipping_redline(span, "Insert")
                 bookmark_name = "%s%s_%d" % (_BOOKMARK_PREFIX, self.session_id, n)
                 bm = self.doc.createInstance("com.sun.star.text.Bookmark")
                 bm.setName(bookmark_name)
                 with self._undo_lock():
-                    para.getText().insertTextContent(para, bm, True)
+                    span.getText().insertTextContent(span, bm, True)
             except Exception:
                 bookmark_name = ""
                 log.debug("EditReviewSession: anchoring failed for change %d", n, exc_info=True)
@@ -371,30 +497,60 @@ class EditReviewSession:
         self.changes.append(ChangeRecord(
             token, bookmark_name, accepted_text, rejected_text,
             original_preview or rejected_text, proposed_preview or accepted_text))
+        # A new pending change exists -> reveal the review fast-travel toolbar (#2). Runs on the
+        # main thread (the edit does), so the LayoutManager call is safe; best-effort/silent.
+        try:
+            from plugin.writer.review_toolbar import refresh_review_toolbar
+
+            refresh_review_toolbar(self.doc)
+        except Exception:
+            log.debug("EditReviewSession: toolbar refresh after record failed", exc_info=True)
         return result
 
     # -- review ------------------------------------------------------------------------------
 
-    def _pending_tokens(self) -> set:
-        """Tokens of this session's changes that still have an unresolved redline."""
-        prefix = self._session_token_prefix()
-        pending = set()
-        try:
-            enum = self.doc.getRedlines().createEnumeration()
-            while enum.hasMoreElements():
-                rl = enum.nextElement()
-                try:
-                    comment = str(rl.getPropertyValue("RedlineComment"))
-                except Exception:
-                    continue
-                if comment.startswith(prefix):
-                    pending.add(comment)
-        except Exception:
-            log.debug("EditReviewSession: pending check failed", exc_info=True)
-        return pending
+    def _pending_tokens(self) -> tuple[set, bool]:
+        """``(tokens of this session's changes that still have an unresolved redline, reliable)``.
 
-    def _paragraph_text_at_anchor(self, record: ChangeRecord) -> str | None:
-        """Current whole-paragraph text at the change's bookmark, or None if the anchor is gone."""
+        ``reliable`` is False when the scan is INCOMPLETE (enum/count error, a count/enumeration
+        mismatch, or an unreadable comment): an under-counted pending set could make ``wait_for_review`` declare
+        the review complete while a change is still open, so the caller must treat unreliable as
+        "not yet complete" rather than done (guard every enumeration)."""
+        prefix = self._session_token_prefix()
+        pending: set = set()
+        try:
+            redlines = self.doc.getRedlines()
+            total = int(redlines.getCount())
+            enum = redlines.createEnumeration()
+        except Exception:
+            log.debug("EditReviewSession: pending check could not enumerate/count", exc_info=True)
+            return pending, False
+        reliable = True
+        seen = 0
+        while True:
+            try:
+                if not enum.hasMoreElements():
+                    break
+                rl = enum.nextElement()
+            except Exception:
+                log.debug("EditReviewSession: pending check could not advance", exc_info=True)
+                return pending, False
+            seen += 1
+            try:
+                comment = str(rl.getPropertyValue("RedlineComment"))
+            except Exception:
+                reliable = False  # an unreadable comment might be one of ours -> can't confirm done
+                continue
+            if comment.startswith(prefix):
+                pending.add(comment)
+        if seen != total:
+            reliable = False  # enumeration shorter than getCount() -> an unresolved change may be in the unseen tail
+        return pending, reliable
+
+    def _change_text_at_anchor(self, record: ChangeRecord) -> str | None:
+        """Current text of the CHANGE's own region (its anchor bookmark span), or None if the anchor
+        is gone. Scoped to the change, not the whole paragraph, so a neighbouring change sharing the
+        paragraph never contaminates this one's reported text."""
         if not record.bookmark:
             return None
         try:
@@ -402,18 +558,28 @@ class EditReviewSession:
             if not bookmarks.hasByName(record.bookmark):
                 return None
             anchor = bookmarks.getByName(record.bookmark).getAnchor()
-            return _paragraph_cursor_for_range(anchor).getString()
+            # Skip tracked DELETIONS so the text reads as the region WOULD after accepting, instead
+            # of gluing struck text to the insertion (e.g. "quickfast"). _outcome is unaffected: a
+            # RESOLVED change has no redlines left, so this equals the raw string there; for a
+            # pending change _outcome short-circuits to "pending" before comparing text.
+            cur = anchor.getText().createTextCursorByRange(anchor)
+            return _string_skipping_redline(cur, "Delete")
         except Exception:
             log.debug("EditReviewSession: anchor read failed for %s", record.bookmark, exc_info=True)
             return None
 
-    def _outcome(self, record: ChangeRecord, pending_tokens: set) -> str:
+    def _outcome(self, record: ChangeRecord, pending_tokens: set, pending_reliable: bool) -> str:
         if record.token in pending_tokens:
             return "pending"
-        current = self._paragraph_text_at_anchor(record)
+        if not pending_reliable:
+            # The pending scan was incomplete, so "not in pending_tokens" does NOT prove this change
+            # is resolved -- it might be unresolved but unseen. Report "pending" rather than guess an
+            # accepted/rejected/modified outcome from the anchor text.
+            return "pending"
+        current = self._change_text_at_anchor(record)
         if current is None:
-            # Anchor paragraph gone: a rejected pure insertion removes the paragraph (and
-            # the bookmark with it); anything else means the user reworked the area.
+            # The anchor bookmark is gone: a rejected pure insertion can take its whole span (and
+            # the bookmark) with it; anything else means the user reworked/removed the area.
             return "rejected" if record.rejected_text == "" else "modified"
         if current == record.accepted_text:
             return "accepted"
@@ -440,7 +606,30 @@ class EditReviewSession:
                 try:
                     manager.unlock()
                 except Exception:
-                    log.debug("EditReviewSession: undo manager unlock failed", exc_info=True)
+                    # A stuck lock can later make a surgical rollback's undo() throw (the manager is
+                    # locked), silently degrading atomicity -- surface it, don't bury at debug.
+                    log.warning("EditReviewSession: undo manager unlock failed; the undo manager may "
+                                "be left locked", exc_info=True)
+
+    def _remove_anchor_bookmarks(self, records) -> None:
+        """Remove the anchor bookmarks of *records*, under the undo lock so the removal stays off the
+        user's undo stack. Best-effort: any failure is logged at debug, never raised. Shared by
+        cleanup() and discard_changes_since()."""
+        try:
+            bookmarks = self.doc.getBookmarks()
+            with self._undo_lock():
+                for record in records:
+                    if not record.bookmark:
+                        continue
+                    try:
+                        if bookmarks.hasByName(record.bookmark):
+                            bm = bookmarks.getByName(record.bookmark)
+                            bm.getAnchor().getText().removeTextContent(bm)
+                    except Exception:
+                        log.debug("EditReviewSession: anchor bookmark removal failed for %s",
+                                  record.bookmark, exc_info=True)
+        except Exception:
+            log.debug("EditReviewSession: anchor bookmark removal failed", exc_info=True)
 
     def cleanup(self) -> None:
         """Remove this session's anchor bookmarks. Safe to call more than once."""
@@ -449,34 +638,47 @@ class EditReviewSession:
         self._cleaned = True
         if not self._active or not self.changes:
             return
-        try:
-            bookmarks = self.doc.getBookmarks()
-            with self._undo_lock():
-                for record in self.changes:
-                    if not record.bookmark:
-                        continue
-                    try:
-                        if bookmarks.hasByName(record.bookmark):
-                            bm = bookmarks.getByName(record.bookmark)
-                            bm.getAnchor().getText().removeTextContent(bm)
-                    except Exception:
-                        log.debug("EditReviewSession: bookmark cleanup failed for %s", record.bookmark, exc_info=True)
-        except Exception:
-            log.debug("EditReviewSession: bookmark cleanup failed", exc_info=True)
+        self._remove_anchor_bookmarks(self.changes)
+
+    def discard_changes_since(self, count: int) -> None:
+        """Drop change records recorded after index *count*, removing their anchor bookmarks.
+
+        Used to roll back a partially-applied batch (a surgical multi-edit that failed mid-apply):
+        the caller undoes the document mutations, then calls this so neither the change
+        list nor the document is left holding records/bookmarks for edits that no longer exist.
+        Best-effort and self-contained: bookmark removal runs under the undo lock (kept off the
+        user's undo stack) and any failure is logged, never raised."""
+        if count < 0 or count >= len(self.changes):
+            return
+        doomed = self.changes[count:]
+        del self.changes[count:]
+        if not self._active:
+            return
+        self._remove_anchor_bookmarks(doomed)
 
     def _review_payload(self, complete: bool, timed_out: bool) -> dict:
-        pending = self._pending_tokens()
+        # Derive BOTH the header and the per-change outcomes from THIS one scan so they can never
+        # disagree. Carry reliability into _outcome (an unreliable scan -> "pending", not a guessed
+        # outcome), AND only report complete when this same scan is reliable and shows nothing pending
+        # (never upgrade a False). Otherwise a transient unreliable/non-empty re-scan here could pair
+        # complete=True with all-"pending" outcomes -- an internally contradictory report.
+        pending, pending_ok = self._pending_tokens()
+        complete = complete and pending_ok and not pending
         return {
             "complete": complete,
             "timed_out": timed_out,
             "changes": [
                 {
                     "id": record.token,
-                    # Three-state outcome (accepted/rejected/modified, or pending on timeout):
+                    # Three-state outcome (accepted/rejected/modified, or pending on timeout/unverified):
                     # a boolean can't express "the user edited this area during review".
-                    "outcome": self._outcome(record, pending),
+                    "outcome": self._outcome(record, pending, pending_ok),
                     "original_preview": _preview(record.original_preview),
                     "proposed_preview": _preview(record.proposed_preview),
+                    # The region's text as it reads NOW (after the user's accept/reject/edit), so the
+                    # agent knows what actually resulted -- not just what it proposed. "" if the
+                    # anchor paragraph is gone (e.g. a rejected pure insertion removed it).
+                    "final_text": _preview(self._change_text_at_anchor(record) or ""),
                 }
                 for record in self.changes
             ],
@@ -506,7 +708,13 @@ class EditReviewSession:
         try:
             deadline = time.monotonic() + max(0.0, timeout)
             timed_out = False
-            while run(self._pending_tokens):
+            while True:
+                pending, reliable = run(self._pending_tokens)
+                # Done ONLY on a reliable, empty scan. An unreliable scan (or remaining tokens) keeps
+                # waiting -- never declare the review complete off a partial read that might have
+                # missed an unresolved change (fail closed).
+                if reliable and not pending:
+                    break
                 if stop_checker is not None and stop_checker():
                     return run(lambda: self._review_payload(complete=False, timed_out=False))
                 if time.monotonic() >= deadline:

--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -1200,7 +1200,8 @@ def _content_has_block_markup(content):
     return any(p in lower for p in _BLOCK_MARKUP_PATTERNS)
 
 
-def replace_preserving_format(model, target_range, new_text, ctx=None):
+def replace_preserving_format(model, target_range, new_text, ctx=None,
+                              in_undo_context=False, split_author=True):
     """Replace text in *target_range* with *new_text* character by
     character, preserving per-character formatting (bold, italic,
     font, color, etc.).
@@ -1208,6 +1209,15 @@ def replace_preserving_format(model, target_range, new_text, ctx=None):
     Cursors are created on ``target_range.getText()`` (the cell, frame, or body
     ``XText`` that owns the range), not ``model.getText()``. The range must lie
     entirely within that text object.
+
+    When recording tracked changes, *split_author* selects the rendering:
+    ``True`` (default) authors the deletion and insertion separately so
+    LibreOffice's by-author coloring shows removed vs new text in two distinct
+    colors; ``False`` records the whole replace as a single atomic op authored
+    once (one color). The split-author two-step is only safe inside an open undo
+    context (``in_undo_context``) that can roll back a half-applied edit, so it is
+    used only when BOTH ``split_author`` and ``in_undo_context`` hold; otherwise
+    the atomic single-op path keeps the edit all-or-nothing.
     """
     # Use the range's OWN text object, not the document body. When target_range
     # lives inside a table cell, model.getText() (the body) is the wrong XText and
@@ -1223,11 +1233,36 @@ def replace_preserving_format(model, target_range, new_text, ctx=None):
     # When recording, replace the whole range in one shot so the edit is a single tracked
     # Delete + Insert the user can accept (-> new text) or reject (-> old text) cleanly.
     if _is_recording_changes(model):
+        if new_text == old_text:
+            return  # no-op: don't record a spurious tracked Delete+Insert (keeps the change count honest)
         cursor = text.createTextCursorByRange(target_range)
+        if not (split_author and in_undo_context):
+            # Single atomic path. Taken when split-author coloring is OFF, OR when the caller has NOT
+            # opened an undo context around this edit -- in which case a delete-then-insert could NOT be
+            # rolled back if the insert failed. Use the SINGLE atomic setString (one UNO action: it
+            # records the whole tracked replace -- Delete+Insert, or Delete-only when new_text is "" --
+            # or changes nothing; never a partial deletion). Whether an undo manager merely EXISTS is
+            # irrelevant -- only an actually-open rollback context makes the two-step safe.
+            # Trade-off on this path: the deletion and insertion share one author (one color).
+            cursor.setString(new_text)
+            return
+        # split_author AND in_undo_context: the caller GUARANTEES this runs inside an open undo context
+        # that will roll back a failed delete+insert, so use the two-step that preserves split-author
+        # deletion coloring. The restore on insert-failure is a best-effort extra net (the caller's
+        # context rollback also cleans up).
+        original = cursor.getString()
         with deletion_author():  # author the deletion distinctly (split by-author coloring)
             cursor.setString("")
         if new_text:
-            text.insertString(cursor, new_text, False)
+            try:
+                text.insertString(cursor, new_text, False)
+            except Exception:
+                try:
+                    text.insertString(cursor, original, False)
+                except Exception:
+                    log.warning("replace_preserving_format: insert failed AND restore failed; "
+                                "range may be left partial", exc_info=True)
+                raise
         return
 
     old_len = len(old_text)

--- a/plugin/writer/inline_review.py
+++ b/plugin/writer/inline_review.py
@@ -5,15 +5,19 @@
 """Inline review of tracked changes.
 
 Accept or reject the tracked change the cursor sits on as ONE unit. A text replace records two
-redlines -- a Delete (struck old text) and an Insert (new text) -- which LibreOffice's native UI
-lets you resolve independently, so accepting one and rejecting the other yields an incoherent
-result. Here we resolve every tracked change in the cursor's paragraph together (a replace's
-delete+insert live in the same paragraph), driving the native ``.uno:AcceptTrackedChange`` /
-``.uno:RejectTrackedChange`` on a paragraph-wide selection.
+redlines -- a Delete (struck old text) and an Insert (new text) -- which must be resolved
+together (accepting one and rejecting the other yields an incoherent result).
 
-Selecting a RANGE and dispatching (rather than selecting a single redline's anchor) is deliberate:
-a pure Delete redline has an empty anchor, so the per-redline ``select(anchor)`` path in
-``tracking.py`` cannot target it; a range selection covers both marks of the pair.
+We select the change's EXACT bounds (both marks of its pair) and drive the native
+``.uno:AcceptTrackedChange`` / ``.uno:RejectTrackedChange`` on that range. On modern LibreOffice
+(>=25.04 / 26.x) this resolves ONLY the targeted change, so a paragraph may hold several agent
+changes that are each accepted/rejected individually. On older builds where an exact-bounds
+dispatch is a no-op, we fall back to a paragraph-wide selection (which resolves everything in
+range, so it refuses when another tracked change shares the paragraph).
+
+Selecting a RANGE rather than a single redline's anchor is deliberate: a pure Delete redline has
+an empty anchor, so the per-redline ``select(anchor)`` path in ``tracking.py`` cannot target it;
+a range selection covers both marks of the pair. The user's own tracked changes are never touched.
 
 This is the model layer; the right-click context menu in ``change_context_menu.py`` calls it.
 """
@@ -32,19 +36,6 @@ _RESOLVE_REFUSED_HINT = (
     "Could not resolve this change here -- it may share a paragraph with one of"
     " your tracked changes or another agent change. Resolve it from Edit > Track Changes > Manage."
 )
-
-
-def _redline_count(model: Any) -> int:
-    """Number of tracked changes (redlines) currently in the document."""
-    n = 0
-    try:
-        enum = model.getRedlines().createEnumeration()
-        while enum.hasMoreElements():
-            enum.nextElement()
-            n += 1
-    except Exception:
-        log.debug("inline_review: could not enumerate redlines", exc_info=True)
-    return n
 
 
 def has_agent_changes(model: Any) -> bool:
@@ -75,10 +66,21 @@ def resolve_all_with_feedback(model: Any, ctx: Any, accept: bool) -> tuple[int, 
     user-facing note when some or all changes were skipped -- they share a paragraph with one of
     the user's own redlines, which resolve-all deliberately won't touch -- and empty when
     everything resolved (or there was nothing to do)."""
-    total = len(agent_changes(model))
+    unreliable_msg = ("Couldn't read this document's tracked changes reliably just now -- nothing was"
+                      " changed. Please try again.")
+    unconfirmed_msg = ("Started resolving changes but couldn't confirm the result -- some may have been"
+                       " resolved. Please review remaining changes in Edit > Track Changes > Manage.")
+    total_tokens, ok = _agent_change_tokens(model)  # reliable count, not best-effort agent_changes
+    if not ok:
+        return 0, unreliable_msg
+    total = len(total_tokens)
     if total == 0:
         return 0, "No agent changes to review in this document."
     n = resolve_all_agent_changes(model, ctx, accept)
+    if n == _RESOLVE_ALL_UNRELIABLE:
+        return 0, unreliable_msg       # nothing was dispatched -> honest "nothing changed"
+    if n == _RESOLVE_ALL_UNCONFIRMED:
+        return 0, unconfirmed_msg      # a dispatch ran -> never claim "nothing changed"
     if n >= total:
         return n, ""
     if n == 0:
@@ -111,7 +113,13 @@ def show_review_message(ctx: Any, message: str) -> None:
 
 
 def _agent_redlines(model: Any) -> list:
-    """[(token, redline)] for every redline tagged by an EditReviewSession."""
+    """[(token, redline)] for every redline tagged by an EditReviewSession.
+
+    BEST-EFFORT and DISPLAY-ONLY: on an enumeration error it returns whatever it gathered so far
+    (a partial list). That is fine for the listing/navigation/bounds callers, which tolerate a
+    short list, but it must NOT back a success/safety decision. The data-safety paths use the
+    reliability-aware ``_agent_change_tokens`` (post-resolve verification) and
+    ``_all_redlines_are_agent`` (global-dispatch guard), which fail CLOSED on an incomplete scan."""
     from plugin.writer.edit_review import TOKEN_PREFIX
 
     out = []
@@ -128,6 +136,140 @@ def _agent_redlines(model: Any) -> list:
     except Exception:
         log.debug("inline_review: agent redline scan failed", exc_info=True)
     return out
+
+
+def _agent_change_tokens(model: Any) -> tuple[set, bool]:
+    """``(set of agent-change tokens on the document's redlines, reliable)``. Used after a resolve
+    dispatch to verify that EXACTLY the target change was resolved.
+
+    ``reliable`` is False when the snapshot is INCOMPLETE -- the enumeration can't start or finish, a
+    redline's RedlineComment can't be read (so we can't tell whether it is one of our tokens), or the
+    scan yields fewer items than the collection's own ``getCount()`` reports. A
+    partial token set makes ``before - after`` unsound (a sibling missing from the BEFORE snapshot
+    could be silently resolved and still compute ``removed == {token}``), so the caller must treat an
+    unreliable snapshot as failure -- never as proof that only the target was removed. Enumerates
+    independently of ``_agent_redlines`` precisely so this guarantee does not ride on a fail-open
+    helper.
+
+    On the ``seen != total`` check (shared by the redline-scan helpers below): comparing the items
+    the enumeration yields against ``getCount()`` is a DEFENSIVE INVARIANT, not a known bug.
+    ``getRedlines()`` is one flat table and this mismatch has NOT been observed in real LibreOffice
+    (a native test confirms count equals enumeration length across body and table-cell containers).
+    It is kept as cheap fail-closed insurance: if it ever did happen, the cost would be silent loss
+    of a user's own redline, so it is worth a count comparison to guard against."""
+    from plugin.writer.edit_review import TOKEN_PREFIX
+
+    out: set = set()
+    try:
+        redlines = model.getRedlines()
+        total = int(redlines.getCount())
+        enum = redlines.createEnumeration()
+    except Exception:
+        return out, False  # can't enumerate / count -> unreliable snapshot
+    reliable = True
+    seen = 0
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            rl = enum.nextElement()
+        except Exception:
+            return out, False  # can't advance the enumeration -> unreliable
+        seen += 1
+        try:
+            comment = str(rl.getPropertyValue("RedlineComment"))
+        except Exception:
+            reliable = False  # can't classify this redline -> token snapshot incomplete
+            continue
+        if comment.startswith(TOKEN_PREFIX):
+            out.add(comment)
+    if seen != total:
+        reliable = False  # enumeration shorter than getCount() -> snapshot incomplete
+    return out, reliable
+
+
+def _all_redlines_are_agent(model: Any) -> bool:
+    """True only if EVERY tracked change in the document is an agent change AND the scan was COMPLETE.
+
+    Gates the global AcceptAll/RejectAll fast path in resolve-all: one global dispatch is safe only
+    when there are no user redlines to clobber, and an incomplete scan can't prove that. So any
+    enumeration/read failure -- or a single non-agent redline -- returns False, falling back to the
+    per-change loop (fail closed). Replaces the old ``len(_agent_redlines) == _redline_count``
+    test, which could spuriously match under a correlated mid-enumeration failure (both undercount to
+    the same point) and then accept the user's redlines in the unscanned tail.
+
+    The scanned count is cross-checked against the redline collection's own ``getCount()`` so an
+    early stop -- ``hasMoreElements()`` going False with redlines still in the tail, i.e. the
+    enumeration yields fewer items than getCount() reports -- also fails closed instead of
+    green-lighting a whole-document accept."""
+    from plugin.writer.edit_review import TOKEN_PREFIX
+
+    try:
+        redlines = model.getRedlines()
+        total = int(redlines.getCount())
+    except Exception:
+        return False  # can't establish the true count -> can't prove completeness -> fail closed
+    if total <= 0:
+        return False  # nothing to resolve via the global path
+    try:
+        enum = redlines.createEnumeration()
+    except Exception:
+        return False
+    seen = 0
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            rl = enum.nextElement()
+            comment = str(rl.getPropertyValue("RedlineComment"))
+        except Exception:
+            return False  # couldn't advance/read a redline -> can't prove all are agent -> fail closed
+        if not comment.startswith(TOKEN_PREFIX):
+            return False  # a user (non-agent) redline is present
+        seen += 1
+    # An enumeration shorter than getCount() leaves seen < total; only a COMPLETE all-agent scan passes.
+    return seen == total
+
+
+def _foreign_redline_ids(model: Any) -> tuple[set, bool]:
+    """``(identifiers of non-agent redlines, reliable)``. The identifiers are the user's OWN tracked
+    changes (plus any we can't classify, counted as foreign). ``reliable`` is False when the snapshot
+    is INCOMPLETE -- the enumeration failed, a foreign redline's identifier couldn't be read, or the
+    scan yields fewer items than the collection's own ``getCount()`` reports -- so
+    a caller can tell "couldn't verify" apart from "no user redlines" and fail CLOSED instead of
+    claiming success without proving the user's changes survived."""
+    from plugin.writer.edit_review import TOKEN_PREFIX
+
+    out: set = set()
+    try:
+        redlines = model.getRedlines()
+        total = int(redlines.getCount())
+        enum = redlines.createEnumeration()
+    except Exception:
+        return out, False  # can't enumerate / count -> unreliable snapshot
+    reliable = True
+    seen = 0
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            rl = enum.nextElement()
+        except Exception:
+            return out, False  # can't advance the enumeration -> unreliable
+        seen += 1
+        try:
+            ours = str(rl.getPropertyValue("RedlineComment")).startswith(TOKEN_PREFIX)
+        except Exception:
+            ours = False  # unclassifiable -> count as foreign so its loss is still detected
+        if ours:
+            continue
+        try:
+            out.add(rl.getPropertyValue("RedlineIdentifier"))
+        except Exception:
+            reliable = False  # a foreign redline we can't track -> snapshot incomplete
+    if seen != total:
+        reliable = False  # enumeration shorter than getCount() -> snapshot incomplete
+    return out, reliable
 
 
 def agent_changes(model: Any) -> list[dict]:
@@ -157,23 +299,47 @@ def agent_changes(model: Any) -> list[dict]:
 
 
 def _change_bounds(model: Any, token: str):
-    """Bounding (start, end) text ranges spanning all redlines of one change, or (None, None).
+    """Bounding (start, end) text ranges spanning ALL redlines of one change, or (None, None).
 
-    Builds the union with ``cursor.gotoRange(..., expand=True)`` rather than
-    ``compareRegionStarts``: the latter is unreliable on redline ranges (a tracked DELETE's text
-    is not in the normal flow), which collapsed the selection for replace changes (Insert+Delete).
-    """
+    Builds the union with ``cursor.gotoRange(..., expand=True)`` rather than ``compareRegionStarts``:
+    the latter is unreliable on redline ranges (a tracked DELETE's text is not in the normal flow),
+    which collapsed the selection for replace changes (Insert+Delete).
+
+    Enumerates COMPLETELY and fails CLOSED (returns (None, None) so the caller refuses): a partial or
+    best-effort scan could miss the Insert OR the Delete mark of a replace and hand back HALF the
+    change's span -- the dispatch would then resolve only half, and if the caller later refuses by
+    conflict the document is left partially resolved. So any enumeration/count error, count/enumeration
+    mismatch (enumeration yields fewer items than getCount() reports), unreadable comment, or a target
+    mark with unreadable / None bounds -> (None, None)."""
+    try:
+        redlines = model.getRedlines()
+        total = int(redlines.getCount())
+        enum = redlines.createEnumeration()
+    except Exception:
+        return None, None
     ranges = []
-    for comment, rl in _agent_redlines(model):
+    seen = 0
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            rl = enum.nextElement()
+            comment = str(rl.getPropertyValue("RedlineComment"))
+        except Exception:
+            return None, None  # can't advance/read a redline -> might miss a target mark -> fail closed
+        seen += 1
         if comment != token:
             continue
         try:
             s = rl.getPropertyValue("RedlineStart")
             e = rl.getPropertyValue("RedlineEnd")
         except Exception:
-            continue
-        if s is not None and e is not None:
-            ranges.append((s, e))
+            return None, None  # a TARGET mark we can't read -> incomplete span -> fail closed
+        if s is None or e is None:
+            return None, None  # a TARGET mark with no bounds -> incomplete span -> fail closed
+        ranges.append((s, e))
+    if seen != total:
+        return None, None  # enumeration shorter than getCount() -> a target mark may be in the tail
     if not ranges:
         return None, None
     try:
@@ -184,8 +350,10 @@ def _change_bounds(model: Any, token: str):
             cursor.gotoRange(e, True)
         return cursor.getStart(), cursor.getEnd()
     except Exception:
-        log.debug("inline_review: _change_bounds union failed", exc_info=True)
-        return ranges[0]
+        # Returning the first mark only would let the caller resolve/navigate HALF a logical change
+        # (a replace's delete OR insert). Fail safe: report no bounds so the caller refuses.
+        log.debug("inline_review: _change_bounds union failed; reporting no bounds", exc_info=True)
+        return None, None
 
 
 def goto_agent_change(model: Any, token: str) -> bool:
@@ -201,6 +369,104 @@ def goto_agent_change(model: Any, token: str) -> bool:
     except Exception:
         log.debug("inline_review: goto_agent_change failed", exc_info=True)
         return False
+
+
+def pending_agent_change_count(model: Any) -> int:
+    """How many agent changes are still pending review -- the toolbar's live counter."""
+    return len(agent_changes(model))
+
+
+def goto_adjacent_agent_change(model: Any, forward: bool = True) -> str | None:
+    """Move the view cursor to the NEXT (``forward``) or PREVIOUS pending agent change, in document
+    order, cycling at the ends. Returns the token jumped to, or None when there are no agent
+    changes. Drives the toolbar's Next/Previous fast-travel.
+
+    The user must be able to START at the very first change. The tricky part: a bare caret sitting
+    at a change's start (e.g. where the agent's edit left it) must NOT be mistaken for "already
+    reviewing that change", or Next would skip it. So we distinguish two states by the SELECTION:
+
+    * The user is REVIEWING a change  -> the change is SELECTED (only this function selects a whole
+      change). Next/Previous then STEP to the adjacent change.
+    * The caret is loose (collapsed)  -> Next goes to the first change whose END is after the caret
+      (the change the caret is inside, or the next one ahead -- never skipping); Previous goes to
+      the last change starting before the caret. A caret at the very top therefore reaches change #0.
+    """
+    changes = agent_changes(model)  # document order of first appearance
+    if not changes:
+        return None
+    items = []  # (token, left_range, right_range) in document order
+    for c in changes:
+        left, right = _change_bounds(model, c["token"])
+        if left is None or right is None:
+            continue
+        try:
+            t = left.getText()
+            items.append((c["token"], t.createTextCursorByRange(left), t.createTextCursorByRange(right)))
+        except Exception:
+            continue
+    if not items:
+        return None
+    n = len(items)
+
+    try:
+        vc = model.getCurrentController().getViewCursor()
+        text = vc.getText()
+        cur_start = text.createTextCursorByRange(vc.getStart())
+        cur_end = text.createTextCursorByRange(vc.getEnd())
+        try:
+            cur_collapsed = bool(vc.isCollapsed())
+        except Exception:
+            cur_collapsed = text.compareRegionStarts(vc.getStart(), vc.getEnd()) == 0
+    except Exception:
+        text = None
+        cur_start = None
+        cur_end = None
+        cur_collapsed = True
+
+    chosen_idx = None
+    if text is None or cur_start is None:
+        chosen_idx = 0 if forward else n - 1
+    else:
+        # Reviewing a change? Only when the selection matches the change's WHOLE span -- both its
+        # start AND end. A collapsed caret never counts (so the first change stays reachable), and a
+        # manual partial selection that merely starts at a change's start must not count either, or
+        # Next/Previous would step away from a change the user didn't actually select.
+        sel_idx = None
+        if not cur_collapsed:
+            for i, (tok, left, right) in enumerate(items):
+                try:
+                    if (text.compareRegionStarts(cur_start, left) == 0
+                            and cur_end is not None
+                            and text.compareRegionEnds(cur_end, right) == 0):
+                        sel_idx = i
+                        break
+                except Exception:
+                    continue
+        if sel_idx is not None:
+            chosen_idx = (sel_idx + 1) % n if forward else (sel_idx - 1) % n
+        elif forward:
+            for i, (tok, left, right) in enumerate(items):
+                try:
+                    if text.compareRegionStarts(cur_start, right) == 1:  # caret before this change's end
+                        chosen_idx = i
+                        break
+                except Exception:
+                    continue
+            if chosen_idx is None:
+                chosen_idx = 0  # caret past the last change -> cycle to the first
+        else:
+            for i in range(n - 1, -1, -1):
+                try:
+                    if text.compareRegionStarts(items[i][1], cur_start) == 1:  # change start before caret
+                        chosen_idx = i
+                        break
+                except Exception:
+                    continue
+            if chosen_idx is None:
+                chosen_idx = n - 1  # caret before the first change -> cycle to the last
+    token = items[chosen_idx][0]
+    goto_agent_change(model, token)
+    return token
 
 
 def cursor_in_agent_change(model: Any) -> str | None:
@@ -234,112 +500,188 @@ def cursor_in_agent_change(model: Any) -> str | None:
 
 
 def _span_contains_point(text: Any, span: Any, point: Any) -> bool:
-    """True if collapsed range ``point`` lies within ``span``'s [start, end] (same ``text``)."""
-    try:
-        if text.compareRegionStarts(point, span) == 1:   # point starts before span -> left of it
-            return False
-        if text.compareRegionEnds(point, span) == -1:    # point ends after span -> right of it
-            return False
-        return True
-    except Exception:
+    """True if collapsed range ``point`` lies within ``span``'s [start, end] (same ``text``).
+
+    Raises (does NOT swallow) on a comparison failure, so the overlap guards can fail CLOSED rather
+    than mistake an uncomparable range for "no overlap".
+    """
+    if text.compareRegionStarts(point, span) == 1:   # point starts before span -> left of it
         return False
+    if text.compareRegionEnds(point, span) == -1:    # point ends after span -> right of it
+        return False
+    return True
+
+
+def _span_has_redline(model: Any, text: Any, span: Any, consider) -> bool:
+    """True if any redline that ``consider(comment)`` selects overlaps ``span`` -- OR if that can't
+    be ruled out. ``consider`` receives the redline's RedlineComment (or None when it can't be read)
+    and returns whether that redline is one the dispatch must NOT touch.
+
+    Data-safety guard: it fails CLOSED. A redline we don't need to protect, or that we can
+    prove sits outside ``span``, is skipped; anything we must protect but can't overlap-check (its
+    position is unreadable / a comparison raises) is treated as a possible overlap and returns True.
+    Crucially, a redline clearly OUTSIDE the span is skipped regardless of whether its comment was
+    readable -- so one unreadable redline elsewhere never permanently blocks resolution.
+
+    The scan is also cross-checked against the collection's ``getCount()``: a count/enumeration
+    mismatch (the enumeration yielding fewer items than getCount() reports) could hide an overlapping
+    user/sibling redline in the unscanned tail, so a short scan returns True (unsafe) instead of a
+    false "no overlap".
+    """
+    try:
+        redlines = model.getRedlines()
+        total = int(redlines.getCount())
+        enum = redlines.createEnumeration()
+    except Exception:
+        log.debug("inline_review: cannot enumerate/count redlines; treating span as unsafe", exc_info=True)
+        return True
+    seen = 0
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            rl = enum.nextElement()
+        except Exception:
+            log.debug("inline_review: cannot advance redline enumeration; treating span as unsafe", exc_info=True)
+            return True
+        seen += 1
+        try:
+            comment = str(rl.getPropertyValue("RedlineComment"))
+        except Exception:
+            comment = None  # unclassifiable -> let the overlap test decide, don't blindly skip
+        if not consider(comment):
+            continue  # not a redline we must protect -> safe to skip
+        try:
+            s = rl.getPropertyValue("RedlineStart")
+            e = rl.getPropertyValue("RedlineEnd")
+            if s is None or e is None:
+                # A redline we must protect whose extent we can't read -> we cannot prove it's
+                # outside the span, so fail CLOSED, not skip-as-safe.
+                log.debug("inline_review: protected redline has no start/end; treating as unsafe")
+                return True
+            rl_span = text.createTextCursorByRange(s)
+            rl_span.gotoRange(e, True)
+            # Overlap iff the redline's start/end falls inside span, or span starts inside it.
+            overlaps = (_span_contains_point(text, span, rl_span.getStart())
+                        or _span_contains_point(text, span, rl_span.getEnd())
+                        or _span_contains_point(text, rl_span, span.getStart()))
+        except Exception:
+            log.debug("inline_review: redline overlap check failed; treating as unsafe", exc_info=True)
+            return True  # can't tell whether it overlaps -> fail closed
+        if overlaps:
+            return True
+    if seen != total:
+        # Enumeration shorter than getCount(): a protected redline may overlap in the unscanned tail.
+        log.debug("inline_review: redline enumeration truncated (%d of %d); treating span as unsafe",
+                  seen, total)
+        return True
+    return False
 
 
 def _foreign_redline_in_span(model: Any, text: Any, span: Any) -> bool:
-    """True if any redline NOT tagged by an EditReviewSession overlaps ``span``.
-
-    The inline resolve drives a paragraph-wide ``.uno`` dispatch that resolves EVERY redline in
-    the range, so when a user-owned tracked change shares those paragraphs we refuse rather than
-    silently accept/reject it. Best-effort: a detection failure falls back to "no foreign
-    redline" so the common case (the user has none of their own) is never blocked.
-    """
+    """True if any redline NOT tagged by an EditReviewSession (i.e. one of the USER's own) overlaps
+    ``span``, or if that can't be ruled out. An accept/reject dispatch over ``span`` resolves every
+    redline it covers, so it must never touch the user's own change. Fails closed (see _span_has_redline)."""
     from plugin.writer.edit_review import TOKEN_PREFIX
-
-    try:
-        enum = model.getRedlines().createEnumeration()
-    except Exception:
-        return False
-    while enum.hasMoreElements():
-        try:
-            rl = enum.nextElement()
-            if str(rl.getPropertyValue("RedlineComment")).startswith(TOKEN_PREFIX):
-                continue  # one of ours -- safe to resolve
-            s = rl.getPropertyValue("RedlineStart")
-            e = rl.getPropertyValue("RedlineEnd")
-            if s is None or e is None:
-                continue
-            rl_span = text.createTextCursorByRange(s)
-            rl_span.gotoRange(e, True)
-            # Overlap iff the foreign redline's start/end falls inside span, or span starts inside it.
-            if (_span_contains_point(text, span, rl_span.getStart())
-                    or _span_contains_point(text, span, rl_span.getEnd())
-                    or _span_contains_point(text, rl_span, span.getStart())):
-                return True
-        except Exception:
-            continue
-    return False
+    # Protect every redline not confirmed to be one of ours (unreadable comment -> protect).
+    return _span_has_redline(model, text, span,
+                             lambda c: c is None or not c.startswith(TOKEN_PREFIX))
 
 
 def _other_agent_redline_in_span(model: Any, text: Any, span: Any, token: str) -> bool:
-    """True if another agent change token overlaps ``span``.
-
-    The inline "this change" command is only truthful when the paragraph-wide dispatch contains
-    one logical agent change. If a second wa-review token shares the paragraph, LibreOffice would
-    resolve both, so we refuse and leave that dense case to the native Manage dialog.
-    """
+    """True if a DIFFERENT agent change token (not ``token``) overlaps ``span``, or if that can't be
+    ruled out. The inline "this change" command is only truthful when the dispatch resolves exactly
+    one logical change; a sibling sharing the span would be resolved too. Fails closed."""
     from plugin.writer.edit_review import TOKEN_PREFIX
-
-    try:
-        enum = model.getRedlines().createEnumeration()
-    except Exception:
-        return False
-    while enum.hasMoreElements():
-        try:
-            rl = enum.nextElement()
-            comment = str(rl.getPropertyValue("RedlineComment"))
-            if not comment.startswith(TOKEN_PREFIX) or comment == token:
-                continue
-            s = rl.getPropertyValue("RedlineStart")
-            e = rl.getPropertyValue("RedlineEnd")
-            if s is None or e is None:
-                continue
-            rl_span = text.createTextCursorByRange(s)
-            rl_span.gotoRange(e, True)
-            if (_span_contains_point(text, span, rl_span.getStart())
-                    or _span_contains_point(text, span, rl_span.getEnd())
-                    or _span_contains_point(text, rl_span, span.getStart())):
-                return True
-        except Exception:
-            continue
-    return False
+    # Protect every redline that is (or might be) one of ours but a DIFFERENT token.
+    return _span_has_redline(model, text, span,
+                             lambda c: c is None or (c.startswith(TOKEN_PREFIX) and c != token))
 
 
-def resolve_agent_change(model: Any, ctx: Any, token: str, accept: bool, refuse_sibling_agent: bool = True) -> bool:
+def _dispatch_resolve(ctx: Any, controller: Any, accept: bool) -> None:
+    """Drive the native accept/reject dispatch on the controller's current selection."""
+    smgr = ctx.getServiceManager()
+    dispatcher = smgr.createInstanceWithContext("com.sun.star.frame.DispatchHelper", ctx)
+    command = ".uno:AcceptTrackedChange" if accept else ".uno:RejectTrackedChange"
+    dispatcher.executeDispatch(controller.getFrame(), command, "", 0, ())
+
+
+def resolve_agent_change(model: Any, ctx: Any, token: str, accept: bool,
+                         refuse_sibling_agent: bool = True, prefer_exact: bool = True) -> bool:
     """Accept/reject ONE agent change (both marks of its pair) by token.
 
-    ``refuse_sibling_agent`` (default True) makes the single "resolve this change" command refuse
-    when ANOTHER agent change shares the paragraph, so it never silently resolves two. resolve-all
-    passes False -- there, resolving sibling agent changes together is the whole point; only a
-    USER redline in the paragraph still blocks it.
+    Modern LibreOffice (>=25.04 / 26.x) resolves a tracked change when the selection covers
+    exactly that redline's marks, so we first select the change's EXACT bounds and dispatch --
+    this resolves ONLY the target, letting a paragraph hold several agent changes that are each
+    accepted/rejected on their own. We refuse when one of the USER's own redlines -- or
+    another agent change -- overlaps that exact span, and verify afterward that EXACTLY the target
+    change was resolved.
 
-    The dispatch selection is expanded to whole PARAGRAPHS around the change: empirically,
-    .uno:Accept/RejectTrackedChange does not resolve redlines when the selection matches the
-    redline bounds exactly, but does on a paragraph-wide selection. Because that dispatch
-    resolves EVERY redline in the selection, we first refuse (return False) when a redline that
-    isn't ours shares those paragraphs -- the user's own tracked changes are never touched.
+    Fallback (``prefer_exact=False``, or an older LibreOffice where an exact-bounds dispatch is a
+    no-op): widen the selection to whole PARAGRAPHS. That dispatch resolves EVERY redline in the
+    range, so we refuse when a foreign -- or, unless ``refuse_sibling_agent=False``, another agent
+    -- change shares those paragraphs. ``resolve_all`` passes ``refuse_sibling_agent=False`` and
+    ``prefer_exact=False`` (resolving sibling agent changes together is the point there).
     """
-    before = len(_agent_redlines(model))
+    before_tokens, before_tokens_ok = _agent_change_tokens(model)
+    if token not in before_tokens:
+        return False
+    before_foreign, before_ok = _foreign_redline_ids(model)  # the user's own redlines -- never lose
+    if not before_tokens_ok or not before_ok:
+        # The PRE-dispatch redline snapshot is incomplete (enumeration error or a count/enumeration
+        # mismatch): we can neither prove the span is clear of collateral nor verify the outcome. Refuse BEFORE
+        # any dispatch -- never mutate first and discover the damage afterwards.
+        log.warning("inline_review: refusing resolve of %s -- pre-dispatch redline snapshot unreliable", token)
+        return False
     left, right = _change_bounds(model, token)
     if left is None:
         return False
     try:
         text = left.getText()
+        controller = model.getCurrentController()
+        view_cursor = controller.getViewCursor()
+
+        # 1) Precise path: select EXACTLY this change's marks and dispatch -- resolves only it.
+        if prefer_exact:
+            exact = text.createTextCursorByRange(left)
+            exact.gotoRange(right, True)
+            if _foreign_redline_in_span(model, text, exact):
+                log.debug("inline_review: refusing inline resolve of %s -- a user redline overlaps it", token)
+                return False
+            if refuse_sibling_agent and _other_agent_redline_in_span(model, text, exact, token):
+                log.debug("inline_review: refusing inline resolve of %s -- another agent change overlaps it", token)
+                return False
+            view_cursor.gotoRange(left, False)
+            view_cursor.gotoRange(right, True)
+            _dispatch_resolve(ctx, controller, accept)
+            after_tokens, after_tokens_ok = _agent_change_tokens(model)
+            removed = before_tokens - after_tokens
+            after_foreign, after_ok = _foreign_redline_ids(model)
+            # "Provably exactly the target": both token snapshots were complete AND only the target's
+            # token vanished AND the user's own redlines were readable before+after with none lost.
+            # Anything we COULDN'T verify (an incomplete snapshot) is failure, never proof.
+            tokens_ok = before_tokens_ok and after_tokens_ok
+            foreign_safe = before_ok and after_ok and not (before_foreign - after_foreign)
+            if removed == {token} and tokens_ok and foreign_safe:
+                return True   # exactly the target -- no sibling change, no user redline touched
+            if removed or not tokens_ok or not foreign_safe:
+                # Touched more than the target (a sibling and/or a user redline), or we couldn't
+                # reliably verify which changes remain / that the user's redlines survived. The guards
+                # above should make this unreachable; if it happens, never report success.
+                log.warning("inline_review: exact resolve of %s affected extra changes %s (token-"
+                            "snapshot reliable=%s, user-redlines provably-safe=%s); not claiming "
+                            "success", token, removed - {token}, tokens_ok, foreign_safe)
+                return False
+            # Nothing changed AND the snapshot was reliable: this build no-ops on an exact-bounds
+            # selection -- widen to paragraph.
+            log.debug("inline_review: exact-bounds resolve of %s was a no-op; widening to paragraph", token)
+
+        # 2) Paragraph-wide path (older LibreOffice, or resolve-all): resolves everything in range,
+        #    so refuse when a redline that we must not touch shares those paragraphs.
         start = text.createTextCursorByRange(left)
         start.gotoStartOfParagraph(False)
         end = text.createTextCursorByRange(right)
         end.gotoEndOfParagraph(True)
-        # Never resolve a paragraph that also holds one of the user's own tracked changes:
-        # the dispatch below would accept/reject it too. Leave that case to the native review UI.
         para_span = text.createTextCursorByRange(start.getStart())
         para_span.gotoRange(end.getEnd(), True)
         if _foreign_redline_in_span(model, text, para_span):
@@ -348,62 +690,111 @@ def resolve_agent_change(model: Any, ctx: Any, token: str, accept: bool, refuse_
         if refuse_sibling_agent and _other_agent_redline_in_span(model, text, para_span, token):
             log.debug("inline_review: refusing inline resolve of %s -- another agent change shares its paragraph", token)
             return False
-        view_cursor = model.getCurrentController().getViewCursor()
         view_cursor.gotoRange(start.getStart(), False)
         view_cursor.gotoRange(end.getEnd(), True)
-        controller = model.getCurrentController()
-        smgr = ctx.getServiceManager()
-        dispatcher = smgr.createInstanceWithContext("com.sun.star.frame.DispatchHelper", ctx)
-        command = ".uno:AcceptTrackedChange" if accept else ".uno:RejectTrackedChange"
-        dispatcher.executeDispatch(controller.getFrame(), command, "", 0, ())
+        _dispatch_resolve(ctx, controller, accept)
     except Exception:
         log.exception("inline_review: resolve_agent_change dispatch failed")
         return False
-    return len(_agent_redlines(model)) < before
+    # The paragraph path may resolve sibling AGENT changes together (resolve_all), but it must still
+    # never touch the USER's own redlines. Refuse to claim success if one disappeared OR if we
+    # couldn't reliably verify they survived (unreliable snapshot -> fail closed).
+    after_foreign, after_ok = _foreign_redline_ids(model)
+    after_tokens, after_tokens_ok = _agent_change_tokens(model)
+    if not after_tokens_ok:
+        log.warning("inline_review: resolve of %s -- could not reliably verify which agent changes "
+                    "remain; not claiming success", token)
+        return False
+    if not (before_ok and after_ok) or (before_foreign - after_foreign):
+        log.warning("inline_review: resolve of %s -- a user redline was lost or could not be "
+                    "verified intact; not claiming success", token)
+        return False
+    return token not in after_tokens
+
+
+# Sentinels (negative so they never collide with a real resolved-count):
+_RESOLVE_ALL_UNRELIABLE = -1   # snapshot unreliable BEFORE any dispatch -> nothing was changed
+_RESOLVE_ALL_UNCONFIRMED = -2  # a dispatch already ran but the final state couldn't be confirmed
 
 
 def resolve_all_agent_changes(model: Any, ctx: Any, accept: bool) -> int:
     """Accept/reject every pending agent change (the user's own redlines stay untouched).
-    Returns how many changes were resolved."""
-    changes = agent_changes(model)
-    if not changes:
+
+    Returns how many changes were resolved, or a negative sentinel: ``_RESOLVE_ALL_UNRELIABLE`` (-1)
+    when the snapshot was unreliable BEFORE any dispatch (genuinely nothing changed -- safe to retry),
+    or ``_RESOLVE_ALL_UNCONFIRMED`` (-2) when a dispatch already ran but the result couldn't be
+    confirmed (some changes MAY have been resolved -- the caller must not claim "nothing changed").
+    Loop control, the completion check, and the count all run off the reliability-aware
+    ``_agent_change_tokens`` (NOT the best-effort ``agent_changes``), so a count/enumeration
+    mismatch can never leave changes pending while reporting completion."""
+    before_tokens, ok = _agent_change_tokens(model)
+    if not ok:
+        log.warning("inline_review: resolve-all aborted -- the redline snapshot is unreliable")
+        return _RESOLVE_ALL_UNRELIABLE  # nothing dispatched yet
+    if not before_tokens:
         return 0
 
     # Common case -- the document holds ONLY the agent's redlines: a single global
     # AcceptAll/RejectAll dispatch is reliable. (A per-change dispatch loop only resolves
     # the FIRST change per call in the live view: the second .uno:AcceptTrackedChange needs
     # the event loop to cycle, which it cannot inside one synchronous handler.)
-    if len(_agent_redlines(model)) == _redline_count(model):
+    if _all_redlines_are_agent(model):
         try:
             controller = model.getCurrentController()
             smgr = ctx.getServiceManager()
             dispatcher = smgr.createInstanceWithContext("com.sun.star.frame.DispatchHelper", ctx)
             command = ".uno:AcceptAllTrackedChanges" if accept else ".uno:RejectAllTrackedChanges"
             dispatcher.executeDispatch(controller.getFrame(), command, "", 0, ())
-            return len(changes) if not agent_changes(model) else 0
+            # Confirm completion against a RELIABLE token snapshot. The dispatch ALREADY mutated, so
+            # an unreliable after-scan is UNCONFIRMED (changes may have resolved), never "nothing".
+            after_tokens, after_ok = _agent_change_tokens(model)
+            if not after_ok:
+                return _RESOLVE_ALL_UNCONFIRMED
+            return max(0, len(before_tokens) - len(after_tokens))  # a dispatch only removes tokens
         except Exception:
             log.exception("inline_review: resolve-all global dispatch failed")
-            return 0
+            return _RESOLVE_ALL_UNCONFIRMED  # the global dispatch may have partially applied
 
     # User redlines are mixed in: resolve agent changes one per pass.
     # Note: We do not call processEventsToIdle() between dispatches here because it blocks
     # indefinitely if the event loop is never completely idle (e.g. active animations, cursors,
     # or background tasks), causing LibreOffice to hang.
-    resolved = 0
-    skip: set[str] = set()  # changes that share a paragraph with a user redline (or failed)
-    for _ in range(200):  # generous upper bound; each pass resolves one change
-        pending = [c for c in agent_changes(model) if c["token"] not in skip]
+    skip: set[str] = set()  # changes that share a paragraph with a user redline (or clear nothing)
+    dispatched = False  # has any resolve attempt run? -> distinguishes "nothing changed" from partial
+    # No fixed cap: each pass either resolves the head change (a token leaves the snapshot) or skips
+    # it (added to `skip`), so the pending set -- tokens minus skip -- strictly shrinks and the loop
+    # always terminates. The snapshot is RE-READ reliably each pass; an unreliable read aborts the
+    # whole operation -- UNCONFIRMED once we've dispatched (changes may already be resolved), else
+    # UNRELIABLE -- rather than terminate early and silently leave changes pending.
+    while True:
+        cur_tokens, ok = _agent_change_tokens(model)
+        if not ok:
+            log.warning("inline_review: resolve-all aborted mid-pass -- the redline snapshot is unreliable")
+            return _RESOLVE_ALL_UNCONFIRMED if dispatched else _RESOLVE_ALL_UNRELIABLE
+        pending = sorted(t for t in cur_tokens if t not in skip)  # sorted -> deterministic order
         if not pending:
             break
-        token = pending[0]["token"]
+        token = pending[0]
+        before_count = len(cur_tokens)
         # resolve-all WANTS sibling agent changes in a paragraph resolved together -- only a USER
         # redline there blocks it (checked inside via _foreign_redline_in_span). Single
         # "resolve this change" keeps refuse_sibling_agent=True so it stays truthful.
-        if not resolve_agent_change(model, ctx, token, accept, refuse_sibling_agent=False):
-            # Refused (shares a paragraph with the user's own redline) or failed: skip it and keep
-            # resolving the rest -- the user handles the skipped one via the native review UI.
-            log.debug("inline_review: skipping %s in resolve-all (foreign redline or failure)", token)
+        resolved = resolve_agent_change(model, ctx, token, accept, refuse_sibling_agent=False, prefer_exact=False)
+        dispatched = True  # resolve_agent_change may mutate even when it ultimately returns False
+        after_tokens, after_ok = _agent_change_tokens(model)
+        if not after_ok:
+            return _RESOLVE_ALL_UNCONFIRMED
+        if not resolved or len(after_tokens) >= before_count:
+            # Refused (a user redline shares its paragraph), failed, or cleared nothing: skip it so
+            # the rest still resolve and a stuck change can't spin the loop -- the user handles the
+            # skipped one via the native review UI.
+            log.debug("inline_review: skipping %s in resolve-all (foreign redline or no change)", token)
             skip.add(token)
-            continue
-        resolved += 1
-    return resolved
+    final_tokens, final_ok = _agent_change_tokens(model)
+    if not final_ok:
+        return _RESOLVE_ALL_UNCONFIRMED if dispatched else _RESOLVE_ALL_UNRELIABLE
+    # Count by how many agent tokens actually disappeared, NOT +1 per pass: one paragraph-wide
+    # dispatch can clear several sibling agent changes at once (common now that the word-level diff
+    # splits an edit into several), so +1 would undercount and make resolve_all_with_feedback report
+    # "N of M" wrong.
+    return max(0, len(before_tokens) - len(final_tokens))  # tokens only leave; never report negative

--- a/plugin/writer/module.yaml
+++ b/plugin/writer/module.yaml
@@ -4,3 +4,13 @@ requires: [document, config, format, events]
 provides_services: [writer_bookmarks, writer_tree, writer_proximity, writer_index]
 
 config: {}
+
+# Review fast-travel (#2): two actions to jump between the agent's pending tracked changes. Handlers
+# live in main.py (writer.review_prev / writer.review_next -> inline_review.goto_adjacent_agent_change).
+# The toolbar that exposes them is defined in the hand-maintained extension/Addons.xcu (the file that
+# actually ships), like every other toolbar/menu in this project.
+actions:
+  review_prev:
+    title: "◀ Prev"
+  review_next:
+    title: "Next ▶"

--- a/plugin/writer/outline.py
+++ b/plugin/writer/outline.py
@@ -45,7 +45,11 @@ class GetDocumentTree(ToolBase):
         'Use content_strategy="heading_only" for a simple outline (headings hierarchy). '
         "Creates _mcp_ bookmarks on headings for stable addressing. "
         "Strategies: heading_only, first_lines (default), full. "
-        "depth=0 for unlimited, depth=1 (default) for top-level only."
+        "depth=0 for unlimited, depth=1 (default) for top-level only. "
+        "IMPORTANT: para_index is an INTERNAL addressing index — NEVER cite paragraph numbers to "
+        "the user (they don't see them and they shift as the document changes). When pointing the "
+        "user to a location or an edit, quote the first few words of its text instead "
+        "(e.g. \"the sentence starting 'The Amazon…'\")."
     )
     parameters = {
         "type": "object",
@@ -64,7 +68,7 @@ class GetDocumentTree(ToolBase):
 class GetHeadingChildren(ToolWriterStructuralBase):
     name = "get_heading_children"
     intent = "navigate"
-    description = "Drill into a heading's children — body paragraphs and sub-headings. Identify the heading by locator (e.g. 'bookmark:_mcp_xxx', 'heading_text:Title'), heading_para_index, or heading_bookmark."
+    description = "Drill into a heading's children — body paragraphs and sub-headings. Identify the heading by locator (e.g. 'bookmark:_mcp_xxx', 'heading_text:Title'), heading_para_index, or heading_bookmark. para_index values are INTERNAL — never cite paragraph numbers to the user; refer to a place by quoting the first words of its text."
     parameters = {
         "type": "object",
         "properties": {

--- a/plugin/writer/review_toolbar.py
+++ b/plugin/writer/review_toolbar.py
@@ -1,0 +1,247 @@
+"""Show the review fast-travel toolbar only while the document has pending agent changes.
+
+The toolbar is declared statically in Addons.xcu and named/hidden-by-default in
+WriterWindowState.xcu. Here we flip its visibility at runtime: shown when
+``pending_agent_change_count(model) > 0``, hidden when it drops back to zero. All LayoutManager
+calls must run on the UNO main thread -- every caller below already does (the agent edit path is
+marshalled via execute_on_main_thread; resolve/navigate handlers and document events fire on the
+main thread).
+"""
+
+import logging
+from typing import Any
+
+import uno
+import unohelper
+from com.sun.star.util import XModifyListener
+
+log = logging.getLogger("writeragent.review_toolbar")
+
+# LO derives this from the OfficeToolBar node oor:name="org.extension.writeragent.toolbar".
+TOOLBAR_RESOURCE_URL = "private:resource/toolbar/addon_org.extension.writeragent.toolbar"
+
+_doc_listener = None
+_modify_listeners = {}  # document RuntimeUID -> its _ReviewModifyListener (so it can be removed on close)
+_docked_uids = set()    # RuntimeUIDs whose toolbar has already been docked once (don't re-dock)
+
+
+def _runtime_uid(model: Any):
+    """The document's RuntimeUID, or None if it can't be read."""
+    try:
+        return model.getRuntimeUID()
+    except Exception:
+        return None
+
+
+class _ReviewModifyListener(unohelper.Base, XModifyListener):
+    """Hides the toolbar after changes are resolved through LibreOffice's NATIVE UI (Edit ->
+    Track Changes -> Accept All, the native context-menu Accept, etc.) -- paths that bypass the
+    WriterAgent handlers. Cheap: while the toolbar is hidden (normal typing) it does nothing; it
+    only recounts when the toolbar is actually showing (i.e. during a review)."""
+
+    def __init__(self, uid):
+        self._uid = uid  # so disposing() can drop the registry entry without re-reading the model
+
+    def modified(self, event):  # noqa: N803 -- UNO signature
+        try:
+            model = event.Source
+            lm = _layout_manager(model)
+            if lm is not None and lm.isElementVisible(TOOLBAR_RESOURCE_URL):
+                refresh_review_toolbar(model)
+        except Exception:
+            log.debug("review_toolbar: modify handler failed", exc_info=True)
+
+    def disposing(self, event):  # noqa: N803
+        # The document we're attached to is being disposed. Drop our registry entry HERE too -- not
+        # only via the OnUnload doc event -- so a crash / force-close, or a failed event-listener
+        # install, can't leak the entry and block a later document that reuses this RuntimeUID.
+        # Only evict if the entry is still OURS: if the RuntimeUID was already recycled for a newer
+        # document, a late disposing() must not evict that newer listener.
+        if self._uid is not None and _modify_listeners.get(self._uid) is self:
+            del _modify_listeners[self._uid]
+            _docked_uids.discard(self._uid)
+
+
+def _register_modify_listener(model: Any) -> None:
+    uid = _runtime_uid(model)
+    if uid is not None and uid in _modify_listeners:
+        return
+    listener = _ReviewModifyListener(uid)
+    try:
+        model.addModifyListener(listener)
+        if uid is not None:
+            _modify_listeners[uid] = listener
+    except Exception:
+        log.debug("review_toolbar: modify listener registration failed", exc_info=True)
+
+
+def _unregister_modify_listener(model: Any) -> None:
+    """Remove the per-document modify listener when the document closes (OnUnload). Without this
+    the listener and its _modify_listeners entry leak; worse, if LibreOffice recycles the
+    RuntimeUID for a later document, _register_modify_listener would skip it and that document
+    would never auto-hide the toolbar. Mirrors the OnUnload teardown in grammar_persistence.py."""
+    uid = _runtime_uid(model)
+    if uid is None:
+        return
+    _docked_uids.discard(uid)
+    listener = _modify_listeners.pop(uid, None)
+    if listener is not None:
+        try:
+            model.removeModifyListener(listener)
+        except Exception:
+            log.debug("review_toolbar: modify listener removal failed", exc_info=True)
+
+
+def _layout_manager(model: Any):
+    try:
+        controller = model.getCurrentController()
+        if controller is None:
+            return None
+        frame = controller.getFrame()
+        if frame is None:
+            return None
+        # XFrame exposes LayoutManager as a property; some builds also have getLayoutManager().
+        lm = getattr(frame, "LayoutManager", None)
+        if lm is None and hasattr(frame, "getLayoutManager"):
+            lm = frame.getLayoutManager()
+        return lm
+    except Exception:
+        log.debug("review_toolbar: layout manager lookup failed", exc_info=True)
+        return None
+
+
+# A docking Y past the existing toolbar rows makes LibreOffice open a NEW full-width row at the
+# bottom of the top docking area, instead of squeezing the toolbar into row 0 (which lands it in the
+# top-right corner). Any value beyond the real rows works; this is comfortably past them.
+_DOCK_NEW_ROW_Y = 30000
+
+
+def _dock_top(lm: Any) -> None:
+    """Dock the toolbar as its OWN full-width row at the top (the look you get by dragging it to
+    the top edge), NOT squeezed into the existing toolbar row. The trick: dock at x=0 with a large
+    y so LibreOffice opens a NEW row at the bottom of the top docking area instead of appending to
+    row 0 (which pushed it to the top-right corner). Best-effort."""
+    try:
+        from com.sun.star.awt import Point
+
+        area = uno.Enum("com.sun.star.ui.DockingArea", "DOCKINGAREA_TOP")
+        pos = Point()
+        pos.X = 0
+        pos.Y = _DOCK_NEW_ROW_Y
+        lm.dockWindow(TOOLBAR_RESOURCE_URL, area, pos)
+    except Exception:
+        log.debug("review_toolbar: dock-to-top failed", exc_info=True)
+
+
+def refresh_review_toolbar(model: Any) -> None:
+    """Show the toolbar iff the document has >=1 pending agent change, else hide it.
+    Best-effort and silent: a Writer without the toolbar, or a non-Writer doc, is a no-op.
+
+    Visibility is per FRAME (each document's own LayoutManager), and every refresh path targets the
+    right document's frame, so multiple open documents each track their own toolbar without a
+    frame-activation listener. Known minor limitation: a SECOND window of the SAME document
+    (Window > New Window) shares one modify listener that only refreshes the active view, so the
+    other view's toolbar can be momentarily stale -- rare; not worth enumerating all frames."""
+    if model is None:
+        return
+    try:
+        from plugin.writer.inline_review import pending_agent_change_count
+
+        lm = _layout_manager(model)
+        if lm is None:
+            return
+        count = pending_agent_change_count(model)
+        if count > 0:
+            lm.showElement(TOOLBAR_RESOURCE_URL)
+            # Extension toolbars default to FLOATING; dock to the top the FIRST time THIS document's
+            # toolbar appears, so it lands with the other toolbars. Only once per document: if the
+            # pending count later cycles 0 -> N -> 0 -> N, we must NOT re-dock and override a user who
+            # has since floated/moved it. If the uid can't be read, fall back to docking on show.
+            uid = _runtime_uid(model)
+            if uid is None or uid not in _docked_uids:
+                _dock_top(lm)
+                if uid is not None:
+                    _docked_uids.add(uid)
+        else:
+            lm.hideElement(TOOLBAR_RESOURCE_URL)
+    except Exception:
+        log.debug("review_toolbar: refresh failed", exc_info=True)
+
+
+def _is_writer(model: Any) -> bool:
+    try:
+        return bool(model) and model.supportsService("com.sun.star.text.TextDocument")
+    except Exception:
+        return False
+
+
+def install_review_toolbar(ctx: Any) -> None:
+    """Set initial toolbar visibility on every open Writer view and on views opened later.
+    Reopening a document that still has pending agent redlines re-shows the toolbar; a clean
+    document keeps it hidden."""
+    global _doc_listener
+    try:
+        from plugin.framework.uno_context import get_desktop
+
+        desktop = get_desktop(ctx)
+        if desktop is not None:
+            frames = desktop.getFrames()
+            if frames is not None:
+                for i in range(frames.getCount()):
+                    try:
+                        frame = frames.getByIndex(i)
+                        controller = frame.getController() if frame is not None else None
+                        model = controller.getModel() if controller is not None else None
+                        if _is_writer(model):
+                            _register_modify_listener(model)
+                            refresh_review_toolbar(model)
+                    except Exception:
+                        log.debug("review_toolbar: frame %s skipped", i, exc_info=True)
+    except Exception:
+        log.debug("review_toolbar: initial sweep failed", exc_info=True)
+
+    if _doc_listener is not None:
+        return
+    try:
+        from plugin.framework.uno_listeners import BaseDocumentEventListener
+
+        class _ToolbarVisibilityListener(BaseDocumentEventListener):  # type: ignore[misc, valid-type]
+            def on_document_event(self, Event: Any) -> None:  # noqa: N803 -- UNO signature
+                try:
+                    name = getattr(Event, "EventName", "") or ""
+                    if name not in ("OnViewCreated", "OnLoadFinished", "OnLoad", "OnNew", "OnUnload"):
+                        return
+                    # Resolve the document model. For OnUnload the ViewController is usually gone and
+                    # Event.Source IS the model; for load events it's the view's model.
+                    controller = getattr(Event, "ViewController", None)
+                    model = None
+                    if controller is not None:
+                        try:
+                            model = controller.getModel()
+                        except Exception:
+                            model = None
+                    if model is None:
+                        source = getattr(Event, "Source", None)
+                        if _is_writer(source):
+                            model = source
+                        elif source is not None and hasattr(source, "getCurrentController"):
+                            c = source.getCurrentController()
+                            model = c.getModel() if c is not None else None
+                    if not _is_writer(model):
+                        return
+                    if name == "OnUnload":
+                        _unregister_modify_listener(model)
+                    else:
+                        _register_modify_listener(model)
+                        refresh_review_toolbar(model)
+                except Exception:
+                    log.debug("review_toolbar: doc-event handling failed", exc_info=True)
+
+        smgr = ctx.getServiceManager()
+        broadcaster = smgr.createInstanceWithContext("com.sun.star.frame.GlobalEventBroadcaster", ctx)
+        listener = _ToolbarVisibilityListener()
+        broadcaster.addDocumentEventListener(listener)
+        _doc_listener = listener
+        log.debug("review_toolbar: visibility listener attached")
+    except Exception:
+        log.debug("review_toolbar: listener install failed", exc_info=True)

--- a/plugin/writer/search.py
+++ b/plugin/writer/search.py
@@ -31,7 +31,13 @@ class SearchInDocument(ToolBase):
     """Search for text in a document with paragraph context."""
 
     name = "search_in_document"
-    description = "Search for text in the document using LibreOffice native search. Returns matches with surrounding paragraph text for context."
+    description = (
+        "Search for text in the document using LibreOffice native search. Returns matches with "
+        "surrounding paragraph text for context. IMPORTANT: each match's paragraph_index is an "
+        "INTERNAL addressing index — NEVER cite paragraph numbers to the user (they don't see them "
+        "and they shift as the document changes). When pointing the user to a match or an edit, "
+        "quote the first few words of its text instead (e.g. \"the sentence starting 'The Amazon…'\")."
+    )
     parameters = {
         "type": "object",
         "properties": {

--- a/plugin/writer/structural.py
+++ b/plugin/writer/structural.py
@@ -18,6 +18,7 @@
 
 (Index refresh, field refresh, and bookmark list/cleanup live in specialized domains.)"""
 
+from plugin.framework.constants import PARAGRAPH_INDEX_DIRECTIVE
 from plugin.framework.tool import ToolBase
 
 from .specialized_base import ToolWriterStructuralBase
@@ -60,7 +61,10 @@ class GotoPage(ToolWriterStructuralBase):
 class GetPageObjects(ToolBase):
     name = "get_page_objects"
     intent = "read"
-    description = "Get images, tables, frames, and Draw shapes visible on a specific physical page. Provide page number, locator, or paragraph_index."
+    description = (
+        "Get images, tables, frames, and Draw shapes visible on a specific physical page. Provide "
+        "page number, locator, or paragraph_index. " + PARAGRAPH_INDEX_DIRECTIVE
+    )
     parameters = {
         "type": "object",
         "properties": {"page": {"type": "integer", "description": "1-based page number to analyze"}, "locator": {"type": "string", "description": "Locator to determine page"}, "paragraph_index": {"type": "integer", "description": "Paragraph index to determine page"}},

--- a/plugin/writer/word_diff_split.py
+++ b/plugin/writer/word_diff_split.py
@@ -1,0 +1,394 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Word-level diff splitter for Track-Changes redlines.
+
+PROBLEM
+-------
+With Track Changes ON, an agent edit today replaces the whole old block with the
+whole new block: one Delete + one Insert (see ``plugin/writer/format.py`` recording
+branch). For a tiny tweak ("teh" -> "the") in a long paragraph that buries the real
+change under a wall of struck-through/inserted text the user cannot meaningfully
+review. There is an *existing* char-by-char diff in ``replace_preserving_format`` but
+it is DISABLED while recording because per-character redlines render as scrambled,
+interleaved garbage.
+
+This module is the PURE-PYTHON, LibreOffice-INDEPENDENT core of the fix. It does NOT
+touch UNO/LO. It decides, for a given ``(old, new)`` pair, whether the edit should be:
+
+  * a single whole-block replacement (the change is "big" -- > ``threshold`` of the
+    words changed), matching today's behaviour; OR
+  * a list of small, surgical sub-edits, each one a contiguous run of WORDS to be
+    replaced / inserted / deleted, with CONSECUTIVE changed words AGGLUTINATED into a
+    single sub-edit.
+
+Each surgical sub-edit carries char offsets into ``old`` plus the exact old/new spans,
+so a later (separate) step in ``format.py`` can turn each sub-edit into its OWN tracked
+Delete+Insert by selecting the sub-range ``old[old_start:old_end]`` of the target range.
+
+TOKENISATION
+------------
+The string is split into an alternating sequence of *word* and *separator* tokens that
+together reconstruct the original string EXACTLY (concatenation is lossless). A "word"
+is a maximal run of non-whitespace; a "separator" is a maximal run of whitespace.
+Punctuation stays attached to the word run it touches (we do not split on punctuation),
+which keeps the token count -- and therefore the change fraction -- intuitive and keeps
+offsets exact. Only WORD tokens participate in the diff; the separators between matched
+words are preserved verbatim and the separators around a changed run are absorbed into
+that run's spans so reconstruction is exact.
+
+CHANGE FRACTION (precise definition)
+------------------------------------
+We run ``difflib.SequenceMatcher`` over the WORD-token sequences of old and new. From
+its opcodes we count:
+
+  * ``changed_words`` = (# old words in 'replace'/'delete' blocks)
+                      + (# new words in 'replace'/'insert' blocks)
+  * ``total_words``   = (# old words in 'equal' blocks)  -- i.e. unchanged words
+                      + ``changed_words``
+
+so ``total_words`` counts each unchanged word once and each changed word once on
+whichever side(s) it appears. The fraction is::
+
+    fraction_changed = changed_words / total_words      (0.0 if total_words == 0)
+
+BOUNDARY SEMANTICS
+------------------
+``fraction_changed > threshold``  -> WHOLE-BLOCK replacement.
+``fraction_changed <= threshold`` -> SURGICAL sub-edits.
+
+So the threshold is the *inclusive upper bound* for staying surgical: a fraction
+EXACTLY at the threshold (e.g. exactly 0.60 with the default) stays SURGICAL. Only a
+fraction strictly ABOVE the threshold flips to a whole-block replacement. Rationale:
+"60% or less changed" is still worth surgically redlining; only past 60% is it noisy
+enough to be a single clean block edit.
+
+Two trivial fast-paths: identical strings -> surgical mode with zero sub-edits;
+``total_words == 0`` (both blank) -> surgical mode with zero sub-edits.
+"""
+
+import difflib
+
+__all__ = [
+    "Token",
+    "SubEdit",
+    "SplitResult",
+    "tokenize",
+    "split_change",
+]
+
+
+class Token:
+    """A single token from :func:`tokenize`.
+
+    Attributes:
+        text:     the raw substring.
+        start:    char offset of the token's first char in the source string.
+        end:      char offset one past the token's last char (``start + len(text)``).
+        is_word:  ``True`` for a non-whitespace run, ``False`` for a whitespace run.
+    """
+
+    __slots__ = ("text", "start", "end", "is_word")
+
+    def __init__(self, text, start, end, is_word):
+        self.text = text
+        self.start = start
+        self.end = end
+        self.is_word = is_word
+
+    def __repr__(self):
+        kind = "W" if self.is_word else "S"
+        return "Token(%s %r @%d:%d)" % (kind, self.text, self.start, self.end)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, Token)
+            and self.text == other.text
+            and self.start == other.start
+            and self.end == other.end
+            and self.is_word == other.is_word
+        )
+
+
+class SubEdit:
+    """One surgical edit: replace ``old[old_start:old_end]`` with ``new_text``.
+
+    Attributes:
+        op:         ``"replace"``, ``"insert"`` or ``"delete"``.
+        old_start:  char offset into ``old`` where the affected span begins.
+        old_end:    char offset into ``old`` where the affected span ends
+                    (``old_start == old_end`` for a pure insertion).
+        old_text:   ``old[old_start:old_end]`` (the text to be deleted; ``""`` for insert).
+        new_text:   the replacement text (``""`` for a pure deletion).
+
+    Applying every sub-edit's ``old[:old_start] / new_text / old[old_end:]`` in order,
+    left-to-right and non-overlapping, reconstructs ``new`` exactly. See
+    :func:`apply_sub_edits`.
+    """
+
+    __slots__ = ("op", "old_start", "old_end", "old_text", "new_text")
+
+    def __init__(self, op, old_start, old_end, old_text, new_text):
+        self.op = op
+        self.old_start = old_start
+        self.old_end = old_end
+        self.old_text = old_text
+        self.new_text = new_text
+
+    def __repr__(self):
+        return "SubEdit(%s old[%d:%d]=%r -> %r)" % (
+            self.op, self.old_start, self.old_end, self.old_text, self.new_text,
+        )
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, SubEdit)
+            and self.op == other.op
+            and self.old_start == other.old_start
+            and self.old_end == other.old_end
+            and self.old_text == other.old_text
+            and self.new_text == other.new_text
+        )
+
+
+class SplitResult:
+    """Outcome of :func:`split_change`.
+
+    Attributes:
+        mode:              ``"block"`` or ``"surgical"``.
+        fraction_changed:  the word-count fraction described in the module docstring.
+        sub_edits:         list of :class:`SubEdit`. For ``mode == "block"`` this is a
+                           single whole-range edit covering all of ``old`` (its ``op`` is
+                           classified the same way surgical ops are: ``insert`` if ``old``
+                           is empty, ``delete`` if ``new`` is empty, else ``replace``). For
+                           ``mode == "surgical"`` it is zero or more surgical sub-edits
+                           (empty when ``old == new``).
+    """
+
+    __slots__ = ("mode", "fraction_changed", "sub_edits")
+
+    def __init__(self, mode, fraction_changed, sub_edits):
+        self.mode = mode
+        self.fraction_changed = fraction_changed
+        self.sub_edits = sub_edits
+
+    @property
+    def is_block(self):
+        return self.mode == "block"
+
+    @property
+    def is_surgical(self):
+        return self.mode == "surgical"
+
+    def __repr__(self):
+        return "SplitResult(mode=%s frac=%.4f, %d sub-edit(s))" % (
+            self.mode, self.fraction_changed, len(self.sub_edits),
+        )
+
+
+def tokenize(s):
+    """Split *s* into alternating word/separator :class:`Token` runs.
+
+    Concatenating ``t.text`` for the returned tokens reproduces *s* exactly, and each
+    token's ``[start:end]`` indexes back into *s*. An empty string yields ``[]``.
+    """
+    tokens = []
+    n = len(s)
+    i = 0
+    while i < n:
+        is_word = not s[i].isspace()
+        j = i + 1
+        while j < n and (not s[j].isspace()) == is_word:
+            j += 1
+        tokens.append(Token(s[i:j], i, j, is_word))
+        i = j
+    return tokens
+
+
+def _word_tokens(tokens):
+    """Return only the word tokens (those that take part in the diff)."""
+    return [t for t in tokens if t.is_word]
+
+
+def split_change(old, new, threshold=0.6):
+    """Decide block-vs-surgical and compute the edits to turn *old* into *new*.
+
+    Args:
+        old:        original block text.
+        new:        replacement block text.
+        threshold:  inclusive upper bound (by changed-word fraction) for staying
+                    surgical. ``fraction <= threshold`` -> surgical; ``> threshold``
+                    -> whole-block. Default ``0.6``.
+
+    Returns:
+        :class:`SplitResult`. See the module docstring for the exact change-fraction
+        definition and boundary semantics.
+    """
+    old = old if old is not None else ""
+    new = new if new is not None else ""
+
+    old_tokens = tokenize(old)
+    new_tokens = tokenize(new)
+    old_words = _word_tokens(old_tokens)
+    new_words = _word_tokens(new_tokens)
+
+    # difflib anchors on equal words. When a word repeats, it may match a different occurrence
+    # than a human would, which can make a surgical redline WIDER than strictly minimal -- but never
+    # wrong: apply_sub_edits() always reconstructs *new* exactly (lossless not minimal).
+    sm = difflib.SequenceMatcher(
+        a=[t.text for t in old_words],
+        b=[t.text for t in new_words],
+        autojunk=False,
+    )
+    opcodes = sm.get_opcodes()
+
+    # --- change fraction (by word count) ---------------------------------------
+    unchanged = 0
+    changed = 0
+    for tag, i1, i2, j1, j2 in opcodes:
+        if tag == "equal":
+            unchanged += (i2 - i1)
+        elif tag == "replace":
+            changed += (i2 - i1) + (j2 - j1)
+        elif tag == "delete":
+            changed += (i2 - i1)
+        elif tag == "insert":
+            changed += (j2 - j1)
+    total = unchanged + changed
+    fraction = (changed / total) if total else 0.0
+
+    # --- whole-block path ------------------------------------------------------
+    # threshold <= 0 means "never split -- always land as ONE block": any actual change then goes
+    # block, including a whitespace-only edit whose word-fraction is 0.0. old == new is still
+    # a no-op (handled by the surgical path returning zero sub-edits below).
+    force_block = threshold <= 0.0 and old != new
+    if force_block or fraction > threshold:
+        # Classify the single whole-range edit with the SAME op semantics the surgical
+        # path uses, so a downstream consumer (format.py recording branch) can branch on
+        # ``op`` uniformly: empty old -> insert, empty new -> delete, else replace. (When
+        # both are empty we never get here: fraction is 0.0, which is never > threshold.)
+        if not old:
+            block_op = "insert"
+        elif not new:
+            block_op = "delete"
+        else:
+            block_op = "replace"
+        block = SubEdit(block_op, 0, len(old), old, new)
+        return SplitResult("block", fraction, [block])
+
+    # --- surgical path ---------------------------------------------------------
+    sub_edits = _build_surgical_edits(old, new, old_words, new_words, opcodes)
+    return SplitResult("surgical", fraction, sub_edits)
+
+
+def _build_surgical_edits(old, new, old_words, new_words, opcodes):
+    """Build surgical :class:`SubEdit`s that reconstruct *new* from *old* EXACTLY.
+
+    ANCHOR MODEL (provably lossless). The matched ("equal") words are byte-identical on
+    both sides and act as fixed anchors. We cut both strings at every matched-word edge,
+    yielding interleaved segments:
+
+        seg, anchor-word, seg, anchor-word, ..., seg
+
+    Anchor-word segments are identical and never edited. Each in-between SEGMENT pairs an
+    old span with a new span; emitting it as ``old[old_lo:old_hi] -> new[new_lo:new_hi]``
+    and concatenating all segments + anchors reproduces *new* exactly, because the cut
+    offsets partition *old* and the replacements supply the corresponding *new* slices.
+
+    TIGHTENING. A raw segment also carries the separators flanking the changed words. We
+    trim the longest COMMON whitespace prefix and suffix shared by the segment's old and
+    new text (whitespace only, so we never split inside a word) and shrink the span
+    accordingly. Trimming a shared prefix/suffix cannot change the result, so it stays
+    lossless while keeping each redline tight on what truly changed. Consecutive changed
+    words sit in one segment, so they AGGLUTINATE into a single sub-edit; a matched word
+    between them splits them into two.
+
+    OP CLASSIFICATION (after trimming): empty old span -> ``insert``; empty new span ->
+    ``delete``; otherwise ``replace``. Segments whose old and new spans are equal (no
+    real change, e.g. anchors with identical separators) are dropped.
+
+    Returns sub-edits sorted by ``old_start`` (non-overlapping by construction).
+    """
+    # Pair up matched words: list of (old_word_index, new_word_index) for every equal
+    # word, in order. These are the anchors.
+    anchors = []
+    for tag, i1, i2, j1, j2 in opcodes:
+        if tag == "equal":
+            for d in range(i2 - i1):
+                anchors.append((i1 + d, j1 + d))
+
+    # Build cut boundaries. A "segment" is the char span between one anchor's end (or
+    # string start) and the next anchor's start (or string end), on each side.
+    sub_edits = []
+
+    prev_old = 0          # char offset in old where the current segment begins
+    prev_new = 0          # char offset in new where the current segment begins
+    for oi, nj in anchors:
+        ow = old_words[oi]
+        nw = new_words[nj]
+        # Segment between previous anchor and this matched word.
+        _emit_segment(sub_edits, old, new, prev_old, ow.start, prev_new, nw.start)
+        # The matched word itself is identical -> skip it (advance past it).
+        prev_old = ow.end
+        prev_new = nw.end
+
+    # Trailing segment after the last anchor (or the whole string if no anchors).
+    _emit_segment(sub_edits, old, new, prev_old, len(old), prev_new, len(new))
+
+    sub_edits.sort(key=lambda e: (e.old_start, e.old_end))
+    return sub_edits
+
+
+def _emit_segment(out, old, new, old_lo, old_hi, new_lo, new_hi):
+    """Append a (possibly trimmed) :class:`SubEdit` for one segment, if it changed."""
+    old_seg = old[old_lo:old_hi]
+    new_seg = new[new_lo:new_hi]
+    if old_seg == new_seg:
+        return  # separators (and anything else) identical -> no edit needed
+
+    # Trim the longest COMMON WHITESPACE prefix shared by both spans.
+    p = 0
+    limit = min(len(old_seg), len(new_seg))
+    while p < limit and old_seg[p] == new_seg[p] and old_seg[p].isspace():
+        p += 1
+    # Trim the longest COMMON WHITESPACE suffix shared by both spans.
+    s = 0
+    while (s < (limit - p)
+           and old_seg[len(old_seg) - 1 - s] == new_seg[len(new_seg) - 1 - s]
+           and old_seg[len(old_seg) - 1 - s].isspace()):
+        s += 1
+
+    old_lo += p
+    new_lo += p
+    old_hi -= s
+    new_hi -= s
+    old_seg = old[old_lo:old_hi]
+    new_seg = new[new_lo:new_hi]
+
+    if not old_seg and not new_seg:
+        return
+    if not old_seg:
+        op = "insert"
+    elif not new_seg:
+        op = "delete"
+    else:
+        op = "replace"
+    out.append(SubEdit(op, old_lo, old_hi, old_seg, new_seg))
+
+
+def apply_sub_edits(old, sub_edits):
+    """Apply *sub_edits* (from a :class:`SplitResult`) to *old*, returning the result.
+
+    The sub-edits are assumed non-overlapping and sorted by ``old_start`` (which is how
+    :func:`split_change` emits them). This mirrors what the LO integration will do --
+    splice each surgical span -- and is the property used by the reconstruction tests.
+    """
+    out = []
+    cursor = 0
+    for e in sorted(sub_edits, key=lambda x: (x.old_start, x.old_end)):
+        out.append(old[cursor:e.old_start])
+        out.append(e.new_text)
+        cursor = e.old_end
+    out.append(old[cursor:])
+    return "".join(out)

--- a/scripts/manifest_registry.py
+++ b/scripts/manifest_registry.py
@@ -222,6 +222,11 @@ def generate_addons_xcu(modules, framework_manifest, output_path):
             _build_menu_entries(submenu, fw_menus, fw_actions, "main", counter,
                                 icon_entries=icon_entries)
 
+    # NOTE: the review fast-travel toolbar's OfficeToolBar node lives in the hand-maintained
+    # extension/Addons.xcu (the file that actually ships -- build_oxt overwrites the generated one
+    # with it), like every other menu/toolbar entry in this project. We deliberately do NOT generate
+    # it here: a second source would only drift from the shipped file.
+
     # Images section — static default icons for menu commands
     if icon_entries:
         images_node = ET.SubElement(addon_ui, "node",
@@ -545,6 +550,7 @@ def generate_manifest_xml(modules, output_path):
         ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/Office/CalcAddIns.xcu'),
         ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/Office/UI/Sidebar.xcu'),
         ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/Office/UI/Factories.xcu'),
+        ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/Office/UI/WriterWindowState.xcu'),
     ]
 
     # Build XML tree

--- a/scripts/manifest_xdl.py
+++ b/scripts/manifest_xdl.py
@@ -59,6 +59,7 @@ def _oor(local):
     """Qualified name in oor: namespace."""
     return "{%s}%s" % (_OOR_NS, local)
 
+
 def _pretty_name(name):
     """Convert dotted or underscored name to title case with spaces."""
     return name.replace(".", " ").replace("_", " ").title()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,9 @@ table = _create_mock_module("com.sun.star.table")
 
 lang = _create_mock_module("com.sun.star.lang")
 
+util = _create_mock_module("com.sun.star.util")
+setattr(util, "XModifyListener", MockBase)  # review_toolbar._ReviewModifyListener subclasses it
+
 
 class MockXEventListener:
     pass

--- a/tests/doc/test_resolve_document_by_url.py
+++ b/tests/doc/test_resolve_document_by_url.py
@@ -1,0 +1,112 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for ``resolve_document_by_url`` targeting by URL *or* RuntimeUID.
+
+The RuntimeUID path lets a caller address a document that has no file URL yet
+(unsaved/untitled), which the URL-only matcher could not reach. UNO is mocked
+here; the live UNO path is exercised by the MCP integration run.
+"""
+from unittest.mock import MagicMock, patch
+
+from plugin.doc.document_helpers import (
+    DocumentType,
+    get_runtime_uid,
+    resolve_document_by_url,
+)
+
+
+def _model(url, uid):
+    m = MagicMock()
+    m.getURL.return_value = url
+    m.RuntimeUID = uid
+    return m
+
+
+def _resolve(models, target, type_map=None):
+    """Run resolve_document_by_url over *models* with UNO desktop/enumeration mocked."""
+    type_map = type_map or {}
+    desktop = MagicMock()
+
+    def make_enum(*_a, **_k):
+        pending = list(models)
+        enum = MagicMock()
+        enum.hasMoreElements.side_effect = lambda: len(pending) > 0
+        enum.nextElement.side_effect = lambda: pending.pop(0)
+        return enum
+
+    desktop.getComponents.return_value.createEnumeration.side_effect = make_enum
+    with patch("plugin.framework.uno_context.get_desktop", return_value=desktop), \
+         patch("plugin.doc.document_helpers.get_document_type",
+               side_effect=lambda m: type_map.get(m, DocumentType.WRITER)):
+        return resolve_document_by_url(MagicMock(), target)
+
+
+def test_match_by_url_regression():
+    a = _model("file:///docs/a.odt", "uid-a")
+    b = _model("file:///docs/b.ods", "uid-b")
+    doc, doc_type = _resolve([a, b], "file:///docs/a.odt")
+    assert doc is a
+    assert doc_type == "writer"
+
+
+def test_match_by_url_doc_type_calc():
+    b = _model("file:///docs/b.ods", "uid-b")
+    doc, doc_type = _resolve([b], "file:///docs/b.ods", type_map={b: DocumentType.CALC})
+    assert doc is b
+    assert doc_type == "calc"
+
+
+def test_match_via_getController_getModel_branch():
+    # An enumerated element that exposes getController().getModel() (a frame) instead of getURL
+    # directly -- the desktop-enumeration path the URL/uid mocks otherwise skip (F4).
+    inner = _model("file:///docs/c.odt", "uid-c")
+    frame = MagicMock(spec=["getController"])  # no getURL attr -> forces the getController branch
+    frame.getController.return_value.getModel.return_value = inner
+    doc, doc_type = _resolve([frame], "file:///docs/c.odt")
+    assert doc is inner
+    assert doc_type == "writer"
+
+
+def test_match_by_uid_when_target_is_not_a_url():
+    a = _model("file:///docs/a.odt", "uid-a")
+    b = _model("file:///docs/b.ods", "uid-b")
+    doc, _ = _resolve([a, b], "uid-b")
+    assert doc is b
+
+
+def test_match_unsaved_doc_by_uid():
+    # The whole point: an unsaved doc (no URL) is reachable only via its RuntimeUID.
+    saved = _model("file:///docs/a.odt", "uid-a")
+    untitled = _model("", "uid-untitled")
+    doc, _ = _resolve([saved, untitled], "uid-untitled")
+    assert doc is untitled
+
+
+def test_no_match_returns_none():
+    a = _model("file:///docs/a.odt", "uid-a")
+    assert _resolve([a], "file:///docs/nope.odt") == (None, None)
+    assert _resolve([a], "uid-does-not-exist") == (None, None)
+
+
+def test_empty_inputs_never_match():
+    # Empty target short-circuits; an empty uid/url must never match anything.
+    assert resolve_document_by_url(MagicMock(), "") == (None, None)
+    blank = _model("", "")
+    assert _resolve([blank], "anything") == (None, None)
+
+
+def test_get_runtime_uid_present_missing_and_error():
+    present = type("M", (), {"RuntimeUID": "abc"})()
+    assert get_runtime_uid(present) == "abc"
+
+    missing = MagicMock(spec=[])  # no RuntimeUID attribute at all
+    assert get_runtime_uid(missing) == ""
+
+    class Boom:
+        @property
+        def RuntimeUID(self):  # e.g. a disposed UNO object
+            raise RuntimeError("disposed")
+
+    assert get_runtime_uid(Boom()) == ""

--- a/tests/mcp/test_list_open_documents.py
+++ b/tests/mcp/test_list_open_documents.py
@@ -37,9 +37,11 @@ def test_list_open_documents_execute():
     mock_doc1 = MagicMock()
     mock_doc1.getURL.return_value = "file:///home/user/document.odt"
     mock_doc1.getController.return_value = None
+    mock_doc1.RuntimeUID = "uid-saved-1"
     mock_doc2 = MagicMock()
     mock_doc2.getURL.return_value = ""  # Untitled document
     mock_doc2.getController.return_value = None
+    mock_doc2.RuntimeUID = "uid-untitled-2"
 
     mock_components = [mock_doc1, mock_doc2]
 
@@ -75,7 +77,37 @@ def test_list_open_documents_execute():
         assert docs[0]["url"] == "file:///home/user/document.odt"
         assert docs[0]["doc_type"] == "writer"
         assert not docs[0]["is_active"]
+        # The stable RuntimeUID is exposed so a caller can target the doc by uid.
+        assert docs[0]["uid"] == "uid-saved-1"
 
         assert docs[1]["name"] == "Untitled"
         assert docs[1]["url"] == ""
         assert docs[1]["doc_type"] == "calc"
+        # An unsaved doc has no URL but still exposes a uid for targeting.
+        assert docs[1]["uid"] == "uid-untitled-2"
+
+
+def test_get_open_documents_lists_untitled_even_when_type_lookup_fails():
+    """D5: an untitled doc (no URL) must never be dropped from the listing on a type-lookup error --
+    its uid is the only handle a caller can target it by. It's listed with doc_type 'unknown'."""
+    from plugin.doc.document_research import get_open_documents
+
+    untitled = MagicMock()
+    untitled.getURL.return_value = ""
+    untitled.getController.return_value = None
+    untitled.RuntimeUID = "uid-untitled-x"
+
+    desktop = MagicMock()
+    enum = MagicMock()
+    elems = [untitled]
+    enum.hasMoreElements.side_effect = lambda: len(elems) > 0
+    enum.nextElement.side_effect = lambda: elems.pop(0)
+    desktop.getComponents.return_value.createEnumeration.return_value = enum
+
+    with patch("plugin.framework.uno_context.get_desktop", return_value=desktop), \
+         patch("plugin.doc.document_helpers.get_document_type", side_effect=RuntimeError("boom")):
+        docs = get_open_documents(MagicMock(), active_model=None)
+
+    assert len(docs) == 1
+    assert docs[0]["url"] == "" and docs[0]["uid"] == "uid-untitled-x"
+    assert docs[0]["doc_type"] == "unknown"

--- a/tests/mcp/test_mcp_doc_key.py
+++ b/tests/mcp/test_mcp_doc_key.py
@@ -1,0 +1,64 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Headless tests for the MCP mutation-gate key.
+
+The per-document mutation gate must give the SAME key whether a document is addressed by its file
+URL or by its RuntimeUID, so two concurrent mutating MCP calls on that document serialize on one
+lock instead of racing on two.
+"""
+from plugin.doc.document_helpers import _normalize_doc_url
+from plugin.mcp.mcp_protocol import _ACTIVE_DOCUMENT_SENTINEL, _resolve_mcp_doc_key
+
+
+class Doc:
+    def __init__(self, uid="", url=""):
+        self._uid = uid
+        self._url = url
+
+    @property
+    def RuntimeUID(self):
+        return self._uid
+
+    def getURL(self):
+        return self._url
+
+
+def test_same_doc_by_url_and_by_uid_map_to_one_key():
+    # The invariant: addressing one resolved document by URL or by uid -> identical gate key.
+    doc = Doc(uid=42, url="file:///docs/a.odt")
+    k_url = _resolve_mcp_doc_key("file:///docs/a.odt", doc)
+    k_uid = _resolve_mcp_doc_key("42", doc)
+    assert k_url == k_uid == "uid:42"
+
+
+def test_saved_doc_without_uid_keys_on_url():
+    doc = Doc(uid="", url="file:///docs/a.odt")
+    assert _resolve_mcp_doc_key("file:///docs/a.odt", doc) == "url:" + _normalize_doc_url("file:///docs/a.odt")
+
+
+def test_unsaved_active_doc_keys_on_uid_not_sentinel():
+    # An unsaved doc has no URL but still has a uid -> addressable by a stable key, not the sentinel.
+    doc = Doc(uid=7, url="")
+    assert _resolve_mcp_doc_key(None, doc) == "uid:7"
+
+
+def test_unresolved_doc_falls_back_to_request_url():
+    assert _resolve_mcp_doc_key("file:///docs/x.odt", None) == "url:" + _normalize_doc_url("file:///docs/x.odt")
+
+
+def test_unresolved_uid_request_cannot_collide_with_resolved_uid_key():
+    # A request literally "uid:7" that fails to resolve must NOT share a gate with the real doc 7.
+    real = Doc(uid=7, url="")
+    assert _resolve_mcp_doc_key("uid:7", None) != _resolve_mcp_doc_key(None, real)
+
+
+def test_no_doc_no_url_is_active_sentinel():
+    assert _resolve_mcp_doc_key(None, None) == _ACTIVE_DOCUMENT_SENTINEL
+
+
+def test_two_different_docs_do_not_collide():
+    a = Doc(uid=1, url="file:///docs/a.odt")
+    b = Doc(uid=2, url="file:///docs/b.odt")
+    assert _resolve_mcp_doc_key("file:///docs/a.odt", a) != _resolve_mcp_doc_key("2", b)

--- a/tests/scripts/test_manifest_xcu_generation.py
+++ b/tests/scripts/test_manifest_xcu_generation.py
@@ -1,0 +1,48 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Structural test for generated registry XCU (E3).
+
+Regression guard: `_oor` once returned None, so ElementTree emitted ``<node None="...">`` and every
+generated Addons.xcu was structurally invalid -- undetected because nothing parsed the generator's
+output. This pins that the qualified-name helper is sane and that a generated Addons.xcu is
+well-formed with proper oor:name attributes (no None=).
+"""
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from manifest_xdl import _OOR_NS, _oor  # noqa: E402  (needs scripts on sys.path)
+
+_OOR_NAME = "{%s}name" % _OOR_NS
+
+
+def test_oor_returns_qualified_name_not_none():
+    assert _oor("name") == "{%s}name" % _OOR_NS
+    assert _oor("op") == "{%s}op" % _OOR_NS
+
+
+def test_oor_attribute_serializes_with_oor_prefix_not_none():
+    el = ET.Element("node", {_oor("name"): "X", _oor("op"): "replace"})
+    xml = ET.tostring(el, encoding="unicode")
+    assert 'oor:name="X"' in xml and 'oor:op="replace"' in xml
+    assert "None=" not in xml
+
+
+def test_generated_addons_xcu_is_well_formed_with_oor_names(tmp_path):
+    from manifest_registry import generate_addons_xcu
+
+    out = tmp_path / "Addons.xcu"
+    generate_addons_xcu([], {}, str(out))
+    content = out.read_text(encoding="utf-8")
+    assert "None=" not in content                      # the _oor=None regression signature
+    root = ET.fromstring(content)                       # must be well-formed XML
+    nodes = [e for e in root.iter("node")]
+    assert nodes, "expected at least the root Addons structure nodes"
+    for n in nodes:
+        assert _OOR_NAME in n.attrib, "a <node> is missing oor:name: %r" % (n.attrib,)

--- a/tests/writer/test_edit_review.py
+++ b/tests/writer/test_edit_review.py
@@ -63,3 +63,463 @@ def test_edit_review_wait_seconds(mode, timeout, expected):
     with patch("plugin.writer.edit_review.get_agent_edit_review_mode", return_value=mode), \
          patch("plugin.framework.config.get_config_int_safe", return_value=timeout):
         assert edit_review_wait_seconds(ctx) == expected
+
+
+# --------------------------------- snapshot_redline_ids reliability + record_mutation fail-closed
+
+_RAISE = object()  # marker: a redline whose RedlineIdentifier read should raise
+
+
+class _FakeRl:
+    def __init__(self, rid, raise_set=False, comment="", raise_comment=False, raise_revert=False):
+        self._rid = rid
+        self._raise_set = raise_set
+        self._raise_revert = raise_revert  # tagging (set token) succeeds, but reverting (set "") fails
+        self._raise_comment = raise_comment
+        self.comment = comment  # current RedlineComment: getPropertyValue returns it, setPropertyValue updates it
+
+    def getPropertyValue(self, name):
+        if name == "RedlineComment":
+            if self._raise_comment:
+                raise RuntimeError("comment unreadable")
+            return self.comment
+        assert name == "RedlineIdentifier"
+        if self._rid is _RAISE:
+            raise RuntimeError("identifier unreadable")
+        return self._rid
+
+    def setPropertyValue(self, name, val):
+        assert name == "RedlineComment"
+        if self._raise_set:
+            raise RuntimeError("set boom")
+        if self._raise_revert and val == "":
+            raise RuntimeError("revert boom")  # cannot clear the tag -> orphan
+        self.comment = val
+
+
+class _FakeEnum:
+    def __init__(self, items, raise_hasmore=False):
+        self._items = list(items)
+        self._raise_hasmore = raise_hasmore
+
+    def hasMoreElements(self):
+        if self._raise_hasmore:
+            raise RuntimeError("hasMore boom")
+        return bool(self._items)
+
+    def nextElement(self):
+        return self._items.pop(0)
+
+
+class _FakeRedlines:
+    def __init__(self, items, count=None, raise_enum=False, raise_count=False, raise_hasmore=False):
+        # items may be raw ids (wrapped in _FakeRl) or already-built _FakeRl objects
+        self._items = [r if isinstance(r, _FakeRl) else _FakeRl(r) for r in items]
+        self._count = count
+        self._raise_enum = raise_enum
+        self._raise_count = raise_count
+        self._raise_hasmore = raise_hasmore
+
+    def getCount(self):
+        if self._raise_count:
+            raise RuntimeError("count boom")
+        return len(self._items) if self._count is None else self._count
+
+    def createEnumeration(self):
+        if self._raise_enum:
+            raise RuntimeError("enum boom")
+        return _FakeEnum(self._items, raise_hasmore=self._raise_hasmore)
+
+
+def _redlines_doc(items, count=None, raise_enum=False, raise_count=False, raise_hasmore=False):
+    doc = MagicMock()
+    doc.getRedlines.return_value = _FakeRedlines(items, count, raise_enum, raise_count, raise_hasmore)
+    return doc
+
+
+def test_snapshot_redline_ids_reliable_when_complete():
+    from plugin.writer.edit_review import snapshot_redline_ids
+    ids, ok = snapshot_redline_ids(_redlines_doc(["a", "b"]))
+    assert ok is True and ids == {"a", "b"}
+
+
+def test_snapshot_redline_ids_unreliable_on_silent_truncation():
+    # 1 redline enumerated but getCount() reports 2 -> a pre-existing redline may be unseen -> a later
+    # edit's new-redline diff could misclassify it -> unreliable.
+    from plugin.writer.edit_review import snapshot_redline_ids
+    _, ok = snapshot_redline_ids(_redlines_doc(["a"], count=2))
+    assert ok is False
+
+
+def test_snapshot_redline_ids_unreliable_on_unreadable_identifier():
+    from plugin.writer.edit_review import snapshot_redline_ids
+    _, ok = snapshot_redline_ids(_redlines_doc(["a", _RAISE]))
+    assert ok is False
+
+
+def test_snapshot_redline_ids_unreliable_on_enum_error():
+    from plugin.writer.edit_review import snapshot_redline_ids
+    _, ok = snapshot_redline_ids(_redlines_doc(["a"], raise_enum=True))
+    assert ok is False
+
+
+def test_snapshot_redline_ids_unreliable_on_count_error():
+    from plugin.writer.edit_review import snapshot_redline_ids
+    _, ok = snapshot_redline_ids(_redlines_doc(["a"], raise_count=True))
+    assert ok is False
+
+
+def test_snapshot_redline_ids_unreliable_on_hasmore_error():
+    # hasMoreElements() throwing must honor the (ids, False) contract, not propagate.
+    from plugin.writer.edit_review import snapshot_redline_ids
+    _, ok = snapshot_redline_ids(_redlines_doc(["a"], raise_hasmore=True))
+    assert ok is False
+
+
+# ----------------------------------------------- _new_redlines_complete + _tag_new_redlines
+
+def test_new_redlines_complete_finds_new_when_complete():
+    from plugin.writer.edit_review import _new_redlines_complete
+    new, ok = _new_redlines_complete(_redlines_doc(["old", "new1", "new2"]), {"old"})
+    assert ok is True and len(new) == 2
+
+
+def test_new_redlines_complete_unreliable_on_silent_truncation():
+    from plugin.writer.edit_review import _new_redlines_complete
+    _, ok = _new_redlines_complete(_redlines_doc(["old", "new1"], count=3), {"old"})
+    assert ok is False
+
+
+def test_new_redlines_complete_unreliable_on_unreadable_id():
+    from plugin.writer.edit_review import _new_redlines_complete
+    _, ok = _new_redlines_complete(_redlines_doc(["old", _RAISE]), {"old"})
+    assert ok is False
+
+
+def test_new_redlines_complete_unreliable_on_hasmore_error():
+    from plugin.writer.edit_review import _new_redlines_complete
+    _, ok = _new_redlines_complete(_redlines_doc(["old"], raise_hasmore=True), {"old"})
+    assert ok is False
+
+
+def test_tag_new_redlines_success_tags_all():
+    from plugin.writer.edit_review import _tag_new_redlines
+    rls = [_FakeRl("a"), _FakeRl("b")]
+    assert _tag_new_redlines(rls, "TOKEN") == (True, 0)   # success, no orphans
+    assert all(r.comment == "TOKEN" for r in rls)
+
+
+def test_tag_new_redlines_all_or_nothing_reverts_on_failure():
+    # Tagging the second redline fails -> the first tag is REVERTED so the change is never half-tagged.
+    # A CLEAN revert is (False, 0) -- failure, no orphan.
+    from plugin.writer.edit_review import _tag_new_redlines
+    rl1, rl2 = _FakeRl("a"), _FakeRl("b", raise_set=True)
+    assert _tag_new_redlines([rl1, rl2], "TOKEN") == (False, 0)
+    assert rl1.comment == ""      # reverted (back to a fresh redline's empty comment)
+    assert rl2.comment == ""      # never tagged (set always raised)
+
+
+def test_tag_new_redlines_reports_orphan_count_when_revert_fails():
+    # rl1 tags OK but its revert fails; rl2's tag fails (triggering the revert). The revert of rl1
+    # cannot remove the token -> (False, 1): failure with one orphan. success and the count are
+    # SEPARATE so the caller can never read it as success.
+    from plugin.writer.edit_review import _tag_new_redlines
+    rl1, rl2 = _FakeRl("a", raise_revert=True), _FakeRl("b", raise_set=True)
+    assert _tag_new_redlines([rl1, rl2], "TOKEN") == (False, 1)
+    assert rl1.comment == "TOKEN"   # still tagged -- the orphan
+    assert rl2.comment == ""        # never tagged (set always raised)
+
+
+def test_tag_new_redlines_single_redline_orphan_is_failure_not_success():
+    # KEY case: ONE redline that mutates-then-throws and can't be reverted. orphans == len
+    # == 1, which an ambiguous int return would make look like full success. The (bool, int) return
+    # keeps it a FAILURE: (False, 1).
+    from plugin.writer.edit_review import _tag_new_redlines
+
+    class _MutateThenThrow(_FakeRl):
+        def setPropertyValue(self, name, val):
+            if val == "":
+                raise RuntimeError("revert cannot clear it")  # revert fails WITHOUT clearing
+            self.comment = val                                # tag writes the token...
+            raise RuntimeError("set wrote then threw")        # ...then throws
+
+    rl = _MutateThenThrow("a")
+    assert _tag_new_redlines([rl], "TOKEN") == (False, 1)   # FAILURE, not (True, ...)
+    assert rl.comment == "TOKEN"                             # the orphan tag remains
+
+
+def test_record_mutation_single_orphan_not_registered():
+    # A SINGLE new redline that mutates-then-throws (orphan==len==1). record_mutation must
+    # NOT register it as a successful change -- it went through the failure path.
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import EditReviewSession
+
+    class _MutateThenThrow(_FakeRl):
+        def setPropertyValue(self, name, val):
+            if val == "":
+                raise RuntimeError("revert cannot clear it")
+            self.comment = val
+            raise RuntimeError("set wrote then threw")
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    rl = _MutateThenThrow("a")
+    with _patch.object(session, "_redline_idents", return_value=(set(), True)), \
+         _patch("plugin.writer.edit_review._new_redlines_complete", return_value=([rl], True)):
+        result = session.record_mutation(lambda: "r")
+
+    assert result == "r"
+    assert session.changes == []   # NOT registered -- the single-orphan failure isn't success
+
+
+def test_record_mutation_does_not_register_when_revert_leaves_orphan():
+    # A dirty revert (orphan remains) must NOT register the change (no half-tagged reviewable change).
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import EditReviewSession
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    rl1, rl2 = _FakeRl("a", raise_revert=True), _FakeRl("b", raise_set=True)
+    with _patch.object(session, "_redline_idents", return_value=(set(), True)), \
+         _patch("plugin.writer.edit_review._new_redlines_complete", return_value=([rl1, rl2], True)):
+        result = session.record_mutation(lambda: "r")
+
+    assert result == "r"
+    assert session.changes == []   # not registered despite the orphan
+
+
+# ---------------------------------------- _review_payload / _outcome honor pending reliability
+
+def test_review_payload_reports_pending_on_unreliable_snapshot():
+    # An unreliable pending scan must report a non-listed change as "pending", never a guessed outcome
+    # from the anchor text.
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import ChangeRecord, EditReviewSession
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    session.changes = [ChangeRecord("t", "bm", "ACCEPTED", "REJECTED", "", "")]
+    with _patch.object(session, "_pending_tokens", return_value=(set(), False)), \
+         _patch.object(session, "_change_text_at_anchor", return_value="ACCEPTED"):
+        payload = session._review_payload(complete=False, timed_out=True)
+    assert payload["changes"][0]["outcome"] == "pending"   # NOT "accepted" -- snapshot unreliable
+
+
+def test_review_payload_reports_real_outcome_on_reliable_snapshot():
+    # Control: a RELIABLE empty snapshot still classifies the change normally (no over-conservatism).
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import ChangeRecord, EditReviewSession
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    session.changes = [ChangeRecord("t", "bm", "ACCEPTED", "REJECTED", "", "")]
+    with _patch.object(session, "_pending_tokens", return_value=(set(), True)), \
+         _patch.object(session, "_change_text_at_anchor", return_value="ACCEPTED"):
+        payload = session._review_payload(complete=True, timed_out=False)
+    assert payload["changes"][0]["outcome"] == "accepted"
+
+
+def test_review_payload_header_and_outcomes_stay_consistent_on_unreliable_rescan():
+    # Even if the caller passes complete=True (its loop scan was clean), a transient UNRELIABLE re-scan
+    # inside the payload must downgrade complete to False so the header matches the all-"pending"
+    # outcomes -- never complete=True alongside pending outcomes (consistency).
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import ChangeRecord, EditReviewSession
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    session.changes = [ChangeRecord("t", "bm", "ACCEPTED", "REJECTED", "", "")]
+    with _patch.object(session, "_pending_tokens", return_value=(set(), False)), \
+         _patch.object(session, "_change_text_at_anchor", return_value="ACCEPTED"):
+        payload = session._review_payload(complete=True, timed_out=False)
+    assert payload["complete"] is False                      # downgraded -- scan unreliable
+    assert payload["changes"][0]["outcome"] == "pending"     # header and body agree
+
+
+def test_record_mutation_does_not_tag_when_after_scan_incomplete():
+    # before-snapshot reliable, but the post-edit scan is incomplete -> leave the edit untagged rather
+    # than register a half-tagged change.
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import EditReviewSession
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    applied = {"n": 0}
+
+    def apply_fn():
+        applied["n"] += 1
+        return "r"
+
+    with _patch.object(session, "_redline_idents", return_value=({"x"}, True)), \
+         _patch("plugin.writer.edit_review._new_redlines_complete", return_value=([], False)):
+        result = session.record_mutation(apply_fn)
+
+    assert result == "r" and applied["n"] == 1 and session.changes == []
+
+
+# ------------------------------------------- _pending_tokens reliability + wait_for_review fail-closed
+
+def test_pending_tokens_reliable_lists_only_session_tokens():
+    from plugin.writer.edit_review import EditReviewSession
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    mine = session._session_token_prefix() + "0"
+    session.doc = _redlines_doc([_FakeRl("i1", comment=mine),
+                                 _FakeRl("i2", comment="wa-review:other:0"),
+                                 _FakeRl("i3", comment="")])
+    pending, ok = session._pending_tokens()
+    assert ok is True and pending == {mine}   # other-session + empty comments excluded
+
+
+def test_pending_tokens_unreliable_on_silent_truncation():
+    from plugin.writer.edit_review import EditReviewSession
+    session = EditReviewSession(_redlines_doc([_FakeRl("i1", comment="")], count=2), MagicMock(),
+                                enabled=True)
+    session._active = True
+    _, ok = session._pending_tokens()
+    assert ok is False
+
+
+def test_pending_tokens_unreliable_on_unreadable_comment():
+    from plugin.writer.edit_review import EditReviewSession
+    session = EditReviewSession(_redlines_doc([_FakeRl("i1", raise_comment=True)]), MagicMock(),
+                                enabled=True)
+    session._active = True
+    _, ok = session._pending_tokens()
+    assert ok is False
+
+
+def test_wait_for_review_not_complete_on_unreliable_pending():
+    # An unreliable pending scan must NOT be read as "done": wait keeps going until the deadline and
+    # reports complete=False / timed_out=True, never a false completion.
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import ChangeRecord, EditReviewSession
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    session.changes = [ChangeRecord("t", "", "", "", "", "")]
+    with _patch.object(session, "_pending_tokens", return_value=(set(), False)), \
+         _patch.object(session, "cleanup"):
+        result = session.wait_for_review(timeout=0.0, poll=0.01)
+    assert result["complete"] is False and result["timed_out"] is True
+
+
+def test_wait_for_review_completes_on_reliable_empty():
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import ChangeRecord, EditReviewSession
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    session.changes = [ChangeRecord("t", "", "", "", "", "")]
+    with _patch.object(session, "_pending_tokens", return_value=(set(), True)), \
+         _patch.object(session, "cleanup"):
+        result = session.wait_for_review(timeout=1.0, poll=0.01)
+    assert result["complete"] is True and result["timed_out"] is False
+
+
+def test_record_mutation_does_not_tag_when_before_snapshot_unreliable():
+    # If the pre-edit redline snapshot is unreliable, the edit still APPLIES but is NOT tagged or
+    # registered -- so a pre-existing user redline can never be mis-stamped as an agent change and
+    # later resolved by Accept/Reject All.
+    from unittest.mock import patch as _patch
+
+    from plugin.writer.edit_review import EditReviewSession
+
+    session = EditReviewSession(MagicMock(), MagicMock(), enabled=True)
+    session._active = True
+    applied = {"n": 0}
+
+    def apply_fn():
+        applied["n"] += 1
+        return "result"
+
+    with _patch.object(session, "_redline_idents", return_value=(set(), False)):
+        result = session.record_mutation(apply_fn)
+
+    assert result == "result"      # the edit ran
+    assert applied["n"] == 1
+    assert session.changes == []   # but nothing was registered/tagged
+
+
+# ----------------------------------------------- discard_changes_since (partial-batch rollback)
+
+def _bookmarks(names, removed):
+    """A fake getBookmarks() collection recording every removeTextContent into *removed*."""
+    class FakeBookmark:
+        def __init__(self, name):
+            self.name = name
+
+        def getAnchor(self):
+            text = MagicMock()
+            text.removeTextContent.side_effect = lambda bm: removed.append(self.name)
+            anchor = MagicMock()
+            anchor.getText.return_value = text
+            return anchor
+
+    class FakeBookmarks:
+        def __init__(self):
+            self._by = {n: FakeBookmark(n) for n in names}
+
+        def hasByName(self, n):
+            return n in self._by
+
+        def getByName(self, n):
+            return self._by[n]
+
+    return FakeBookmarks()
+
+
+def _session_with_changes(doc, tokens_bookmarks):
+    from plugin.writer.edit_review import ChangeRecord, EditReviewSession
+
+    session = EditReviewSession(doc, MagicMock(), enabled=True)
+    session._active = True
+    session.changes = [ChangeRecord(t, b, "", "", "", "") for t, b in tokens_bookmarks]
+    return session
+
+
+def test_discard_changes_since_drops_records_and_removes_bookmarks():
+    # A failed surgical batch: trim every change recorded since the pre-batch count, and remove the
+    # now-orphaned anchor bookmarks so the document keeps no bookkeeping for edits that were undone.
+    removed = []
+    doc = MagicMock()
+    doc.getBookmarks.return_value = _bookmarks(["bm0", "bm1", "bm2"], removed)
+    session = _session_with_changes(doc, [("t0", "bm0"), ("t1", "bm1"), ("t2", "bm2")])
+
+    session.discard_changes_since(1)
+
+    assert [c.token for c in session.changes] == ["t0"]  # records after index 1 dropped
+    assert removed == ["bm1", "bm2"]                      # their bookmarks removed, t0's kept
+
+
+def test_discard_changes_since_noop_when_count_at_or_beyond_length():
+    doc = MagicMock()
+    session = _session_with_changes(doc, [("t0", "bm0")])
+
+    session.discard_changes_since(1)   # nothing recorded after index 1
+    session.discard_changes_since(9)   # out of range
+    session.discard_changes_since(-1)  # guarded against negative slice
+
+    assert [c.token for c in session.changes] == ["t0"]
+    doc.getBookmarks.assert_not_called()  # never touched the document for a no-op
+
+
+def test_discard_changes_since_inactive_session_only_trims_list():
+    # If recording degraded (never went active), there are no bookmarks in the doc to remove; still
+    # trim the in-memory list and do NOT touch the document.
+    doc = MagicMock()
+    session = _session_with_changes(doc, [("t0", "bm0"), ("t1", "bm1")])
+    session._active = False
+
+    session.discard_changes_since(0)
+
+    assert session.changes == []
+    doc.getBookmarks.assert_not_called()

--- a/tests/writer/test_format.py
+++ b/tests/writer/test_format.py
@@ -9,6 +9,8 @@
 
 import base64
 
+import pytest
+
 from plugin.writer.format import strip_embedded_image_data, _apply_image_export_options
 
 
@@ -38,3 +40,128 @@ def test_apply_image_export_options_skips_when_include_images_true():
     b64 = base64.b64encode(b"x").decode("ascii")
     html = f'<img src="data:image/png;base64,{b64}"/>'
     assert _apply_image_export_options(html, include_images=True) == html
+
+
+# ---------------------------------- recording-mode replace atomicity (fallback)
+
+class _FakeCursor:
+    def __init__(self):
+        self.value = "OLD TEXT"
+
+    def getString(self):
+        return self.value
+
+    def setString(self, v):  # the tracked delete empties the range
+        self.value = v
+
+
+class _FakeText:
+    """Records insertString calls; the first (the new text) FAILS, so a restore must follow."""
+
+    def __init__(self):
+        self.cursor = _FakeCursor()
+        self.inserts = []
+        self._failed_once = False
+
+    def createTextCursorByRange(self, _r):
+        return self.cursor
+
+    def insertString(self, _cursor, s, _sel):
+        self.inserts.append(s)
+        if not self._failed_once:
+            self._failed_once = True
+            raise RuntimeError("insert boom")  # the new-text insert fails after the delete
+
+
+class _FakeRange:
+    def __init__(self, text):
+        self._text = text
+
+    def getText(self):
+        return self._text
+
+    def getString(self):
+        return self._text.cursor.getString()
+
+
+def test_replace_preserving_format_restores_original_on_insert_failure():
+    # inside an undo context (in_undo_context=True) the replace deletes then inserts. If the
+    # insert fails after the delete, the ORIGINAL is restored (best-effort net; the caller's context
+    # rollback also cleans up). The failure still propagates.
+    import contextlib
+    from unittest.mock import patch
+
+    import plugin.writer.format as fmt
+
+    text = _FakeText()
+    target = _FakeRange(text)
+    with patch("plugin.writer.format._is_recording_changes", return_value=True), \
+         patch("plugin.writer.format.deletion_author", lambda: contextlib.nullcontext()), \
+         pytest.raises(RuntimeError, match="insert boom"):
+        fmt.replace_preserving_format(object(), target, "NEW TEXT", in_undo_context=True)
+
+    # The new-text insert was attempted and failed; then the ORIGINAL was re-inserted (restore) so
+    # the range is never left a bare partial deletion.
+    assert text.inserts == ["NEW TEXT", "OLD TEXT"]
+
+
+def test_replace_preserving_format_atomic_setstring_when_not_in_undo_context():
+    # when the caller has NOT opened an undo context (in_undo_context=False --
+    # the default, used by whole-block / streamed / direct callers), there is nothing to roll back a
+    # delete-then-insert, so the recording replace uses a SINGLE atomic setString (one UNO action) --
+    # never a separate delete + insert that could fail mid-way into a partial deletion. Whether an undo
+    # manager merely EXISTS is irrelevant; only an actually-open context makes the two-step safe.
+    from unittest.mock import patch
+
+    import plugin.writer.format as fmt
+
+    text = _FakeText()
+    target = _FakeRange(text)
+    with patch("plugin.writer.format._is_recording_changes", return_value=True):
+        fmt.replace_preserving_format(object(), target, "NEW TEXT")  # in_undo_context defaults to False
+
+    assert text.cursor.getString() == "NEW TEXT"  # single atomic replace
+    assert text.inserts == []                     # no delete-then-insert two-step at all
+
+
+def test_replace_preserving_format_atomic_when_split_author_false_even_in_undo_context():
+    # Configurable coloring: split_author=False forces the SINGLE atomic setString (one author -> one
+    # color) even INSIDE an open undo context, where split_author=True (the default) would use the
+    # two-step delete+insert for split-author coloring. The two-step is gated on BOTH flags, so turning
+    # coloring off collapses every recorded replace -- surgical or whole-block -- to one color, still
+    # all-or-nothing.
+    from unittest.mock import patch
+
+    import plugin.writer.format as fmt
+
+    text = _FakeText()
+    target = _FakeRange(text)
+    with patch("plugin.writer.format._is_recording_changes", return_value=True):
+        fmt.replace_preserving_format(object(), target, "NEW TEXT",
+                                      in_undo_context=True, split_author=False)
+
+    assert text.cursor.getString() == "NEW TEXT"  # single atomic replace, not the two-step
+    assert text.inserts == []                     # no delete-then-insert two-step at all
+
+
+def test_replace_preserving_format_two_step_when_split_author_true_in_undo_context():
+    # Complement: with split_author=True (default) AND an open undo context, the replace uses the
+    # two-step (delete authored distinctly via deletion_author, then insert) so by-author coloring
+    # renders two colors. A clean (non-failing) insert leaves exactly the new text.
+    import contextlib
+    from unittest.mock import patch
+
+    import plugin.writer.format as fmt
+
+    class _OkText(_FakeText):
+        def insertString(self, _cursor, s, _sel):  # never fails -> no restore
+            self.inserts.append(s)
+
+    text = _OkText()
+    target = _FakeRange(text)
+    with patch("plugin.writer.format._is_recording_changes", return_value=True), \
+         patch("plugin.writer.format.deletion_author", lambda: contextlib.nullcontext()):
+        fmt.replace_preserving_format(object(), target, "NEW TEXT", in_undo_context=True)
+
+    assert text.cursor.getString() == ""   # the deletion emptied the range (step 1)
+    assert text.inserts == ["NEW TEXT"]    # then the new text was inserted (step 2)

--- a/tests/writer/test_inline_review_guards.py
+++ b/tests/writer/test_inline_review_guards.py
@@ -1,0 +1,487 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Headless tests for the inline-review resolve guards.
+
+These pin, without a live LibreOffice, the two data-safety properties of accepting/rejecting one
+tracked change:
+
+  * the overlap guards fail CLOSED: any error determining whether the USER's own (or another
+    agent's) redline overlaps the span is treated as "unsafe" (refuse), never "no overlap, proceed".
+  * resolve_agent_change reports success only when EXACTLY the target token was resolved, not
+    merely when some redline count dropped.
+
+UNO ranges are faked with integer positions; redline geometry is exercised for real.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugin.writer.inline_review import (
+    _agent_change_tokens,
+    _all_redlines_are_agent,
+    _change_bounds,
+    _foreign_redline_ids,
+    _foreign_redline_in_span,
+    _other_agent_redline_in_span,
+    _span_contains_point,
+    resolve_agent_change,
+)
+from plugin.writer.edit_review import TOKEN_PREFIX
+
+
+def _sign(n):
+    return (n > 0) - (n < 0)
+
+
+class FakeRange:
+    """A [s, e] range over a shared text, identified by integer positions."""
+
+    def __init__(self, s, e):
+        self.s = s
+        self.e = e
+
+    def getStart(self):
+        return FakeRange(self.s, self.s)
+
+    def getEnd(self):
+        return FakeRange(self.e, self.e)
+
+    def getText(self):
+        return FakeText()
+
+    def gotoRange(self, other, expand):
+        if expand:
+            self.s = min(self.s, other.s)
+            self.e = max(self.e, other.e)
+        else:
+            self.s = self.e = other.s
+
+
+class FakeText:
+    """compareRegionStarts/Ends with UNO semantics (1 => R1 before R2); optionally raises."""
+
+    def __init__(self, raise_compare=False):
+        self.raise_compare = raise_compare
+
+    def createTextCursorByRange(self, r):
+        return FakeRange(r.s, r.e)
+
+    def compareRegionStarts(self, r1, r2):
+        if self.raise_compare:
+            raise RuntimeError("compare boom")
+        return _sign(r2.s - r1.s)
+
+    def compareRegionEnds(self, r1, r2):
+        if self.raise_compare:
+            raise RuntimeError("compare boom")
+        return _sign(r2.e - r1.e)
+
+
+class FakeRedline:
+    def __init__(self, comment, s, e, raise_on=None):
+        self._props = {
+            "RedlineComment": comment,
+            "RedlineStart": FakeRange(s, s),
+            "RedlineEnd": FakeRange(e, e),
+            "RedlineType": "Insert",
+            "RedlineIdentifier": "%s:%d:%d" % (comment, s, e),
+        }
+        self._raise_on = raise_on or set()
+
+    def getPropertyValue(self, name):
+        if name in self._raise_on:
+            raise RuntimeError("prop boom")
+        return self._props[name]
+
+
+class FakeEnum:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def hasMoreElements(self):
+        return bool(self._items)
+
+    def nextElement(self):
+        return self._items.pop(0)
+
+
+class FakeRedlines:
+    def __init__(self, items, raise_enum=False, count=None, raise_count=False):
+        self._items = items
+        self._raise = raise_enum
+        self._count = count          # override getCount() to simulate a silent enum truncation
+        self._raise_count = raise_count
+
+    def createEnumeration(self):
+        if self._raise:
+            raise RuntimeError("enum boom")
+        return FakeEnum(self._items)
+
+    def getCount(self):
+        if self._raise_count:
+            raise RuntimeError("count boom")
+        return len(self._items) if self._count is None else self._count
+
+
+class FakeModel:
+    def __init__(self, redlines):
+        self._rl = redlines
+
+    def getRedlines(self):
+        return self._rl
+
+
+# --------------------------------------------------------------------------- _span_contains_point
+
+def test_span_contains_point_geometry():
+    text = FakeText()
+    span = FakeRange(10, 20)
+    assert _span_contains_point(text, span, FakeRange(15, 15)) is True   # inside
+    assert _span_contains_point(text, span, FakeRange(5, 5)) is False    # left
+    assert _span_contains_point(text, span, FakeRange(25, 25)) is False  # right
+
+
+def test_span_contains_point_raises_on_compare_error():
+    # must NOT swallow -> callers fail closed.
+    with pytest.raises(RuntimeError):
+        _span_contains_point(FakeText(raise_compare=True), FakeRange(10, 20), FakeRange(15, 15))
+
+
+# --------------------------------------------------------------------------- foreign-redline guard
+
+def test_foreign_redline_overlap_detected():
+    span = FakeRange(10, 20)
+    model = FakeModel(FakeRedlines([FakeRedline("", 15, 25)]))  # user redline (no token) overlaps
+    assert _foreign_redline_in_span(model, FakeText(), span) is True
+
+
+def test_foreign_redline_no_overlap():
+    span = FakeRange(10, 20)
+    model = FakeModel(FakeRedlines([FakeRedline("", 30, 40)]))  # user redline far away
+    assert _foreign_redline_in_span(model, FakeText(), span) is False
+
+
+def test_foreign_redline_ours_is_not_foreign():
+    span = FakeRange(10, 20)
+    # Our own agent redline overlapping must be skipped BEFORE any comparison (not "foreign").
+    model = FakeModel(FakeRedlines([FakeRedline(TOKEN_PREFIX + "s:1", 15, 25)]))
+    assert _foreign_redline_in_span(model, FakeText(), span) is False
+
+
+def test_foreign_redline_fails_closed_on_enum_error():
+    model = FakeModel(FakeRedlines([], raise_enum=True))
+    assert _foreign_redline_in_span(model, FakeText(), FakeRange(10, 20)) is True
+
+
+def test_foreign_redline_fails_closed_on_per_redline_error():
+    span = FakeRange(10, 20)
+    # A user redline whose RedlineStart read blows up -> can't tell if it overlaps -> refuse.
+    model = FakeModel(FakeRedlines([FakeRedline("", 15, 25, raise_on={"RedlineStart"})]))
+    assert _foreign_redline_in_span(model, FakeText(), span) is True
+
+
+def test_foreign_redline_fails_closed_on_compare_error():
+    span = FakeRange(10, 20)
+    model = FakeModel(FakeRedlines([FakeRedline("", 15, 25)]))
+    assert _foreign_redline_in_span(model, FakeText(raise_compare=True), span) is True
+
+
+def test_foreign_redline_fails_closed_on_silent_truncation():
+    # A user redline far from the span (no overlap), but getCount() reports another redline that the
+    # enumeration did NOT yield -- it could overlap in the unscanned tail -> fail closed.
+    span = FakeRange(10, 20)
+    model = FakeModel(FakeRedlines([FakeRedline("", 30, 40)], count=2))  # 1 enumerated, count says 2
+    assert _foreign_redline_in_span(model, FakeText(), span) is True
+
+
+def test_foreign_redline_with_no_bounds_fails_closed():
+    # A user redline we must protect but whose RedlineStart/End is None -> we can't prove it's
+    # outside the span -> fail closed, NOT skip-as-safe (None-bounds hole).
+    span = FakeRange(10, 20)
+    rl = FakeRedline("", 15, 25)
+    rl._props["RedlineStart"] = None
+    model = FakeModel(FakeRedlines([rl]))
+    assert _foreign_redline_in_span(model, FakeText(), span) is True
+
+
+# --------------------------------------------------------------------- other-agent (sibling) guard
+
+def test_other_agent_overlap_detected():
+    span = FakeRange(10, 20)
+    target = TOKEN_PREFIX + "s:1"
+    sibling = TOKEN_PREFIX + "s:2"
+    model = FakeModel(FakeRedlines([FakeRedline(sibling, 15, 25)]))
+    assert _other_agent_redline_in_span(model, FakeText(), span, target) is True
+
+
+def test_other_agent_same_token_not_flagged():
+    span = FakeRange(10, 20)
+    target = TOKEN_PREFIX + "s:1"
+    model = FakeModel(FakeRedlines([FakeRedline(target, 15, 25)]))  # the target itself, not a sibling
+    assert _other_agent_redline_in_span(model, FakeText(), span, target) is False
+
+
+def test_other_agent_fails_closed_on_error():
+    span = FakeRange(10, 20)
+    target = TOKEN_PREFIX + "s:1"
+    model = FakeModel(FakeRedlines([], raise_enum=True))
+    assert _other_agent_redline_in_span(model, FakeText(), span, target) is True
+
+
+# --------------------------------------------------------- resolve targets exactly the change
+
+def _resolve(token, token_sets, refuse_sibling=True, prefer_exact=True, foreign_sets=None):
+    """Run resolve_agent_change with the geometry helpers stubbed, driving _agent_change_tokens
+    through *token_sets* and _foreign_redline_ids through *foreign_sets*.
+
+    Each _agent_change_tokens result is an ``(tokens, reliable)`` tuple; a bare set entry in
+    *token_sets* is treated as ``(set, True)`` (reliable snapshot) so existing cases stay terse.
+    Each _foreign_redline_ids result is an ``(ids, reliable)`` tuple. Default foreign: always
+    ``(empty, reliable)`` -- the user has no redlines and verification succeeds."""
+    import contextlib
+    model = MagicMock()
+    token_side = [t if isinstance(t, tuple) else (set(t), True) for t in token_sets]
+    foreign_patch = (patch("plugin.writer.inline_review._foreign_redline_ids", side_effect=foreign_sets)
+                     if foreign_sets is not None
+                     else patch("plugin.writer.inline_review._foreign_redline_ids", return_value=(set(), True)))
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("plugin.writer.inline_review._agent_change_tokens", side_effect=token_side))
+        stack.enter_context(patch("plugin.writer.inline_review._change_bounds", return_value=(MagicMock(), MagicMock())))
+        stack.enter_context(patch("plugin.writer.inline_review._foreign_redline_in_span", return_value=False))
+        stack.enter_context(patch("plugin.writer.inline_review._other_agent_redline_in_span", return_value=False))
+        stack.enter_context(patch("plugin.writer.inline_review._dispatch_resolve"))
+        stack.enter_context(foreign_patch)
+        return resolve_agent_change(model, MagicMock(), token, True,
+                                    refuse_sibling_agent=refuse_sibling, prefer_exact=prefer_exact)
+
+
+def test_resolve_exact_success_only_target_gone():
+    assert _resolve("T", [{"T", "S"}, {"S"}]) is True
+
+
+def test_resolve_target_plus_collateral_reports_failure():
+    # Target AND a sibling vanished -> NOT "exactly one" -> must fail strictly: the command
+    # promises to resolve only the target, so resolving extra changes is a violation, not a success.
+    assert _resolve("T", [{"T", "S"}, set()]) is False
+
+
+def test_resolve_only_sibling_resolved_reports_failure():
+    # The target did NOT resolve but a sibling did -> honest failure, do not claim success.
+    assert _resolve("T", [{"T", "S"}, {"T"}]) is False
+
+
+def test_resolve_refuses_when_user_redline_disappears():
+    # The target resolved cleanly by token, BUT one of the user's own redlines vanished -> the
+    # dispatch touched the user's data -> must NOT claim success (user-redline protection).
+    assert _resolve("T", [{"T", "S"}, {"S"}], foreign_sets=[({"user-rl"}, True), (set(), True)]) is False
+
+
+def test_resolve_refuses_when_foreign_snapshot_unreliable():
+    # The target resolved by token, but the user-redline snapshot was UNRELIABLE (couldn't enumerate
+    # / read an identifier) -> "couldn't verify" must not pass as "nothing lost" -> fail closed.
+    assert _resolve("T", [{"T", "S"}, {"S"}], foreign_sets=[(set(), False), (set(), True)]) is False
+
+
+def test_resolve_refuses_when_before_token_snapshot_unreliable():
+    # The BEFORE agent-token snapshot was incomplete (enumeration failed mid-scan). A sibling could
+    # be missing from it, so "removed == {target}" can't prove only the target went -> fail closed.
+    assert _resolve("T", [({"T", "S"}, False), ({"S"}, True)]) is False
+
+
+def test_resolve_refuses_when_after_token_snapshot_unreliable():
+    # The AFTER agent-token snapshot was incomplete -> we can't trust which changes remain, so even
+    # an apparent "exactly the target removed" is not provable -> fail closed.
+    assert _resolve("T", [({"T", "S"}, True), ({"S"}, False)]) is False
+
+
+def test_resolve_paragraph_path_refuses_when_after_token_snapshot_unreliable():
+    # No-op exact dispatch widens to the paragraph path; there, an unreliable after-token snapshot
+    # means we can't prove the target is gone -> must not claim success.
+    # calls: before(reliable), exact-after(reliable, no-op), paragraph-after(UNRELIABLE).
+    assert _resolve("T", [({"T", "S"}, True), ({"T", "S"}, True), ({"S"}, False)]) is False
+
+
+def test_resolve_noop_falls_through_to_paragraph_then_succeeds():
+    # Exact dispatch changed nothing (old build) -> paragraph path -> target gone, no user redline
+    # lost -> success.
+    assert _resolve("T", [{"T", "S"}, {"T", "S"}, {"S"}]) is True
+
+
+def test_resolve_absent_token_returns_false():
+    assert _resolve("T", [{"S"}]) is False
+
+
+def test_resolve_paragraph_path_refuses_when_user_redline_lost():
+    # The exact dispatch no-ops (widen to paragraph); the paragraph dispatch then makes a user redline
+    # disappear (present before, gone after). The paragraph-path foreign-loss guard must refuse,
+    # mirroring the exact-path twin. calls: before, exact-after(no-op), paragraph-after.
+    assert _resolve(
+        "T",
+        [({"T", "S"}, True), ({"T", "S"}, True), ({"S"}, True)],
+        foreign_sets=[({"u"}, True), ({"u"}, True), (set(), True)],
+    ) is False
+
+
+# ----------------------------------------------------------------- _all_redlines_are_agent
+
+def _agent_rl():
+    return FakeRedline(TOKEN_PREFIX + "s:1", 0, 0)
+
+
+def _user_rl():
+    return FakeRedline("", 0, 0)  # no agent token comment
+
+
+def test_all_redlines_are_agent_true_when_complete_and_all_agent():
+    model = FakeModel(FakeRedlines([_agent_rl(), _agent_rl()]))
+    assert _all_redlines_are_agent(model) is True
+
+
+def test_all_redlines_are_agent_false_with_a_user_redline():
+    model = FakeModel(FakeRedlines([_agent_rl(), _user_rl()]))
+    assert _all_redlines_are_agent(model) is False
+
+
+def test_all_redlines_are_agent_false_on_silent_truncation():
+    # The enumeration yields only the two leading agent redlines but getCount() reports 3 (a user
+    # redline sits in the unscanned tail). Count cross-check must fail closed.
+    model = FakeModel(FakeRedlines([_agent_rl(), _agent_rl()], count=3))
+    assert _all_redlines_are_agent(model) is False
+
+
+def test_all_redlines_are_agent_false_on_enum_error():
+    model = FakeModel(FakeRedlines([_agent_rl()], raise_enum=True))
+    assert _all_redlines_are_agent(model) is False
+
+
+def test_all_redlines_are_agent_false_on_count_error():
+    model = FakeModel(FakeRedlines([_agent_rl()], raise_count=True))
+    assert _all_redlines_are_agent(model) is False
+
+
+def test_all_redlines_are_agent_false_on_empty_document():
+    model = FakeModel(FakeRedlines([]))
+    assert _all_redlines_are_agent(model) is False
+
+
+def test_all_redlines_are_agent_false_on_unreadable_comment():
+    model = FakeModel(FakeRedlines([_agent_rl(), FakeRedline("", 0, 0, raise_on={"RedlineComment"})]))
+    assert _all_redlines_are_agent(model) is False
+
+
+# -------------------------------------------- token/foreign snapshot completeness (getCount)
+
+def test_agent_change_tokens_reliable_when_complete():
+    model = FakeModel(FakeRedlines([_agent_rl(), _user_rl()]))
+    tokens, reliable = _agent_change_tokens(model)
+    assert reliable is True and tokens == {TOKEN_PREFIX + "s:1"}
+
+
+def test_agent_change_tokens_unreliable_on_silent_truncation():
+    # The enumeration yields 1 redline but getCount() reports 2 (a redline silently dropped) -> the
+    # token snapshot can't be trusted for a "removed == {token}" comparison -> reliable False.
+    model = FakeModel(FakeRedlines([_agent_rl()], count=2))
+    tokens, reliable = _agent_change_tokens(model)
+    assert reliable is False
+
+
+def test_agent_change_tokens_unreliable_on_count_error():
+    model = FakeModel(FakeRedlines([_agent_rl()], raise_count=True))
+    _, reliable = _agent_change_tokens(model)
+    assert reliable is False
+
+
+def test_foreign_redline_ids_reliable_when_complete():
+    model = FakeModel(FakeRedlines([_agent_rl(), _user_rl()]))
+    ids, reliable = _foreign_redline_ids(model)
+    assert reliable is True  # the user redline (no token) is the only foreign id, scan complete
+
+
+def test_foreign_redline_ids_unreliable_on_silent_truncation():
+    # getCount() says 3 but only 2 redlines enumerated -> a user redline may sit in the unscanned
+    # tail; we must not later read "no user redline lost" off this incomplete set -> reliable False.
+    model = FakeModel(FakeRedlines([_agent_rl(), _user_rl()], count=3))
+    _, reliable = _foreign_redline_ids(model)
+    assert reliable is False
+
+
+def test_foreign_redline_ids_unreliable_on_count_error():
+    model = FakeModel(FakeRedlines([_user_rl()], raise_count=True))
+    _, reliable = _foreign_redline_ids(model)
+    assert reliable is False
+
+
+# --------------------------------------------------- _change_bounds fail-closed
+
+def test_change_bounds_returns_span_on_complete_scan():
+    # The two marks of a replace (Delete + Insert) share the token; a complete scan returns the
+    # union span (non-None), so the caller can resolve the WHOLE change.
+    target = TOKEN_PREFIX + "s:1"
+    model = FakeModel(FakeRedlines([FakeRedline(target, 10, 15), FakeRedline(target, 15, 20)]))
+    left, right = _change_bounds(model, target)
+    assert left is not None and right is not None
+
+
+def test_change_bounds_fail_closed_on_silent_truncation():
+    # getCount() says 3 but only the 2 target marks enumerate -> a mark may be in the unscanned tail
+    # -> returning a span here could cover only half the change -> fail closed.
+    target = TOKEN_PREFIX + "s:1"
+    model = FakeModel(FakeRedlines([FakeRedline(target, 10, 15), FakeRedline(target, 15, 20)], count=3))
+    assert _change_bounds(model, target) == (None, None)
+
+
+def test_change_bounds_fail_closed_on_unreadable_comment():
+    # A redline whose comment can't be read might BE a target mark we'd miss -> fail closed.
+    target = TOKEN_PREFIX + "s:1"
+    model = FakeModel(FakeRedlines([FakeRedline(target, 10, 15),
+                                    FakeRedline("", 0, 0, raise_on={"RedlineComment"})]))
+    assert _change_bounds(model, target) == (None, None)
+
+
+def test_change_bounds_fail_closed_on_unreadable_target_bounds():
+    # A TARGET mark whose Start can't be read -> we can't build the complete span -> fail closed
+    # (the old code skipped it and could return only the other half).
+    target = TOKEN_PREFIX + "s:1"
+    model = FakeModel(FakeRedlines([FakeRedline(target, 10, 15),
+                                    FakeRedline(target, 15, 20, raise_on={"RedlineStart"})]))
+    assert _change_bounds(model, target) == (None, None)
+
+
+def test_change_bounds_fail_closed_on_none_target_bounds():
+    target = TOKEN_PREFIX + "s:1"
+    rl = FakeRedline(target, 15, 20)
+    rl._props["RedlineEnd"] = None
+    model = FakeModel(FakeRedlines([FakeRedline(target, 10, 15), rl]))
+    assert _change_bounds(model, target) == (None, None)
+
+
+# ------------------------------------------ refuse BEFORE dispatch on an unreliable before-snapshot
+
+def test_resolve_does_not_dispatch_when_before_token_snapshot_unreliable():
+    # The before token snapshot is unreliable -> we must refuse BEFORE _dispatch_resolve, never
+    # mutate first and only then return False (the damage would already be done).
+    model = MagicMock()
+    with patch("plugin.writer.inline_review._agent_change_tokens", return_value=({"T"}, False)), \
+         patch("plugin.writer.inline_review._foreign_redline_ids", return_value=(set(), True)), \
+         patch("plugin.writer.inline_review._change_bounds", return_value=(MagicMock(), MagicMock())), \
+         patch("plugin.writer.inline_review._foreign_redline_in_span", return_value=False), \
+         patch("plugin.writer.inline_review._other_agent_redline_in_span", return_value=False), \
+         patch("plugin.writer.inline_review._dispatch_resolve") as dispatch:
+        result = resolve_agent_change(model, MagicMock(), "T", True)
+    assert result is False
+    dispatch.assert_not_called()
+
+
+def test_resolve_does_not_dispatch_when_before_foreign_snapshot_unreliable():
+    model = MagicMock()
+    with patch("plugin.writer.inline_review._agent_change_tokens", return_value=({"T"}, True)), \
+         patch("plugin.writer.inline_review._foreign_redline_ids", return_value=(set(), False)), \
+         patch("plugin.writer.inline_review._change_bounds", return_value=(MagicMock(), MagicMock())), \
+         patch("plugin.writer.inline_review._foreign_redline_in_span", return_value=False), \
+         patch("plugin.writer.inline_review._other_agent_redline_in_span", return_value=False), \
+         patch("plugin.writer.inline_review._dispatch_resolve") as dispatch:
+        result = resolve_agent_change(model, MagicMock(), "T", True)
+    assert result is False
+    dispatch.assert_not_called()

--- a/tests/writer/test_inline_review_uno.py
+++ b/tests/writer/test_inline_review_uno.py
@@ -12,9 +12,12 @@ from plugin.testing_runner import native_test, setup, teardown
 from plugin.tests.testing_utils import TestingFactory
 from plugin.writer.edit_review import EditReviewSession
 from plugin.writer.inline_review import (
+    _change_bounds,
     agent_changes,
     cursor_in_agent_change,
+    goto_adjacent_agent_change,
     has_agent_changes,
+    pending_agent_change_count,
     resolve_agent_change,
     resolve_all_agent_changes,
     resolve_all_with_feedback,
@@ -245,6 +248,79 @@ def test_resolve_all_agent_changes_spares_user_redlines_uno():
 
 
 @native_test
+def test_resolve_all_counts_siblings_cleared_together_uno():
+    """resolve-all must count EVERY agent change that disappears, even when one paragraph-wide
+    dispatch clears several siblings in the same clean paragraph at once (a user redline elsewhere
+    forces the per-change path). The old +1-per-pass undercounted -> false 'Resolved 1 of 2'.
+    (ported from feat 4c7afb98; more relevant now that an edit is split into several.)"""
+    _body("The quick brown fox.", "Lonely user paragraph.")
+    _agent_edit(("quick", "fast"), ("fox", "dog"))                     # two agent changes, SAME para 1
+    _tracked_replace("Lonely user paragraph.", "Lonely user EDITED.")  # user redline in para 2 -> mixed path
+    n = resolve_all_agent_changes(_doc, _ctx, True)
+    assert n == 2, "both same-paragraph agent changes must be counted, got %d" % n
+    assert not has_agent_changes(_doc), "no agent change left pending"
+    _body("reset")
+
+
+@native_test
+def test_resolve_all_global_path_when_only_agent_redlines_uno():
+    """Gate: a document holding ONLY agent changes (no user redlines) takes the global
+    AcceptAll fast path (_all_redlines_are_agent True) -- every change resolves and counts, leaving
+    zero redlines. The mixed-redline per-change loop is covered by the *spares_user_redlines* tests;
+    this pins the OTHER branch and that its (now reliability-checked) count is honest."""
+    _body("The quick brown fox.", "Another clean clause here.")
+    _agent_edit(("quick", "fast"), ("Another clean clause here.", "Another EDITED clause here."))
+    n_changes = len(agent_changes(_doc))
+    assert n_changes >= 2, "precondition: multiple agent changes, got %d" % n_changes
+    assert _redline_count() > 0, "precondition: redlines present"
+    n = resolve_all_agent_changes(_doc, _ctx, True)
+    assert n == n_changes, "global path must resolve AND count every agent change, got %d of %d" % (n, n_changes)
+    assert not has_agent_changes(_doc), "no agent change left pending"
+    assert _redline_count() == 0, "global AcceptAll must clear all redlines, got %d" % _redline_count()
+    _body("reset")
+
+
+@native_test
+def test_snapshot_reliable_with_table_cell_redline_uno():
+    """Robustness: the snapshot helpers fail closed when the redline enumeration is shorter
+    than getRedlines().getCount() (a silent truncation). That guard must NOT misfire on a HEALTHY doc
+    whose redlines live in a NON-BODY container -- here a table cell. getRedlines() is one flat table
+    spanning body + cells, so getCount() must equal the enumeration length; this pins that, proving
+    resolve never spuriously refuses on documents containing tables."""
+    from plugin.writer.inline_review import _agent_change_tokens, _foreign_redline_ids
+
+    _body("Body clause one here.")
+    text = _doc.getText()
+    cur = text.createTextCursor()
+    cur.gotoEnd(False)
+    text.insertControlCharacter(cur, _PARA_BREAK, False)
+    table = _doc.createInstance("com.sun.star.text.TextTable")
+    table.initialize(1, 1)
+    text.insertTextContent(cur, table, False)
+    cell_text = table.getCellByName("A1").getText()
+    cell_text.setString("Cell clause two here.")
+
+    # A tracked change in the BODY and another inside the TABLE CELL.
+    _tracked_replace("Body clause one here.", "Body clause ONE here.")
+    _doc.setPropertyValue("RecordChanges", True)
+    cc = cell_text.createTextCursor()
+    cc.gotoStart(False)
+    cc.gotoEnd(True)
+    cc.setString("")
+    cell_text.insertString(cc, "Cell clause TWO here.", False)
+    _doc.setPropertyValue("RecordChanges", False)
+
+    assert _redline_count() >= 2, "precondition: redlines in both the body and the table cell"
+    assert _redline_count() == len(_doc.getRedlines()), "enumeration length must equal getCount()"
+    _, tokens_reliable = _agent_change_tokens(_doc)
+    _, foreign_reliable = _foreign_redline_ids(_doc)
+    assert tokens_reliable is True, "a table-cell redline must NOT make the token snapshot 'unreliable'"
+    assert foreign_reliable is True, "a table-cell redline must NOT make the foreign snapshot 'unreliable'"
+    _accept_all()
+    _body("reset")
+
+
+@native_test
 def test_cursor_in_agent_change_detects_token_uno():
     _body("Plain paragraph.", "Target clause here.")
     session = _agent_edit(("Target clause here.", "Target EDITED here."))
@@ -258,42 +334,73 @@ def test_cursor_in_agent_change_detects_token_uno():
 
 
 @native_test
-def test_resolve_refuses_when_user_redline_shares_paragraph_uno():
-    """Token-scoping guarantee for the SAME-paragraph case: the paragraph-wide dispatch resolves
-    every redline in the selection, so when one of the user's OWN tracked changes shares a
-    paragraph with an agent change the inline resolve refuses and touches NOTHING -- the user
-    resolves that one via the native UI. (Existing user-redline tests put them in separate
-    paragraphs, where the dispatch never reached them.)"""
+def test_resolve_spares_user_redline_in_same_paragraph_uno():
+    """The precise (exact-bounds) resolve accepts the agent change WITHOUT touching the user's
+    own (non-overlapping) tracked change in the SAME paragraph. Modern LibreOffice resolves only
+    the selected marks, so -- unlike the old paragraph-wide dispatch -- we no longer refuse here.
+    The OVERLAPPING case is refused -- covered by
+    test_resolve_refuses_when_user_redline_overlaps_change_uno."""
     _body("The quick brown fox jumps.")
     _tracked_replace("quick", "fast")     # the user's own (untokened) redline ...
     _agent_edit(("fox", "dog"))           # ... and an agent change in the SAME paragraph
-    _caret_in("dog")
     before = _redline_count()
+    _caret_in("dog")
     ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
-    assert ok is False, "must refuse when a user redline shares the paragraph: %r" % msg
-    assert msg and "Manage" in msg, "refusal must carry a user-facing hint (shown in the UI): %r" % msg
-    assert _redline_count() == before, "neither the agent change nor the user's redline may be touched"
-    assert has_agent_changes(_doc), "the agent change stays pending for the native UI"
+    assert ok, "the agent change must resolve precisely, sparing the user's redline: %r" % msg
+    assert not has_agent_changes(_doc), "the agent change was accepted"
+    assert _redline_count() < before, "the agent change's marks were resolved"
+    assert _redline_count() >= 1 and _find("fast") is not None, \
+        "the user's own redline must remain pending and untouched, got %d redlines" % _redline_count()
     _body("reset")
 
 
 @native_test
-def test_resolve_refuses_when_another_agent_change_shares_paragraph_uno():
-    """Inline "this change" also refuses when another agent token is in the same paragraph.
-
-    The dispatch selection is paragraph-wide, so accepting one token here would accept the other
-    token too and misrepresent the command as a single-change action.
-    """
-    _body("Alpha beta gamma.")
-    _agent_edit(("Alpha", "One"), ("gamma", "three"))
+def test_resolve_refuses_when_user_redline_overlaps_change_uno():
+    """SAFETY (the data-loss guard): when one of the USER's own tracked changes OVERLAPS the
+    agent change's exact span, the precise resolve must REFUSE -- an exact-bounds dispatch would
+    resolve the user's redline too. Resolve by token to force the _foreign_redline_in_span guard.
+    Nothing may be touched. (This is the branch the spares-user test does NOT cover.)"""
+    _body("The quick brown fox.")
+    _agent_edit(("fox", "dog"))               # agent change fox -> dog (tokened)
+    _tracked_replace("dog", "cat")            # user edits the agent's inserted word -> overlapping redline
     changes = agent_changes(_doc)
-    assert len(changes) == 2, changes
-    _caret_in("One")
+    assert changes, "agent change should still be listed"
+    token = changes[0]["token"]
     before = _redline_count()
+    ok = resolve_agent_change(_doc, _ctx, token, True)
+    assert ok is False, "must refuse to resolve an agent change whose exact span overlaps a user redline"
+    assert _redline_count() == before, "nothing may be resolved -- the user's redline must survive intact"
+    _body("reset")
+
+
+@native_test
+def test_resolve_one_of_several_agent_changes_in_paragraph_uno():
+    """Core: with several agent changes in ONE paragraph, accepting one resolves ONLY it and
+    leaves the others pending. Modern LibreOffice resolves the exact selection -- the old code
+    refused this dense case and forced 'accept all'."""
+    _body("Alpha beta gamma delta.")
+    _agent_edit(("Alpha", "One"), ("gamma", "Three"))
+    assert len(agent_changes(_doc)) == 2, agent_changes(_doc)
+    _caret_in("One")
     ok, msg = resolve_change_at_cursor(_doc, _ctx, True)
-    assert ok is False, "must refuse when another agent change shares the paragraph: %r" % msg
-    assert _redline_count() == before, "no same-paragraph agent change should be resolved by the single-change UI"
-    assert len(agent_changes(_doc)) == 2, "both agent changes stay pending"
+    assert ok, "accepting one of several same-paragraph agent changes must work now: %r" % msg
+    left = agent_changes(_doc)
+    assert len(left) == 1 and left[0]["new"] == "Three", "only the targeted change resolved: %r" % left
+    _body("reset")
+
+
+@native_test
+def test_resolve_reject_one_of_several_agent_changes_in_paragraph_uno():
+    """Rejecting one of several same-paragraph agent changes restores only that word and leaves
+    the others pending."""
+    _body("Alpha beta gamma delta.")
+    _agent_edit(("Alpha", "One"), ("gamma", "Three"))
+    _caret_in("Three")
+    ok, msg = resolve_change_at_cursor(_doc, _ctx, False)
+    assert ok, "rejecting one of several must work: %r" % msg
+    left = agent_changes(_doc)
+    assert len(left) == 1 and left[0]["new"] == "One", "only the targeted change rejected: %r" % left
+    assert _find("gamma") is not None, "reject restored the original 'gamma'"
     _body("reset")
 
 
@@ -331,4 +438,74 @@ def test_resolve_all_with_feedback_reports_skipped_then_silent_when_clean_uno():
     _agent_edit(("Clean one.", "Clean one EDITED."), ("Clean two.", "Clean two EDITED."))
     n2, msg2 = resolve_all_with_feedback(_doc, _ctx, True)
     assert n2 == 2 and msg2 == "", "all-clean resolve-all returns no message, got n=%d msg=%r" % (n2, msg2)
+    _body("reset")
+
+
+# --- fast-travel: count + next/previous navigation -------------------------------------
+
+def _three_changes():
+    # Leading plain paragraph so the document start is unambiguously BEFORE every change
+    # (otherwise the cursor at offset 0 coincides with the first change's start).
+    _body("Intro paragraph, no change.",
+          "First clause here.", "Second clause here.", "Third clause here.")
+    _agent_edit(("First clause here.", "Alpha one."),
+                ("Second clause here.", "Beta two."),
+                ("Third clause here.", "Gamma three."))
+    return [c["token"] for c in agent_changes(_doc)]  # document order
+
+
+@native_test
+def test_pending_count_reflects_agent_changes_uno():
+    assert pending_agent_change_count(_doc) == 0, "clean doc has 0 pending"
+    _three_changes()
+    assert pending_agent_change_count(_doc) == 3, pending_agent_change_count(_doc)
+    _body("reset")
+
+
+@native_test
+def test_fast_travel_next_visits_in_order_and_cycles_uno():
+    order = _three_changes()
+    assert len(order) == 3, order
+    _doc.getCurrentController().getViewCursor().gotoRange(_doc.getText().getStart(), False)
+    visited = [goto_adjacent_agent_change(_doc, True) for _ in range(4)]
+    assert visited == [order[0], order[1], order[2], order[0]], \
+        "next must walk doc order then cycle: %r vs order %r" % (visited, order)
+    _body("reset")
+
+
+@native_test
+def test_fast_travel_prev_visits_in_reverse_and_cycles_uno():
+    order = _three_changes()
+    _doc.getCurrentController().getViewCursor().gotoRange(_doc.getText().getEnd(), False)
+    visited = [goto_adjacent_agent_change(_doc, False) for _ in range(4)]
+    assert visited == [order[2], order[1], order[0], order[2]], \
+        "prev must walk reverse then cycle: %r vs order %r" % (visited, order)
+    _body("reset")
+
+
+@native_test
+def test_fast_travel_next_from_caret_at_change_start_does_not_skip_uno():
+    """A bare (collapsed) caret resting at a change's start -- e.g. where an agent edit left it --
+    must let the user START at that change: Next goes to IT, not the one after. Regression for the
+    fast-travel bug where 'strictly after the cursor' skipped the change under the caret."""
+    order = _three_changes()
+    vc = _doc.getCurrentController().getViewCursor()
+    # Caret exactly at the FIRST change's start.
+    left0, _ = _change_bounds(_doc, order[0])
+    vc.gotoRange(left0, False)
+    assert goto_adjacent_agent_change(_doc, True) == order[0], "must not skip the change at the caret (first)"
+    # Caret exactly at the MIDDLE change's start.
+    left1, _ = _change_bounds(_doc, order[1])
+    vc.gotoRange(left1, False)
+    assert goto_adjacent_agent_change(_doc, True) == order[1], "must not skip the change at the caret (middle)"
+    # But once a change is SELECTED (reviewing it), Next must STEP to the following change.
+    assert goto_adjacent_agent_change(_doc, True) == order[2], "selected change -> Next advances"
+    _body("reset")
+
+
+@native_test
+def test_fast_travel_none_when_no_changes_uno():
+    _body("Nothing tracked here.")
+    assert pending_agent_change_count(_doc) == 0
+    assert goto_adjacent_agent_change(_doc, True) is None, "no changes -> nowhere to travel"
     _body("reset")

--- a/tests/writer/test_paragraph_index_directive.py
+++ b/tests/writer/test_paragraph_index_directive.py
@@ -1,0 +1,28 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Coverage test for the 'never cite paragraph numbers' directive (#1 / E4).
+
+Every model-facing tool that returns a para_index / paragraph_index to the model must tell it not to
+cite that number to the user (the index is internal and shifts as the document changes). This pins
+that coverage so a future tool can't quietly start leaking an index without the directive.
+"""
+from plugin.framework.constants import PARAGRAPH_INDEX_DIRECTIVE
+from plugin.writer.outline import GetDocumentTree, GetHeadingChildren
+from plugin.writer.search import SearchInDocument
+from plugin.writer.structural import GetPageObjects
+
+# Model-facing tools whose results expose a paragraph index to the model.
+_INDEX_TOOLS = (GetPageObjects, GetDocumentTree, GetHeadingChildren, SearchInDocument)
+
+
+def test_index_tools_warn_against_citing_paragraph_numbers():
+    for tool_cls in _INDEX_TOOLS:
+        desc = (tool_cls.description or "").lower()
+        assert "cite paragraph numbers" in desc, "%s leaks an index without the directive" % tool_cls.name
+
+
+def test_get_page_objects_uses_the_central_directive_constant():
+    # The previously-uncovered tool now carries the canonical constant verbatim (single source).
+    assert PARAGRAPH_INDEX_DIRECTIVE in GetPageObjects.description

--- a/tests/writer/test_resolve_all_loop.py
+++ b/tests/writer/test_resolve_all_loop.py
@@ -1,0 +1,152 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Headless tests for resolve-all's per-change loop.
+
+The mixed-redlines loop must process EVERY agent change -- resolving what it can and skipping the
+ones blocked by a user redline -- and terminate without a fixed iteration cap, so a document with
+many changes is never truncated (which would make the feedback misattribute unprocessed changes).
+"""
+from unittest.mock import MagicMock, patch
+
+from plugin.writer.inline_review import resolve_all_agent_changes, resolve_all_with_feedback
+
+
+def _run_loop(tokens, blocked):
+    """Drive resolve_all_agent_changes through the mixed-redlines loop path with a fake document
+    whose agent change TOKENS are *tokens*; tokens in *blocked* refuse to resolve (user redline).
+    Loop control now runs off the reliability-aware _agent_change_tokens (returns (set, True))."""
+    state = {"tokens": list(tokens)}
+
+    def fake_tokens(model):
+        return set(state["tokens"]), True
+
+    def fake_resolve(model, ctx, token, accept, refuse_sibling_agent=True, prefer_exact=True):
+        if token in blocked:
+            return False
+        if token in state["tokens"]:
+            state["tokens"].remove(token)
+        return True
+
+    with patch("plugin.writer.inline_review._agent_change_tokens", side_effect=fake_tokens), \
+         patch("plugin.writer.inline_review.resolve_agent_change", side_effect=fake_resolve), \
+         patch("plugin.writer.inline_review._all_redlines_are_agent", return_value=False):  # -> loop path
+        n = resolve_all_agent_changes(MagicMock(), MagicMock(), True)
+    return n, state["tokens"]
+
+
+def test_loop_resolves_everything():
+    n, left = _run_loop(["A", "B", "C"], blocked=set())
+    assert n == 3 and left == []
+
+
+def test_loop_skips_blocked_resolves_rest():
+    n, left = _run_loop(["A", "B", "C"], blocked={"C"})
+    assert n == 2 and left == ["C"]   # C left for the native Manage dialog
+
+
+def test_loop_terminates_when_all_blocked():
+    # Every change blocked by a user redline -> loop still terminates, resolves nothing.
+    n, left = _run_loop(["A", "B"], blocked={"A", "B"})
+    assert n == 0 and left == ["A", "B"]
+
+
+def test_loop_handles_many_changes_without_cap():
+    # Far more than the old magic-200 bound: all must resolve, proving there's no truncation.
+    tokens = ["t%d" % i for i in range(500)]
+    n, left = _run_loop(tokens, blocked=set())
+    assert n == 500 and left == []
+
+
+def test_feedback_message_partial_vs_all_vs_none():
+    # resolve_all_with_feedback wording, driven by resolve_all_agent_changes' count. The total now
+    # comes from the reliability-aware _agent_change_tokens, not the best-effort agent_changes.
+    with patch("plugin.writer.inline_review._agent_change_tokens", return_value=({"A", "B"}, True)), \
+         patch("plugin.writer.inline_review.resolve_all_agent_changes", return_value=2):
+        n, msg = resolve_all_with_feedback(MagicMock(), MagicMock(), True)
+        assert n == 2 and msg == ""           # everything resolved -> no message
+    with patch("plugin.writer.inline_review._agent_change_tokens", return_value=({"A", "B"}, True)), \
+         patch("plugin.writer.inline_review.resolve_all_agent_changes", return_value=1):
+        n, msg = resolve_all_with_feedback(MagicMock(), MagicMock(), True)
+        assert n == 1 and "Resolved 1 of 2" in msg
+    with patch("plugin.writer.inline_review._agent_change_tokens", return_value=({"A"}, True)), \
+         patch("plugin.writer.inline_review.resolve_all_agent_changes", return_value=0):
+        n, msg = resolve_all_with_feedback(MagicMock(), MagicMock(), True)
+        assert n == 0 and "None could be resolved" in msg
+
+
+def test_resolve_all_aborts_when_before_snapshot_unreliable():
+    # The redline snapshot can't be enumerated reliably -> resolve-all refuses entirely with the
+    # sentinel (never a partial count derived from a truncated scan).
+    from plugin.writer.inline_review import _RESOLVE_ALL_UNRELIABLE
+    with patch("plugin.writer.inline_review._agent_change_tokens", return_value=(set(), False)):
+        n = resolve_all_agent_changes(MagicMock(), MagicMock(), True)
+    assert n == _RESOLVE_ALL_UNRELIABLE
+
+
+def test_resolve_all_aborts_when_snapshot_unreliable_mid_loop():
+    # Reliable at entry, then the snapshot goes unreliable on a later pass -> abort with the sentinel
+    # rather than terminate early and silently leave changes pending.
+    from plugin.writer.inline_review import _RESOLVE_ALL_UNRELIABLE
+    calls = {"n": 0}
+
+    def flaky_tokens(model):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {"A", "B"}, True        # entry snapshot: reliable
+        return {"A", "B"}, False           # every later read: unreliable
+
+    with patch("plugin.writer.inline_review._agent_change_tokens", side_effect=flaky_tokens), \
+         patch("plugin.writer.inline_review.resolve_agent_change", return_value=True), \
+         patch("plugin.writer.inline_review._all_redlines_are_agent", return_value=False):
+        n = resolve_all_agent_changes(MagicMock(), MagicMock(), True)
+    assert n == _RESOLVE_ALL_UNRELIABLE
+
+
+def test_feedback_unreliable_snapshot_reports_try_again():
+    # resolve_all_with_feedback surfaces an honest "try again" (and 0 resolved) on an unreliable
+    # snapshot, never a misleading completion message.
+    with patch("plugin.writer.inline_review._agent_change_tokens", return_value=(set(), False)):
+        n, msg = resolve_all_with_feedback(MagicMock(), MagicMock(), True)
+    assert n == 0 and "try again" in msg.lower()
+
+
+def test_resolve_all_global_unconfirmed_after_dispatch():
+    # Global fast path: the dispatch ALREADY ran, then the after-scan is unreliable -> UNCONFIRMED
+    # (changes may have resolved), never "nothing changed".
+    from plugin.writer.inline_review import _RESOLVE_ALL_UNCONFIRMED
+    with patch("plugin.writer.inline_review._agent_change_tokens",
+               side_effect=[({"A", "B"}, True), (set(), False)]), \
+         patch("plugin.writer.inline_review._all_redlines_are_agent", return_value=True):
+        n = resolve_all_agent_changes(MagicMock(), MagicMock(), True)
+    assert n == _RESOLVE_ALL_UNCONFIRMED
+
+
+def test_resolve_all_unconfirmed_when_unreliable_after_a_resolve():
+    # Loop path: a resolve already ran, THEN the snapshot goes unreliable -> UNCONFIRMED, not -1.
+    from plugin.writer.inline_review import _RESOLVE_ALL_UNCONFIRMED
+    calls = {"n": 0}
+
+    def flaky_tokens(model):
+        calls["n"] += 1
+        # 1: entry (reliable); 2: loop-top pass 1 (reliable) -> resolve runs; 3: after-resolve (unreliable)
+        return ({"A", "B"}, True) if calls["n"] <= 2 else ({"A", "B"}, False)
+
+    with patch("plugin.writer.inline_review._agent_change_tokens", side_effect=flaky_tokens), \
+         patch("plugin.writer.inline_review.resolve_agent_change", return_value=True), \
+         patch("plugin.writer.inline_review._all_redlines_are_agent", return_value=False):
+        n = resolve_all_agent_changes(MagicMock(), MagicMock(), True)
+    assert n == _RESOLVE_ALL_UNCONFIRMED
+
+
+def test_feedback_unconfirmed_reports_partial_not_nothing():
+    # The -2 sentinel must NEVER produce a "nothing was changed" message; it says some may have
+    # resolved and to review the rest.
+    from plugin.writer.inline_review import _RESOLVE_ALL_UNCONFIRMED
+    with patch("plugin.writer.inline_review._agent_change_tokens", return_value=({"A", "B"}, True)), \
+         patch("plugin.writer.inline_review.resolve_all_agent_changes", return_value=_RESOLVE_ALL_UNCONFIRMED):
+        n, msg = resolve_all_with_feedback(MagicMock(), MagicMock(), True)
+    assert n == 0
+    assert "nothing was changed" not in msg.lower()
+    assert "couldn't confirm" in msg.lower() and "review" in msg.lower()

--- a/tests/writer/test_review_toolbar_lifecycle.py
+++ b/tests/writer/test_review_toolbar_lifecycle.py
@@ -1,0 +1,109 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Headless tests for the review toolbar's per-document modify-listener lifecycle.
+
+The listener must be torn down when the document is disposed even if the OnUnload document event
+never reaches us (crash / force-close / a failed event-listener install) -- otherwise the listener
+and its registry entry leak, and a later document that reuses the RuntimeUID would be skipped.
+"""
+from unittest.mock import MagicMock, patch
+
+import plugin.writer.review_toolbar as rt
+
+
+class FakeModel:
+    def __init__(self, uid):
+        self._uid = uid
+        self.listeners = []
+
+    def getRuntimeUID(self):
+        return self._uid
+
+    def addModifyListener(self, listener):
+        self.listeners.append(listener)
+
+    def removeModifyListener(self, listener):
+        self.listeners.remove(listener)
+
+
+def test_disposing_drops_registry_entry():
+    # The crash / force-close path: UNO calls disposing() on the listener; the entry must go.
+    rt._modify_listeners.clear()
+    model = FakeModel("uid-1")
+    rt._register_modify_listener(model)
+    assert "uid-1" in rt._modify_listeners
+    listener = rt._modify_listeners["uid-1"]
+    assert listener in model.listeners
+
+    listener.disposing(MagicMock())
+    assert "uid-1" not in rt._modify_listeners
+
+
+def test_unregister_removes_listener_and_entry():
+    # The clean OnUnload path still works.
+    rt._modify_listeners.clear()
+    model = FakeModel("uid-2")
+    rt._register_modify_listener(model)
+    rt._unregister_modify_listener(model)
+    assert "uid-2" not in rt._modify_listeners
+    assert model.listeners == []
+
+
+def test_disposing_is_idempotent_and_safe():
+    # disposing() for a uid that's already gone (e.g. OnUnload ran first) must not raise.
+    rt._modify_listeners.clear()
+    listener = rt._ReviewModifyListener("uid-3")
+    listener.disposing(MagicMock())
+    assert "uid-3" not in rt._modify_listeners
+
+
+def test_disposing_does_not_evict_a_recycled_uid_entry():
+    # If the RuntimeUID was recycled for a newer document, a late disposing() from the OLD listener
+    # must not evict the NEW listener's entry (which would disable auto-hide on the new doc).
+    rt._modify_listeners.clear()
+    old = rt._ReviewModifyListener("uid-R")
+    rt._modify_listeners["uid-R"] = old
+    new = rt._ReviewModifyListener("uid-R")
+    rt._modify_listeners["uid-R"] = new  # uid recycled -> new owner
+    old.disposing(MagicMock())
+    assert rt._modify_listeners["uid-R"] is new
+
+
+def test_register_dedups_by_uid():
+    rt._modify_listeners.clear()
+    model = FakeModel("uid-4")
+    rt._register_modify_listener(model)
+    first = rt._modify_listeners["uid-4"]
+    rt._register_modify_listener(model)  # second call -> dedup, no duplicate listener
+    assert rt._modify_listeners["uid-4"] is first
+    assert len(model.listeners) == 1
+
+
+def test_toolbar_docks_once_per_document():
+    # dock on first appearance only; cycling pending 0->N->0->N must not re-dock and override a
+    # user who has since moved/floated the toolbar.
+    rt._modify_listeners.clear()
+    rt._docked_uids.clear()
+    model = MagicMock()
+    model.getRuntimeUID.return_value = "uid-D"
+    with patch("plugin.writer.review_toolbar._layout_manager", return_value=MagicMock()), \
+         patch("plugin.writer.review_toolbar._dock_top") as dock, \
+         patch("plugin.writer.inline_review.pending_agent_change_count", side_effect=[1, 0, 1]):
+        rt.refresh_review_toolbar(model)   # 0 -> 1 : show + dock
+        rt.refresh_review_toolbar(model)   #   -> 0 : hide
+        rt.refresh_review_toolbar(model)   # 0 -> 1 : show, NO re-dock
+    assert dock.call_count == 1
+    assert "uid-D" in rt._docked_uids
+
+
+def test_disposing_clears_docked_state():
+    rt._modify_listeners.clear()
+    rt._docked_uids.clear()
+    listener = rt._ReviewModifyListener("uid-E")
+    rt._modify_listeners["uid-E"] = listener
+    rt._docked_uids.add("uid-E")
+    listener.disposing(MagicMock())
+    assert "uid-E" not in rt._modify_listeners
+    assert "uid-E" not in rt._docked_uids

--- a/tests/writer/test_split_redlines_uno.py
+++ b/tests/writer/test_split_redlines_uno.py
@@ -1,0 +1,508 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# A small edit (1-2 words) inside a long block must land as TIGHT surgical redlines
+# -- one reviewable change per changed run -- instead of a whole-paragraph delete+insert. A
+# large edit (> threshold of words changed) still lands as a single clean block change. The
+# split is internal: the agent issues one edit and simply gets one outcome per sub-change.
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test, setup, teardown
+from plugin.tests.testing_utils import TestingFactory
+from plugin.writer.content import _record_preserve_replace
+from plugin.writer.edit_review import EditReviewSession
+from plugin.writer.inline_review import agent_changes, resolve_agent_change
+
+_PARA_BREAK = uno.getConstantByName("com.sun.star.text.ControlCharacter.PARAGRAPH_BREAK")
+
+_doc = None
+_ctx = None
+
+
+@setup
+def my_setup(ctx):
+    global _doc, _ctx
+    _ctx = ctx
+    _doc = TestingFactory.create_native_doc(ctx, doc_type="writer", hidden=True)
+
+
+@teardown
+def my_teardown(ctx):
+    global _doc
+    if _doc:
+        _doc.close(True)
+    _doc = None
+
+
+def _find(needle):
+    sd = _doc.createSearchDescriptor()
+    sd.setSearchString(needle)
+    return _doc.findFirst(sd)
+
+
+def _body(*paragraphs):
+    text = _doc.getText()
+    _doc.setPropertyValue("RecordChanges", False)
+    cur = text.createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEnd(True)
+    cur.setString("")
+    cur.gotoStart(False)
+    for i, para in enumerate(paragraphs):
+        if i:
+            text.insertControlCharacter(cur, _PARA_BREAK, False)
+        text.insertString(cur, para, False)
+    if len(_doc.getRedlines()):
+        _accept_all()
+
+
+def _accept_all():
+    helper = _ctx.getServiceManager().createInstanceWithContext("com.sun.star.frame.DispatchHelper", _ctx)
+    helper.executeDispatch(_doc.getCurrentController().getFrame(), ".uno:AcceptAllTrackedChanges", "", 0, ())
+
+
+def _para_with(needle):
+    f = _find(needle)
+    if f is None:
+        return None
+    t = f.getText().createTextCursorByRange(f.getStart())
+    t.gotoStartOfParagraph(False)
+    t.gotoEndOfParagraph(True)
+    return t.getString()
+
+
+_LONG = "The quick brown fox jumps over the lazy dog near the river bank today."
+
+
+@native_test
+def test_split_small_change_makes_tight_surgical_changes_uno():
+    """Two non-adjacent word tweaks in a long paragraph -> TWO tight surgical changes (just the
+    words), not one whole-paragraph delete+insert."""
+    _body(_LONG)
+    found = _find(_LONG)
+    new = _LONG.replace("quick", "fast").replace("lazy", "sleepy")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, True)
+    session.cleanup()
+    changes = agent_changes(_doc)
+    assert len(changes) == 2, "a 2-word tweak must split into 2 surgical changes: %r" % changes
+    assert sorted(c["old"] for c in changes) == ["lazy", "quick"], changes
+    assert sorted(c["new"] for c in changes) == ["fast", "sleepy"], changes
+    _body("reset")
+
+
+@native_test
+def test_split_adjacent_words_agglutinate_into_one_change_uno():
+    """Two ADJACENT changed words collapse into ONE surgical change (consecutive run)."""
+    _body(_LONG)
+    found = _find(_LONG)
+    new = _LONG.replace("quick brown", "slow grey")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, True)
+    session.cleanup()
+    changes = agent_changes(_doc)
+    assert len(changes) == 1, "adjacent changed words must agglutinate into 1 change: %r" % changes
+    assert changes[0]["old"] == "quick brown" and changes[0]["new"] == "slow grey", changes[0]
+    _body("reset")
+
+
+@native_test
+def test_split_changes_resolve_individually_uno():
+    """Each surgical change is its own reviewable unit -- accept one, the other stays."""
+    _body(_LONG)
+    found = _find(_LONG)
+    new = _LONG.replace("quick", "fast").replace("lazy", "sleepy")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, True)
+    session.cleanup()
+    changes = agent_changes(_doc)
+    assert len(changes) == 2, changes
+    tok = [c["token"] for c in changes if c["new"] == "fast"][0]
+    assert resolve_agent_change(_doc, _ctx, tok, True) is True, "one surgical change must resolve alone"
+    left = agent_changes(_doc)
+    assert len(left) == 1 and left[0]["new"] == "sleepy", "the other surgical change stays pending: %r" % left
+    _body("reset")
+
+
+@native_test
+def test_split_large_change_stays_single_block_uno():
+    """A change above the threshold (most words changed) stays ONE clean block edit."""
+    _body("alpha beta gamma")
+    found = _find("alpha beta gamma")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, "totally different replacement words", _ctx, True)
+    session.cleanup()
+    changes = agent_changes(_doc)
+    assert len(changes) == 1, "a >threshold change must stay a single block change: %r" % changes
+    _body("reset")
+
+
+@native_test
+def test_split_accept_all_reconstructs_new_text_uno():
+    """Accepting every surgical change yields exactly the agent's intended new text."""
+    para = "The quick brown fox jumps over the lazy dog."
+    new = "The fast brown fox leaps over the lazy dog."  # quick->fast, jumps->leaps
+    _body(para)
+    found = _find(para)
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, True)
+    session.cleanup()
+    assert len(agent_changes(_doc)) == 2, agent_changes(_doc)
+    _accept_all()
+    assert _para_with("brown") == new, "accepting all surgical edits must yield the new text, got %r" % _para_with("brown")
+    _body("reset")
+
+
+@native_test
+def test_split_off_when_not_recording_single_change_uno():
+    """With split disabled (review recording off) the edit is one whole replace, as before."""
+    _body(_LONG)
+    found = _find(_LONG)
+    new = _LONG.replace("quick", "fast").replace("lazy", "sleepy")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, False)  # split=False
+    session.cleanup()
+    changes = agent_changes(_doc)
+    assert len(changes) == 1, "split=False must keep the old single-change behaviour: %r" % changes
+    _body("reset")
+
+
+@native_test
+def test_diff_threshold_default_constant_uno():
+    """The surgical-vs-block threshold is a named module constant (env-overridable via
+    WRITERAGENT_AGENT_EDIT_DIFF_THRESHOLD, NOT a settings-UI config key), defaulting to 0.6."""
+    from plugin.writer.content import _WORD_DIFF_THRESHOLD
+    assert _WORD_DIFF_THRESHOLD == 0.6, "_WORD_DIFF_THRESHOLD should default to 0.6"
+
+
+@native_test
+def test_review_payload_includes_final_text_uno():
+    """Per-change final_text is the CHANGE's OWN region (scoped to its anchor span), not
+    the whole paragraph -- so neighbouring changes in the same paragraph don't contaminate each
+    other's report, and a change deep in a long paragraph is never truncated out of the preview."""
+    _body("Intro.", _LONG)
+    found = _find(_LONG)
+    new = _LONG.replace("quick", "fast").replace("lazy", "sleepy")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, True)
+        payload = session._review_payload(complete=False, timed_out=False)
+    session.cleanup()
+    changes = payload["changes"]
+    assert len(changes) == 2, changes
+    fts = [c.get("final_text") or "" for c in changes]
+    joined = " ".join(fts)
+    # Each change reports its own inserted word; struck old text is skipped (no "quickfast" glue).
+    assert "fast" in joined and "sleepy" in joined, fts
+    assert "quickfast" not in joined and "sleepylazy" not in joined, fts
+    # Scoped per change -> the two reports differ and neither carries the OTHER change's word
+    # (nor the unrelated "brown" between them, which the old whole-paragraph final_text included).
+    fast_ft = next(ft for ft in fts if "fast" in ft)
+    sleepy_ft = next(ft for ft in fts if "sleepy" in ft)
+    assert "sleepy" not in fast_ft and "brown" not in fast_ft, fast_ft
+    assert "fast" not in sleepy_ft and "brown" not in sleepy_ft, sleepy_ft
+    _body("reset")
+
+
+@native_test
+def test_e2e_split_navigate_resolve_report_uno():
+    """End-to-end (logical, not GUI): agent edit changes 2 words in a long paragraph -> splits into
+    2 surgical changes -> fast-travel visits them -> accept one individually ->
+    per-change report shows outcome + final_text."""
+    from plugin.writer.inline_review import (goto_adjacent_agent_change,
+                                             pending_agent_change_count, resolve_agent_change)
+    _body("Intro.", _LONG)
+    found = _find(_LONG)
+    new = _LONG.replace("quick", "fast").replace("lazy", "sleepy")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, True)
+        assert pending_agent_change_count(_doc) == 2, "split into 2 surgical changes"
+        _doc.getCurrentController().getViewCursor().gotoRange(_doc.getText().getStart(), False)
+        first = goto_adjacent_agent_change(_doc, True)
+        assert first is not None, "fast-travel must land on a change"
+        assert resolve_agent_change(_doc, _ctx, first, True) is True, "accept that one alone"
+        assert pending_agent_change_count(_doc) == 1, "the other stays pending"
+        payload = session._review_payload(complete=False, timed_out=False)
+    session.cleanup()
+    chs = payload["changes"]
+    assert len(chs) == 2, chs
+    # Per-change outcome is now scoped to the change's own region, so a PARTIAL resolution
+    # of two changes sharing a paragraph reports the accepted one as "accepted" and the other as
+    # "pending" -- the per-change outcome is reliable, no longer a whole-paragraph approximation.
+    by_outcome = {c["outcome"]: c for c in chs}
+    assert set(by_outcome) == {"accepted", "pending"}, chs
+    assert "fast" in (by_outcome["accepted"]["final_text"] or ""), by_outcome["accepted"]
+    assert "sleepy" in (by_outcome["pending"]["final_text"] or ""), by_outcome["pending"]
+    _body("reset")
+
+
+@native_test
+def test_pure_insertion_and_deletion_outcomes_uno():
+    """Edge: pure-insertion and pure-deletion changes (the redline shapes the scoping fix
+    changed, not covered by the replace tests) report outcome + final_text from their own scoped
+    anchor span."""
+    # Pure insertion, accepted -> "accepted", inserted word present in final_text.
+    _body("The lazy dog.")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, _find("dog"), "dog runs", _ctx, True)
+        chs = agent_changes(_doc)
+        assert len(chs) == 1 and "runs" in chs[0]["new"], chs
+        assert resolve_agent_change(_doc, _ctx, chs[0]["token"], True) is True
+        ins = session._review_payload(complete=False, timed_out=False)["changes"][0]
+    session.cleanup()
+    assert ins["outcome"] == "accepted" and "runs" in (ins["final_text"] or ""), ins
+
+    # Pure deletion, rejected -> "rejected", restored word present in final_text.
+    _body("The lazy dog.")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, _find("lazy "), "", _ctx, True)
+        chs = agent_changes(_doc)
+        assert len(chs) == 1 and "lazy" in chs[0]["old"], chs
+        assert resolve_agent_change(_doc, _ctx, chs[0]["token"], False) is True
+        dele = session._review_payload(complete=False, timed_out=False)["changes"][0]
+    session.cleanup()
+    assert dele["outcome"] == "rejected" and "lazy" in (dele["final_text"] or ""), dele
+    _body("reset")
+
+
+@native_test
+def test_split_three_runs_resolve_individually_and_reconstruct_uno():
+    """THREE surgical changes in one paragraph -> three independently reviewable changes. This
+    exercises the real right-to-left offset application for 3+ runs (the central risk, previously
+    only smoke-tested with two words): resolve the middle one alone, then accept the rest and confirm
+    the paragraph reconstructs to the agent's text exactly."""
+    base = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu"
+    _body("Intro.", base)
+    found = _find(base)
+    new = base.replace("beta", "BETA").replace("delta", "DELTA").replace("zeta", "ZETA")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, True)
+        chs = agent_changes(_doc)
+        assert len(chs) == 3, chs   # three independent surgical runs
+        mid = [c for c in chs if "DELTA" in c["new"]][0]
+        assert resolve_agent_change(_doc, _ctx, mid["token"], True) is True  # accept the middle alone
+        assert len(agent_changes(_doc)) == 2, "the other two stay pending"
+    session.cleanup()
+    _accept_all()  # accept the remaining two
+    assert _para_with("alpha") == new, "paragraph must reconstruct to the agent's text exactly"
+    _body("reset")
+
+
+@native_test
+def test_final_text_not_truncated_for_deep_change_uno():
+    """A change deep in a long paragraph (well past the preview cap) is still shown in
+    final_text, because final_text is the change's OWN region, not the paragraph's first N chars."""
+    long_para = ("alpha " * 120) + "TARGETWORD " + ("omega " * 40)  # TARGETWORD sits ~720 chars in
+    _body("Intro.", long_para)
+    found = _find(long_para)
+    new = long_para.replace("TARGETWORD", "REPLACEMENT")
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, found, new, _ctx, True)
+        payload = session._review_payload(complete=False, timed_out=False)
+    session.cleanup()
+    chs = payload["changes"]
+    assert len(chs) == 1, chs
+    ft = chs[0]["final_text"] or ""
+    assert "REPLACEMENT" in ft, "deep change must appear in final_text (N2): %r" % ft
+    _body("reset")
+
+
+@native_test
+def test_block_safe_for_surgical_guard_uno():
+    """The surgical path only runs on a clean SINGLE-paragraph plain-text block; otherwise
+    char offsets diverge from cursor stops, so it must fall back to the whole-block replace."""
+    from plugin.writer.content import _block_safe_for_surgical
+    _body("Just some plain words here.")
+    assert _block_safe_for_surgical(_find("Just some plain words here.")) is True, "clean block is safe"
+    # a range spanning TWO paragraphs -> unsafe
+    _body("First para here.", "Second para here.")
+    cur = _doc.getText().createTextCursor()
+    cur.gotoStart(False)
+    cur.gotoEnd(True)
+    assert _block_safe_for_surgical(cur) is False, "multi-paragraph block must be unsafe"
+    # a block that already holds a tracked change (struck text) -> unsafe
+    _body("Alpha beta gamma delta.")
+    _doc.setPropertyValue("RecordChanges", True)
+    f = _find("beta")
+    tc = f.getText().createTextCursorByRange(f)
+    tc.setString("")
+    f.getText().insertString(tc, "BETA", False)
+    _doc.setPropertyValue("RecordChanges", False)
+    para = _find("Alpha")
+    pc = para.getText().createTextCursorByRange(para.getStart())
+    pc.gotoStartOfParagraph(False)
+    pc.gotoEndOfParagraph(True)
+    assert _block_safe_for_surgical(pc) is False, "block with a pre-existing tracked change must be unsafe"
+    _accept_all()
+    _body("reset")
+
+
+@native_test
+def test_go_right_chunks_past_short_cap_uno():
+    """_go_right moves/selects correctly PAST goRight's 32767 short cap (chunked). This is
+    the offset helper the surgical path uses; before the fix a raw goRight(>32767) overflowed.
+    Tested directly because the surgical path needs a search range (which we can't build for a
+    35000-char block via findFirst)."""
+    from plugin.writer.content import _go_right
+    _body(("word " * 7000) + "TARGET tail.")    # ~35000 chars, one paragraph, past the short cap
+    cur = _doc.getText().createTextCursor()
+    cur.gotoStart(False)
+    _go_right(cur, len("word " * 7000), False)   # move to offset 35000 (> 32767)
+    _go_right(cur, len("TARGET"), True)          # select the next word
+    assert cur.getString() == "TARGET", "chunked goRight landed at the wrong offset: %r" % cur.getString()
+    _body("reset")
+
+
+@native_test
+def test_surgical_partial_apply_rolls_back_atomically_uno():
+    """Atomicity: when a surgical sub-edit fails AFTER an earlier one already landed (a
+    replace deletes then inserts -- insertString can throw post-delete), the WHOLE batch must roll
+    back. Proves the two UNO semantics the fix relies on and unit fakes can't: (a) undoing the
+    grouped context removes the first sub-edit's tagged redlines, (b) the orphan anchor bookmark is
+    cleaned -- so the document is byte-for-byte pristine and the failure is surfaced, not swallowed."""
+    import plugin.writer.format as fmt
+
+    base = "The quick brown fox jumps over the lazy dog near the river."
+    _body(base)
+    found = _find(base)
+    new = base.replace("quick", "fast").replace("lazy", "sleepy")  # exactly two surgical sub-edits
+
+    redlines_before = len(_doc.getRedlines())
+    bookmarks_before = set(_doc.getBookmarks().getElementNames())
+
+    real = fmt.replace_preserving_format
+    state = {"n": 0}
+
+    def flaky(*a, **k):
+        state["n"] += 1
+        if state["n"] == 2:  # second applied sub-edit: simulate insertString failing after the delete
+            raise RuntimeError("simulated mid-apply failure")
+        return real(*a, **k)
+
+    raised = False
+    fmt.replace_preserving_format = flaky
+    try:
+        with EditReviewSession(_doc, _ctx, enabled=True) as session:
+            _record_preserve_replace(session, _doc, found, new, _ctx, True)
+    except RuntimeError as e:
+        raised = True
+        assert "mid-apply failure" in str(e), e
+    finally:
+        fmt.replace_preserving_format = real
+    session.cleanup()
+
+    assert raised, "a mid-apply sub-edit failure must propagate (honest failure), not be swallowed"
+    assert state["n"] == 2, "expected 1 ok + 1 failing apply, got %d calls" % state["n"]
+    # All-or-nothing: document rolled back to the original.
+    assert _para_with("fox") == base, "paragraph must be rolled back to the original: %r" % _para_with("fox")
+    assert len(_doc.getRedlines()) == redlines_before, \
+        "the first sub-edit's tracked change must be undone (no redlines left): %d" % len(_doc.getRedlines())
+    assert set(_doc.getBookmarks().getElementNames()) == bookmarks_before, \
+        "no orphan anchor bookmark may survive the rollback"
+    assert len(session.changes) == 0, "partial change records must be trimmed: %r" % session.changes
+    _body("reset")
+
+
+@native_test
+def test_surgical_first_subedit_failure_preserves_prior_undo_uno():
+    """Empty-context safety: if the FIRST surgical sub-edit fails BEFORE mutating anything,
+    the undo context is empty and discarded on leave -- so the rollback must NOT call undo() (that
+    would revert the user's PRIOR action). Proves the empty-context-discard semantics with a real
+    undoable user edit that must survive the failed batch."""
+    import plugin.writer.format as fmt
+
+    _body("Alpha beta gamma delta epsilon zeta.")
+    # A real, undoable user edit BEFORE the agent batch -- it MUST survive the rollback.
+    _doc.setPropertyValue("RecordChanges", False)
+    text = _doc.getText()
+    cur = text.createTextCursor()
+    cur.gotoEnd(False)
+    text.insertString(cur, " USEREDIT", False)
+    assert "USEREDIT" in _para_with("Alpha"), "precondition: the user edit is present"
+
+    base = "Alpha beta gamma delta epsilon zeta. USEREDIT"
+    found = _find(base)
+    new = base.replace("beta", "BETA").replace("delta", "DELTA")  # two surgical sub-edits
+
+    real = fmt.replace_preserving_format
+
+    def always_fail(*a, **k):
+        raise RuntimeError("first sub-edit fails before mutating")
+
+    raised = False
+    fmt.replace_preserving_format = always_fail
+    try:
+        with EditReviewSession(_doc, _ctx, enabled=True) as session:
+            _record_preserve_replace(session, _doc, found, new, _ctx, True)
+    except RuntimeError:
+        raised = True
+    finally:
+        fmt.replace_preserving_format = real
+    session.cleanup()
+
+    assert raised, "the failure must propagate"
+    assert "USEREDIT" in _para_with("Alpha"), \
+        "rollback wrongly reverted the user's prior action: %r" % _para_with("Alpha")
+    assert len(session.changes) == 0, "nothing was applied, so no change records: %r" % session.changes
+    _body("reset")
+
+
+@native_test
+def test_prior_surgical_batch_survives_later_empty_failed_batch_uno():
+    """Two surgical batches in one session (the all_matches case) on a REAL undo manager.
+    Batch 1 applies and leaves its uniquely-titled context on the undo stack; batch 2's first sub-edit
+    fails before mutating, so its context is EMPTY and discarded on leave -- exposing batch 1's title
+    on top. The per-batch-unique title must stop batch 2's rollback from undoing batch 1's good edit
+    (a constant title would match and revert it)."""
+    import plugin.writer.format as fmt
+
+    b1 = "The quick brown fox jumps over the lazy dog."
+    b2 = "A nimble red cat leaps across the small wooden fence."
+    _body(b1, b2)
+    new1 = b1.replace("quick", "fast").replace("lazy", "sleepy")
+    new2 = b2.replace("nimble", "quick").replace("small", "tiny")
+
+    real = fmt.replace_preserving_format
+    raised = False
+    with EditReviewSession(_doc, _ctx, enabled=True) as session:
+        _record_preserve_replace(session, _doc, _find(b1), new1, _ctx, True)  # batch 1 succeeds
+        changes_after_b1 = len(session.changes)
+        assert changes_after_b1 >= 1, "batch 1 must record at least one change"
+
+        def always_fail(*a, **k):  # batch 2's first sub-edit fails before mutating -> empty context
+            raise RuntimeError("batch2 boom")
+
+        fmt.replace_preserving_format = always_fail
+        try:
+            _record_preserve_replace(session, _doc, _find(b2), new2, _ctx, True)
+        except RuntimeError:
+            raised = True
+        finally:
+            fmt.replace_preserving_format = real
+
+        assert raised, "batch 2's failure must propagate"
+        assert len(session.changes) == changes_after_b1, "batch 2 must not drop batch 1's records"
+    session.cleanup()
+
+    # Batch 1's edit must still be present (NOT reverted by batch 2's rollback). _para_with skips the
+    # tracked deletions, so the live paragraph reads as the post-accept text.
+    assert "fast" in (_para_with("brown") or ""), \
+        "batch 1's surgical edit was wrongly reverted by batch 2's rollback: %r" % _para_with("brown")
+    _body("reset")
+
+
+@native_test
+def test_softpagebreak_offset_safe_whitelist_uno():
+    """An automatic SoftPageBreak (layout-only -- contributes 0 chars to getString() and is
+    not a goRight stop; verified live that navigating getString offsets across one lands exactly
+    right) must NOT force whole-block, so a paragraph that merely straddles a page boundary keeps
+    its surgical sub-edits. Real content portions DO shift offsets and must keep forcing block.
+    Pins the offset-safe whitelist (a layout-dependent behavioural test would be flaky headless)."""
+    from plugin.writer.content import _OFFSET_SAFE_PORTION_TYPES
+    assert "Text" in _OFFSET_SAFE_PORTION_TYPES
+    assert "SoftPageBreak" in _OFFSET_SAFE_PORTION_TYPES, \
+        "SoftPageBreak is offset-safe and must be allowed (else page-straddling paragraphs lose surgical)"
+    for content_portion in ("TextField", "Footnote", "Bookmark", "Ruby", "Frame", "Redline"):
+        assert content_portion not in _OFFSET_SAFE_PORTION_TYPES, \
+            "%s shifts getString offsets vs goRight and must keep forcing whole-block" % content_portion

--- a/tests/writer/test_surgical_offset_guard.py
+++ b/tests/writer/test_surgical_offset_guard.py
@@ -1,0 +1,632 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Headless tests for the surgical tracked-change offset safety net.
+
+The surgical path in ``_record_preserve_replace`` places each sub-edit by counting characters
+(``_go_right``) from the block start, then replaces. If the cursor ever lands short (goRight stops
+early), the edit would hit the WRONG characters and silently corrupt the document. These tests pin,
+WITHOUT a live LibreOffice (a fake UNO text/cursor), that:
+
+  * ``_go_right`` reports whether the FULL move happened (True) or it stopped short (False),
+  * a sub-edit whose offset can't be reached aborts surgical and falls back to ONE whole-block
+    replace (never a misplaced edit),
+  * the happy path records exactly the surgical sub-edits, and
+  * an offset that drifts AFTER the pre-flight validation fails LOUD (raises) instead of corrupting.
+
+The real splitter (``word_diff_split.split_change``) is used for real; only UNO is faked.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugin.writer.content import (
+    _AGENT_EDIT_UNDO_TITLE,
+    _GO_RIGHT_CHUNK,
+    _SURGICAL_UNDO_TITLE,
+    _go_right,
+    _record_html_atomically,
+    _record_preserve_replace,
+)
+from plugin.framework.errors import ToolExecutionError
+from plugin.writer.word_diff_split import split_change
+
+_THRESHOLD = 0.6
+
+
+class FakeCursor:
+    """A model text cursor over *block*. ``max_reach`` is the furthest char index goRight can reach
+    (to simulate an early stop); ``shift`` skews getString to simulate offset drift."""
+
+    def __init__(self, block, max_reach, shift=0):
+        self.block = block
+        self.max_reach = max_reach
+        self.shift = shift
+        self.start = 0
+        self.end = 0
+
+    def goRight(self, n, expand):
+        target = self.end + n
+        reached = min(target, self.max_reach)
+        if expand:
+            self.end = reached
+        else:
+            self.start = self.end = reached
+        return reached == target
+
+    def getString(self):
+        return self.block[self.start + self.shift:self.end + self.shift]
+
+
+class FakeText:
+    def __init__(self, block, max_reach=None, drift_after=None):
+        self.block = block
+        self.max_reach = len(block) if max_reach is None else max_reach
+        self.drift_after = drift_after
+        self.created = 0
+
+    def createTextCursorByRange(self, anchor):
+        self.created += 1
+        shift = 1 if (self.drift_after is not None and self.created > self.drift_after) else 0
+        return FakeCursor(self.block, self.max_reach, shift)
+
+
+class FakeFound:
+    def __init__(self, block, max_reach=None, drift_after=None):
+        self.block = block
+        self._text = FakeText(block, max_reach, drift_after)
+
+    def getString(self):
+        return self.block
+
+    def getText(self):
+        return self._text
+
+    def getStart(self):
+        return "ANCHOR"
+
+
+class FakeSession:
+    """Records every record_mutation call and applies its fn (to exercise apply_se).
+
+    A record is appended only AFTER its fn succeeds -- mirroring the real session, where apply_fn
+    raising means no ChangeRecord lands -- so ``changes`` reflects exactly the sub-edits that took,
+    which the rollback then trims back via ``discard_changes_since``."""
+
+    def __init__(self):
+        self.calls = []  # (original_preview, proposed_preview)
+        self.changes = []
+        self.discarded_to = None
+
+    def record_mutation(self, fn, original_preview=None, proposed_preview=None):
+        fn()  # if this raises, nothing is recorded (real session appends only after apply_fn returns)
+        self.calls.append((original_preview, proposed_preview))
+        self.changes.append((original_preview, proposed_preview))
+
+    def discard_changes_since(self, count):
+        self.discarded_to = count
+        del self.changes[count:]
+
+
+class FakeUndoManager:
+    """Faithful-enough XUndoManager: models the undo STACK so the per-batch-unique title and the
+    empty-context-discard-on-leave semantics are exercised for real, not hard-coded.
+
+    ``record_action()`` (wired through the replace mock for each landed mutation) records an action
+    in the open context; ``leaveUndoContext`` pushes a NON-empty context's title onto the stack and
+    DISCARDS an empty one (matching the UNO contract). ``prior`` seeds the stack with actions that
+    predate the batch (e.g. an earlier successful surgical match, or an unrelated user action)."""
+
+    def __init__(self, prior=(), locked=False):
+        self.stack = list(prior)   # titles already on the stack, oldest..newest
+        self.entered = []
+        self.leaves = 0
+        self.undos = 0
+        self._locked = locked
+        self._open = []            # [title, action_count] per currently-open context
+
+    def isLocked(self):
+        return self._locked
+
+    def enterUndoContext(self, title):
+        self.entered.append(title)
+        self._open.append([title, 0])
+
+    def record_action(self):
+        if self._open:
+            self._open[-1][1] += 1
+
+    def leaveUndoContext(self):
+        self.leaves += 1
+        title, n = self._open.pop()
+        if n > 0:
+            self.stack.append(title)        # non-empty context lands as one combined action
+            if self._open:                  # nested -> counts as an action of its parent
+                self._open[-1][1] += 1
+        # an empty context is discarded (nothing pushed) -- the UNO contract
+
+    def getAllUndoActionTitles(self):       # newest-first, per UNO
+        return tuple(reversed(self.stack))
+
+    def undo(self):
+        self.undos += 1
+        if self.stack:
+            self.stack.pop()
+
+
+class FakeDoc:
+    def __init__(self, undo_mgr):
+        self._um = undo_mgr
+
+    def getUndoManager(self):
+        return self._um
+
+
+def _wire_replace(um, replace_script):
+    """A replace_preserving_format stand-in: each call consumes the next entry of *replace_script*
+    (an Exception instance/class -> raise it; anything else -> success). On success it records an
+    action in *um*'s open context so the fake's stack reflects what actually landed. No script ->
+    every call succeeds."""
+    script = list(replace_script) if replace_script is not None else None
+    state = {"i": 0}
+
+    def fake_replace(*a, **k):
+        outcome = None
+        if script is not None and state["i"] < len(script):
+            outcome = script[state["i"]]
+        state["i"] += 1
+        if isinstance(outcome, BaseException) or (isinstance(outcome, type) and issubclass(outcome, BaseException)):
+            raise outcome
+        if um is not None:
+            um.record_action()
+        return None
+
+    return fake_replace
+
+
+def _run(found, old, new, max_runs=10_000, threshold=_THRESHOLD, doc=None, replace_side_effect=None,
+         session=None, split_author=True):
+    session = session if session is not None else FakeSession()
+    if doc is None:
+        doc = FakeDoc(FakeUndoManager())  # a real (unlocked) faithful undo manager by default
+    um = getattr(doc, "_um", None)
+    # The tuning knobs are plain module constants now (env-overridable, not config keys); pin them so
+    # each test is deterministic. _SPLIT_AUTHOR_COLORS default True == today's two-step behaviour; set
+    # False to exercise the one-color path.
+    with patch("plugin.writer.content._block_safe_for_surgical", return_value=True), \
+         patch("plugin.writer.content._WORD_DIFF_THRESHOLD", threshold), \
+         patch("plugin.writer.content._MAX_SURGICAL_RUNS", max_runs), \
+         patch("plugin.writer.content._SPLIT_AUTHOR_COLORS", split_author), \
+         patch("plugin.writer.format.replace_preserving_format",
+               side_effect=_wire_replace(um, replace_side_effect)) as mock_replace:
+        _record_preserve_replace(session, doc, found, new, MagicMock(), split=True)
+    return session, mock_replace
+
+
+# --------------------------------------------------------------------------- _go_right
+
+def test_go_right_full_move_returns_true():
+    c = FakeCursor("x" * 100, max_reach=100)
+    assert _go_right(c, 50, False) is True
+    assert c.start == 50
+
+
+def test_go_right_partial_move_returns_false():
+    # goRight can only reach 30 of the requested 50 -> must report failure, not silently stop.
+    c = FakeCursor("x" * 100, max_reach=30)
+    assert _go_right(c, 50, False) is False
+
+
+def test_go_right_consumes_full_count_past_short_cap():
+    # A count larger than the C++ short chunk must still fully consume when reachable.
+    big = _GO_RIGHT_CHUNK * 3 + 7
+    c = FakeCursor("x" * (big + 10), max_reach=big + 10)
+    assert _go_right(c, big, False) is True
+    assert c.start == big
+
+
+# --------------------------------------------------------------------------- surgical happy path
+
+def test_surgical_happy_path_records_each_sub_edit():
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    result = split_change(old, new, _THRESHOLD)
+    assert result.is_surgical and len(result.sub_edits) >= 2  # sanity: this IS the surgical case
+
+    session, mock_replace = _run(FakeFound(old), old, new)
+
+    # one recorded mutation per sub-edit, no whole-block fallback
+    assert len(session.calls) == len(result.sub_edits)
+    assert mock_replace.call_count == len(result.sub_edits)
+    recorded = {(o, p) for o, p in session.calls}
+    expected = {(se.old_text, se.new_text) for se in result.sub_edits}
+    assert recorded == expected
+
+
+def test_surgical_insertion_sub_edit_validates_empty_old_text():
+    # A pure insertion (old_start == old_end, empty old_text) must pass the pre-flight, not fall back.
+    old = "hello world"
+    new = "hello big world"
+    result = split_change(old, new, _THRESHOLD)
+    assert result.is_surgical and any(se.old_text == "" for se in result.sub_edits)
+
+    session, mock_replace = _run(FakeFound(old), old, new)
+    assert len(session.calls) == len(result.sub_edits)
+    assert mock_replace.call_count == len(result.sub_edits)
+
+
+# --------------------------------------------------------------------------- fallback / fail-loud
+
+def test_unreachable_offset_falls_back_to_whole_block():
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    # Cursor can only reach char 10; the second sub-edit (deep in the block) is unreachable.
+    session, mock_replace = _run(FakeFound(old, max_reach=10), old, new)
+
+    # Pre-flight aborts surgical -> exactly ONE whole-block replace of the entire old text.
+    assert len(session.calls) == 1
+    assert mock_replace.call_count == 1
+    original_preview, proposed_preview = session.calls[0]
+    assert original_preview == old
+    assert proposed_preview == new
+
+
+def test_too_many_surgical_runs_falls_back_to_block():
+    # A very scattered edit (3 changed runs) with the cap at 2 must land as ONE whole-block change.
+    old = "a b c d e f g"
+    new = "a X c Y e Z g"
+    result = split_change(old, new, _THRESHOLD)
+    assert result.is_surgical and len(result.sub_edits) == 3  # sanity: 3 surgical runs
+
+    session, mock_replace = _run(FakeFound(old), old, new, max_runs=2)
+    assert len(session.calls) == 1                 # one whole-block mutation, not 3
+    assert session.calls[0][0] == old              # original_preview is the whole old text
+    assert mock_replace.call_count == 1
+
+
+def test_surgical_runs_at_cap_stay_surgical():
+    old = "a b c d e f g"
+    new = "a X c Y e Z g"
+    session, mock_replace = _run(FakeFound(old), old, new, max_runs=3)
+    assert len(session.calls) == 3                 # at the cap -> still surgical, one per run
+    assert mock_replace.call_count == 3
+
+
+def test_threshold_flows_into_block_vs_surgical_decision():
+    # the CONFIGURED threshold must actually change the block-vs-surgical OUTCOME end-to-end
+    # through _record_preserve_replace, not just be readable. Same edit (~0.36 changed fraction):
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    # threshold BELOW the change fraction -> one whole block.
+    block_session, block_replace = _run(FakeFound(old), old, new, threshold=0.3)
+    assert len(block_session.calls) == 1
+    assert block_replace.call_count == 1
+    # threshold ABOVE the change fraction -> surgical sub-edits.
+    surg_session, surg_replace = _run(FakeFound(old), old, new, threshold=0.6)
+    assert len(surg_session.calls) == 2
+    assert surg_replace.call_count == 2
+
+
+def test_offset_drift_after_preflight_raises():
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    n_edits = len(split_change(old, new, _THRESHOLD).sub_edits)
+    # Honest cursors during the pre-flight pass (n_edits creations), drifted ones afterward (apply).
+    found = FakeFound(old, drift_after=n_edits)
+    with pytest.raises(RuntimeError, match="drifted"):
+        _run(found, old, new)
+
+
+# --------------------------------------------------------- atomicity: rollback on mid-apply failure
+
+def test_midapply_failure_undoes_batch_and_trims_partial_records():
+    # Two sub-edits pass the pre-flight; the FIRST applied (right-to-left) replace lands, the SECOND
+    # raises (insertString failing after the delete). The batch must be rolled back as a unit: undo
+    # the grouped context and drop the partial change record, then re-raise (all-or-nothing).
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    assert len(split_change(old, new, _THRESHOLD).sub_edits) == 2  # sanity: exactly two sub-edits
+    um = FakeUndoManager()
+
+    with pytest.raises(RuntimeError, match="insert boom"):
+        _run(FakeFound(old), old, new, doc=FakeDoc(um),
+             replace_side_effect=[None, RuntimeError("insert boom")])
+
+    assert len(um.entered) == 1 and um.entered[0].startswith(_SURGICAL_UNDO_TITLE)  # grouped, unique title
+    assert um.leaves == 1                        # context closed exactly once (rollback path)
+    assert um.undos == 1                         # our context was on top -> undone
+    assert um.stack == []                        # the batch's action was undone off the stack
+
+
+def test_midapply_failure_session_records_rolled_back():
+    # Same scenario, asserting the SESSION side: the one change recorded before the failure is
+    # discarded back to the pre-batch count so no orphan reviewable change survives a failed batch.
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    um = FakeUndoManager()
+    session = FakeSession()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _run(FakeFound(old), old, new, doc=FakeDoc(um), session=session,
+             replace_side_effect=[None, RuntimeError("boom")])
+
+    assert session.discarded_to == 0     # trimmed back to the pre-batch length
+    assert session.changes == []         # the partial record is gone
+
+
+def test_failed_undo_keeps_partial_records_rather_than_orphaning():
+    # A later sub-edit fails AND the rollback undo() itself fails: the partial edit is still live, so
+    # its change record must be KEPT (not trimmed) -- dropping it would orphan a tagged redline with
+    # no reviewable change. The original error is still re-raised.
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+
+    class ExplodingUndoManager(FakeUndoManager):
+        def undo(self):
+            self.undos += 1
+            raise RuntimeError("undo unavailable")
+
+    um = ExplodingUndoManager()
+    session = FakeSession()
+    with pytest.raises(RuntimeError, match="boom"):
+        _run(FakeFound(old), old, new, doc=FakeDoc(um), session=session,
+             replace_side_effect=[None, RuntimeError("boom")])
+
+    assert um.undos == 1                 # undo was attempted
+    assert session.discarded_to is None  # but records were NOT trimmed (undo failed)
+    assert len(session.changes) == 1     # the partial record survives for review/cleanup
+
+
+def test_first_subedit_failure_skips_undo_when_context_empty():
+    # The FIRST applied sub-edit fails before any mutation lands -> the undo context is empty and
+    # discarded on leave, so OUR title is NOT on top. We must NOT call undo() (it would revert an
+    # unrelated user action); we still re-raise and there is nothing to trim.
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    um = FakeUndoManager(prior=["Typing"])  # a prior, unrelated user action on the stack
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _run(FakeFound(old), old, new, doc=FakeDoc(um),
+             replace_side_effect=[RuntimeError("boom")])
+
+    assert um.leaves == 1
+    assert um.undos == 0          # context empty -> our title not on top -> do not clobber the user
+    assert um.stack == ["Typing"]  # the user's prior action is intact
+
+
+def test_prior_successful_batch_not_undone_by_empty_failed_batch():
+    # in an all_matches loop an earlier surgical batch succeeds and leaves its
+    # uniquely-titled context on top of the undo stack. A LATER batch whose first sub-edit fails before
+    # mutating has an EMPTY context that is discarded on leave -- exposing the earlier batch's title on
+    # top. A CONSTANT title would match and undo that good edit; the per-batch-unique title must not.
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    um = FakeUndoManager()
+    session = FakeSession()
+
+    # Batch 1: applies cleanly (both sub-edits land) -> its context is pushed onto the stack.
+    _run(FakeFound(old), old, new, doc=FakeDoc(um), session=session)
+    assert um.undos == 0 and len(um.stack) == 1   # batch 1's completed context on top
+    m1_title = um.stack[0]
+    m1_change_count = len(session.changes)
+    assert m1_change_count == 2
+
+    # Batch 2: first sub-edit fails before mutating -> empty context -> discarded on leave.
+    with pytest.raises(RuntimeError, match="boom"):
+        _run(FakeFound(old), old, new, doc=FakeDoc(um), session=session,
+             replace_side_effect=[RuntimeError("boom")])
+
+    assert um.undos == 0                          # batch 1 was NOT undone
+    assert um.stack == [m1_title]                 # batch 1's context still on the stack
+    assert len(session.changes) == m1_change_count  # batch 1's records intact, none added/removed
+    assert um.entered[0] != um.entered[1]         # the two batches received DISTINCT unique titles
+
+
+def test_no_undo_manager_falls_back_to_whole_block():
+    # If the document exposes no usable undo manager, the surgical multi-edit path can't guarantee
+    # all-or-nothing, so it degrades to ONE whole-block replace (a single mutation) rather than
+    # applying several unrollback-able tracked changes (fallback).
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+
+    class NoUndoDoc:
+        def getUndoManager(self):
+            raise RuntimeError("no undo manager here")
+
+    session, mock_replace = _run(FakeFound(old), old, new, doc=NoUndoDoc())
+    assert len(session.calls) == 1            # exactly one whole-block mutation
+    assert mock_replace.call_count == 1
+    assert session.calls[0][0] == old         # original_preview is the whole old text
+
+
+def test_locked_undo_manager_falls_back_to_whole_block():
+    # a LOCKED undo manager silently ignores enterUndoContext, so a surgical
+    # batch would record no context and have NO rollback. Detect the lock (isLocked) and degrade to
+    # one whole-block replace rather than apply a multi-edit batch we cannot undo.
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    um = FakeUndoManager(locked=True)
+
+    session, mock_replace = _run(FakeFound(old), old, new, doc=FakeDoc(um))
+
+    assert um.entered == []                    # never opened a context (it would be a no-op)
+    assert len(session.calls) == 1             # exactly one whole-block mutation
+    assert mock_replace.call_count == 1
+    assert session.calls[0][0] == old
+
+
+def test_leave_context_failure_on_success_does_not_roll_back():
+    # leaveUndoContext() is always attempted, but if it FAILS on the success path the
+    # applied edits must stand -- no undo of valid changes, no crash; the failure is surfaced via log.
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+
+    class LeaveFailsUndoManager(FakeUndoManager):
+        def leaveUndoContext(self):
+            self.leaves += 1
+            raise RuntimeError("leave boom")
+
+    um = LeaveFailsUndoManager()
+    session, _ = _run(FakeFound(old), old, new, doc=FakeDoc(um))
+
+    assert um.leaves == 1            # the leave was attempted (enter/leave pairing honored)
+    assert um.undos == 0             # successful edits were NOT rolled back by a failed leave
+    assert len(session.calls) == 2   # both sub-edits applied and kept
+    assert len(session.changes) == 2
+    assert session.discarded_to is None
+
+
+# ------------------------------------------------- configurable split-author coloring (consistency)
+
+# A whole-block change (no shared words -> 100% changed -> above threshold) so split_change never
+# goes surgical and _record_preserve_replace takes the _whole() path.
+_WB_OLD = "the quick brown fox"
+_WB_NEW = "a completely different unrelated statement here now"
+
+
+def test_whole_block_split_author_on_opens_context_for_two_step():
+    # The KEY consistency fix: with split-author coloring ON (default), even a WHOLE-BLOCK replace is
+    # wrapped in an undo context and asks format for the two-step (so it renders in two colors, like a
+    # surgical edit). Before, whole-block was always the single-author single-op (one color).
+    assert not split_change(_WB_OLD, _WB_NEW, _THRESHOLD).is_surgical  # sanity: whole-block path
+    um = FakeUndoManager()
+    session, mock_replace = _run(FakeFound(_WB_OLD), _WB_OLD, _WB_NEW, doc=FakeDoc(um), split_author=True)
+
+    assert len(session.calls) == 1                      # one whole-block mutation
+    assert len(um.entered) == 1                         # opened ONE undo context for atomicity
+    assert um.entered[0].startswith(_SURGICAL_UNDO_TITLE)
+    assert um.leaves == 1 and um.undos == 0             # closed cleanly; no rollback on success
+    _, kwargs = mock_replace.call_args
+    assert kwargs["in_undo_context"] is True            # tells format the two-step is safe...
+    assert kwargs["split_author"] is True               # ... and to use it (two colors)
+
+
+def test_whole_block_split_author_off_stays_atomic_no_context():
+    # Coloring OFF -> the whole-block replace stays the single atomic setString (one color), opening
+    # no undo context at all (nothing to roll back).
+    um = FakeUndoManager()
+    session, mock_replace = _run(FakeFound(_WB_OLD), _WB_OLD, _WB_NEW, doc=FakeDoc(um), split_author=False)
+
+    assert len(session.calls) == 1
+    assert um.entered == []                             # one color -> no undo context needed
+    _, kwargs = mock_replace.call_args
+    assert kwargs["in_undo_context"] is False           # single atomic setString
+    assert kwargs["split_author"] is False
+
+
+def test_whole_block_split_author_on_locked_manager_falls_back_to_atomic():
+    # Coloring ON but the undo manager is LOCKED (enterUndoContext is a no-op): we can't guarantee a
+    # rollback for the two-step, so degrade to the atomic single-op (one color) -- never a
+    # non-atomic edit. split_author still reflects config; format's gate (needs BOTH flags) renders
+    # one color anyway because in_undo_context is False.
+    um = FakeUndoManager(locked=True)
+    session, mock_replace = _run(FakeFound(_WB_OLD), _WB_OLD, _WB_NEW, doc=FakeDoc(um), split_author=True)
+
+    assert len(session.calls) == 1
+    assert um.entered == []                             # locked -> enterUndoContext refused
+    _, kwargs = mock_replace.call_args
+    assert kwargs["in_undo_context"] is False           # fell back to the atomic single-op
+
+
+def test_surgical_split_author_off_threads_one_color_inside_context():
+    # Surgical path honours the SAME coloring choice: with coloring off, each sub-edit replace is the
+    # atomic single-op (one color) but still INSIDE the grouped undo context (atomicity unchanged).
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    um = FakeUndoManager()
+    session, mock_replace = _run(FakeFound(old), old, new, doc=FakeDoc(um), split_author=False)
+
+    assert len(session.calls) >= 2                      # surgical: per-changed-run sub-edits
+    assert um.entered                                   # surgical always groups in one context
+    for _, kwargs in mock_replace.call_args_list:
+        assert kwargs["in_undo_context"] is True        # inside the batch context...
+        assert kwargs["split_author"] is False          # ... but one color (atomic single-op)
+
+
+def test_surgical_split_author_on_threads_two_color_inside_context():
+    # Complement: with coloring on (default) the surgical sub-edits ask for the two-step (two colors).
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the fast brown fox jumps over the sleepy dog"
+    session, mock_replace = _run(FakeFound(old), old, new, split_author=True)
+
+    assert len(session.calls) >= 2
+    for _, kwargs in mock_replace.call_args_list:
+        assert kwargs["in_undo_context"] is True
+        assert kwargs["split_author"] is True
+
+
+# ------------------------------------------- _record_html_atomically (HTML/import delete-then-insert)
+# These paths (replace_full_document, replace_single_range_with_content, selection insert) setString("")
+# then run a separate HTML import that can throw. record_mutation opens no context, so the wrapper must
+# group the whole edit in one undo context and roll back a failed import (no stranded deletion), or
+# refuse before mutating when no rollback is available.
+
+def test_html_atomic_rolls_back_partial_edit_on_import_failure():
+    um = FakeUndoManager()
+    session = FakeSession()
+
+    def mutate():
+        um.record_action()                       # the setString("") delete lands in the open context
+        raise RuntimeError("import boom")        # then the HTML import fails after the delete
+
+    with pytest.raises(RuntimeError, match="import boom"):
+        _record_html_atomically(session, FakeDoc(um), mutate, True, proposed_preview="x")
+
+    assert len(um.entered) == 1 and um.entered[0].startswith(_AGENT_EDIT_UNDO_TITLE)
+    assert um.leaves == 1
+    assert um.undos == 1            # the partial deletion was undone (document restored)
+    assert session.changes == []   # nothing registered as a reviewable change
+
+
+def test_html_atomic_success_opens_and_closes_context():
+    um = FakeUndoManager()
+    session = FakeSession()
+    _record_html_atomically(session, FakeDoc(um), lambda: um.record_action(), True, proposed_preview="x")
+
+    assert len(um.entered) == 1 and um.entered[0].startswith(_AGENT_EDIT_UNDO_TITLE)
+    assert um.leaves == 1 and um.undos == 0   # closed cleanly; no rollback on success
+    assert len(session.changes) == 1
+
+
+def test_html_atomic_refuses_when_no_undo_manager():
+    # Recording a reviewable change with no usable manager: refuse BEFORE mutating (an HTML import has
+    # no atomic single-op fallback), so the document is never half-edited.
+    class NoUndoDoc:
+        def getUndoManager(self):
+            raise RuntimeError("no undo manager")
+
+    session = FakeSession()
+    calls = {"n": 0}
+    with pytest.raises(ToolExecutionError):
+        _record_html_atomically(session, NoUndoDoc(), lambda: calls.__setitem__("n", calls["n"] + 1),
+                                True, proposed_preview="x")
+    assert calls["n"] == 0          # refused before running the mutation
+    assert session.changes == []
+
+
+def test_html_atomic_refuses_when_undo_manager_locked():
+    um = FakeUndoManager(locked=True)
+    session = FakeSession()
+    calls = {"n": 0}
+    with pytest.raises(ToolExecutionError):
+        _record_html_atomically(session, FakeDoc(um), lambda: calls.__setitem__("n", calls["n"] + 1),
+                                True, proposed_preview="x")
+    assert um.entered == []         # never opened (a locked context is a no-op)
+    assert calls["n"] == 0          # never mutated
+    assert session.changes == []
+
+
+def test_html_not_recording_runs_directly_without_context():
+    # No review contract -> run the mutation directly (today's behaviour), never touching the undo
+    # manager and never refusing.
+    class NoUndoDoc:
+        def getUndoManager(self):
+            raise AssertionError("must not be consulted when not recording")
+
+    session = FakeSession()
+    calls = {"n": 0}
+    _record_html_atomically(session, NoUndoDoc(), lambda: calls.__setitem__("n", calls["n"] + 1),
+                            False, proposed_preview="x")
+    assert calls["n"] == 1
+    assert len(session.changes) == 1

--- a/tests/writer/test_tag_redlines_toolbar.py
+++ b/tests/writer/test_tag_redlines_toolbar.py
@@ -1,0 +1,170 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Headless test: streamed edits reveal the review toolbar.
+
+Streamed edit paths tag their redlines via ``tag_agent_redlines`` (not via record_mutation), so the
+toolbar refresh must live there too — otherwise the fast-travel toolbar never appears for those
+edits even though pending agent changes exist.
+"""
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugin.writer.edit_review import tag_agent_redlines
+
+
+def _fake_toolbar_module():
+    # review_toolbar.py imports com.sun.star.util (not in the headless UNO mock), so inject a fake
+    # module for tag_agent_redlines' lazy ``from plugin.writer.review_toolbar import ...`` to find.
+    m = types.ModuleType("plugin.writer.review_toolbar")
+    m.refresh_review_toolbar = MagicMock()
+    return m
+
+
+class FakeRedline:
+    def __init__(self, rid, raise_set=False, raise_revert=False):
+        self.rid = rid
+        self.comment = None
+        self._raise_set = raise_set
+        self._raise_revert = raise_revert  # tagging succeeds, but reverting (set "") fails -> orphan
+
+    def getPropertyValue(self, name):
+        if name == "RedlineIdentifier":
+            return self.rid
+        if name == "RedlineComment":
+            return self.comment if self.comment is not None else ""
+        raise KeyError(name)
+
+    def setPropertyValue(self, name, val):
+        assert name == "RedlineComment"
+        if self._raise_set:
+            raise RuntimeError("set boom")
+        if self._raise_revert and val == "":
+            raise RuntimeError("revert boom")
+        self.comment = val
+
+
+class FakeEnum:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def hasMoreElements(self):
+        return bool(self._items)
+
+    def nextElement(self):
+        return self._items.pop(0)
+
+
+class FakeRedlines:
+    def __init__(self, items, count=None):
+        self._items = items
+        self._count = count
+
+    def getCount(self):
+        return len(self._items) if self._count is None else self._count
+
+    def createEnumeration(self):
+        return FakeEnum(self._items)
+
+
+class FakeModel:
+    def __init__(self, redlines):
+        self._rl = redlines
+
+    def getRedlines(self):
+        return self._rl
+
+
+def test_refreshes_toolbar_when_new_redline_tagged():
+    rl_old, rl_new = FakeRedline("old1"), FakeRedline("new1")
+    doc = FakeModel(FakeRedlines([rl_old, rl_new]))
+    fake = _fake_toolbar_module()
+    with patch.dict(sys.modules, {"plugin.writer.review_toolbar": fake}):
+        token = tag_agent_redlines(doc, before_ids={"old1"}, before_reliable=True)
+    assert token is not None
+    assert rl_new.comment == token   # only the new redline got tagged
+    assert rl_old.comment is None
+    fake.refresh_review_toolbar.assert_called_once_with(doc)
+
+
+def test_no_refresh_when_nothing_new_tagged():
+    rl = FakeRedline("old1")
+    doc = FakeModel(FakeRedlines([rl]))
+    fake = _fake_toolbar_module()
+    with patch.dict(sys.modules, {"plugin.writer.review_toolbar": fake}):
+        token = tag_agent_redlines(doc, before_ids={"old1"}, before_reliable=True)
+    assert token is None
+    fake.refresh_review_toolbar.assert_not_called()
+
+
+# The toolbar's only contract on a REFUSAL is: tag_agent_redlines returns None and NEVER refreshes
+# the toolbar -- on ANY refusal path. The SPECIFIC refusal/orphan/revert internals (return values,
+# all-or-nothing revert, orphan accounting, and the single-orphan==len failure case) are unit-tested
+# against _tag_new_redlines / record_mutation in test_edit_review.py; here we only pin that no refusal
+# path triggers a toolbar refresh. Each builder returns (doc, kwargs) for one refusal scenario.
+
+def _refusal_default_no_reliable():
+    # before_reliable omitted -> defaults to False (an unverified snapshot fails closed).
+    return FakeModel(FakeRedlines([FakeRedline("old1"), FakeRedline("new1")])), {"before_ids": {"old1"}}
+
+
+def _refusal_before_unreliable():
+    return (FakeModel(FakeRedlines([FakeRedline("old1"), FakeRedline("new1")])),
+            {"before_ids": {"old1"}, "before_reliable": False})
+
+
+def _refusal_after_scan_incomplete():
+    # getCount() reports more than the enumeration yields -> incomplete scan.
+    return (FakeModel(FakeRedlines([FakeRedline("old1"), FakeRedline("new1")], count=3)),
+            {"before_ids": {"old1"}, "before_reliable": True})
+
+
+def _refusal_partial_tag_reverted():
+    # Two new redlines; tagging the second fails -> the first is reverted (complete-or-none).
+    return (FakeModel(FakeRedlines([FakeRedline("old1"), FakeRedline("a"), FakeRedline("b", raise_set=True)])),
+            {"before_ids": {"old1"}, "before_reliable": True})
+
+
+def _refusal_revert_leaves_orphan():
+    # First tags OK but its revert fails (orphan); second's tag fails (triggers the revert).
+    return (FakeModel(FakeRedlines([FakeRedline("old1"),
+                                    FakeRedline("a", raise_revert=True), FakeRedline("b", raise_set=True)])),
+            {"before_ids": {"old1"}, "before_reliable": True})
+
+
+def _refusal_single_orphan():
+    # ONE new redline that mutates-then-throws and can't be reverted (orphans == len == 1): an
+    # ambiguous int would have read this as success.
+    class MutateThenThrow(FakeRedline):
+        def setPropertyValue(self, name, val):
+            assert name == "RedlineComment"
+            if val == "":
+                raise RuntimeError("revert cannot clear")
+            self.comment = val
+            raise RuntimeError("set wrote then threw")
+
+    return (FakeModel(FakeRedlines([FakeRedline("old1"), MutateThenThrow("a")])),
+            {"before_ids": {"old1"}, "before_reliable": True})
+
+
+@pytest.mark.parametrize("build", [
+    _refusal_default_no_reliable,
+    _refusal_before_unreliable,
+    _refusal_after_scan_incomplete,
+    _refusal_partial_tag_reverted,
+    _refusal_revert_leaves_orphan,
+    _refusal_single_orphan,
+], ids=["default_no_reliable", "before_unreliable", "after_scan_incomplete",
+        "partial_tag_reverted", "revert_leaves_orphan", "single_orphan"])
+def test_no_refresh_on_any_refusal_path(build):
+    """tag_agent_redlines returns None and never refreshes the toolbar on ANY refusal path."""
+    doc, kwargs = build()
+    fake = _fake_toolbar_module()
+    with patch.dict(sys.modules, {"plugin.writer.review_toolbar": fake}):
+        token = tag_agent_redlines(doc, **kwargs)
+    assert token is None
+    fake.refresh_review_toolbar.assert_not_called()

--- a/tests/writer/test_track_changes_reviewable_uno.py
+++ b/tests/writer/test_track_changes_reviewable_uno.py
@@ -19,6 +19,7 @@ from plugin.testing_runner import native_test, setup, teardown
 from plugin.tests.testing_utils import TestingFactory
 from plugin.doc.document_helpers import WriterStreamedRewriteSession, WriterStreamedAppendSession
 from plugin.writer.content import ApplyDocumentContent
+import plugin.writer.content as _content
 from plugin.writer.edit_review import EditReviewSession, get_agent_edit_review_mode
 from plugin.framework.config import set_config, get_config
 import plugin.writer.format as fmt
@@ -259,6 +260,123 @@ def test_split_authors_insert_vs_delete_uno():
     finally:
         set_config(_ctx, _FLAG, prev)
         _reject_all()
+
+
+# --- split-author coloring is a plain constant (env-overridable, NOT a config key) and CONSISTENT
+# --- across the whole-block AND surgical paths: ON (default) -> two authors/two colors, OFF -> one.
+# --- Tests pin the module constants directly. The whole-block path is forced by pinning the
+# --- diff-threshold constant to 0.0 (any change lands as one block); the surgical path is exercised
+# --- by a small one-word change at the default threshold.
+
+
+@native_test
+def test_split_authors_whole_block_on_two_colors_uno():
+    """The consistency fix: a WHOLE-BLOCK agent edit also authors its Delete distinctly (two colors),
+    not just the surgical path. Before, whole-block was authored as one (one color). Threshold 0.0
+    forces the whole-block path; accept must still reconstruct exactly the new text (atomicity)."""
+    _reset("Old clause body here.")
+    prev = get_config(_ctx, _FLAG)
+    prev_split, prev_thresh = _content._SPLIT_AUTHOR_COLORS, _content._WORD_DIFF_THRESHOLD
+    set_config(_ctx, _FLAG, "record")
+    _content._SPLIT_AUTHOR_COLORS = True
+    _content._WORD_DIFF_THRESHOLD = 0.0  # any change -> ONE whole block (not surgical)
+    try:
+        res = ApplyDocumentContent().execute(
+            _tool_ctx(), target="search", old_content="Old clause body here.", content=["New clause body here."])
+        assert res.get("status") == "ok", res
+        by_type = {r["type"]: r["RedlineAuthor"] for r in _redlines()}
+        assert by_type.get("Insert") == "WriterAgent", "insert authored WriterAgent: %r" % by_type
+        assert by_type.get("Delete") == "WriterAgent (deletions)", \
+            "whole-block deletion must be authored distinctly (two colors): %r" % by_type
+        _accept_all()
+        assert _para_text() == "New clause body here.", \
+            "accept must reconstruct exactly the new text (whole-block atomicity), got %r" % _para_text()
+    finally:
+        set_config(_ctx, _FLAG, prev)
+        _content._SPLIT_AUTHOR_COLORS, _content._WORD_DIFF_THRESHOLD = prev_split, prev_thresh
+        if len(_doc.getRedlines()):
+            _reject_all()
+
+
+@native_test
+def test_split_authors_whole_block_off_one_color_uno():
+    """Toggle OFF: a whole-block edit's Delete and Insert share ONE author (one color), and the edit
+    stays atomic -- accept reconstructs exactly the new text."""
+    _reset("Old clause body here.")
+    prev = get_config(_ctx, _FLAG)
+    prev_split, prev_thresh = _content._SPLIT_AUTHOR_COLORS, _content._WORD_DIFF_THRESHOLD
+    set_config(_ctx, _FLAG, "record")
+    _content._SPLIT_AUTHOR_COLORS = False
+    _content._WORD_DIFF_THRESHOLD = 0.0  # force whole-block
+    try:
+        res = ApplyDocumentContent().execute(
+            _tool_ctx(), target="search", old_content="Old clause body here.", content=["New clause body here."])
+        assert res.get("status") == "ok", res
+        authors = {r["RedlineAuthor"] for r in _redlines()}
+        assert authors == {"WriterAgent"}, "toggle off -> one author / one color, got %r" % authors
+        _accept_all()
+        assert _para_text() == "New clause body here.", \
+            "accept must reconstruct exactly the new text, got %r" % _para_text()
+    finally:
+        set_config(_ctx, _FLAG, prev)
+        _content._SPLIT_AUTHOR_COLORS, _content._WORD_DIFF_THRESHOLD = prev_split, prev_thresh
+        if len(_doc.getRedlines()):
+            _reject_all()
+
+
+@native_test
+def test_html_import_failure_rolls_back_in_review_mode_uno():
+    """Atomicity for the HTML/import path: in record mode replace_full_document does setString('')
+    then imports HTML. If the import throws AFTER the delete, the whole edit is rolled back -- the
+    document keeps its original text with no stranded tracked deletion, and no agent change lands."""
+    _reset("Original body text to keep.")
+    prev = get_config(_ctx, _FLAG)
+    set_config(_ctx, _FLAG, "record")
+    real = fmt._insert_mixed_or_plain_html
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated HTML import failure")
+
+    fmt._insert_mixed_or_plain_html = _boom
+    try:
+        res = None
+        try:
+            res = ApplyDocumentContent().execute(_tool_ctx(), target="full_document", content=["<p>New body.</p>"])
+        except Exception:
+            res = {"status": "error", "raised": True}
+        assert res.get("status") == "error", "the failed import must surface as an error: %r" % res
+        assert _para_text() == "Original body text to keep.", \
+            "document must be restored (no stranded deletion), got %r" % _para_text()
+        assert _redline_types() == [], \
+            "no tracked change may survive the rolled-back edit, got %r" % _redline_types()
+    finally:
+        fmt._insert_mixed_or_plain_html = real
+        set_config(_ctx, _FLAG, prev)
+        if len(_doc.getRedlines()):
+            _reject_all()
+
+
+@native_test
+def test_split_authors_surgical_off_one_color_uno():
+    """Toggle OFF collapses the SURGICAL path to one author too (consistency both ways)."""
+    _reset("Old clause body here.")
+    prev = get_config(_ctx, _FLAG)
+    prev_split = _content._SPLIT_AUTHOR_COLORS
+    set_config(_ctx, _FLAG, "record")
+    _content._SPLIT_AUTHOR_COLORS = False  # default threshold -> small change takes the surgical path
+    try:
+        res = ApplyDocumentContent().execute(
+            _tool_ctx(), target="search", old_content="Old clause body here.", content=["New clause body here."])
+        assert res.get("status") == "ok", res
+        authors = {r["RedlineAuthor"] for r in _redlines()}
+        assert authors == {"WriterAgent"}, "surgical toggle off -> one author, got %r" % authors
+        _accept_all()
+        assert _para_text() == "New clause body here.", "accept must yield the new text, got %r" % _para_text()
+    finally:
+        set_config(_ctx, _FLAG, prev)
+        _content._SPLIT_AUTHOR_COLORS = prev_split
+        if len(_doc.getRedlines()):
+            _reject_all()
 
 
 # --- the apply_document_content tool end to end (config read + session wiring) -----------

--- a/tests/writer/test_word_diff_split.py
+++ b/tests/writer/test_word_diff_split.py
@@ -1,0 +1,559 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for the pure-python word-level diff splitter.
+
+No UNO / LibreOffice. Pure algorithm + reconstruction property tests.
+"""
+
+import pytest
+
+from plugin.writer.word_diff_split import (
+    SubEdit,
+    apply_sub_edits,
+    split_change,
+    tokenize,
+)
+
+
+# ---------------------------------------------------------------------------
+# tokenize: lossless, exact offsets
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        "",
+        "hello",
+        "hello world",
+        "  leading",
+        "trailing  ",
+        "  both sides  ",
+        "multiple   spaces\tand\ttabs",
+        "punctuation, yes! really? sure.",
+        "line\nbreak\nhere",
+        "café déjà naïve",
+    ],
+)
+def test_tokenize_is_lossless(s):
+    toks = tokenize(s)
+    assert "".join(t.text for t in toks) == s
+    # offsets index back exactly
+    for t in toks:
+        assert s[t.start:t.end] == t.text
+    # alternating word / separator, contiguous
+    for a, b in zip(toks, toks[1:]):
+        assert a.end == b.start
+        assert a.is_word != b.is_word
+
+
+def test_tokenize_empty():
+    assert tokenize("") == []
+
+
+def test_tokenize_word_vs_separator_classification():
+    toks = tokenize(" a  b ")
+    kinds = [(t.text, t.is_word) for t in toks]
+    assert kinds == [
+        (" ", False),
+        ("a", True),
+        ("  ", False),
+        ("b", True),
+        (" ", False),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# split_change: mode + sub-edit shape on the required edge cases
+# ---------------------------------------------------------------------------
+
+def test_identical_strings_no_sub_edits():
+    r = split_change("the quick brown fox", "the quick brown fox")
+    assert r.mode == "surgical"
+    assert r.sub_edits == []
+    assert r.fraction_changed == 0.0
+
+
+def test_both_empty_no_sub_edits():
+    r = split_change("", "")
+    assert r.mode == "surgical"
+    assert r.sub_edits == []
+    assert r.fraction_changed == 0.0
+
+
+def test_single_word_changed_in_long_sentence_one_surgical_edit():
+    old = "the quick brown fox jumps over the lazy dog today"
+    new = "the quick brown cat jumps over the lazy dog today"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 1
+    e = r.sub_edits[0]
+    assert e.op == "replace"
+    assert e.old_text == "fox"
+    assert e.new_text == "cat"
+    assert old[e.old_start:e.old_end] == "fox"
+
+
+def test_two_non_adjacent_words_changed_two_surgical_edits():
+    old = "the quick brown fox jumps over the lazy dog today"
+    new = "the slow brown fox leaps over the lazy dog today"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 2
+    assert {e.old_text for e in r.sub_edits} == {"quick", "jumps"}
+    assert {e.new_text for e in r.sub_edits} == {"slow", "leaps"}
+
+
+def test_two_adjacent_words_changed_agglutinated_into_one():
+    old = "the quick brown fox jumps over the lazy dog today"
+    new = "the speedy tan fox jumps over the lazy dog today"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 1
+    e = r.sub_edits[0]
+    assert e.op == "replace"
+    assert e.old_text == "quick brown"
+    assert e.new_text == "speedy tan"
+
+
+def test_three_adjacent_words_changed_agglutinated_into_one():
+    old = "k1 alpha beta gamma k2 k3 k4 k5"
+    new = "k1 X Y Z k2 k3 k4 k5"
+    r = split_change(old, new, threshold=0.9)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 1, "consecutive changed words must merge into ONE sub-edit"
+    e = r.sub_edits[0]
+    assert e.op == "replace"
+    assert e.old_text == "alpha beta gamma"
+    assert e.new_text == "X Y Z"
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_adjacent_replace_and_insert_merge_into_one():
+    # A replace immediately followed by an insertion (no matched word between them) lives
+    # in a single segment and must agglutinate into one sub-edit.
+    old = "k1 alpha k2 k3 k4 k5"
+    new = "k1 X NEWWORD k2 k3 k4 k5"
+    r = split_change(old, new, threshold=0.9)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 1
+    assert r.sub_edits[0].op == "replace"
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_pure_insertion_old_subset_of_new():
+    old = "the quick fox jumps over the lazy dog today here"
+    new = "the quick brown fox jumps over the lazy dog today here"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 1
+    e = r.sub_edits[0]
+    assert e.op == "insert"
+    assert "brown" in e.new_text
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_pure_deletion():
+    old = "the quick brown fox jumps over the lazy dog today here"
+    new = "the quick fox jumps over the lazy dog today here"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 1
+    e = r.sub_edits[0]
+    assert e.op == "delete"
+    assert "brown" in e.old_text
+    assert e.new_text == ""
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_empty_old_is_pure_insertion():
+    r = split_change("", "hello world")
+    # 100% changed -> block by the > threshold rule
+    assert r.mode == "block"
+    # block op must be classified like surgical ops: empty old -> insert (not "replace").
+    assert len(r.sub_edits) == 1
+    e = r.sub_edits[0]
+    assert e.op == "insert"
+    assert e.old_text == ""
+    assert e.old_start == e.old_end == 0
+    assert e.new_text == "hello world"
+    assert apply_sub_edits("", r.sub_edits) == "hello world"
+
+
+def test_empty_new_is_pure_deletion():
+    r = split_change("hello world", "")
+    assert r.mode == "block"
+    assert len(r.sub_edits) == 1
+    e = r.sub_edits[0]
+    assert e.op == "delete"
+    assert e.new_text == ""
+    assert e.old_start == 0
+    assert e.old_end == len("hello world")
+    assert e.old_text == "hello world"
+    assert apply_sub_edits("hello world", r.sub_edits) == ""
+
+
+# ---------------------------------------------------------------------------
+# threshold / boundary semantics: <= threshold stays surgical, > flips to block
+# ---------------------------------------------------------------------------
+
+def test_just_below_threshold_is_surgical():
+    # 6 unchanged + replace(2 old, 2 new): changed = 2+2 = 4, total = 6+4 = 10
+    # -> fraction = 0.4 (< 0.6). 'replace' counts changed words on BOTH sides.
+    old = "k1 k2 k3 r1 r2 k4 k5 k6"
+    new = "k1 k2 k3 s1 s2 k4 k5 k6"
+    r = split_change(old, new, threshold=0.6)
+    assert pytest.approx(r.fraction_changed) == 0.4
+    assert r.mode == "surgical"
+
+
+def test_exactly_at_threshold_stays_surgical():
+    # Construct fraction == exactly 0.6: 4 unchanged + 6 changed words, all replaces
+    # 'replace' counts changed on BOTH sides, so use equal-size replace runs.
+    # old: 5 unchanged ... actually craft: unchanged=4, changed(old=3,new=3)=6, total=10.
+    old = "k1 k2 k3 k4 r1 r2 r3"          # 4 keep + 3 replace = 7 old words
+    new = "k1 k2 k3 k4 s1 s2 s3"          # 4 keep + 3 replace = 7 new words
+    r = split_change(old, new, threshold=0.6)
+    # changed = 3 (old) + 3 (new) = 6 ; unchanged = 4 ; total = 10 ; frac = 0.6
+    assert pytest.approx(r.fraction_changed) == 0.6
+    assert r.mode == "surgical", "exactly-at-threshold must stay surgical (inclusive)"
+
+
+def test_just_above_threshold_is_block():
+    # unchanged=3, replace old=4/new=4 -> changed=8, total=11, frac ~0.727 > 0.6
+    old = "k1 k2 k3 r1 r2 r3 r4"
+    new = "k1 k2 k3 s1 s2 s3 s4"
+    r = split_change(old, new, threshold=0.6)
+    assert r.fraction_changed > 0.6
+    assert r.mode == "block"
+    assert len(r.sub_edits) == 1
+    assert r.sub_edits[0].op == "replace"
+    assert r.sub_edits[0].old_start == 0
+    assert r.sub_edits[0].old_end == len(old)
+    assert r.sub_edits[0].new_text == new
+
+
+def test_custom_threshold_one_keeps_everything_surgical():
+    # Everything changed but threshold 1.0 -> fraction (1.0) is NOT > 1.0 -> surgical
+    old = "alpha beta gamma"
+    new = "delta epsilon zeta"
+    r = split_change(old, new, threshold=1.0)
+    assert pytest.approx(r.fraction_changed) == 1.0
+    assert r.mode == "surgical"
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_custom_threshold_zero_forces_block_on_any_change():
+    old = "the quick brown fox jumps over the lazy dog"
+    new = "the quick brown cat jumps over the lazy dog"
+    r = split_change(old, new, threshold=0.0)
+    assert r.fraction_changed > 0.0
+    assert r.mode == "block"
+
+
+def test_repeating_binary_fraction_at_threshold_stays_surgical():
+    # frac = 2/3 (a value with no exact binary float representation). When the threshold
+    # is the SAME computed value, ``frac > threshold`` must be False -> surgical. Guards
+    # against a float-equality off-by-epsilon flipping the boundary.
+    old = "k r1"          # 1 unchanged + 1 replace(old) ...
+    new = "k s1"          # ... + 1 replace(new) -> changed=2, total=3, frac=2/3
+    r = split_change(old, new, threshold=2 / 3)
+    assert r.fraction_changed == 2 / 3
+    assert r.mode == "surgical", "frac == threshold (2/3) must stay surgical"
+
+
+def test_repeating_binary_fraction_just_below_threshold_flips_block():
+    old = "k r1"
+    new = "k s1"
+    # threshold a hair below 2/3 -> frac (2/3) IS > threshold -> block
+    r = split_change(old, new, threshold=0.666)
+    assert r.fraction_changed > 0.666
+    assert r.mode == "block"
+
+
+def test_one_third_fraction_at_threshold_stays_surgical():
+    old = "k1 k2"          # 2 unchanged
+    new = "k1 k2 x"        # + 1 insert -> changed=1, total=3, frac=1/3
+    r = split_change(old, new, threshold=1 / 3)
+    assert r.fraction_changed == 1 / 3
+    assert r.mode == "surgical"
+
+
+def test_single_token_replace_is_surgical_block_or_surgical_by_threshold():
+    # A single word fully changed: frac = 2/2 = 1.0. With default 0.6 -> block.
+    r = split_change("hello", "goodbye")
+    assert r.fraction_changed == 1.0
+    assert r.mode == "block"
+    assert apply_sub_edits("hello", r.sub_edits) == "goodbye"
+    # ... but with threshold 1.0 it stays surgical (1.0 is not > 1.0).
+    r2 = split_change("hello", "goodbye", threshold=1.0)
+    assert r2.mode == "surgical"
+    assert len(r2.sub_edits) == 1
+    assert r2.sub_edits[0].op == "replace"
+    assert apply_sub_edits("hello", r2.sub_edits) == "goodbye"
+
+
+def test_block_op_is_replace_when_both_sides_nonempty():
+    old = "completely different content here now"
+    new = "totally other stuff appears instead"
+    r = split_change(old, new, threshold=0.6)
+    assert r.mode == "block"
+    assert r.sub_edits[0].op == "replace"
+    assert r.sub_edits[0].old_text == old
+    assert r.sub_edits[0].new_text == new
+
+
+# ---------------------------------------------------------------------------
+# whitespace / punctuation specifics
+# ---------------------------------------------------------------------------
+
+def test_leading_trailing_whitespace_preserved_in_reconstruction():
+    old = "   the quick brown fox jumps over the lazy dog   "
+    new = "   the quick brown cat jumps over the lazy dog   "
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_punctuation_attached_to_word():
+    # Punctuation rides with the word run, so "today," is one token. Change "you"->"we".
+    old = "hello, world! how are you doing today, friend"
+    new = "hello, world! how are we doing today, friend"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 1
+    assert r.sub_edits[0].old_text == "you"
+    assert r.sub_edits[0].new_text == "we"
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_punctuation_token_change_is_one_edit():
+    # Changing the trailing punctuation of a word changes that whole token.
+    old = "wait here now, friend and stay"
+    new = "wait here now. friend and stay"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert len(r.sub_edits) == 1
+    assert r.sub_edits[0].old_text == "now,"
+    assert r.sub_edits[0].new_text == "now."
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_internal_multispace_change_reconstructs():
+    # Whitespace-only change between two MATCHED words: invisible to a word diff, but
+    # reconciled into a tiny 'replace' so reconstruction is exact.
+    old = "alpha    beta gamma delta epsilon zeta eta"
+    new = "alpha beta gamma delta epsilon zeta eta"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert apply_sub_edits(old, r.sub_edits) == new
+    # The single edit touches only the separator span. Common whitespace is trimmed, so
+    # "    " -> " " is recorded tightly as deleting the 3 extra spaces.
+    assert len(r.sub_edits) == 1
+    e = r.sub_edits[0]
+    assert e.old_text == "   "
+    assert e.new_text == ""
+    assert e.op == "delete"
+
+
+def test_leading_whitespace_only_change_reconstructs():
+    old = "   hello world here"
+    new = " hello world here"
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+def test_trailing_whitespace_only_change_reconstructs():
+    old = "hello world here   "
+    new = "hello world here "
+    r = split_change(old, new)
+    assert r.mode == "surgical"
+    assert apply_sub_edits(old, r.sub_edits) == new
+
+
+# ---------------------------------------------------------------------------
+# reconstruction property: applying sub-edits to `old` yields `new` exactly
+# ---------------------------------------------------------------------------
+
+RECONSTRUCT_CASES = [
+    ("", ""),
+    ("a", "a"),
+    ("the quick brown fox", "the quick brown fox"),
+    ("the quick brown fox jumps over", "the quick brown cat jumps over"),
+    ("the quick brown fox jumps over", "the slow brown fox leaps over"),
+    ("the quick brown fox jumps over", "the speedy tan fox jumps over"),
+    ("the quick fox jumps over the lazy dog", "the quick brown fox jumps over the lazy dog"),
+    ("the quick brown fox jumps over the lazy dog", "the quick fox jumps over the lazy dog"),
+    ("hello world", "goodbye cruel world"),
+    ("one two three four five", "one 2 three 4 five"),
+    ("a b c d e", "a x c y e"),
+    ("a b c d e", "a x y d e"),
+    ("   pad both   ", "   pad now both   "),
+    ("first. second. third.", "first. SECOND. third."),
+    ("insert at end here", "insert at end here now"),
+    ("prepend the rest", "really prepend the rest"),
+    ("delete from end now", "delete from end"),
+    ("delete from start now", "from start now"),
+    ("tabs\tand\nnewlines stay", "tabs\tand\nnewlines remain"),
+    ("café déjà vu always", "café deja vu always"),
+    ("aaa bbb ccc ddd eee fff ggg", "aaa ZZZ ccc ddd YYY fff ggg"),
+    ("alpha    beta gamma", "alpha beta gamma"),
+    ("   leading spaces here", " leading spaces here"),
+    ("trailing spaces here   ", "trailing spaces here "),
+    ("tab\tbetween words", "tab between words"),
+    ("a b c d e f g h i j", "a b c d e f g h i j"),
+    ("word", "word changed entirely now"),
+    ("word changed entirely now", "word"),
+    # adjacency: three consecutive words changed should agglutinate (reconstruction here)
+    ("k1 a b c k2 k3 k4 k5", "k1 X Y Z k2 k3 k4 k5"),
+    # adjacent replace + insert with no anchor between
+    ("k1 a k2 k3 k4 k5", "k1 X NEW k2 k3 k4 k5"),
+    # two changes separated by one anchor -> two segments
+    ("k1 a m b k2 k3 k4", "k1 X m Y k2 k3 k4"),
+    # punctuation-only token change
+    ("wait here now, friend and stay", "wait here now. friend and stay"),
+    # word transposition (difflib may resolve as replace; only losslessness asserted)
+    ("alpha beta gamma delta", "beta alpha gamma delta"),
+    # repeated identical words around a change
+    ("aaa aaa aaa bbb aaa", "aaa aaa ZZZ bbb aaa"),
+    # separator grows / shrinks between matched words
+    ("alpha beta gamma delta", "alpha  beta gamma delta"),
+    ("alpha\tbeta gamma delta", "alpha beta gamma delta"),
+    # only-whitespace strings of differing length
+    ("    ", "  "),
+    ("  ", "    "),
+]
+
+
+@pytest.mark.parametrize("old,new", RECONSTRUCT_CASES)
+def test_apply_sub_edits_reconstructs_new_exactly(old, new):
+    for thr in (0.0, 0.3, 0.6, 0.9, 1.0):
+        r = split_change(old, new, threshold=thr)
+        assert apply_sub_edits(old, r.sub_edits) == new, (
+            "reconstruction failed for thr=%s mode=%s" % (thr, r.mode)
+        )
+
+
+@pytest.mark.parametrize("old,new", RECONSTRUCT_CASES)
+def test_surgical_sub_edits_are_disjoint_and_sorted(old, new):
+    r = split_change(old, new, threshold=1.0)  # force surgical where possible
+    if r.mode != "surgical":
+        return
+    prev_end = -1
+    for e in r.sub_edits:
+        assert e.old_start <= e.old_end
+        assert e.old_start >= prev_end, "sub-edits overlap or are unsorted"
+        # old_text matches the recorded span
+        assert old[e.old_start:e.old_end] == e.old_text
+        prev_end = e.old_end
+
+
+@pytest.mark.parametrize("old,new", RECONSTRUCT_CASES)
+def test_sub_edit_op_types_are_consistent(old, new):
+    r = split_change(old, new, threshold=1.0)
+    if r.mode != "surgical":
+        return
+    for e in r.sub_edits:
+        if e.op == "insert":
+            assert e.old_text == ""
+            assert e.old_start == e.old_end
+        elif e.op == "delete":
+            assert e.new_text == ""
+            assert e.old_start < e.old_end
+        else:
+            assert e.op == "replace"
+
+
+@pytest.mark.parametrize("old,new", RECONSTRUCT_CASES)
+def test_op_shape_invariant_holds_in_both_modes(old, new):
+    # The op label must be consistent with the spans in BOTH block and surgical mode, so
+    # the format.py recording branch can branch on ``op`` uniformly without special-casing
+    # the whole-block edit.
+    for thr in (0.0, 0.6, 1.0):
+        r = split_change(old, new, threshold=thr)
+        for e in r.sub_edits:
+            if e.op == "insert":
+                assert e.old_text == "" and e.old_start == e.old_end
+            elif e.op == "delete":
+                assert e.new_text == "" and e.old_start < e.old_end
+            else:
+                assert e.op == "replace"
+                assert e.old_text != "" and e.new_text != ""
+            # op never lies about emptiness
+            assert (e.op == "insert") == (e.old_text == "")
+            assert (e.op == "delete") == (e.new_text == "")
+
+
+# ---------------------------------------------------------------------------
+# SubEdit dataclass-ish equality (used by other assertions)
+# ---------------------------------------------------------------------------
+
+def test_subedit_equality():
+    a = SubEdit("replace", 0, 3, "fox", "cat")
+    b = SubEdit("replace", 0, 3, "fox", "cat")
+    c = SubEdit("delete", 0, 3, "fox", "")
+    assert a == b
+    assert a != c
+
+
+# ---------------------------------------------------------------------------
+# randomized property test: reconstruction + invariants hold for many inputs
+# ---------------------------------------------------------------------------
+
+def test_randomized_reconstruction_and_invariants():
+    import random
+
+    rng = random.Random(20240620)
+    vocab = ["the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog",
+             "a", "b", "c", "x,", "y.", "z!", "café", "déjà", "naïve"]
+    seps = [" ", "  ", "   ", "\t", "\n", " \t "]
+
+    def rnd_text():
+        n = rng.randint(0, 9)
+        if n == 0:
+            return rng.choice(["", " ", "  ", "x", "\t"])
+        parts = []
+        if rng.random() < 0.4:
+            parts.append(rng.choice(seps))
+        for i in range(n):
+            parts.append(rng.choice(vocab))
+            if i < n - 1:
+                parts.append(rng.choice(seps))
+        if rng.random() < 0.4:
+            parts.append(rng.choice(seps))
+        return "".join(parts)
+
+    for _ in range(3000):
+        old, new = rnd_text(), rnd_text()
+        for thr in (0.0, 0.3, 0.6, 1.0):
+            r = split_change(old, new, threshold=thr)
+            # losslessness
+            assert apply_sub_edits(old, r.sub_edits) == new, (old, new, thr, r.mode)
+            # non-overlap, sorted, spans match recorded old_text
+            prev_end = -1
+            for e in sorted(r.sub_edits, key=lambda x: (x.old_start, x.old_end)):
+                assert e.old_start >= prev_end
+                assert old[e.old_start:e.old_end] == e.old_text
+                prev_end = e.old_end
+
+
+# --------------------------------------------------------------------------- threshold <= 0
+
+def test_threshold_zero_forces_block_on_whitespace_only_change():
+    # A whitespace-only change has a 0.0 word-fraction; at threshold 0 it must STILL land as one
+    # block ("never split"), not a surgical separator redline.
+    r = split_change("a b c", "a  b c", 0.0)
+    assert r.is_block and len(r.sub_edits) == 1
+
+
+def test_threshold_zero_forces_block_on_word_change():
+    r = split_change("a b c", "a X c", 0.0)
+    assert r.is_block
+
+
+def test_threshold_zero_no_change_records_nothing():
+    # old == new is still a no-op even at threshold 0 (no spurious block edit).
+    r = split_change("a b c", "a b c", 0.0)
+    assert r.is_surgical and r.sub_edits == []


### PR DESCRIPTION
## What this adds

An opt-in **agent edit review** mode for Writer. With `doc.agent_edit_review_mode` set to
`record` or `wait`, edits made by the agent (via `apply_document_content`) land as native
**tracked changes** the user accepts/rejects, each tagged so the tool reports a per-change
outcome. Default `off` → behaviour is unchanged.

### Feature
- **Surgical splitting** — a one/two-word tweak in a long paragraph records as tight
  per-changed-run tracked changes (a pure word-level diff) instead of a whole-paragraph
  delete+insert; large edits stay a single block. Lossless, validated with a randomized
  property test.
- **Split-author coloring** — the deletion is authored distinctly from the insertion so
  LibreOffice's by-author coloring shows removed vs new text in two colors, consistently for
  whole-block and surgical edits. Toggle via `WRITERAGENT_AGENT_EDIT_SPLIT_AUTHOR_COLORS`.
- **Review toolbar + context menu** to accept/reject/navigate pending agent changes.
- **Document identification by RuntimeUID** — open documents are addressable by a stable id
  (works for unsaved/untitled documents); concurrent mutating MCP calls on the same document
  serialize through one gate.

### Data-safety / robustness
- **Atomicity** — surgical batches and HTML/import edits (full-document, single-range,
  selection) run inside a grouped undo context; a mid-apply failure rolls back rather than
  leaving a half-applied edit.
- **Fail-closed** — accept/reject refuses unless it can prove it is resolving exactly the
  agent's change (never the user's own redlines); unreliable UNO reads (enumeration/identifier
  errors) refuse rather than guess.
- State (RecordChanges, redline authors, anchor bookmarks, listeners, undo contexts) is always
  restored/cleaned, including on exceptions.

## Tests

Pure-Python suites plus native UNO suites (run inside a headless LibreOffice).

One native test (`test_apply_document_content_wait_timeout_zero_returns_pending_uno`) does not pass
under the macro-based test runner: it drives a background thread that marshals work to the main
thread, which the runner itself occupies, so the marshaled work is never serviced. It passes in a
normally-running LibreOffice where the main loop is free.
