### PR TITLE
feat(mcp): expose specialized tools over MCP via tool_exposure_mode

### DIFF
--- a/docs/mcp-protocol.md
+++ b/docs/mcp-protocol.md
@@ -359,6 +359,26 @@ An outer MCP model that **alternates** between unrelated tool groups in one long
 
 **Still required internally:** Even with a larger MCP surface, the internal agent stack remains necessary for features that are **not** orchestrated by an MCP client— notably the **background grammar checker** ([`docs/realtime-grammar-checker-plan.md`](realtime-grammar-checker-plan.md)) and similar automatic pipelines we may add later. Those run on their own schedules inside LibreOffice; an outer model cannot replace them by calling MCP tools in a chat session.
 
+### Exposing specialized tools directly: `mcp.tool_exposure_mode` (experimental)
+
+An experimental config, `mcp.tool_exposure_mode` (default `delegate`), controls how the ~138 specialized tools are surfaced over MCP. The default is unchanged; the two opt-in modes let clients reach the specialized tools **without** the delegate sub-agent (so no LLM backend is needed for tool access):
+
+| Mode | `tools/list` | For |
+|------|--------------|-----|
+| `delegate` *(default)* | core only; specialized reached via the `delegate_*` gateway | unchanged behavior |
+| `direct_flat` | core **+ all MCP-reachable specialized** (already doc-type filtered, so ~74 on Calc / ~102 on Writer, not all 138 at once; Writer sidebar-only flows excluded) | clients with native tool-search (Claude API; OpenAI `defer_loading`) |
+| `direct_discovery` | core **+ a `find_tools` search tool** | any client (engine-agnostic) |
+
+In both direct modes the specialized tools are invoked **by name** — which already works, since `tools/call` routes through the registry, not the advertised list.
+
+The direct modes **add** direct access; they don't remove delegation. The `delegate_to_specialized_*` gateway stays listed in every mode (it is core-tier), so a client can still delegate if it prefers — this is intentional, the direct modes are additive.
+
+`find_tools(query, domain?)` (advertised only in `direct_discovery`) ranks the hidden catalog with a pure-Python lexical ranker (BM25-lite + substring bonus; no venv/embeddings) and returns ready-to-call schemas plus per-domain usage guidance. It is document-optional (discovery works with no document open; with no document the per-domain guidance is app-neutral) and is rejected by name in the other modes.
+
+> Note: with **no document open** and no `X-Document-URL`, `direct_flat` can't filter by document type, so it lists the **broad** tool catalog (core + specialized, all apps); once a document is active or targeted the list narrows to that app's tools. An `X-Document-URL` that doesn't resolve keeps the normal filtered list (and `tools/call` returns `DOCUMENT_NOT_FOUND`). `delegate` and `direct_discovery` keep the normal document-filtered list (in `direct_discovery`, `find_tools` covers the full no-document catalog on demand).
+
+> Note: `tools/list` is not re-sent when the mode changes mid-connection (`listChanged` is `false`), so reconnect after switching modes.
+
 ---
 
 ## Current Status — What Was Implemented

--- a/plugin/calc/python/venv.py
+++ b/plugin/calc/python/venv.py
@@ -66,6 +66,28 @@ _PARAMETERS_NON_CALC = {
     "required": ["code"],
 }
 
+# Superset advertised when the target app is unknown (e.g. MCP discovery with no document
+# open), so a caller heading for Calc still sees data_range. data_range/data are Calc-only.
+_PARAMETERS_NEUTRAL = {
+    "type": "object",
+    "properties": {
+        "code": {
+            "type": "string",
+            "description": "Python / Numpy source. Set `result` to the return value (NumPy ndarray, Pandas DataFrame, list, dict, or scalar).",
+        },
+        "data_range": {
+            "type": "string",
+            "description": "(Calc only) Optional A1 range (e.g. B1:B10); values are injected as variable `data`.",
+        },
+        "data": {
+            "type": "array",
+            "items": {"type": "array", "items": {}},
+            "description": "(Calc only) Optional 2D array of cell values as `data` (prefer data_range for bulk data).",
+        },
+    },
+    "required": ["code"],
+}
+
 _DESCRIPTION_CALC = (
     "Run Python code. Set `result` to a return value (NumPy ndarray, Pandas DataFrame, list, dict, or scalar). "
     + PYTHON_VENV_AUTO_IMPORTS_TOOL_NOTE
@@ -86,12 +108,23 @@ _DESCRIPTION_DRAW = (
     + "Use document tools to read or change the slide/page; this tool does not inject spreadsheet `data`."
 )
 
+# Used when the target app is unknown (e.g. discovery with no document open): covers both
+# the Calc data_range path and the Writer/Draw no-injection path, to match the superset schema.
+_DESCRIPTION_NEUTRAL = (
+    "Run Python code in the configured venv. Set `result` to a return value (NumPy ndarray, Pandas DataFrame, list, dict, or scalar). "
+    + PYTHON_VENV_AUTO_IMPORTS_TOOL_NOTE
+    + "In Calc, optional data_range (e.g. 'Sheet1.B1:B10') injects cell values as `data`; "
+    "in Writer or Draw/Impress use document tools to read or change content (no spreadsheet `data` injection)."
+)
+
 
 def _venv_tool_description(doc_type: str | None) -> str:
     if doc_type == "calc":
         base = _DESCRIPTION_CALC
     elif doc_type in ("draw", "impress"):
         base = _DESCRIPTION_DRAW
+    elif doc_type is None:
+        base = _DESCRIPTION_NEUTRAL
     else:
         base = _DESCRIPTION_WRITER
     hint = format_matplotlib_plot_hint(doc_type=doc_type)
@@ -142,6 +175,10 @@ class RunVenvPythonScript(ToolCalcPythonBase):
     def get_parameters(self, doc_type: str | None = None) -> dict | None:
         if doc_type == "calc":
             return _PARAMETERS_CALC
+        if doc_type is None:
+            # App unknown (e.g. discovery with no document) -> advertise the superset so a
+            # caller targeting Calc still sees data_range (marked Calc-only).
+            return _PARAMETERS_NEUTRAL
         return _PARAMETERS_NON_CALC
 
     def get_description(self, doc_type: str | None = None) -> str:

--- a/plugin/doc/__init__.py
+++ b/plugin/doc/__init__.py
@@ -19,6 +19,7 @@ class CommonModule(ModuleBase):
             document_research_grep_tool,
             document_research_specialized,
             document_research_tools,
+            find_tools_tool,
             print_doc,
             undo,
         )
@@ -32,6 +33,7 @@ class CommonModule(ModuleBase):
             document_research_grep_tool,
             document_research_fts_tool,
             document_research_specialized,
+            find_tools_tool,
             print_doc,
             undo,
         )

--- a/plugin/doc/find_tools_tool.py
+++ b/plugin/doc/find_tools_tool.py
@@ -1,0 +1,372 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""``find_tools`` -- MCP discovery meta-tool for the ``direct_discovery`` exposure mode.
+
+The MCP server advertises a small core tool set; the ~100+ specialized tools are
+callable by name but hidden from ``tools/list`` to keep it short. ``find_tools`` lets a
+client search that hidden catalog by free-text query and/or specialized domain and get
+back ready-to-call MCP schemas -- so any MCP client (Claude, Codex, generic) can reach
+the full tool set without the delegate sub-agent (no LLM backend) and without bloating
+context.
+
+Ranking is pure-Python lexical (BM25-lite + substring bonus): no venv, no numpy, no
+embeddings, so the ranker itself can't fail when those aren't ready. find_tools is
+document-optional (``requires_document = False``) -- discovery works whether or not a
+document is open. A semantic backend is a clean later upgrade behind the embeddings
+venv -- ``_rank``'s signature stays stable.
+
+Only advertised in ``tools/list`` when ``mcp.tool_exposure_mode == "direct_discovery"``
+(gated by name in ``plugin/mcp/mcp_protocol.py``); ``tier="mcp"`` keeps it off the chat
+agent's tool list.
+"""
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from typing import Any
+
+from plugin.framework.tool import ToolBase, ToolContext
+
+_DEFAULT_LIMIT = 8
+_MAX_LIMIT = 50
+_FINISH_TOOL = "specialized_workflow_finished"
+# In direct_discovery mode the delegate gateway is not the intended route, so keep
+# its (core-tier) gateway tools out of discovery results.
+_GATEWAY_PREFIX = "delegate_to_specialized_"
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+# Dropped from query token scoring (kept for the raw-substring bonus) so common words
+# like "a"/"the" don't surface unrelated tools.
+_STOPWORDS = frozenset({
+    "a", "an", "the", "to", "from", "of", "and", "or", "for", "with", "in", "on",
+    "is", "it", "this", "that", "my", "your", "into", "as", "at", "by",
+})
+
+
+def _tokenize(text: Any) -> list[str]:
+    # Strip accents so e.g. "rodapé"/"gráfico" tokenize like their unaccented forms --
+    # a small help for non-English queries. Full cross-language matching needs the
+    # semantic ranker / per-domain synonyms (a documented later upgrade).
+    s = unicodedata.normalize("NFKD", str(text or "").lower())
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return _TOKEN_RE.findall(s)
+
+
+def _doc_tokens(schema: dict) -> list[str]:
+    """Searchable token bag for a tool schema: name tokens weighted x3, description x1."""
+    name_toks = _tokenize(str(schema.get("name") or "").replace("_", " "))
+    body_toks = _tokenize(schema.get("description") or "")
+    return name_toks * 3 + body_toks
+
+
+def _doc_filter(doc: Any) -> dict:
+    """Registry kwargs for the active document.
+
+    With no open document the registry filters out every app-specific tool (by
+    ``uno_services``), which would leave discovery almost empty -- so pass
+    ``filter_doc_type=False`` to list the whole catalog instead.
+    """
+    return {} if doc is not None else {"filter_doc_type": False}
+
+
+def _rank(schemas: list[dict], query: str | None, limit: int) -> list[dict]:
+    """Rank tool schemas against a free-text query (BM25-lite + substring bonus).
+
+    Deterministic and dependency-free. Empty query -> registry order, truncated to
+    ``limit``. With a query, schemas with no token overlap and no raw-substring hit
+    score 0 and are dropped. Stable secondary sort by name.
+    """
+    q = (query or "").strip()
+    if not q:
+        return schemas[:limit]
+
+    q_all = set(_tokenize(q))
+    q_tokens = (q_all - _STOPWORDS) or q_all  # if the query is all stopwords, keep them
+    raw_q = q.lower()
+    docs = [(s, _doc_tokens(s)) for s in schemas]
+    n = len(docs)
+    if not n:
+        return []
+    avgdl = sum(len(d) for _, d in docs) / n or 0.0
+    k1, b = 1.2, 0.75
+    df = {qt: sum(1 for _, d in docs if qt in d) for qt in q_tokens}
+
+    scored: list[tuple[float, str, dict]] = []
+    for schema, d in docs:
+        dl = len(d)
+        score = 0.0
+        for qt in q_tokens:
+            f = d.count(qt)
+            if not f:
+                continue
+            n_q = df.get(qt) or 1
+            idf = math.log(1 + (n - n_q + 0.5) / (n_q + 0.5))
+            denom = f + k1 * (1 - b + b * (dl / avgdl if avgdl else 0.0))
+            score += idf * (f * (k1 + 1)) / denom
+        name = str(schema.get("name") or "")
+        if raw_q in name.lower():
+            score += 2.0
+        elif raw_q in str(schema.get("description") or "").lower():
+            score += 0.5
+        if score > 0:
+            scored.append((score, name, schema))
+
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    return [s for _, _, s in scored[:limit]]
+
+
+def _agent_label_for_doc_type(doc_type: str | None) -> str:
+    return {"calc": "Calc", "draw": "Draw", "impress": "Draw",
+            "writer": "Writer"}.get((doc_type or "").lower(), "Writer")
+
+
+def get_domain_guidance(domain: str, *, agent_label: str = "Writer", ctx: Any = None) -> str:
+    """Static per-domain usage guidance for direct callers (mirrors the delegate's hints).
+
+    Returns ``""`` for live-context domains (shapes canvas / spreadsheet snapshot /
+    open-docs) that require a running document and for unknown domains.
+    """
+    if domain == "footnotes":
+        return ("For footnotes_insert: if the task quotes or names the document anchor "
+                "(e.g. a sentence), pass that exact string as insert_after_text so the "
+                "note is placed after that text.")
+    if domain == "charts":
+        if agent_label == "Calc":
+            return "When creating a chart in Calc, you MUST specify the data range explicitly (e.g. data_range='A1:B10')."
+        if agent_label is None:
+            # App unknown (no document open): cover both so the advice isn't Writer-biased.
+            return ("For charts: in Calc you MUST pass an explicit data range (e.g. "
+                    "data_range='A1:B10'); in Writer or Draw/Impress you MUST pass both the "
+                    "`headers` and `rows` parameters.")
+        return ("When creating or editing a chart in Writer or Draw/Impress, you MUST "
+                "specify both the `headers` and `rows` parameters.")
+    if domain == "images":
+        return ("Discover local image files with list_nearby_image_files before insert_image "
+                "when the user refers to a photo in the folder.")
+    if domain == "analysis":
+        return ("For stats, cleaning, regression, clustering, or simulation on tabular data "
+                "use analyze_data; for charts use plot_data (or auto_plot=true); for live "
+                "single-cell what-if use calc_goal_seek; for constrained optimization use "
+                "calc_solver. Always pass a data_range (A1 address) for bulk data.")
+    if domain == "python":
+        if agent_label is None:
+            # App unknown (no document open): cover both so the advice isn't Writer-biased.
+            return ("run_venv_python_script: in Calc, pass `data_range` (an A1 address) to inject "
+                    "cell values as `data`; in Writer or Draw/Impress it does not inject "
+                    "spreadsheet data -- use document tools for content.")
+        try:
+            from plugin.framework.constants import python_specialized_sub_agent_hint
+            return (python_specialized_sub_agent_hint(agent_label) or "").strip()
+        except Exception:
+            return ""
+    if domain == "document_research":
+        try:
+            from plugin.doc.document_research import get_document_research_workflow_hint
+            return (get_document_research_workflow_hint(getattr(ctx, "ctx", None)) or "").strip()
+        except Exception:
+            return ""
+    return ""
+
+
+def sidebar_only_tool_names(registry: Any, doc: Any) -> frozenset:
+    """Tool names in Writer sidebar-only domains (e.g. brainstorming, writing_plan).
+
+    Those flows depend on bespoke session orchestration / finish tools that the direct
+    MCP modes don't provide, so the delegate keeps them off MCP (``tool.py`` /
+    ``WRITER_SIDEBAR_ONLY_DOMAINS``). The direct modes -- ``find_tools`` and
+    ``direct_flat``'s ``tools/list`` -- must exclude them the same way.
+    """
+    try:
+        from plugin.framework.constants import WRITER_SIDEBAR_ONLY_DOMAINS
+        tools = registry.get_tools(doc=doc, exclude_tiers=(), **_doc_filter(doc))
+    except Exception:
+        return frozenset()
+    out = set()
+    for t in tools:
+        if getattr(t, "specialized_domain", None) in WRITER_SIDEBAR_ONLY_DOMAINS:
+            name = getattr(t, "name", None)
+            if isinstance(name, str):
+                out.add(name)
+    return frozenset(out)
+
+
+class FindTools(ToolBase):
+    """Discover registry tools by free-text query and/or specialized domain.
+
+    Returns ready-to-call MCP schemas for tools that are callable by name but hidden
+    from the default ``tools/list``. Pure-Python lexical ranking (no venv, no embeddings)
+    and document-optional, so discovery works even with no document open.
+    """
+
+    name = "find_tools"
+    description = (
+        "Discover additional tools that are available but not listed here. This MCP "
+        "server exposes a small core tool set; many specialized capabilities (e.g. "
+        "footnotes, charts, images, data analysis, document research) are callable by "
+        "name but hidden from the default list to keep it short. Call find_tools with a "
+        "natural-language `query` describing what you want to do (e.g. \"insert a "
+        "footnote\", \"make a bar chart from a range\") to get the matching tools and "
+        "their full input schemas, ready to call directly. Pass a `domain` to list every "
+        "tool in one area. Call with no arguments to see the available domains and a "
+        "sample of tools. Always prefer calling a tool returned by find_tools over giving "
+        "up because a capability seems missing."
+    )
+    tier = "mcp"
+    is_mutation = False
+    requires_document = False  # discovery needs no open document
+    parameters = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": ("Natural-language description of the task you want to accomplish "
+                                "(e.g. 'insert a footnote', 'create a chart from a cell range'). "
+                                "Tools are ranked by relevance to it. Optional."),
+            },
+            "domain": {
+                "type": "string",
+                "description": ("Optional specialized area to scope results to (e.g. 'footnotes', "
+                                "'charts', 'images', 'analysis', 'document_research'). Call "
+                                "find_tools with no arguments to see the available domains."),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of tools to return (default 8).",
+                "minimum": 1,
+                "maximum": _MAX_LIMIT,
+            },
+        },
+        "required": [],
+    }
+
+    def execute(self, ctx: ToolContext, query: str | None = None,
+                domain: str | None = None, limit: int | None = None,
+                **kwargs: Any) -> dict[str, Any]:
+        registry = ctx.services.get("tools") if ctx.services else None
+        if registry is None:
+            return self._tool_error("Tool registry unavailable.", code="SERVICE_UNAVAILABLE")
+
+        # Normalize client-supplied inputs (an MCP client can send anything).
+        query = query if isinstance(query, str) else None
+        domain = domain.strip().lower() if isinstance(domain, str) and domain.strip() else None
+        # A domain listing promises "every tool in one area", so with no explicit limit
+        # default it to the max (a domain rarely has more); a free-text query keeps the
+        # small default to stay token-cheap.
+        default_n = _MAX_LIMIT if domain else _DEFAULT_LIMIT
+        try:
+            top_n = int(limit) if limit else default_n
+        except (TypeError, ValueError, OverflowError):
+            top_n = default_n
+        top_n = max(1, min(top_n, _MAX_LIMIT))
+
+        doc = getattr(ctx, "doc", None)
+        domains = self._available_domains(registry, doc)
+
+        from plugin.framework.constants import WRITER_SIDEBAR_ONLY_DOMAINS
+        if domain and domain in WRITER_SIDEBAR_ONLY_DOMAINS:
+            # Sidebar-only flows aren't reachable over MCP (they need bespoke session
+            # orchestration), so don't even surface their required-core tools.
+            schemas = []
+        elif domain:
+            # active_domain narrowing: the domain's specialized tools + their required
+            # core tools (the registry bypasses tier exclusion when active_domain is set).
+            schemas = registry.get_schemas("mcp", doc=doc, active_domain=domain, **_doc_filter(doc))
+        else:
+            # global search: surface the hidden specialized tools only -- exclude core
+            # (already in tools/list, so re-listing it just pollutes discovery), the mcp
+            # tier (so the discovery tools don't return themselves), and workflow-control.
+            schemas = registry.get_schemas(
+                "mcp", doc=doc, exclude_tiers=frozenset({"mcp", "specialized_control", "core"}),
+                **_doc_filter(doc))
+
+        # Drop the workflow finish tool (re-added by the domain narrowing), the delegate
+        # gateway tools, and Writer sidebar-only flows (which need bespoke orchestration
+        # the direct modes don't provide); guard against malformed (non-dict) schemas.
+        sidebar_only = sidebar_only_tool_names(registry, doc)
+        candidates = []
+        for s in (schemas or []):
+            if not isinstance(s, dict):
+                continue
+            name = s.get("name")
+            # Drop schemas without a usable, callable name: a malformed schema can carry a
+            # non-string or even unhashable name (e.g. a list). Returning it would both
+            # break the `in sidebar_only` membership test and hand back an uncallable tool.
+            if not isinstance(name, str) or not name:
+                continue
+            if name == _FINISH_TOOL or name.startswith(_GATEWAY_PREFIX) or name in sidebar_only:
+                continue
+            candidates.append(s)
+        ranked = _rank(candidates, query, top_n)
+
+        result: dict[str, Any] = {
+            "status": "ok",
+            "query": query,
+            "domain": domain,
+            "available_domains": domains,
+            "tools": ranked,
+        }
+        if doc is None:
+            result["note"] = ("No document is open, so results span all document types; "
+                              "open the matching document before calling an app-specific tool.")
+        # Per-domain usage guidance (the load-bearing hints the delegate injects).
+        # Always a dict {domain: text}: for an explicit `domain` it's that one; for a
+        # free-text `query` we infer the domains of the returned tools so the caller
+        # still gets the hints (e.g. "charts need a data_range") it would otherwise
+        # lose vs the delegate path.
+        # With no open document the target app is unknown, so use neutral (app-agnostic)
+        # guidance instead of defaulting to Writer (which would give wrong chart advice).
+        doc_type = getattr(ctx, "doc_type", None) if doc is not None else None
+        label = _agent_label_for_doc_type(doc_type) if doc_type else None
+        if domain:
+            target_domains = [domain]
+        else:
+            name_to_domain = self._tool_domains(registry, doc)
+            seen: set[str] = set()
+            target_domains = []
+            for s in ranked:
+                d = name_to_domain.get(str(s.get("name") or ""))
+                if d and d not in seen:
+                    seen.add(d)
+                    target_domains.append(d)
+        guidance = {}
+        for d in target_domains:
+            g = get_domain_guidance(d, agent_label=label, ctx=ctx)
+            if g:
+                guidance[d] = g
+        if guidance:
+            result["domain_guidance"] = guidance
+        return result
+
+    @staticmethod
+    def _available_domains(registry: Any, doc: Any) -> list[str]:
+        """Distinct specialized domains reachable over MCP, sorted.
+
+        Excludes Writer sidebar-only domains (they need bespoke session orchestration the
+        direct modes can't provide), matching the delegate.
+        """
+        from plugin.framework.constants import WRITER_SIDEBAR_ONLY_DOMAINS
+        try:
+            tools = registry.get_tools(doc=doc, exclude_tiers=(), **_doc_filter(doc))
+        except Exception:
+            return []
+        return sorted({
+            d for t in tools
+            if (d := getattr(t, "specialized_domain", None)) and d not in WRITER_SIDEBAR_ONLY_DOMAINS
+        })
+
+    @staticmethod
+    def _tool_domains(registry: Any, doc: Any) -> dict[str, str]:
+        """Map tool name -> its specialized domain, to infer guidance from query results."""
+        try:
+            tools = registry.get_tools(doc=doc, exclude_tiers=(), **_doc_filter(doc))
+        except Exception:
+            return {}
+        out: dict[str, str] = {}
+        for t in tools:
+            d = getattr(t, "specialized_domain", None)
+            name = getattr(t, "name", None)
+            if d and isinstance(name, str):
+                out[name] = str(d)
+        return out

--- a/plugin/framework/tool.py
+++ b/plugin/framework/tool.py
@@ -244,6 +244,9 @@ class ToolBase(ABC):
     long_running: bool = False
     is_final_answer_tool: bool = False
     doc_types: list[str] | None = None
+    # When False, the MCP executor runs the tool even with no document open (e.g. the
+    # find_tools discovery meta-tool); the default requires an open document.
+    requires_document: bool = True
     required_core_tools: ClassVar[frozenset[str] | None] = None
 
     def detects_mutation(self):

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -81,6 +81,28 @@ _doc_gates: dict[str, threading.Lock] = {}
 _doc_gates_guard = threading.Lock()
 
 
+def _real_active_document(doc_svc):
+    """The active document, or None when no real document is open.
+
+    LibreOffice's Start Center is a live component but not a document, so
+    get_active_document() returns it when nothing is open. A real document -- even an
+    unsupported type like Math/Base -- supports ``com.sun.star.document.OfficeDocument``;
+    the Start Center does not. So only the Start Center is normalized to None (real but
+    unsupported docs are left to fail with the clearer "unsupported document" error). This
+    keeps the MCP layer (NO_DOCUMENT_OPEN, find_tools' no-doc catalog, direct_flat's no-doc
+    broadening) consistent in the real "no document open" state.
+    """
+    doc = doc_svc.get_active_document()
+    if doc is None:
+        return None
+    try:
+        if not doc.supportsService("com.sun.star.document.OfficeDocument"):
+            return None
+    except Exception:
+        pass  # can't introspect -> keep it (don't break a real document)
+    return doc
+
+
 def _resolve_mcp_doc_key(document_url, doc):
     """Stable per-document key for the mutation gate, derived from the RESOLVED document (``doc``).
 
@@ -418,17 +440,56 @@ class MCPProtocolHandler:
     def _mcp_ping(self, params):
         return wire_types.ping_result()
 
+    def _tool_exposure_mode(self):
+        """Read mcp.tool_exposure_mode (delegate | direct_flat | direct_discovery)."""
+        try:
+            return self.services.config.get("mcp.tool_exposure_mode", "delegate") or "delegate"
+        except Exception:
+            return "delegate"
+
     def _mcp_tools_list(self, params, document_url=None):
         def _get_doc():
             doc_svc = self.services.document
             if document_url:
                 doc, _ = doc_svc.resolve_document_by_url(document_url)
                 return doc
-            return doc_svc.get_active_document()
+            return _real_active_document(doc_svc)
 
         doc = self.queue_executor.execute(_get_doc, timeout=10.0)
 
-        schemas = self.tool_registry.get_schemas("mcp", doc=doc, exclude_tiers=frozenset({"specialized", "specialized_control"}))
+        mode = self._tool_exposure_mode()
+        # direct_flat advertises the specialized tools directly (control tools stay hidden --
+        # they only make sense inside an active delegated domain). Every other mode keeps
+        # today's core-only list (specialized tools are still callable by name -- via the
+        # delegate gateway, or the find_tools discovery tool in direct_discovery).
+        if mode == "direct_flat":
+            exclude_tiers = frozenset({"specialized_control"})
+        else:
+            exclude_tiers = frozenset({"specialized", "specialized_control"})
+
+        # In direct_flat with no target at all (no active doc AND no document_url), don't
+        # filter by doc type, or app-specific tools would be dropped with no find_tools
+        # fallback. An unresolvable document_url is a DOCUMENT_NOT_FOUND case, not a
+        # no-target broaden, so it keeps normal filtering -- as do delegate (byte-for-byte
+        # unchanged) and direct_discovery (find_tools has its own no-doc catalog).
+        broaden = mode == "direct_flat" and doc is None and not document_url
+        doc_filter = {"filter_doc_type": False} if broaden else {}
+        schemas = self.tool_registry.get_schemas("mcp", doc=doc, exclude_tiers=exclude_tiers, **doc_filter)
+
+        if mode == "direct_flat":
+            # Keep Writer sidebar-only flows (brainstorming, writing_plan) out of the flat
+            # list -- they need bespoke session orchestration the direct modes don't give.
+            from plugin.doc.find_tools_tool import sidebar_only_tool_names
+            sidebar_only = sidebar_only_tool_names(self.tool_registry, doc)
+            if sidebar_only:
+                schemas = [s for s in schemas if s.get("name") not in sidebar_only]
+
+        # find_tools is the discovery search tool, useful only in direct_discovery mode
+        # (small core list + on-demand search). delegate advertises the gateway and
+        # direct_flat already lists everything, so hide it by name in those modes.
+        if mode != "direct_discovery":
+            schemas = [s for s in schemas if s.get("name") != "find_tools"]
+
         return wire_types.list_tools_result(schemas)
 
     def _mcp_resources_list(self, params):
@@ -446,6 +507,19 @@ class MCPProtocolHandler:
         arg_document_url = arguments.pop("document_url", None)
         if arg_document_url:
             document_url = arg_document_url
+
+        # find_tools is the discovery search tool; it is only advertised in
+        # direct_discovery mode, so reject calling it by name in other modes -- otherwise
+        # the default (delegate) behavior would not really be unchanged.
+        if tool_name == "find_tools" and self._tool_exposure_mode() != "direct_discovery":
+            return {
+                "content": [{"type": "text", "text": json.dumps({
+                    "status": "error", "code": "UNKNOWN_TOOL",
+                    "message": "Tool 'find_tools' is only available when mcp.tool_exposure_mode is 'direct_discovery'.",
+                }, ensure_ascii=False)}],
+                "isError": True,
+            }
+
         tool = self.tool_registry.get(tool_name)
         is_long_running = getattr(tool, "long_running", False) if tool else False
 
@@ -592,7 +666,7 @@ class MCPProtocolHandler:
             if document_url:
                 doc, doc_type = doc_svc.resolve_document_by_url(document_url)
             else:
-                doc = doc_svc.get_active_document()
+                doc = _real_active_document(doc_svc)
                 if doc:
                     doc_type = doc_svc.detect_doc_type(doc)
             import uno
@@ -603,10 +677,13 @@ class MCPProtocolHandler:
 
         doc, doc_type, ctx, doc_key = self.queue_executor.execute(_get_context, timeout=10.0)
 
-        if doc is None and not document_url:
-            return {"status": "error", "code": "NO_DOCUMENT_OPEN", "message": "No document open in LibreOffice."}
-        elif doc is None:
+        # Document-optional tools (e.g. find_tools) run with no document; an explicit
+        # document_url that doesn't resolve is always an error, though.
+        tool = self.tool_registry.get(tool_name)
+        if doc is None and document_url:
             return {"status": "error", "code": "DOCUMENT_NOT_FOUND", "message": "No document open matching X-Document-URL: %s" % document_url, "details": {"document_url": document_url}}
+        if doc is None and getattr(tool, "requires_document", True):
+            return {"status": "error", "code": "NO_DOCUMENT_OPEN", "message": "No document open in LibreOffice."}
 
         from plugin.framework.tool import ToolContext
 
@@ -622,7 +699,6 @@ class MCPProtocolHandler:
 
         # Sub-tools invoked by a delegating tool run in-process (not via this method),
         # so the gate is not re-entered on the same thread -> no self-deadlock.
-        tool = self.tool_registry.get(tool_name)
         needs_gate = _tool_needs_document_mutation_gate(tool, arguments)
         with _document_mutation_gate(doc_key, enabled=needs_gate):
             t0 = time.perf_counter()
@@ -645,14 +721,17 @@ class MCPProtocolHandler:
                 if doc is None:
                     return {"status": "error", "code": "DOCUMENT_NOT_FOUND", "message": "No document open matching X-Document-URL: %s" % (document_url or ""), "details": {"document_url": document_url}}
             else:
-                doc = doc_svc.get_active_document()
+                doc = _real_active_document(doc_svc)
                 if doc:
                     doc_type = doc_svc.detect_doc_type(doc)
         except Exception as e:
             log.warning("Error resolving context in execution: %s", type(e).__name__)
             pass
 
-        if doc is None:
+        # Document-optional tools (e.g. the find_tools discovery meta-tool) run with no
+        # document open; every other tool still requires one.
+        tool = self.tool_registry.get(tool_name)
+        if doc is None and getattr(tool, "requires_document", True):
             return {"status": "error", "code": "NO_DOCUMENT_OPEN", "message": "No document open in LibreOffice."}
 
         # Get UNO context
@@ -678,7 +757,6 @@ class MCPProtocolHandler:
         context = ToolContext(doc=doc, ctx=ctx, doc_type=doc_type, services=self.services, caller="mcp", active_page_index=active_page_idx)
 
         doc_key = _resolve_mcp_doc_key(document_url, doc)
-        tool = self.tool_registry.get(tool_name)
         needs_gate = _tool_needs_document_mutation_gate(tool, arguments)
         with _document_mutation_gate(doc_key, enabled=needs_gate):
             t0 = time.perf_counter()
@@ -743,7 +821,7 @@ class MCPProtocolHandler:
     def _detect_active_doc_type(self):
         try:
             doc_svc = self.services.document
-            doc = doc_svc.get_active_document()
+            doc = _real_active_document(doc_svc)
             if doc:
                 return doc_svc.detect_doc_type(doc)
         except Exception as e:

--- a/plugin/mcp/module.yaml
+++ b/plugin/mcp/module.yaml
@@ -19,6 +19,20 @@ config:
     widget: number
     label: MCP Port
     public: true
+  tool_exposure_mode:
+    type: string
+    default: delegate
+    widget: select
+    label: MCP Tool Exposure
+    helper: "How specialized tools are surfaced to MCP clients. delegate=reached via the delegate gateway (today's behavior); direct_flat=all MCP-reachable specialized tools listed directly, excluding sidebar-only flows (best for clients with their own tool-search); direct_discovery=small core list plus a find_tools search tool that reveals the rest on demand (best for any client)."
+    public: true
+    options:
+      - value: delegate
+        label: Delegate (default)
+      - value: direct_flat
+        label: Direct — list all tools
+      - value: direct_discovery
+        label: Direct — discovery (find_tools)
   cors_allow_private_origins:
     type: boolean
     default: true

--- a/tests/mcp/test_find_tools.py
+++ b/tests/mcp/test_find_tools.py
@@ -1,0 +1,632 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for the find_tools discovery meta-tool + its tools/list gating.
+
+Registry is mocked (the tool's own logic + the protocol gating are what we assert
+here); the real registry / domain-narrowing path is covered by the live MCP run.
+"""
+from unittest.mock import MagicMock
+
+from plugin.doc.find_tools_tool import FindTools, _rank, get_domain_guidance
+from plugin.framework.tool import ToolBase, ToolRegistry
+from plugin.mcp.mcp_protocol import MCPProtocolHandler
+from plugin.writer.specialized_base import ToolWriterSpecialBase
+
+
+# --------------------------------------------------------------------------- #
+# tool metadata + pure ranker
+# --------------------------------------------------------------------------- #
+
+def test_find_tools_properties():
+    tool = FindTools()
+    assert tool.name == "find_tools"
+    assert tool.tier == "mcp"           # hidden from the chat agent's tool list
+    assert tool.is_mutation is False
+    assert tool.requires_document is False   # discovery works with no document open
+
+
+def test_rank_name_substring_outranks_description():
+    schemas = [
+        {"name": "unrelated_tool", "description": "mentions footnote here"},
+        {"name": "footnotes_insert", "description": "add a note"},
+    ]
+    assert _rank(schemas, "footnote", 5)[0]["name"] == "footnotes_insert"
+
+
+def test_rank_empty_query_returns_input_order_truncated():
+    schemas = [{"name": "a", "description": ""}, {"name": "b", "description": ""}]
+    assert _rank(schemas, "", 1) == schemas[:1]
+
+
+def test_rank_no_overlap_is_dropped():
+    schemas = [{"name": "footnotes_insert", "description": "add a note"}]
+    assert _rank(schemas, "zzz_no_such_capability", 5) == []
+
+
+def test_rank_multiword_query():
+    schemas = [
+        {"name": "create_chart", "description": "make a chart from a data range"},
+        {"name": "footnotes_insert", "description": "insert a footnote at an anchor"},
+        {"name": "noise", "description": "totally unrelated text"},
+    ]
+    ranked = _rank(schemas, "insert a footnote", 2)
+    assert ranked[0]["name"] == "footnotes_insert"
+
+
+def test_get_domain_guidance():
+    assert "data range" in get_domain_guidance("charts", agent_label="Calc").lower()
+    assert "headers" in get_domain_guidance("charts", agent_label="Writer").lower()
+    assert "insert_after_text" in get_domain_guidance("footnotes")
+    assert get_domain_guidance("totally_unknown_domain") == ""
+
+
+# --------------------------------------------------------------------------- #
+# execute() with a mocked registry
+# --------------------------------------------------------------------------- #
+
+def _ctx(registry, doc_type="writer"):
+    ctx = MagicMock()
+    ctx.services.get.side_effect = lambda name: registry if name == "tools" else None
+    ctx.doc = MagicMock()
+    ctx.doc_type = doc_type
+    ctx.ctx = MagicMock()
+    return ctx
+
+
+def _schema(name, desc="a tool"):
+    return {"name": name, "description": desc, "inputSchema": {"type": "object", "properties": {}}}
+
+
+def test_execute_domain_returns_domain_schemas_without_finish_tool():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [
+        _schema("footnotes_insert"), _schema("footnotes_list"),
+        _schema("specialized_workflow_finished", "finish"),
+    ]
+    registry.get_tools.return_value = [
+        MagicMock(specialized_domain="footnotes"), MagicMock(specialized_domain=None),
+    ]
+    ctx = _ctx(registry)
+
+    result = FindTools().execute(ctx, domain="footnotes")
+
+    names = {t["name"] for t in result["tools"]}
+    assert {"footnotes_insert", "footnotes_list"} <= names
+    assert "specialized_workflow_finished" not in names         # finish tool stripped
+    for t in result["tools"]:
+        assert "inputSchema" in t
+    registry.get_schemas.assert_called_once_with("mcp", doc=ctx.doc, active_domain="footnotes")
+    assert "footnotes" in result["available_domains"]
+    assert "insert_after_text" in result["domain_guidance"]["footnotes"]
+
+
+def test_execute_query_ranks_top_n():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [
+        _schema("footnotes_insert", "insert a footnote at an anchor"),
+        _schema("create_chart", "make a chart from a range"),
+        _schema("unrelated", "something else entirely"),
+    ]
+    registry.get_tools.return_value = []
+    ctx = _ctx(registry)
+
+    result = FindTools().execute(ctx, query="insert a footnote", limit=2)
+
+    names = [t["name"] for t in result["tools"]]
+    assert len(names) <= 2
+    assert names[0] == "footnotes_insert"
+    # global branch hides mcp + control + core tiers (core is already in tools/list)
+    registry.get_schemas.assert_called_once_with(
+        "mcp", doc=ctx.doc, exclude_tiers=frozenset({"mcp", "specialized_control", "core"}))
+
+
+def test_execute_unknown_query_returns_empty():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [_schema("footnotes_insert", "add a note")]
+    registry.get_tools.return_value = []
+    result = FindTools().execute(_ctx(registry), query="zzz_no_such_capability")
+    assert result["tools"] == []
+
+
+def test_execute_no_args_lists_domains():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [_schema("a"), _schema("b")]
+    registry.get_tools.return_value = [
+        MagicMock(specialized_domain="footnotes"), MagicMock(specialized_domain="charts"),
+    ]
+    result = FindTools().execute(_ctx(registry))
+    assert sorted(result["available_domains"]) == ["charts", "footnotes"]
+    assert result["tools"]                                       # global listing, no query
+
+
+def test_execute_no_registry_errors():
+    ctx = MagicMock()
+    ctx.services.get.side_effect = lambda name: None
+    result = FindTools().execute(ctx)
+    assert result.get("status") == "error"
+
+
+# --------------------------------------------------------------------------- #
+# tools/list gating: find_tools only in direct_discovery
+# --------------------------------------------------------------------------- #
+
+def _handler(mode, schemas):
+    services = MagicMock()
+    services.tools.get_schemas.return_value = list(schemas)
+    services.config.get.side_effect = (
+        lambda key, default=None: mode if key == "mcp.tool_exposure_mode" else default
+    )
+    services.get.side_effect = lambda name: getattr(services, name, None)
+
+    def _inline(fn, *a, **k):
+        k.pop("timeout", None)
+        return fn(*a, **k)
+
+    services.main_thread.execute.side_effect = _inline
+    services.document.get_active_document.return_value = MagicMock()
+    return MCPProtocolHandler(services)
+
+
+def _list_names(mode):
+    schemas = [
+        {"name": "find_tools", "description": "discovery", "inputSchema": {}},
+        {"name": "insert_footnote", "description": "footnote", "inputSchema": {}},
+        {"name": "apply_document_content", "description": "core", "inputSchema": {}},
+    ]
+    handler = _handler(mode, schemas)
+    return {t["name"] for t in handler._mcp_tools_list({})["tools"]}
+
+
+def test_find_tools_listed_only_in_direct_discovery():
+    assert "find_tools" not in _list_names("delegate")
+    assert "find_tools" not in _list_names("direct_flat")
+    assert "find_tools" in _list_names("direct_discovery")
+
+
+def test_gating_keeps_other_tools():
+    # the name filter only drops find_tools, never the real tools
+    assert "apply_document_content" in _list_names("delegate")
+    assert "insert_footnote" in _list_names("direct_discovery")
+
+
+# --------------------------------------------------------------------------- #
+# real-registry tests: validate the FindTools <-> ToolRegistry contract and the
+# per-mode tools/list sizing (the actual product promise) without mocking the
+# registry internals. Universal (uno_services=None) fakes so no live doc is needed.
+# --------------------------------------------------------------------------- #
+
+class _FtBase(ToolWriterSpecialBase):
+    # _is_specialized_domain_tool requires an instance of the real specialized base
+    # (tool.py:435), not just a specialized_domain attribute. uno_services=None keeps
+    # the fakes universal so the test needs no live Writer document.
+    specialized_domain = "footnotes"
+    uno_services = None
+    is_mutation = False
+    description = "footnotes domain tool"
+    parameters = {"type": "object", "properties": {}, "required": []}
+
+    def execute(self, ctx, **kwargs):
+        return {"status": "ok"}
+
+
+class _FtInsert(_FtBase):
+    name = "footnotes_insert"
+    description = "insert a footnote at an anchor"
+
+
+class _FtList(_FtBase):
+    name = "footnotes_list"
+    description = "list the footnotes in the document"
+
+
+class _FinishTool(ToolBase):
+    name = "specialized_workflow_finished"
+    description = "finish the specialized workflow"
+    tier = "specialized_control"
+    is_mutation = False
+    parameters = {"type": "object", "properties": {}, "required": []}
+
+    def execute(self, ctx, **kwargs):
+        return {}
+
+
+class _GatewayTool(ToolBase):
+    name = "delegate_to_specialized_writer_toolset"
+    description = "delegate to a specialized writer toolset"
+    tier = "core"
+    is_mutation = False
+    parameters = {"type": "object", "properties": {}, "required": []}
+
+    def execute(self, ctx, **kwargs):
+        return {}
+
+
+class _CoreTool(ToolBase):
+    name = "apply_document_content"
+    description = "core document edit"
+    tier = "core"
+    is_mutation = False
+    parameters = {"type": "object", "properties": {}, "required": []}
+
+    def execute(self, ctx, **kwargs):
+        return {}
+
+
+class _BrainstormTool(_FtBase):
+    # Writer sidebar-only domain (WRITER_SIDEBAR_ONLY_DOMAINS): must NOT leak into the
+    # direct MCP modes, since its flow needs a bespoke finish tool the direct modes lack.
+    name = "brainstorm_research_web"
+    specialized_domain = "brainstorming"
+    description = "brainstorm research on the web"
+
+
+class _AppSpecificTool(ToolBase):
+    # An app-specific specialized tool (uno_services set) -> the registry filters it out
+    # when there's no open document, unless discovery lists the full catalog.
+    name = "create_chart"
+    description = "create a chart from a data range"
+    tier = "specialized"
+    is_mutation = False
+    uno_services = ["com.sun.star.text.TextDocument"]
+    parameters = {"type": "object", "properties": {}, "required": []}
+
+    def execute(self, ctx, **kwargs):
+        return {}
+
+
+class _AppSpecificCoreTool(ToolBase):
+    # An app-specific *core* tool: must stay filtered out with no document in delegate /
+    # direct_discovery (the no-doc broad catalog is direct_flat-only).
+    name = "calc_only_core"
+    description = "a calc-only core tool"
+    tier = "core"
+    is_mutation = False
+    uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
+    parameters = {"type": "object", "properties": {}, "required": []}
+
+    def execute(self, ctx, **kwargs):
+        return {}
+
+
+def _real_registry():
+    reg = ToolRegistry(MagicMock())
+    for cls in (FindTools, _FtInsert, _FtList, _FinishTool, _GatewayTool, _CoreTool, _BrainstormTool):
+        reg.register(cls())
+    return reg
+
+
+def _ctx_real(registry):
+    ctx = MagicMock()
+    ctx.services.get.side_effect = lambda name: registry if name == "tools" else None
+    ctx.doc = None          # universal fakes pass with no active document
+    ctx.doc_type = "writer"
+    ctx.ctx = MagicMock()
+    return ctx
+
+
+def _handler_real(mode, registry):
+    services = MagicMock()
+    services.tools = registry
+    services.config.get.side_effect = (
+        lambda key, default=None: mode if key == "mcp.tool_exposure_mode" else default
+    )
+    services.get.side_effect = lambda name: getattr(services, name, None)
+
+    def _inline(fn, *a, **k):
+        k.pop("timeout", None)
+        return fn(*a, **k)
+
+    services.main_thread.execute.side_effect = _inline
+    services.document.get_active_document.return_value = None
+    return MCPProtocolHandler(services)
+
+
+def test_execute_domain_real_registry():
+    result = FindTools().execute(_ctx_real(_real_registry()), domain="footnotes")
+    names = {t["name"] for t in result["tools"]}
+    assert {"footnotes_insert", "footnotes_list"} <= names
+    assert "specialized_workflow_finished" not in names      # finish stripped
+    assert "delegate_to_specialized_writer_toolset" not in names
+    assert "find_tools" not in names                          # self not surfaced
+
+
+def test_mode_sizing_real_registry():
+    reg = _real_registry()
+
+    def names(mode):
+        return {t["name"] for t in _handler_real(mode, reg)._mcp_tools_list({})["tools"]}
+
+    spec = {"footnotes_insert", "footnotes_list"}
+    delegate = names("delegate")
+    assert not (spec & delegate) and "find_tools" not in delegate
+    assert "apply_document_content" in delegate
+    flat = names("direct_flat")
+    assert spec <= flat and "find_tools" not in flat          # specialized exposed, no find_tools
+    discovery = names("direct_discovery")
+    assert "find_tools" in discovery and not (spec & discovery)  # small list + find_tools
+
+
+# --------------------------------------------------------------------------- #
+# robustness regressions (the review's SHOULD-FIX hardenings)
+# --------------------------------------------------------------------------- #
+
+def test_execute_tolerates_malformed_schemas():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [
+        {"name": 123, "description": ["x"], "inputSchema": {}},   # non-string name/desc
+        "not_a_dict",                                             # non-dict candidate
+        _schema("footnotes_insert", "add a note"),
+    ]
+    registry.get_tools.return_value = []
+    result = FindTools().execute(_ctx(registry), query="footnote")
+    assert result["status"] == "ok"
+
+
+def test_execute_tolerates_infinite_limit():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [_schema("a")]
+    registry.get_tools.return_value = []
+    assert FindTools().execute(_ctx(registry), limit=float("inf"))["status"] == "ok"
+
+
+def test_execute_tolerates_non_string_inputs():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [_schema("a")]
+    registry.get_tools.return_value = []
+    assert FindTools().execute(_ctx(registry), query=["not", "str"], domain=123)["status"] == "ok"
+
+
+def test_execute_excludes_gateway_from_global():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [
+        _schema("delegate_to_specialized_writer_toolset", "delegate"),
+        _schema("footnotes_insert", "insert a footnote"),
+    ]
+    registry.get_tools.return_value = []
+    names = {t["name"] for t in FindTools().execute(_ctx(registry), query="footnote")["tools"]}
+    assert "delegate_to_specialized_writer_toolset" not in names
+
+
+# --------------------------------------------------------------------------- #
+# review follow-ups: domain normalization, query-path guidance, mode gating on
+# tools/call, and document-optional execution
+# --------------------------------------------------------------------------- #
+
+def test_execute_normalizes_domain_case_and_whitespace():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [_schema("footnotes_insert")]
+    registry.get_tools.return_value = []
+    ctx = _ctx(registry)
+    result = FindTools().execute(ctx, domain="  Footnotes ")
+    assert result["domain"] == "footnotes"
+    registry.get_schemas.assert_called_once_with("mcp", doc=ctx.doc, active_domain="footnotes")
+
+
+def test_execute_query_path_infers_domain_guidance():
+    # A free-text query (no explicit domain) still surfaces the matched domain's hints,
+    # as a {domain: text} dict, so callers don't lose the delegate's load-bearing guidance.
+    result = FindTools().execute(_ctx_real(_real_registry()), query="insert a footnote")
+    assert "footnotes_insert" in {t["name"] for t in result["tools"]}
+    assert "insert_after_text" in result["domain_guidance"]["footnotes"]
+
+
+def test_find_tools_call_blocked_outside_direct_discovery():
+    handler = _handler_real("delegate", _real_registry())
+    res = handler._mcp_tools_call({"name": "find_tools", "arguments": {}})
+    assert res["isError"] is True
+    assert "direct_discovery" in res["content"][0]["text"]
+
+
+def test_execute_tool_on_main_runs_document_optional_without_doc():
+    # find_tools (requires_document=False) must NOT short-circuit on NO_DOCUMENT_OPEN
+    # even though get_active_document() returns None.
+    handler = _handler_real("direct_discovery", _real_registry())
+    res = handler._execute_tool_on_main("find_tools", {})
+    assert res.get("status") == "ok"
+
+
+def test_execute_tool_on_main_still_requires_doc_for_normal_tools():
+    handler = _handler_real("direct_discovery", _real_registry())
+    res = handler._execute_tool_on_main("apply_document_content", {})
+    assert res.get("code") == "NO_DOCUMENT_OPEN"
+
+
+def test_global_search_excludes_core_tools():
+    # Global (no-domain) discovery surfaces hidden specialized tools, not the core
+    # tools already advertised in tools/list (apply_document_content is core here).
+    result = FindTools().execute(_ctx_real(_real_registry()), query="document")
+    names = {t["name"] for t in result["tools"]}
+    assert "apply_document_content" not in names
+
+
+def test_domain_listing_not_truncated_at_default():
+    # "Pass a domain to list every tool in one area" -> a domain with >8 tools must not
+    # be silently capped at the small free-text default.
+    registry = MagicMock()
+    registry.get_schemas.return_value = [_schema(f"footnotes_{i}") for i in range(12)]
+    registry.get_tools.return_value = [MagicMock(specialized_domain="footnotes")]
+    result = FindTools().execute(_ctx(registry), domain="footnotes")
+    assert len(result["tools"]) == 12
+
+
+def test_rank_is_accent_insensitive():
+    schemas = [{"name": "footnotes_insert", "description": "insere uma nota de rodape"}]
+    # an accented query still matches the unaccented description token
+    assert _rank(schemas, "rodapé", 5)[0]["name"] == "footnotes_insert"
+
+
+def test_find_tools_excludes_sidebar_only_domains():
+    # brainstorming is sidebar-only: not an available domain, and its tool is not
+    # surfaced even when it would match the query.
+    result = FindTools().execute(_ctx_real(_real_registry()), query="research")
+    assert "brainstorming" not in result["available_domains"]
+    assert "brainstorm_research_web" not in {t["name"] for t in result["tools"]}
+
+
+def test_direct_flat_excludes_sidebar_only_domains():
+    names = {t["name"] for t in _handler_real("direct_flat", _real_registry())._mcp_tools_list({})["tools"]}
+    assert "footnotes_insert" in names              # normal specialized still exposed
+    assert "brainstorm_research_web" not in names   # sidebar-only kept out
+
+
+def test_no_document_discovery_lists_full_catalog():
+    # With no document open, discovery must still surface app-specific specialized tools
+    # (the registry would otherwise filter them out by uno_services) and flag the state.
+    reg = ToolRegistry(MagicMock())
+    reg.register(FindTools())
+    reg.register(_AppSpecificTool())
+    result = FindTools().execute(_ctx_real(reg), query="chart")   # _ctx_real has doc=None
+    assert "create_chart" in {t["name"] for t in result["tools"]}
+    assert "note" in result
+
+
+def test_explicit_sidebar_domain_returns_no_tools():
+    # An explicit sidebar-only domain must surface nothing -- not even its required-core.
+    result = FindTools().execute(_ctx_real(_real_registry()), domain="brainstorming")
+    assert result["tools"] == []
+    assert result["domain"] == "brainstorming"
+
+
+def test_get_domain_guidance_is_app_neutral_when_app_unknown():
+    # No app context -> chart guidance must cover BOTH Calc (data_range) and Writer/Draw
+    # (headers/rows), not silently assume Writer.
+    g = get_domain_guidance("charts", agent_label=None)
+    assert "data_range" in g and "headers" in g
+
+
+def test_no_document_chart_guidance_is_app_neutral():
+    registry = MagicMock()
+    registry.get_schemas.return_value = [_schema("create_chart")]
+    registry.get_tools.return_value = []
+    ctx = MagicMock()
+    ctx.services.get.side_effect = lambda name: registry if name == "tools" else None
+    ctx.doc = None
+    ctx.doc_type = None
+    result = FindTools().execute(ctx, domain="charts")
+    g = result["domain_guidance"]["charts"]
+    assert "data_range" in g and "headers" in g
+
+
+def test_get_domain_guidance_python_is_app_neutral_when_app_unknown():
+    # python guidance with no app must cover Calc (data_range) AND Writer/Draw (document
+    # tools), not assume non-Calc.
+    g = get_domain_guidance("python", agent_label=None)
+    assert "data_range" in g
+    assert "document tools" in g.lower()
+
+
+def test_run_venv_python_advertises_superset_when_doc_unknown():
+    # With no document (doc_type=None) the python tool must advertise the superset schema
+    # so discovery still surfaces data_range (Calc-only), not just `code`.
+    from plugin.calc.python.venv import RunVenvPythonScript
+    params = RunVenvPythonScript().get_parameters(None)
+    assert "data_range" in params["properties"]
+
+
+def test_run_venv_python_description_neutral_when_doc_unknown():
+    # The no-doc description must match the superset schema: mention Calc's data_range AND
+    # the Writer/Draw path, not the Writer-only "does not inject" text.
+    from plugin.calc.python.venv import RunVenvPythonScript
+    desc = RunVenvPythonScript().get_description(None)
+    assert "data_range" in desc
+    assert "document tools" in desc.lower()
+
+
+def test_execute_tolerates_unhashable_name():
+    # A malformed schema whose `name` is unhashable (a list) must not crash the sidebar filter.
+    registry = MagicMock()
+    registry.get_schemas.return_value = [
+        {"name": ["bad"], "description": "x", "inputSchema": {}},
+        _schema("footnotes_insert", "insert a footnote"),
+    ]
+    registry.get_tools.return_value = []
+    result = FindTools().execute(_ctx(registry), query="footnote")
+    assert result["status"] == "ok"
+
+
+def test_execute_drops_schemas_with_unusable_names():
+    # Beyond not crashing: a schema with a non-string/empty name is dropped, not returned
+    # (it isn't a callable MCP tool).
+    registry = MagicMock()
+    registry.get_schemas.return_value = [
+        {"name": ["bad"], "description": "x", "inputSchema": {}},
+        {"name": "", "description": "y", "inputSchema": {}},
+        _schema("footnotes_insert", "insert a footnote"),
+    ]
+    registry.get_tools.return_value = []
+    names = [t.get("name") for t in FindTools().execute(_ctx(registry), query="footnote")["tools"]]
+    assert ["bad"] not in names and "" not in names
+    assert "footnotes_insert" in names
+
+
+def test_direct_flat_lists_app_specific_tools_without_document():
+    # direct_flat with no document open must still list app-specific specialized tools
+    # (uno_services), since that mode has no find_tools fallback.
+    reg = ToolRegistry(MagicMock())
+    for cls in (FindTools, _FtInsert, _AppSpecificTool):
+        reg.register(cls())
+    names = {t["name"] for t in _handler_real("direct_flat", reg)._mcp_tools_list({})["tools"]}
+    assert "create_chart" in names        # app-specific surfaces despite no doc
+    assert "footnotes_insert" in names
+
+
+def test_delegate_no_doc_keeps_doc_type_filtering():
+    # The no-doc broad catalog is direct_flat-only: delegate (default) must stay byte-for-
+    # byte unchanged -- an app-specific core tool is still filtered out with no document.
+    reg = ToolRegistry(MagicMock())
+    for cls in (_CoreTool, _AppSpecificCoreTool):
+        reg.register(cls())
+    names = {t["name"] for t in _handler_real("delegate", reg)._mcp_tools_list({})["tools"]}
+    assert "apply_document_content" in names   # universal core stays
+    assert "calc_only_core" not in names       # app-specific core filtered (no document)
+
+
+def test_direct_flat_unresolved_document_url_does_not_broaden():
+    # An explicit but unresolvable X-Document-URL is NOT "no target": don't broaden the
+    # catalog -- keep normal filtering (the app-specific tool stays filtered).
+    reg = ToolRegistry(MagicMock())
+    for cls in (FindTools, _FtInsert, _AppSpecificTool):
+        reg.register(cls())
+    handler = _handler_real("direct_flat", reg)
+    handler.services.document.resolve_document_by_url.return_value = (None, None)
+    names = {t["name"] for t in handler._mcp_tools_list({}, document_url="file:///missing.odt")["tools"]}
+    assert "create_chart" not in names
+
+
+def test_real_active_document_treats_start_center_as_none():
+    # The Start Center is a live (non-document) component, so it does not support the
+    # OfficeDocument service. _real_active_document must normalize that to None so "no
+    # document open" is detected -- the live state that doc=None unit tests alone don't reach.
+    # A real but unsupported doc (Math/Base) DOES support OfficeDocument, so it passes through
+    # and is left to fail with the clearer "unsupported document" error.
+    from plugin.mcp.mcp_protocol import _real_active_document
+
+    doc_svc = MagicMock()
+    phantom = MagicMock()
+    phantom.supportsService.return_value = False             # Start Center: not a document
+    doc_svc.get_active_document.return_value = phantom
+    assert _real_active_document(doc_svc) is None
+
+    real = MagicMock()
+    real.supportsService.return_value = True                 # real doc (any type) passes through
+    doc_svc.get_active_document.return_value = real
+    assert _real_active_document(doc_svc) is real
+
+    doc_svc.get_active_document.return_value = None
+    assert _real_active_document(doc_svc) is None             # None stays None
+
+
+def test_direct_flat_treats_start_center_as_no_document():
+    # End to end: with the Start Center active (no real doc), direct_flat must broaden to
+    # the full catalog, not return almost nothing.
+    reg = ToolRegistry(MagicMock())
+    for cls in (FindTools, _FtInsert, _AppSpecificTool):
+        reg.register(cls())
+    handler = _handler_real("direct_flat", reg)
+    phantom = MagicMock()
+    phantom.supportsService.return_value = False             # Start Center: not a document
+    handler.services.document.get_active_document.return_value = phantom
+    names = {t["name"] for t in handler._mcp_tools_list({})["tools"]}
+    assert "create_chart" in names


### PR DESCRIPTION
Implements discussion #353.

## Problem
Over MCP we advertise ~12 core tools; the ~138 specialized ones are only
reachable through the `delegate_to_specialized_*` gateway, which spins up a
sub-agent (a second LLM call) — so it only works when an LLM backend is
configured. This makes them reachable directly.

## What this adds
An experimental `mcp.tool_exposure_mode` flag. **Default is unchanged** —
`delegate` stays byte-for-byte today's behavior.

| Mode | What it does | For |
|---|---|---|
| `delegate` (default) | today's behavior, unchanged | clients with a sub-agent backend |
| `direct_flat` | advertises all specialized tools in `tools/list` | clients with native tool-search (Claude; OpenAI gpt-5.4+) |
| `direct_discovery` | small core list + a `find_tools` search tool | everyone, engine-agnostic |

### `direct_discovery` → `find_tools` (the main one)
A single server-side search tool — the proven pattern (Docker MCP Gateway,
Cloudflare, IBM ContextForge, FastMCP):
- `find_tools(query, domain?)` — `domain` pre-filters via the existing domain
  registry; `query` ranks over tool name/description/args; returns the top
  matches as ready-to-call schemas, plus the available domains and per-domain hints.
- The ~12 core tools stay listed as usual; `find_tools` only appears in this mode.
- Ranker is keyword-based (BM25-lite + substring bonus, accent-insensitive;
  pure Python, no venv/embeddings). As you noted, it leans on telling the agent
  which domains to search. Embeddings would be a natural future upgrade.

### `direct_flat` — opt-in for capable clients
Off by default. It's the "server half" capable clients need for their built-in
tool-search to kick in, and it skips the `find_tools` round-trip for them. For
clients without native search it's the bloat case, so it's explicitly a
capable-client flag.

### Delegate hints folded in
The per-domain hints the delegate adds (e.g. charts in Calc needs a `data_range`)
are folded into the direct modes — into tool descriptions / `find_tools` output —
so the agent still gets them.
