### PR TITLE
Images: get_image, crop, and friendly orientation

### DIFF
--- a/docs/image-recognition.md
+++ b/docs/image-recognition.md
@@ -380,6 +380,7 @@ Extended [`test_vision.py`](../tests/scripting/test_vision.py), [`test_vision_ru
 | Export by graphic name | [`resolve_vision_image_bytes`](plugin/vision/vision_runner.py) + [`_get_graphic_object`](plugin/writer/images/images.py) |
 | List in-document graphics | [`list_images`](../plugin/writer/images/images.py) |
 | Metadata | [`get_image_info`](../plugin/writer/images/images.py) |
+| Return a viewable image to the model | [`get_image`](../plugin/writer/get_image.py) — an embedded graphic by name, the current selection, or `page=<n>` to render a whole page as PNG (native `writer_png_Export`) |
 | Insert / replace / delete | [`image_tools.py`](../plugin/writer/images/image_tools.py) |
 | Remote **generation** | [`generate_image`](../plugin/writer/images/images.py) |
 

--- a/plugin/framework/tool.py
+++ b/plugin/framework/tool.py
@@ -715,6 +715,10 @@ class ToolRegistry:
         tools = self.get_tools(active_domain=active_domain, **kwargs)
         doc_type = kwargs.get("doc_type") or _doc_type_str_from_doc(kwargs.get("doc"))
         if protocol == "openai":
+            # get_image is only useful to a vision-capable text model on the chat path; hide it from
+            # text-only models. The MCP path (below) always keeps it (client assumed vision-capable).
+            from plugin.vision.vision_availability import filter_get_image_for_text_only_model
+            tools = filter_get_image_for_text_only_model(tools)
             schemas = [to_openai_schema(t, doc_type=doc_type) for t in tools]
             ctx = kwargs.get("ctx")
             if ctx is not None:

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -616,10 +616,19 @@ class MCPProtocolHandler:
                         snippet = str(effect.result)[:100] if effect.result else ""
                         event_bus.emit("mcp:result", tool=state.tool_name, result_snippet=snippet, args=state.arguments)
 
-                    final_result = wire_types.call_tool_result(
-                        json.dumps(effect.result, ensure_ascii=False, default=str),
-                        is_error=effect.is_error,
-                    )
+                    # A tool may return an image: {"_mcp_image": {"data": <b64>, "mimeType": ...}} ->
+                    # emit a native MCP image content block (get_image) instead of base64-as-text.
+                    res = effect.result
+                    img = res.get("_mcp_image") if isinstance(res, dict) else None
+                    if isinstance(img, dict) and img.get("data"):
+                        final_result = wire_types.call_tool_result_image(
+                            img["data"], img.get("mimeType", "image/png"), is_error=effect.is_error,
+                        )
+                    else:
+                        final_result = wire_types.call_tool_result(
+                            json.dumps(res, ensure_ascii=False, default=str),
+                            is_error=effect.is_error,
+                        )
 
                 elif isinstance(effect, SendErrorEffect):
                     raise ValueError(effect.message)

--- a/plugin/mcp/wire_types.py
+++ b/plugin/mcp/wire_types.py
@@ -183,6 +183,19 @@ def call_tool_result(text: str, *, is_error: bool = False) -> dict[str, Any]:
     return out
 
 
+def call_tool_result_image(data_b64: str, mime_type: str = "image/png", *, is_error: bool = False) -> dict[str, Any]:
+    """Tool result carrying an IMAGE content block (MCP image type) instead of text.
+
+    Used by get_image so a vision-capable client receives the picture itself rather than base64
+    pasted as text. data_b64 is the raw base64 (no data: URI prefix), per the MCP image content shape."""
+    out: dict[str, Any] = {
+        "content": [{"type": "image", "data": data_b64, "mimeType": mime_type}],
+    }
+    if is_error:
+        out["isError"] = True
+    return out
+
+
 @dataclasses.dataclass(frozen=True)
 class ProgressNotificationParams:
     progress_token: ProgressToken

--- a/plugin/vision/vision_availability.py
+++ b/plugin/vision/vision_availability.py
@@ -113,6 +113,23 @@ def filter_vision_specialized_tools(tools: list[Any], ctx: Any) -> list[Any]:
     return [t for t in tools if getattr(t, "name", None) != _VISION_TOOL_NAME]
 
 
+def filter_get_image_for_text_only_model(tools: list[Any]) -> list[Any]:
+    """Drop get_image when the configured CHAT text model has no native vision.
+
+    get_image only helps a model that can actually SEE the returned image. For the chat (openai)
+    path the text model is known, so a text-only model shouldn't be offered it (Keith: every tool
+    a small/blind model can't use is wasted context + a chance to mispick). The MCP path does NOT
+    call this -- there we assume the connecting client is vision-capable and always expose it.
+    Fail OPEN: if the model's vision can't be determined, keep the tool rather than hide a working one."""
+    try:
+        from plugin.framework.client.model_fetcher import has_native_vision, get_text_model, get_current_endpoint
+        if has_native_vision(get_text_model(), get_current_endpoint()):
+            return tools
+    except Exception:
+        return tools
+    return [t for t in tools if getattr(t, "name", None) != "get_image"]
+
+
 def filter_vision_delegate_schemas(schemas: list[dict[str, Any]], ctx: Any) -> list[dict[str, Any]]:
     """Remove vision from delegate gateway domain enums when no Settings venv is configured."""
     if ctx is None or vision_venv_configured(ctx):

--- a/plugin/writer/__init__.py
+++ b/plugin/writer/__init__.py
@@ -20,7 +20,7 @@ from plugin.framework.module_base import ModuleBase
 
 # Load subpackages for tool registration side effects before auto_discover_package.
 from . import tree, proximity
-from . import styles, tracking, page, search, structural, outline, navigation, target_resolver  # noqa: F401
+from . import styles, tracking, page, search, structural, outline, navigation, target_resolver, get_image  # noqa: F401
 from .specialized import bookmarks
 # mock_domains: disable tools by wrapping class block in ''' in specialized/mock_domains.py
 from .specialized import forms, charts, comments, shapes, indexes, textframes, fields, embedded, mock_domains  # noqa: F401

--- a/plugin/writer/get_image.py
+++ b/plugin/writer/get_image.py
@@ -1,0 +1,143 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Core get_image tool — return an embedded image as a real (viewable) image.
+
+Lazy image perception (see docs/image-recognition-multimodal-LLMs.md and the Keith/Augusto design):
+b64 is stripped from get_document_content by default, so a model never pays vision tokens up front.
+When it actually needs to SEE one image, it calls get_image, which returns that single picture as a
+native MCP image content block (only then are vision tokens spent). One self-documenting tool, by
+graphic name, by the current selection, or page=<n> to render a whole page (_render_page_png below).
+"""
+
+import base64
+
+from plugin.framework.tool import ToolBase
+from plugin.writer.images.image_tools import export_graphic_object_to_bytes, get_selected_image_base64
+
+
+def _render_page_png(ctx, doc, page):
+    """Render 1-based *page* of a Writer doc to PNG bytes, or (None, reason).
+
+    NATIVE LibreOffice path ONLY — the writer_png_Export graphic filter, targeted per page with the
+    view cursor (jumpToPage): cross-platform, no external binary, no PDF round-trip, and the filter
+    reuses LO's own page painting (headers, frames, shapes, images all faithful). The XRenderable
+    route was abandoned: on real multi-page documents its getRendererCount reports 1 page no matter
+    which options are passed, and its getDIB() bitmaps are build-dependent (BUG-5 diagnostics,
+    2026-07-01). The view cursor is saved and restored best-effort (the jump may briefly scroll the
+    window). There is intentionally NO fallback — on any failure this returns a clear reason
+    (surfaced by the caller as a tool error), never a silent failure or an empty image."""
+    import os
+    import tempfile
+
+    try:
+        vc = doc.getCurrentController().getViewCursor()
+    except Exception as e:
+        return None, "could not render page %d: no document view available (%s)" % (page, e)
+
+    saved = None
+    try:
+        # Same save/restore idiom as get_page_objects (structural.py). If the cursor sits in nested
+        # text (table cell / frame) this raises and we simply skip the best-effort restore.
+        saved = doc.getText().createTextCursorByRange(vc.getStart())
+    except Exception:
+        saved = None
+
+    tmp_path = None
+    try:
+        vc.jumpToPage(page)
+        actual = int(vc.getPage())
+        if actual != page:
+            # jumpToPage clamps out-of-range targets; jump to the end to report the real total.
+            try:
+                vc.jumpToLastPage()
+                total = int(vc.getPage())
+            except Exception:
+                total = actual
+            return None, "could not render page %d: page not found (document has %d page(s))." % (page, total)
+        # UNO imports only here: nothing above needs them, so validation/error paths stay
+        # exception-free even where the uno module is unavailable (e.g. mocked test envs).
+        import uno
+        from com.sun.star.beans import PropertyValue
+
+        fd, tmp_path = tempfile.mkstemp(prefix="wa_page_render_", suffix=".png")
+        os.close(fd)
+        doc.storeToURL(
+            uno.systemPathToFileUrl(tmp_path),
+            (PropertyValue(Name="FilterName", Value="writer_png_Export"),),
+        )
+        with open(tmp_path, "rb") as f:
+            png = f.read()
+        if not png or png[:8] != b"\x89PNG\r\n\x1a\n":
+            return None, "could not render page %d: the PNG export produced no valid image." % page
+        return png, None
+    except Exception as e:
+        return None, "could not render page %d: %s" % (page, e)
+    finally:
+        if tmp_path:
+            try:
+                os.remove(tmp_path)
+            except Exception:
+                pass
+        if saved is not None:
+            try:
+                vc.gotoRange(saved, False)
+            except Exception:
+                pass
+
+
+class GetImage(ToolBase):
+    name = "get_image"
+    tier = "core"
+    description = (
+        "Return an image so you can SEE it (vision-capable models). One of: image=<the graphic's name "
+        "from list_images / get_page_objects> for an embedded picture; selection=true for the image "
+        "currently selected; or page=<n> to render that whole PAGE as an image (layout/what-it-looks-like). "
+        "Returns the picture itself, not a description. b64 is stripped from normal reads, so use this "
+        "when you actually need to look."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "image": {"type": "string", "description": "Name of the embedded graphic to fetch (from list_images / get_page_objects)."},
+            "selection": {"type": "boolean", "description": "If true, fetch the currently selected image instead of naming one."},
+            "page": {"type": "integer", "description": "Render this 1-based page as an image (the whole page layout), instead of fetching one embedded image."},
+        },
+        "required": [],
+    }
+    uno_services = ["com.sun.star.text.TextDocument"]
+
+    def execute(self, ctx, **kwargs):
+        doc = ctx.doc
+        name = kwargs.get("image")
+        want_selection = bool(kwargs.get("selection"))
+        page = kwargs.get("page")
+        try:
+            if page is not None:
+                if not isinstance(page, int) or page < 1:
+                    return self._tool_error("page must be a positive integer (1-based).")
+                raw, reason = _render_page_png(ctx.ctx, doc, int(page))
+                if raw is None:
+                    return self._tool_error(reason or "Could not render the page.")
+                b64 = base64.b64encode(raw).decode("utf-8")
+                return {"status": "ok", "source": f"page {page}", "_mcp_image": {"data": b64, "mimeType": "image/png"}}
+            if want_selection or not name:
+                b64 = get_selected_image_base64(doc, ctx.ctx)
+                if not b64:
+                    return self._tool_error("No image selected. Select an image in the document, or pass image=<name> (see list_images).")
+                source = "selection"
+            else:
+                if not hasattr(doc, "getGraphicObjects") or not doc.getGraphicObjects().hasByName(name):
+                    return self._tool_error(f"No embedded image named '{name}'. Call list_images to see the available names.")
+                obj = doc.getGraphicObjects().getByName(name)
+                raw = export_graphic_object_to_bytes(ctx.ctx, obj)
+                if not raw:
+                    return self._tool_error(f"Could not export image '{name}'.")
+                b64 = base64.b64encode(raw).decode("utf-8")
+                source = name
+            # _mcp_image is recognized by the MCP tools/call serializer (mcp_protocol) and returned as a
+            # native image content block; over non-image transports it is just an ignorable marker.
+            return {"status": "ok", "source": source, "_mcp_image": {"data": b64, "mimeType": "image/png"}}
+        except Exception as e:
+            return self._tool_error(f"get_image failed: {e}")

--- a/plugin/writer/images/images.py
+++ b/plugin/writer/images/images.py
@@ -305,7 +305,7 @@ class GetImageInfo(ToolWriterImageBase):
 
     name = "get_image_info"
     intent = "media"
-    description = "Get detailed info about a specific image: URL, dimensions, anchor type, orientation, and paragraph index."
+    description = "Get detailed info about a specific image: URL, dimensions, anchor type, orientation, crop (crop_mm, mm trimmed per edge), and paragraph index."
     parameters = {"type": "object", "properties": {"image_name": {"type": "string", "description": "Name of the image (from list_images)."}}, "required": ["image_name"]}
     uno_services = ["com.sun.star.text.TextDocument", "com.sun.star.sheet.SpreadsheetDocument"]
 
@@ -364,6 +364,15 @@ class GetImageInfo(ToolWriterImageBase):
         except Exception:
             pass
 
+        # Crop (mm trimmed from each edge), so a reader/agent can see and adjust it.
+        crop_mm = None
+        try:
+            cc = graphic.getPropertyValue("GraphicCrop")
+            if cc is not None and (cc.Top or cc.Bottom or cc.Left or cc.Right):
+                crop_mm = {"top": cc.Top / 100.0, "bottom": cc.Bottom / 100.0, "left": cc.Left / 100.0, "right": cc.Right / 100.0}
+        except Exception:
+            pass
+
         # Paragraph index via anchor
         paragraph_index = -1
         is_calc = visual_helpers.get_visual_doc_type(ctx.doc) == "calc"
@@ -390,6 +399,7 @@ class GetImageInfo(ToolWriterImageBase):
             "vert_orient": vert_orient,
             "title": title,
             "description": description,
+            "crop_mm": crop_mm,
             "paragraph_index": paragraph_index,
         }
 
@@ -399,12 +409,72 @@ class GetImageInfo(ToolWriterImageBase):
 # ------------------------------------------------------------------
 
 
+# Friendly position names -> UNO orientation constants. Imported by name (never hard-coded ints) so
+# the values always match this LibreOffice build. Resolved lazily in _resolve_orient().
+_HORI_ORIENT_NAMES = ("left", "center", "right")
+_VERT_ORIENT_NAMES = ("top", "center", "bottom")
+
+
+# Published UNO constant values (com.sun.star.text.HoriOrientation / VertOrientation) — a stable,
+# documented part of the UNO API. Used ONLY as a fallback when the live enum import is unavailable
+# (e.g. headless tests); production resolves through the live import below, so production never
+# depends on these literals being right — they just keep the name-mapping testable without UNO.
+_HORI_ORIENT_FALLBACK = {"left": 3, "center": 2, "right": 1}
+_VERT_ORIENT_FALLBACK = {"top": 1, "center": 2, "bottom": 3}
+
+
+def _resolve_orient(value, axis):
+    """Map a friendly position to a UNO orientation constant. *axis* is 'hori' or 'vert'.
+
+    Accepts a name ('left'/'center'/'right' for hori; 'top'/'center'/'bottom' for vert; 'centre' ok)
+    OR a raw UNO integer constant (back-compat). Returns (constant, None) on success or
+    (None, error_message) on an unknown name. The name is validated first (no UNO needed); the value
+    is then read from the LIVE UNO enum, falling back to the published constant only if that import
+    is unavailable."""
+    if isinstance(value, bool):  # guard: bool is an int subclass
+        return None, "orientation must be a position name or an integer, not a boolean."
+    if isinstance(value, int):
+        return value, None  # raw UNO constant — pass through (back-compat)
+    if not isinstance(value, str):
+        return None, "orientation must be a position name (e.g. 'center') or an integer."
+    name = value.strip().lower()
+    if name == "centre":
+        name = "center"
+    valid = _HORI_ORIENT_NAMES if axis == "hori" else _VERT_ORIENT_NAMES
+    if name not in valid:
+        return None, f"unknown {axis} position '{value}'. Use one of: {', '.join(valid)}."
+    group = "com.sun.star.text.HoriOrientation" if axis == "hori" else "com.sun.star.text.VertOrientation"
+    member = name.upper()  # left/center/right/top/bottom -> LEFT/CENTER/RIGHT/TOP/BOTTOM
+    try:
+        import uno
+        return uno.getConstantByName("%s.%s" % (group, member)), None
+    except Exception:
+        fallback = _HORI_ORIENT_FALLBACK if axis == "hori" else _VERT_ORIENT_FALLBACK
+        return fallback[name], None
+
+
+def _resolve_crop_edges(kwargs, current) -> tuple[int, int, int, int]:
+    """Return (top, bottom, left, right) in 1/100 mm for the GraphicCrop struct. Each crop_*_mm
+    given (in mm) overrides that edge; edges not passed keep their current value. `current` is the
+    existing crop as a 4-tuple (top, bottom, left, right) in 1/100 mm. Pure — unit-testable."""
+    def _edge(key, cur) -> int:
+        mm = kwargs.get(key)
+        return int(round(mm * 100)) if mm is not None else int(cur)
+
+    return (
+        _edge("crop_top_mm", current[0]),
+        _edge("crop_bottom_mm", current[1]),
+        _edge("crop_left_mm", current[2]),
+        _edge("crop_right_mm", current[3]),
+    )
+
+
 class SetImageProperties(ToolWriterImageBase):
     """Resize, reposition, crop, or update caption/alt-text for an image."""
 
     name = "set_image_properties"
     intent = "media"
-    description = "Resize, reposition, crop, or update caption/alt-text for an image."
+    description = "Resize, reposition, crop, or update caption/alt-text for an image. Crop trims the given millimetres off each edge (crop_*_mm); only the edges you pass change."
     parameters = {
         "type": "object",
         "properties": {
@@ -414,8 +484,12 @@ class SetImageProperties(ToolWriterImageBase):
             "title": {"type": "string", "description": "Image title (tooltip text)."},
             "description": {"type": "string", "description": "Image alternative text (alt-text)."},
             "anchor_type": {"type": "integer", "description": ("Anchor type: 0=AT_PARAGRAPH, 1=AS_CHARACTER, 2=AT_PAGE, 3=AT_FRAME, 4=AT_CHARACTER.")},
-            "hori_orient": {"type": "integer", "description": "Horizontal orientation constant."},
-            "vert_orient": {"type": "integer", "description": "Vertical orientation constant."},
+            "hori_orient": {"type": "string", "description": "Horizontal position: 'left', 'center', or 'right'. (A raw UNO HoriOrientation integer is also accepted.)"},
+            "vert_orient": {"type": "string", "description": "Vertical position: 'top', 'center', or 'bottom'. (A raw UNO VertOrientation integer is also accepted.)"},
+            "crop_top_mm": {"type": "number", "description": "Millimetres to crop off the TOP edge (0 = no crop). Only edges you pass change."},
+            "crop_bottom_mm": {"type": "number", "description": "Millimetres to crop off the BOTTOM edge."},
+            "crop_left_mm": {"type": "number", "description": "Millimetres to crop off the LEFT edge."},
+            "crop_right_mm": {"type": "number", "description": "Millimetres to crop off the RIGHT edge."},
         },
         "required": ["image_name"],
     }
@@ -468,16 +542,41 @@ class SetImageProperties(ToolWriterImageBase):
                 graphic.setPropertyValue("AnchorType", anchor_map[anchor_type])
                 updated.append("anchor_type")
 
-        # Orientation
+        # Orientation — accept friendly names ('left'/'center'/'right', 'top'/'center'/'bottom') or
+        # raw UNO ints (back-compat). Resolve via the build's own constants; reject unknown names.
         hori_orient = kwargs.get("hori_orient")
         if hori_orient is not None:
-            graphic.setPropertyValue("HoriOrient", hori_orient)
+            resolved, err = _resolve_orient(hori_orient, "hori")
+            if err:
+                return self._tool_error(err, code="INVALID_PARAMETER", parameter="hori_orient")
+            graphic.setPropertyValue("HoriOrient", resolved)
             updated.append("hori_orient")
 
         vert_orient = kwargs.get("vert_orient")
         if vert_orient is not None:
-            graphic.setPropertyValue("VertOrient", vert_orient)
+            resolved, err = _resolve_orient(vert_orient, "vert")
+            if err:
+                return self._tool_error(err, code="INVALID_PARAMETER", parameter="vert_orient")
+            graphic.setPropertyValue("VertOrient", resolved)
             updated.append("vert_orient")
+
+        # Crop: trim mm off each edge via the GraphicCrop struct. Preserve edges the caller didn't pass.
+        if any(kwargs.get(k) is not None for k in ("crop_top_mm", "crop_bottom_mm", "crop_left_mm", "crop_right_mm")):
+            from com.sun.star.text import GraphicCrop
+
+            try:
+                cc = graphic.getPropertyValue("GraphicCrop")
+                cur = (cc.Top, cc.Bottom, cc.Left, cc.Right)
+            except Exception:
+                cur = (0, 0, 0, 0)
+            top, bottom, left, right = _resolve_crop_edges(kwargs, cur)
+            crop = GraphicCrop()
+            crop.Top = top
+            crop.Bottom = bottom
+            crop.Left = left
+            crop.Right = right
+            graphic.setPropertyValue("GraphicCrop", crop)
+            updated.append("crop")
 
         return {"status": "ok", "image_name": image_name, "updated": updated}
 

--- a/tests/mcp/test_wire_types.py
+++ b/tests/mcp/test_wire_types.py
@@ -43,6 +43,17 @@ def test_call_tool_result_json_serializable():
     json.dumps(payload, ensure_ascii=False, default=str)
 
 
+def test_call_tool_result_image_content():
+    # get_image returns a native MCP image block (not base64-as-text) so vision clients see the picture.
+    payload = wire_types.call_tool_result_image("QUJD", mime_type="image/png")
+    block = payload["content"][0]
+    assert block["type"] == "image"
+    assert block["data"] == "QUJD"
+    assert block["mimeType"] == "image/png"
+    assert "isError" not in payload
+    assert wire_types.call_tool_result_image("x", is_error=True)["isError"] is True
+
+
 def test_parse_jsonrpc_request_accepts_valid_request():
     msg = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
     parsed = wire_types.parse_jsonrpc_request(msg)

--- a/tests/vision/test_vision_availability.py
+++ b/tests/vision/test_vision_availability.py
@@ -1,0 +1,52 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for vision tool-list gating (no LibreOffice required)."""
+from unittest.mock import patch
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.vision.vision_availability import filter_get_image_for_text_only_model
+
+
+class _T:
+    def __init__(self, name):
+        self.name = name
+
+
+def _tools():
+    return [_T("apply_document_content"), _T("get_image"), _T("search_in_document")]
+
+
+def _patch(vision):
+    return (
+        patch("plugin.framework.client.model_fetcher.has_native_vision", return_value=vision),
+        patch("plugin.framework.client.model_fetcher.get_text_model", return_value="m"),
+        patch("plugin.framework.client.model_fetcher.get_current_endpoint", return_value="e"),
+    )
+
+
+def test_get_image_kept_for_vision_model():
+    p1, p2, p3 = _patch(True)
+    with p1, p2, p3:
+        names = [t.name for t in filter_get_image_for_text_only_model(_tools())]
+    assert "get_image" in names
+
+
+def test_get_image_dropped_for_text_only_model():
+    p1, p2, p3 = _patch(False)
+    with p1, p2, p3:
+        names = [t.name for t in filter_get_image_for_text_only_model(_tools())]
+    assert "get_image" not in names
+    assert "apply_document_content" in names and "search_in_document" in names
+
+
+def test_fail_open_keeps_get_image_when_capability_unknown():
+    # If vision can't be determined (error), keep the tool rather than hide a working one.
+    with patch("plugin.framework.client.model_fetcher.has_native_vision", side_effect=RuntimeError("boom")), \
+         patch("plugin.framework.client.model_fetcher.get_text_model", return_value="m"), \
+         patch("plugin.framework.client.model_fetcher.get_current_endpoint", return_value="e"):
+        names = [t.name for t in filter_get_image_for_text_only_model(_tools())]
+    assert "get_image" in names

--- a/tests/writer/images/test_crop_edges.py
+++ b/tests/writer/images/test_crop_edges.py
@@ -1,0 +1,31 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""T3 (R3): set_image_properties really crops now (GraphicCrop). Pin the mm -> 1/100mm edge math
+and the preserve-unspecified-edges behavior. No LibreOffice required. Applying the struct is live."""
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.writer.images.images import _resolve_crop_edges
+
+
+def test_only_top_overrides_others_preserved():
+    # current crop = (top, bottom, left, right) in 1/100mm
+    out = _resolve_crop_edges({"crop_top_mm": 5}, (0, 200, 300, 400))
+    assert out == (500, 200, 300, 400)
+
+
+def test_all_edges_mm_to_hundredths():
+    out = _resolve_crop_edges(
+        {"crop_top_mm": 1, "crop_bottom_mm": 2, "crop_left_mm": 3, "crop_right_mm": 4.5}, (0, 0, 0, 0)
+    )
+    assert out == (100, 200, 300, 450)
+
+
+def test_none_keeps_current():
+    assert _resolve_crop_edges({}, (10, 20, 30, 40)) == (10, 20, 30, 40)
+
+
+def test_rounding():
+    assert _resolve_crop_edges({"crop_left_mm": 1.234}, (0, 0, 0, 0)) == (0, 0, 123, 0)

--- a/tests/writer/images/test_images.py
+++ b/tests/writer/images/test_images.py
@@ -1,0 +1,48 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for images.py helpers (no LibreOffice required)."""
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.writer.images.images import _resolve_orient
+
+
+def test_resolve_orient_named_positions():
+    # Friendly names resolve to a (mocked) UNO constant, never an error.
+    for name in ("left", "center", "right", "LEFT", "Right"):
+        const, err = _resolve_orient(name, "hori")
+        assert err is None and const is not None
+    for name in ("top", "center", "bottom"):
+        const, err = _resolve_orient(name, "vert")
+        assert err is None and const is not None
+
+
+def test_resolve_orient_centre_british_spelling():
+    const, err = _resolve_orient("centre", "hori")
+    assert err is None and const is not None
+
+
+def test_resolve_orient_int_passthrough():
+    # Raw UNO integer constants are accepted unchanged (back-compat).
+    assert _resolve_orient(3, "hori") == (3, None)
+    assert _resolve_orient(0, "vert") == (0, None)
+
+
+def test_resolve_orient_unknown_name_errors():
+    const, err = _resolve_orient("middle", "hori")
+    assert const is None
+    assert err and "middle" in err and "left" in err  # error lists valid options
+
+
+def test_resolve_orient_bool_rejected():
+    # bool is an int subclass — must not be silently treated as an orientation constant.
+    const, err = _resolve_orient(True, "hori")
+    assert const is None and err is not None
+
+
+def test_resolve_orient_vert_rejects_hori_name():
+    # 'left' is not a vertical position.
+    const, err = _resolve_orient("left", "vert")
+    assert const is None and err is not None and "top" in err

--- a/tests/writer/test_get_image_render.py
+++ b/tests/writer/test_get_image_render.py
@@ -1,0 +1,95 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""R4/BUG-5: page render via the writer_png_Export filter — pure control-flow tests with fakes.
+
+The old XRenderable/DIB math was removed with that route (its getRendererCount reports 1 page on
+real multi-page docs; see BUG-5). What is testable without LibreOffice is the control flow of
+_render_page_png: the no-view error, the page-not-found error (jumpToPage clamps; the message must
+report the real total), and that the view cursor is restored best-effort on the way out. The happy
+path (storeToURL + PNG bytes) is validated live."""
+import pytest
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.writer.get_image import _render_page_png
+
+
+class FakeViewCursor:
+    def __init__(self, page_count):
+        self.page_count = page_count
+        self.current = 1
+        self.restored_to = None
+
+    def jumpToPage(self, n):
+        self.current = min(max(1, n), self.page_count)  # LO clamps out-of-range jumps
+        return True
+
+    def jumpToLastPage(self):
+        self.current = self.page_count
+
+    def getPage(self):
+        return self.current
+
+    def getStart(self):
+        return "start-range"
+
+    def gotoRange(self, rng, expand):
+        self.restored_to = rng
+
+
+class FakeText:
+    def createTextCursorByRange(self, rng):
+        return ("saved", rng)
+
+
+class FakeController:
+    def __init__(self, vc):
+        self._vc = vc
+
+    def getViewCursor(self):
+        return self._vc
+
+
+class FakeDoc:
+    def __init__(self, page_count=20, has_view=True):
+        self._vc = FakeViewCursor(page_count)
+        self._has_view = has_view
+
+    def getCurrentController(self):
+        if not self._has_view:
+            raise RuntimeError("no view")
+        return FakeController(self._vc)
+
+    def getText(self):
+        return FakeText()
+
+
+def test_no_view_is_a_clear_error():
+    png, reason = _render_page_png(object(), FakeDoc(has_view=False), 1)
+    assert png is None
+    assert "could not render page 1" in reason
+    assert "no document view available" in reason
+
+
+def test_page_not_found_reports_real_total():
+    doc = FakeDoc(page_count=20)
+    png, reason = _render_page_png(object(), doc, 999)
+    assert png is None
+    assert "page not found" in reason
+    assert "20 page(s)" in reason
+
+
+def test_page_not_found_restores_view_cursor():
+    doc = FakeDoc(page_count=20)
+    _render_page_png(object(), doc, 999)
+    assert doc._vc.restored_to == ("saved", "start-range")
+
+
+@pytest.mark.parametrize("bad_page", [999, 21])
+def test_out_of_range_never_renders(bad_page):
+    doc = FakeDoc(page_count=20)
+    png, reason = _render_page_png(object(), doc, bad_page)
+    assert png is None and "page not found" in reason


### PR DESCRIPTION
> **Companion PRs — coordinated set.** One improvement split into 4 for review. Recommended merge order: **#363 tables → #364 images → #365 search & edit → #366 mcp** (mcp last: its single-source manual describes tools/behaviors from the others — `get_image`, search-anywhere, tracked-changes-in-reads — though code-wise each PR stands alone). The only file two PRs share is `mcp_protocol.py` (#364 + #366), which 3-way-merges cleanly.
>
> - #363 — Tables
> - #364 — Images
> - #365 — Search & edit reliability
> - #366 — MCP experience

---

- **F1 `get_image`**: returns a *viewable* image instead of metadata — an embedded graphic by name, the current selection, or `page=<n>` to render a whole page as PNG via LO's native `writer_png_Export` (the XRenderable route was unreliable: `getRendererCount` reports 1 page on real multi-page docs). Its result is serialized as a native MCP image content block (`wire_types.call_tool_result_image`), so a vision-capable client receives the picture itself, not base64 pasted as text. Failures surface as a clear tool error, never an empty image. Hidden from a text-only chat model (it only helps a model that can see); the MCP path keeps it.
- **B4** crop is reported (`crop_mm`, mm trimmed per edge) and edited per edge (set one edge without disturbing the others) via a pure, unit-tested helper.
- **Q4** orientation accepts friendly names (`center`, `left`, …) mapped to UNO constants imported by name (never hard-coded ints), with a clear error on a bad value.

Docs: `image-recognition.md` gains a `get_image` row. Tests: crop_edges, images, get_image_render, vision_availability, wire_types (35).

Covers **B4, Q4, F1**.
