### PR TITLE
fix(mcp): run tools/list doc-type filtering on the main thread

### DIFF
--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -466,15 +466,6 @@ class MCPProtocolHandler:
             return "delegate"
 
     def _mcp_tools_list(self, params, document_url=None):
-        def _get_doc():
-            doc_svc = self.services.document
-            if document_url:
-                doc, _ = doc_svc.resolve_document_by_url(document_url)
-                return doc
-            return _real_active_document(doc_svc)
-
-        doc = self.queue_executor.execute(_get_doc, timeout=10.0)
-
         mode = self._tool_exposure_mode()
         # Direct modes (direct_flat / direct_discovery) intentionally skip the delegate
         # sub-agent so MCP hosts work without a WriterAgent LLM endpoint configured.
@@ -490,26 +481,42 @@ class MCPProtocolHandler:
         else:
             exclude_tiers = frozenset({"specialized", "specialized_control"})
 
-        # In direct_flat with no target at all (no active doc AND no document_url), don't
-        # filter by doc type, or app-specific tools would be dropped with no find_tools
-        # fallback. An unresolvable document_url is a DOCUMENT_NOT_FOUND case, not a
-        # no-target broaden, so it keeps normal filtering -- as do delegate (byte-for-byte
-        # unchanged) and direct_discovery (find_tools has its own no-doc catalog).
-        broaden = mode == "direct_flat" and doc is None and not document_url
-        doc_filter = {"filter_doc_type": False} if broaden else {}
-        schemas = self.tool_registry.get_schemas("mcp", doc=doc, exclude_tiers=exclude_tiers, **doc_filter)
+        def _resolve_and_filter():
+            # Runs on the main (VCL) thread. Resolving the document AND filtering tools by
+            # doc type both touch UNO -- get_schemas() -> supports_doc() calls
+            # doc.supportsService() -- so the WHOLE block must be marshaled, not just the
+            # doc lookup. Doing the doc-type filtering on the MCP request thread trips the
+            # UNO thread guard and fails tools/list with a 500.
+            doc_svc = self.services.document
+            if document_url:
+                doc, _ = doc_svc.resolve_document_by_url(document_url)
+            else:
+                doc = _real_active_document(doc_svc)
 
-        if mode == "direct_flat":
-            # Keep Writer sidebar-only flows (brainstorming, writing_plan) out of the flat
-            # list -- they need bespoke session orchestration the direct modes don't give.
-            from plugin.doc.find_tools_tool import sidebar_only_tool_names
-            sidebar_only = sidebar_only_tool_names(self.tool_registry, doc)
-            if sidebar_only:
-                schemas = [s for s in schemas if s.get("name") not in sidebar_only]
+            # In direct_flat with no target at all (no active doc AND no document_url), don't
+            # filter by doc type, or app-specific tools would be dropped with no find_tools
+            # fallback. An unresolvable document_url is a DOCUMENT_NOT_FOUND case, not a
+            # no-target broaden, so it keeps normal filtering -- as do delegate (byte-for-byte
+            # unchanged) and direct_discovery (find_tools has its own no-doc catalog).
+            broaden = mode == "direct_flat" and doc is None and not document_url
+            doc_filter = {"filter_doc_type": False} if broaden else {}
+            schemas = self.tool_registry.get_schemas("mcp", doc=doc, exclude_tiers=exclude_tiers, **doc_filter)
+
+            if mode == "direct_flat":
+                # Keep Writer sidebar-only flows (brainstorming, writing_plan) out of the flat
+                # list -- they need bespoke session orchestration the direct modes don't give.
+                from plugin.doc.find_tools_tool import sidebar_only_tool_names
+                sidebar_only = sidebar_only_tool_names(self.tool_registry, doc)
+                if sidebar_only:
+                    schemas = [s for s in schemas if s.get("name") not in sidebar_only]
+            return schemas
+
+        schemas = self.queue_executor.execute(_resolve_and_filter, timeout=10.0)
 
         # find_tools is the discovery search tool, useful only in direct_discovery mode
         # (small core list + on-demand search). delegate advertises the gateway and
         # direct_flat already lists everything, so hide it by name in those modes.
+        # Pure name filtering -- no UNO -- so it stays off the main thread.
         if mode != "direct_discovery":
             schemas = [s for s in schemas if s.get("name") != "find_tools"]
 

--- a/tests/mcp/test_find_tools.py
+++ b/tests/mcp/test_find_tools.py
@@ -160,6 +160,79 @@ def test_gating_keeps_other_tools():
     assert "insert_footnote" in _list_names("direct_discovery")
 
 
+def test_tools_list_filters_on_main_thread():
+    # Regression: the doc-type filtering (get_schemas -> supports_doc -> doc.supportsService)
+    # touches UNO, so it must run INSIDE the main-thread executor, not on the MCP request
+    # thread -- otherwise the UNO thread guard fails tools/list with a 500. Affects every
+    # mode (all pass the live doc to get_schemas), so delegate is enough to exercise it.
+    on_main = {"in": False}
+
+    def _exec(fn, *a, **k):
+        k.pop("timeout", None)
+        on_main["in"] = True
+        try:
+            return fn(*a, **k)
+        finally:
+            on_main["in"] = False
+
+    def _get_schemas(*a, **k):
+        assert on_main["in"], "get_schemas (UNO doc-type filtering) ran off the main thread"
+        return [{"name": "insert_footnote", "description": "f", "inputSchema": {}}]
+
+    services = MagicMock()
+    services.config.get.side_effect = (
+        lambda key, default=None: "delegate" if key == "mcp.tool_exposure_mode" else default
+    )
+    services.get.side_effect = lambda name: getattr(services, name, None)
+    services.main_thread.execute.side_effect = _exec
+    services.tools.get_schemas.side_effect = _get_schemas
+    services.document.get_active_document.return_value = MagicMock()  # a document is open
+
+    result = MCPProtocolHandler(services)._mcp_tools_list({})
+    assert any(t["name"] == "insert_footnote" for t in result["tools"])
+    services.tools.get_schemas.assert_called()  # the thread assertion only fires if get_schemas ran
+
+
+def test_tools_list_direct_flat_filters_sidebar_on_main_thread():
+    # direct_flat runs a SECOND UNO-touching filter inside the same block --
+    # sidebar_only_tool_names -> get_tools -> doc.supportsService -- so pin it to the main
+    # thread independently of get_schemas (a regression that pulls only the sidebar block
+    # off-thread would otherwise pass every other test).
+    from unittest.mock import patch
+
+    on_main = {"in": False}
+
+    def _exec(fn, *a, **k):
+        k.pop("timeout", None)
+        on_main["in"] = True
+        try:
+            return fn(*a, **k)
+        finally:
+            on_main["in"] = False
+
+    def _get_schemas(*a, **k):
+        assert on_main["in"], "get_schemas (UNO doc-type filtering) ran off the main thread"
+        return [{"name": "create_chart", "description": "c", "inputSchema": {}}]
+
+    def _sidebar(registry, doc):
+        assert on_main["in"], "sidebar_only_tool_names (UNO get_tools filtering) ran off the main thread"
+        return frozenset()
+
+    services = MagicMock()
+    services.config.get.side_effect = (
+        lambda key, default=None: "direct_flat" if key == "mcp.tool_exposure_mode" else default
+    )
+    services.get.side_effect = lambda name: getattr(services, name, None)
+    services.main_thread.execute.side_effect = _exec
+    services.tools.get_schemas.side_effect = _get_schemas
+    services.document.get_active_document.return_value = MagicMock()  # a document is open
+
+    with patch("plugin.doc.find_tools_tool.sidebar_only_tool_names", _sidebar):
+        result = MCPProtocolHandler(services)._mcp_tools_list({})
+    assert any(t["name"] == "create_chart" for t in result["tools"])
+    services.tools.get_schemas.assert_called()
+
+
 def test_initialize_instructions_mentions_find_tools_in_direct_discovery():
     handler = _handler("direct_discovery", [])
     result = handler._mcp_initialize({})


### PR DESCRIPTION
## Problem
On current `master` (UNO thread guard now enabled by default for dev builds),
every MCP `tools/list` returns **HTTP 500** when a document is open:

> UNO thread violation: 'UNO.supportsService' touched UNO from background task
> 'process_request_thread'; marshal via execute_on_main_thread().

This breaks native tool discovery for MCP clients — and since clients poll
`tools/list`, the violation dialog pops repeatedly. `tools/call` is unaffected,
so individual tools keep working; it's specifically the list that fails.

## Cause
`_mcp_tools_list` resolved the active document on the main thread (via the queue
executor) but then called `tool_registry.get_schemas(doc=doc)` on the MCP
**request thread**. The doc-type filter inside — `supports_doc()` →
`doc.supportsService()` — is a UNO call, so it trips the guard.

It's pre-existing (every `tool_exposure_mode` passes the live doc to
`get_schemas`); it only surfaced now that the guard enforces it. `tools/call`
was fine because it's already marshaled via `_execute_tool_on_main`.

## Fix
Marshal the whole resolve-and-filter block (document lookup + `get_schemas` +
the `direct_flat` sidebar-name filtering — all of which touch UNO) into a single
`queue_executor.execute()` on the main thread. The pure `find_tools` name-gating
stays off the main thread.

## Test
Adds `test_tools_list_filters_on_main_thread`: a main-thread executor sets an
`on_main` flag and `get_schemas` asserts it's set. Fails before the change
(filtering ran off-thread), passes after. Full `tests/mcp` suite green.

Found while testing the new UNO thread guard on macOS, as suggested in #353.
