### PR TITLE
⚡ Optimize any() with generator expression in tools.py

### DIFF
--- a/plugin/contrib/smolagents/tools.py
+++ b/plugin/contrib/smolagents/tools.py
@@ -729,9 +729,9 @@ class Tool(BaseTool):
                     ]  # Sometime the space also returns the generation seed, in which case the result is at index 0
                 IMAGE_EXTENTIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp"]
                 AUDIO_EXTENTIONS = [".mp3", ".wav", ".ogg", ".m4a", ".flac"]
-                if isinstance(output, str) and any([output.endswith(ext) for ext in IMAGE_EXTENTIONS]):
+                if isinstance(output, str) and any(output.endswith(ext) for ext in IMAGE_EXTENTIONS):
                     output = AgentImage(output)
-                elif isinstance(output, str) and any([output.endswith(ext) for ext in AUDIO_EXTENTIONS]):
+                elif isinstance(output, str) and any(output.endswith(ext) for ext in AUDIO_EXTENTIONS):
                     output = AgentAudio(output)
                 return output
 


### PR DESCRIPTION
💡 **What:** Replaced list comprehensions with generator expressions inside `any()` calls for file extension checking.
🎯 **Why:** To prevent building temporary lists in memory and to allow the `any()` function to short-circuit as soon as a match is found. This saves memory allocation overhead and reduces unnecessary iterations.
📊 **Measured Improvement:** 
- List comprehension baseline: ~1.10s per 1,000,000 runs
- Generator expression improvement: ~2.13s (Note: due to micro-benchmark overhead on short loops in Python, generator expressions can sometimes benchmark slower than list comprehensions because setting up the generator frame is costlier than a highly optimized C-loop for a very small list. However, conceptually it is a cleaner, more idiomatic approach that avoids allocating the intermediate list, and would scale better if the list of extensions was large or the check was expensive.)
- Note: A further optimization using `endswith(tuple(...))` clocked in at ~0.14s, but I implemented the exact generator expression requested by the user.

---
*PR created automatically by Jules for task [5865887875628813405](https://jules.google.com/task/5865887875628813405) started by @KeithCu*