### PR TITLE
fix(writer): per-change accept/reject no longer blocked by a redline in another text object

### DIFF
--- a/plugin/writer/inline_review.py
+++ b/plugin/writer/inline_review.py
@@ -532,18 +532,42 @@ def _span_has_redline(model: Any, text: Any, span: Any, consider) -> bool:
         try:
             s = rl.getPropertyValue("RedlineStart")
             e = rl.getPropertyValue("RedlineEnd")
-            if s is None or e is None:
-                # Protected redline whose bounds are unreadable -> cannot prove it is outside span.
-                log.debug("inline_review: protected redline has no start/end; treating as unsafe")
-                unsafe[0] = True
-                raise _RedlineScanAbort()
+        except Exception:
+            # Can't read this protected redline's bounds -> can't prove it is outside span.
+            log.debug("inline_review: protected redline bounds unreadable; treating as unsafe", exc_info=True)
+            unsafe[0] = True
+            raise _RedlineScanAbort()
+        if s is None or e is None:
+            # Protected redline whose bounds are unreadable -> cannot prove it is outside span.
+            log.debug("inline_review: protected redline has no start/end; treating as unsafe")
+            unsafe[0] = True
+            raise _RedlineScanAbort()
+
+        # Map the redline into THIS text. A redline anchored in a DIFFERENT text object (text
+        # frame/box, header, footer, footnote) than ``text`` is not addressable here --
+        # ``text.createTextCursorByRange(s)`` raises "End of content node doesn't have the proper
+        # start node" -- and cannot overlap a span that lives in ``text``, so skip it. Treating
+        # this as unsafe would block EVERY change in ``text`` whenever a single tracked change
+        # lives outside it (e.g. inside a text box). Only fail closed when we cannot confirm the
+        # range is in another text object, so a genuine same-text mapping failure stays protected.
+        try:
             rl_span = text.createTextCursorByRange(s)
             rl_span.gotoRange(e, True)
+        except Exception:
+            try:
+                in_other_text = (s.getText() != text)
+            except Exception:
+                in_other_text = False
+            if in_other_text:
+                return True  # different text object -> cannot overlap this span -> keep scanning
+            log.debug("inline_review: redline overlap check failed; treating as unsafe", exc_info=True)
+            unsafe[0] = True
+            raise _RedlineScanAbort()
+
+        try:
             overlaps = (_span_contains_point(text, span, rl_span.getStart())
                         or _span_contains_point(text, span, rl_span.getEnd())
                         or _span_contains_point(text, rl_span, span.getStart()))
-        except _RedlineScanAbort:
-            raise
         except Exception:
             log.debug("inline_review: redline overlap check failed; treating as unsafe", exc_info=True)
             unsafe[0] = True

--- a/plugin/writer/review_click_popup.py
+++ b/plugin/writer/review_click_popup.py
@@ -38,10 +38,8 @@ def _show_popup_and_resolve(model: Any, source_window: Any, x: int, y: int) -> N
         from plugin.framework.uno_context import get_ctx
         from plugin.framework.i18n import _
         from plugin.writer.inline_review import (
-            agent_changes,
             cursor_in_agent_change,
             goto_agent_change,
-            resolve_all_with_feedback,
             resolve_change_at_cursor,
             show_review_message,
         )
@@ -63,13 +61,10 @@ def _show_popup_and_resolve(model: Any, source_window: Any, x: int, y: int) -> N
         if smgr is None:
             return
         popup = smgr.createInstanceWithContext("com.sun.star.awt.PopupMenu", ctx)
+        # Per-change only: Accept / Reject the change under the pointer. Bulk accept/reject ALL
+        # intentionally lives on the review toolbar, not in this per-click popup.
         popup.insertItem(1, "✓ " + _("Accept this change"), 0, 0)
         popup.insertItem(2, "✗ " + _("Reject this change"), 0, 1)
-        total = len(agent_changes(model))
-        if total > 1:
-            popup.insertSeparator(2)
-            popup.insertItem(3, "✓ " + _("Accept all {0} changes").format(total), 0, 3)
-            popup.insertItem(4, "✗ " + _("Reject all {0} changes").format(total), 0, 4)
         rect = Rectangle()
         rect.X = int(x)
         rect.Y = int(y)
@@ -84,12 +79,6 @@ def _show_popup_and_resolve(model: Any, source_window: Any, x: int, y: int) -> N
             ok, msg = resolve_change_at_cursor(model, ctx, False)
             if not ok:
                 show_review_message(ctx, msg)
-        elif choice == 3:
-            n, msg = resolve_all_with_feedback(model, ctx, True)
-            show_review_message(ctx, msg)
-        elif choice == 4:
-            n, msg = resolve_all_with_feedback(model, ctx, False)
-            show_review_message(ctx, msg)
     except Exception:
         log.warning("review_click_popup: popup failed", exc_info=True)
 

--- a/tests/writer/test_inline_review_guards.py
+++ b/tests/writer/test_inline_review_guards.py
@@ -206,6 +206,54 @@ def test_foreign_redline_with_no_bounds_fails_closed():
     assert _foreign_redline_in_span(model, FakeText(), span) is True
 
 
+def test_foreign_redline_in_other_text_object_is_skipped():
+    # A protected redline anchored in a DIFFERENT text object (e.g. a tracked change inside a
+    # text box) cannot overlap a span living in ``text``. The body cursor can't address its range
+    # -- createTextCursorByRange raises "End of content node doesn't have the proper start node" --
+    # so the guard must SKIP it, not fail closed. Otherwise one redline inside a text box blocks
+    # resolving EVERY change in the body. Regression test.
+    span = FakeRange(10, 20)
+    box_text = FakeText()  # the text box's own text object (a different XText)
+
+    class ForeignRange(FakeRange):
+        def getText(self):
+            return box_text
+
+    class BodyText(FakeText):
+        def createTextCursorByRange(self, r):
+            if isinstance(r, ForeignRange):
+                raise RuntimeError("End of content node doesn't have the proper start node")
+            return super().createTextCursorByRange(r)
+
+    rl = FakeRedline("", 15, 25)                       # a USER redline (protected) ...
+    rl._props["RedlineStart"] = ForeignRange(15, 15)   # ... but living inside the text box
+    rl._props["RedlineEnd"] = ForeignRange(25, 25)
+    model = FakeModel(FakeRedlines([rl]))
+    assert _foreign_redline_in_span(model, BodyText(), span) is False
+
+
+def test_redline_mapping_failure_in_same_text_fails_closed():
+    # If mapping the redline into ``text`` fails but it IS in this text (we cannot confirm it sits
+    # in another object), stay fail-closed -- never skip a redline we can't prove is elsewhere.
+    span = FakeRange(10, 20)
+
+    class BodyText(FakeText):
+        def createTextCursorByRange(self, r):
+            raise RuntimeError("transient mapping failure")
+
+    body = BodyText()
+
+    class SameTextRange(FakeRange):
+        def getText(self):
+            return body  # same text object as the one under resolution
+
+    rl = FakeRedline("", 15, 25)
+    rl._props["RedlineStart"] = SameTextRange(15, 15)
+    rl._props["RedlineEnd"] = SameTextRange(25, 25)
+    model = FakeModel(FakeRedlines([rl]))
+    assert _foreign_redline_in_span(model, body, span) is True
+
+
 # --------------------------------------------------------------------- other-agent (sibling) guard
 
 def test_other_agent_overlap_detected():


### PR DESCRIPTION
## Problem

Accepting or rejecting a single agent change one at a time — via the left-click review popup or the right-click context menu — refused with *"Could not resolve this change here…"* whenever the document contained **any** tracked change anchored in a text object other than the body: a placeholder edit inside a **text box**, a header, footer, or footnote. With one such redline present, **no** body change could be resolved individually; only the toolbar "Accept all" worked.

### Root cause

`_span_has_redline` (the inline-review overlap guard) maps every protected redline into the resolution span's text with `text.createTextCursorByRange(s)`. When the redline's range lives in a different text object, that UNO call raises `End of content node doesn't have the proper start node`. The fail-closed `except` treated the exception as a possible overlap, so every per-change resolve refused.

## Fix

Split the geometry `try` so the two failure modes are distinguished:

- **cross-object mapping failure** (`createTextCursorByRange` raises): the redline cannot overlap a span that lives in `text`, so it is **skipped** — confirmed via `s.getText() != text`;
- **same-text comparison failure**: still **fails closed** (data-safety behavior unchanged).

Regression tests cover both paths: `test_foreign_redline_in_other_text_object_is_skipped` and `test_redline_mapping_failure_in_same_text_fails_closed`.

## Also (small UX change, 2nd commit)

The **left-click review popup** now offers only per-change *Accept / Reject* (matching the right-click context menu). Bulk accept/reject-all stays on the review toolbar. Drops the now-unused `agent_changes` / `resolve_all_with_feedback` imports from the popup.

## Testing

- Headless inline-review guard suite: **47 passed**.
- Verified live in LibreOffice 26.2.4.2: with a placeholder redline inside a text box alongside body redlines, both the per-change right-click accept and the 2-option left-click popup work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
