### PR TITLE
Search & edit reliability (includes B9)

### DIFF
--- a/docs/writer-tracking-api-reference.md
+++ b/docs/writer-tracking-api-reference.md
@@ -91,3 +91,18 @@ frame = ctx.doc.getCurrentController().getFrame()
 
 dispatcher.executeDispatch(frame, ".uno:AcceptAllTrackedChanges", "", 0, ())
 ```
+
+### Accepting or rejecting a single change
+
+`.uno:AcceptTrackedChange` / `.uno:RejectTrackedChange` act on the *selected* change, so the view cursor must sit on it first. `XRedline` objects from `getRedlines()` are property sets with **no** `getAnchor()` method; select the change by its live span instead:
+
+```python
+start = redline.getPropertyValue("RedlineStart")
+cursor = start.getText().createTextCursorByRange(start)
+cursor.gotoRange(redline.getPropertyValue("RedlineEnd"), True)
+# then dispatch .uno:AcceptTrackedChange / .uno:RejectTrackedChange
+```
+
+### What the shipped tool returns
+
+`track_changes_list` reports, per change, the author and type plus the change **text** (for a deletion, the removed text via `RedlineText`) and its **location** (body, table cell, header/footer, and so on), along with the document's current review mode. That is enough for a model to decide what to accept or reject without a second lookup.

--- a/plugin/doc/document_helpers.py
+++ b/plugin/doc/document_helpers.py
@@ -230,6 +230,81 @@ def get_string_without_tracked_deletions(text_range) -> str:
     return "".join(parts)
 
 
+def collect_tracked_changes(text_range, max_per_change: int = 300, max_changes: int = 100):
+    """Walk text portions and collect tracked insertions/deletions WITH their text, so a reader can
+    see what is pending and that it awaits the user's review (rather than the default read, which
+    hides deletions and gives no hint that changes are pending).
+
+    Returns a list of ``{"type": "insertion"|"deletion", "text": str}`` in document order. Best-effort:
+    returns ``[]`` on any failure. Mirrors get_string_without_tracked_deletions' portion walk, but also
+    toggles on Insert redlines and buffers the text of each change instead of dropping deletions."""
+    out: list[dict] = []
+    if hasattr(text_range, "_mock_return_value") or type(text_range).__name__ in ("Mock", "MagicMock"):
+        return out
+    try:
+        para_enum = text_range.createEnumeration()
+    except Exception:
+        return out
+
+    in_delete = False
+    in_insert = False
+    del_buf: list[str] = []
+    ins_buf: list[str] = []
+
+    def _flush(buf, kind):
+        if buf and len(out) < max_changes:
+            out.append({"type": kind, "text": "".join(buf)[:max_per_change]})
+        buf.clear()
+
+    try:
+        while para_enum.hasMoreElements() and len(out) < max_changes:
+            para = para_enum.nextElement()
+            try:
+                portion_enum = para.createEnumeration()
+            except Exception:
+                continue
+            while portion_enum.hasMoreElements():
+                portion = portion_enum.nextElement()
+                try:
+                    try:
+                        ptype = portion.getPropertyValue("TextPortionType")
+                    except Exception:
+                        ptype = portion.TextPortionType
+                except Exception:
+                    continue
+
+                if ptype == "Redline":
+                    try:
+                        rtype = str(portion.getPropertyValue("RedlineType"))
+                    except Exception:
+                        rtype = ""
+                    if rtype == "Delete":
+                        if in_delete:
+                            _flush(del_buf, "deletion")
+                        in_delete = not in_delete
+                    elif rtype == "Insert":
+                        if in_insert:
+                            _flush(ins_buf, "insertion")
+                        in_insert = not in_insert
+                    continue
+
+                try:
+                    chunk = portion.getString()
+                except Exception:
+                    chunk = ""
+                if not chunk:
+                    continue
+                if in_delete:
+                    del_buf.append(chunk)
+                elif in_insert:
+                    ins_buf.append(chunk)
+        _flush(del_buf, "deletion")
+        _flush(ins_buf, "insertion")
+    except Exception:
+        return out
+    return out
+
+
 def build_writer_rewrite_prompt(original_text: str, instructions: str) -> str:
     """Return a direct rewrite prompt for Writer selection edits."""
     return f"Rewrite the following text according to the instructions below. Output only the rewritten text with no labels, headings, or explanations.\n\nInstructions: {instructions}\n\nText to rewrite:\n{original_text}"

--- a/plugin/doc/undo.py
+++ b/plugin/doc/undo.py
@@ -3,9 +3,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Undo/redo tools for all document types via XUndoManager."""
+"""Undo/redo tools for all document types via XUndoManager.
 
-from plugin.framework.tool import ToolBaseDummy
+Re-enabled (was ToolBaseDummy): with review mode off an agent's bad edit was unrecoverable
+except by the user's own Ctrl+Z — the agent had no rollback at all. The undo stack is SHARED
+with the user's manual edits, so the descriptions steer the model to undo only its own last
+action and to tell the user."""
+
+from plugin.framework.tool import ToolBase
 
 
 def _get_undo_manager(doc):
@@ -15,11 +20,16 @@ def _get_undo_manager(doc):
     raise RuntimeError("Document does not support undo.")
 
 
-class Undo(ToolBaseDummy):
+class Undo(ToolBase):
     """Undo the last action."""
 
     name = "undo"
-    description = "Undo the last action in the document. Can undo multiple steps. Works on all document types."
+    description = (
+        "Undo the last change(s) in the document (all document types). CAUTION: the undo stack "
+        "interleaves YOUR edits with the user's own edits — call this only immediately after an "
+        "edit of yours went wrong, undo exactly the steps you caused, and tell the user what you "
+        "undid. Result reports undone plus can_undo/can_redo."
+    )
     parameters = {"type": "object", "properties": {"steps": {"type": "integer", "description": "Number of steps to undo (default: 1)."}}, "required": []}
     uno_services = None
     is_mutation = True
@@ -39,11 +49,15 @@ class Undo(ToolBaseDummy):
             return self._tool_error(str(e))
 
 
-class Redo(ToolBaseDummy):
+class Redo(ToolBase):
     """Redo the last undone action."""
 
     name = "redo"
-    description = "Redo the last undone action in the document. Can redo multiple steps. Works on all document types."
+    description = (
+        "Redo the last undone change(s) in the document (all document types). Same caution as "
+        "undo: the stack is shared with the user's edits — redo only what you yourself just "
+        "undid, and tell the user."
+    )
     parameters = {"type": "object", "properties": {"steps": {"type": "integer", "description": "Number of steps to redo (default: 1)."}}, "required": []}
     uno_services = None
     is_mutation = True

--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -23,7 +23,7 @@ import threading
 
 from plugin.framework.tool import ToolBase, ToolBaseDummy
 from plugin.framework.constants import APPLY_DOCUMENT_CONTENT_TOOL_RESEARCH_HINT
-from plugin.doc.document_helpers import normalize_linebreaks, get_string_without_tracked_deletions
+from plugin.doc.document_helpers import normalize_linebreaks, get_string_without_tracked_deletions, collect_tracked_changes
 from plugin.writer.edit_review import EditReviewSession, edit_review_wait_seconds, review_recording_enabled, get_agent_edit_review_mode
 from plugin.framework.errors import safe_json_loads, ToolExecutionError
 import re as re_mod
@@ -306,6 +306,95 @@ def _find_first_range(doc, search_string):
     return _find_chained_range(doc, search_string, all_matches=False)
 
 
+def _iter_drawing_shapes(container):
+    """Yield every drawing shape on a container, recursing into group shapes.
+
+    ``doc.findFirst``/``findAll`` (the search path) cover body, table cells, text frames and inline
+    (AS_CHARACTER) shape text but NOT floating drawing-layer shapes on ``getDrawPage()``. Walking the
+    draw page (groups included) lets us both detect and edit text that lives only inside such a box."""
+    try:
+        n = int(container.getCount())
+    except Exception:
+        return
+    for i in range(n):
+        try:
+            shape = container.getByIndex(i)
+        except Exception:
+            continue
+        try:
+            is_group = shape.supportsService("com.sun.star.drawing.GroupShape")
+        except Exception:
+            is_group = False
+        if is_group:
+            yield from _iter_drawing_shapes(shape)
+        else:
+            yield shape
+
+
+def _drawing_shape_object_containing(doc, search_string):
+    """First drawing-layer shape whose text contains *search_string*, else None. Fully defensive."""
+    needle = (search_string or "").strip()
+    if not needle:
+        return None
+    try:
+        if not hasattr(doc, "getDrawPage"):
+            return None
+        draw_page = doc.getDrawPage()
+    except Exception:
+        return None
+    for shape in _iter_drawing_shapes(draw_page):
+        try:
+            text = shape.getString() if hasattr(shape, "getString") else ""
+        except Exception:
+            continue
+        if text and needle in text:
+            return shape
+    return None
+
+
+def _drawing_shape_containing(doc, search_string):
+    """Name of a drawing-layer shape whose text contains *search_string*, else None.
+
+    When search/replace finds nothing, this lets the caller tell the agent the text is actually
+    inside a floating shape -- an actionable signal (edit it in place or via the shapes toolset)
+    instead of retrying blindly (note 7). Fully defensive: any failure returns None."""
+    shape = _drawing_shape_object_containing(doc, search_string)
+    if shape is None:
+        return None
+    return (getattr(shape, "Name", "") or "").strip() or "(unnamed shape)"
+
+
+def _replace_text_in_shape(shape, old, new):
+    """Replace the first occurrence of *old* with *new* inside a drawing shape's own text,
+    preserving the formatting of the surrounding text via a text cursor. Returns True on success.
+
+    Uses character-offset navigation (goRight) which aligns with getString() for single-paragraph
+    shape text (the common case for callouts / text boxes); fully defensive on any UNO failure."""
+    try:
+        xtext = shape.getText()
+        s = xtext.getString()
+    except Exception:
+        return False
+    idx = s.find(old)
+    if idx < 0:
+        return False
+    # goRight counts UTF-16 code units, while str offsets count code points. Convert so astral
+    # characters (emoji, rare CJK) in the shape text don't misalign the selection / corrupt text.
+    left_units = len(s[:idx].encode("utf-16-le")) // 2
+    old_units = len(old.encode("utf-16-le")) // 2
+    if old_units <= 0:
+        return False
+    try:
+        cursor = xtext.createTextCursorByRange(xtext.getStart())
+        if left_units:
+            cursor.goRight(left_units, False)
+        cursor.goRight(old_units, True)
+        cursor.setString(new)
+        return True
+    except Exception:
+        return False
+
+
 def _normalize_search_string_for_find(s):
     """Collapse horizontal whitespace (incl. NBSP & friends) to a single ASCII
     space; preserve newlines for literal find.
@@ -322,6 +411,27 @@ def _all_start_indices(haystack, needle):
     while i >= 0:
         out.append(i)
         i = haystack.find(needle, i + len(needle))
+    return out
+
+
+def _find_ranges_regex_case(doc, pattern, use_regex, case_sensitive, all_matches):
+    """Direct SearchDescriptor find honoring an EXPLICIT regex / case_sensitive request. No
+    paragraph chaining, no NBSP-flex, no case fallback — so counts line up with
+    search_in_document for the text the EDIT path can reach (body, table cells, text frames;
+    search_in_document additionally sweeps drawing shapes and comments, which no edit reaches).
+    Used only when the caller opts in; the default search path is left untouched. Returns a single
+    range (all_matches False) or a list (all_matches True)."""
+    sd = doc.createSearchDescriptor()
+    sd.SearchString = pattern
+    sd.SearchRegularExpression = bool(use_regex)
+    sd.SearchCaseSensitive = bool(case_sensitive)
+    if not all_matches:
+        return doc.findFirst(sd)
+    out = []
+    found = doc.findFirst(sd)
+    while found is not None and len(out) < _MAX_SEARCH_REPLACEMENTS:
+        out.append(found)
+        found = doc.findNext(found.getEnd(), sd)
     return out
 
 
@@ -550,15 +660,15 @@ def _record_html_atomically(session, doc, mutate, track_reviewable, **record_kwa
     and the import either both land or neither does.
 
     record_mutation() opens no undo context, so a throwing import would otherwise strand a bare
-    deletion (a half-applied edit) and register no reviewable change. Unlike the plain-text path there
-    is no atomic single-op variant of an HTML import, so when recording a reviewable change we wrap the
-    whole mutation in ONE grouped undo context and, on failure, undo it (reverting the partial
-    deletion) before re-raising. If no usable/unlocked undo manager is available we REFUSE before
-    mutating (fail closed) rather than risk a partial edit. When NOT recording (no review contract) the
-    mutation runs directly, exactly as before."""
-    if not track_reviewable:
-        return session.record_mutation(mutate, **record_kwargs)
-
+    deletion (a half-applied edit). Unlike the plain-text path there is no atomic single-op variant of
+    an HTML import, so we wrap the whole mutation in ONE grouped undo context and, on failure, undo it
+    (reverting the partial deletion) before re-raising. This holds in ALL modes -- review recording ON
+    or OFF -- because the delete-before-insert is non-atomic either way: e.g. block/rich HTML into a
+    table cell deletes the match and THEN throws (format.replace_single_range_with_content), which with
+    review off previously stranded the deletion + flattened text (status "error" but the doc changed).
+    If no usable/unlocked undo manager is available we REFUSE before mutating (fail closed) rather than
+    risk a partial edit. ``track_reviewable`` no longer gates atomicity; ``session.record_mutation``
+    records a reviewable change (or not) from the session's own enabled state."""
     undo_title = _next_agent_edit_undo_title()
     try:
         mgr = doc.getUndoManager()
@@ -569,7 +679,7 @@ def _record_html_atomically(session, doc, mutate, track_reviewable, **record_kwa
         # No rollback available -> we cannot guarantee all-or-nothing, and an HTML import has no atomic
         # single-op fallback. Refuse BEFORE any mutation so the document is never left half-edited.
         raise ToolExecutionError(
-            "Cannot apply this content edit atomically in review mode (no usable undo context); "
+            "Cannot apply this content edit atomically (no usable undo context); "
             "refusing rather than risk a half-applied edit.")
 
     changes_before = len(session.changes)
@@ -581,6 +691,68 @@ def _record_html_atomically(session, doc, mutate, track_reviewable, **record_kwa
     finally:
         # Pair the enter with exactly one leave; on failure undo the partial edit and drop its record.
         _close_surgical_context(mgr, session, changes_before, applied_ok, undo_title)
+
+
+# --- post-edit echo (edited_context) ---------------------------------------
+_EDITED_CONTEXT_MAX_CHARS = 700
+
+
+def _collapsed_anchor(text_range):
+    """A collapsed model cursor at *text_range*'s start. Positions (unlike content ranges)
+    survive a delete-then-import replace, so this anchors the echo window across the edit.
+    Best-effort: None when the range's text does not support cursors (echo is then skipped)."""
+    try:
+        return text_range.getText().createTextCursorByRange(text_range.getStart())
+    except Exception:
+        return None
+
+
+def _selection_anchor(doc):
+    """Collapsed anchor at the view cursor's start (the selection insert site)."""
+    try:
+        vc = doc.getCurrentController().getViewCursor()
+        return vc.getText().createTextCursorByRange(vc.getStart())
+    except Exception:
+        return None
+
+
+def _paragraph_window_text(anchor, max_chars=_EDITED_CONTEXT_MAX_CHARS):
+    """Plain text of the paragraph around *anchor* plus one neighbor each side, read AFTER the
+    edit. Returns None instead of guessing when the paragraph walk fails (e.g. exotic nested
+    text) — the echo must be right or absent, never wrong. In record/wait the returned text is
+    the current text model, i.e. it includes the pending tracked change."""
+    if anchor is None:
+        return None
+    try:
+        text = anchor.getText()
+        start = text.createTextCursorByRange(anchor.getStart())
+        start.gotoStartOfParagraph(False)
+        start.gotoPreviousParagraph(False)   # False at the first paragraph -> stays put
+        start.gotoStartOfParagraph(False)
+        end = text.createTextCursorByRange(anchor.getEnd())
+        end.gotoEndOfParagraph(False)
+        end.gotoNextParagraph(False)         # False at the last paragraph -> stays put
+        end.gotoEndOfParagraph(False)
+        span = text.createTextCursorByRange(start.getStart())
+        span.gotoRange(end.getEnd(), True)
+        s = span.getString()
+    except Exception:
+        return None
+    if not s or not s.strip():
+        return None
+    if len(s) > max_chars:
+        head = int(max_chars * 0.6)
+        tail = max_chars - head - 7
+        s = s[:head] + " [...] " + s[-tail:]
+    return s
+
+
+def _attach_edited_context(result, anchor):
+    """Add edited_context (the touched paragraph(s) as they now read) to a successful result."""
+    snippet = _paragraph_window_text(anchor)
+    if snippet:
+        result["edited_context"] = snippet
+    return result
 
 
 def _record_preserve_replace(session, doc, found, new_text, uno_ctx, split):
@@ -780,9 +952,32 @@ class GetDocumentContent(ToolBase):
         )
         doc_len = ctx.services.document.get_document_length(ctx.doc)
         result = {"status": "ok", "content": content, "length": len(content), "document_length": doc_len}
+        # Machine-readable truncation signal: without it the only clue was the in-band marker
+        # string, which a model must know to look for. (length counts HTML chars; document_length
+        # and scope='range' offsets are plain-text chars — use those for follow-up range reads.)
+        if max_chars and isinstance(content, str) and content.endswith("[... truncated ...]"):
+            result["truncated"] = True
         if scope == "range" and range_start is not None and range_end is not None:
             result["start"] = int(range_start)
             result["end"] = int(range_end)
+
+        # The HTML content above hides tracked deletions and gives no sign that changes are pending.
+        # When the document has tracked changes, surface them explicitly (insertion vs deletion, with
+        # text) and say they await the user's review — so the model treats them as pending, not errors,
+        # and never resolves them itself.
+        try:
+            if hasattr(ctx.doc, "getRedlines") and ctx.doc.getRedlines().getCount() > 0:
+                changes = collect_tracked_changes(ctx.doc.getText())
+                if changes:
+                    result["tracked_changes"] = changes
+                    result["tracked_changes_note"] = (
+                        "This document has %d change(s) recorded as tracked changes (listed in "
+                        "tracked_changes as insertions/deletions). They are PENDING the user's review — "
+                        "not errors and not yet final. Do NOT accept or reject them yourself; that is the "
+                        "user's decision." % len(changes)
+                    )
+        except Exception:
+            log.debug("get_document_content: could not collect tracked changes", exc_info=True)
         return result
 
 
@@ -842,10 +1037,14 @@ class ApplyDocumentContent(ToolBase):
     parameters = {
         "type": "object",
         "properties": {
-            "content": {"type": "array", "items": {"type": "string"}, "description": ("List of HTML fragments or plain-text fragments (one per block); shape and math per system prompt (APPLY_DOCUMENT_CONTENT AND HTML). No Markdown.")},
+            "content": {"type": "array", "items": {"type": "string"}, "description": ("List of HTML fragments or plain-text fragments (one per block); shape and math per the APPLY_DOCUMENT_CONTENT AND HTML rules — get_guidance('editing-html') serves them if they are not in your context. No Markdown.")},
             "target": {"type": "string", "enum": ["beginning", "end", "selection", "full_document", "search"], "description": "Where to apply the content."},
             "old_content": {"type": "string", "description": ("Substring to find when target='search'. Not for whole-document replace — use target='full_document' instead.")},
-            "all_matches": {"type": "boolean", "description": "Replace all occurrences (true) or first only. Default false. Only for target='search'."},
+            "all_matches": {"type": "boolean", "description": "Replace all occurrences (true) or first only. Default false. Only for target='search' with position='replace'."},
+            "position": {"type": "string", "enum": ["replace", "before", "after"], "description": ("For target='search': 'replace' (default) replaces the match; 'before'/'after' INSERT the content next to the match and leave the matched text untouched (result reports inserted=true instead of replaced_count).")},
+            "dry_run": {"type": "boolean", "description": "For target='search': do NOT edit. Return how many times old_content matches and where each match lives, so you can check before committing."},
+            "regex": {"type": "boolean", "description": "For target='search': treat old_content as a regular expression (default false = literal). Regex mode is single-paragraph (no cross-paragraph chaining)."},
+            "case_sensitive": {"type": "boolean", "description": "For target='search': force case-sensitive (true) or case-insensitive (false) matching. Omit for the default lenient match."},
         },
         "required": ["content"],
     }
@@ -859,6 +1058,30 @@ class ApplyDocumentContent(ToolBase):
             return edit_review_wait_seconds(uno_ctx)
         except Exception:
             return 0
+
+    def _annotate_review_status(self, uno_ctx, result):
+        """Tag a successful edit result with the CURRENT review status, so the model gets a fresh,
+        per-call signal even if the guidance it read earlier (the connect-time pointer, a pulled
+        review-modes topic, or the sidebar prompt) is stale — that text is static while the user
+        can toggle the mode mid-session. Only annotates the non-wait path:
+        with recording on but no blocking wait, the edit landed as a tracked change the agent must
+        not resolve and whose accept/reject outcome it will not be told."""
+        if not isinstance(result, dict) or result.get("status") != "ok":
+            return result
+        try:
+            mode = get_agent_edit_review_mode(uno_ctx)
+        except Exception:
+            return result
+        if mode not in ("record", "wait"):
+            return result  # off -> edit is live; nothing to add
+        result = dict(result)
+        result["review_mode"] = mode
+        result["pending_review"] = True
+        result["message"] = (result.get("message") or "") + (
+            " Applied as a tracked change pending the user's review — do not accept or reject it"
+            " yourself, and you will not be notified whether it is later accepted or rejected."
+        )
+        return result
 
     def _wait_enabled_globally(self):
         """Config read without a tool context, for long_running/is_async (called by the
@@ -893,7 +1116,56 @@ class ApplyDocumentContent(ToolBase):
         # the main thread via marshalling, so the toggle is handled safely instead of erroring.
         return threading.current_thread() is not threading.main_thread()
 
+    def _dry_run_preview(self, ctx, **kwargs):
+        """Resolve old_content matches WITHOUT editing, for target='search'. Reports the count and
+        each match's location + a short snippet, so the model can check before committing."""
+        from plugin.writer import search as search_mod
+
+        target = kwargs.get("target")
+        old_content = kwargs.get("old_content")
+        if not target and old_content is not None:
+            target = "search"
+        if target != "search" or old_content is None:
+            return self._tool_error("dry_run only applies to target='search' with old_content.")
+        from . import format as format_support
+
+        old_stripped = str(old_content).strip()
+        s = old_stripped
+        if format_support.content_has_markup(s):
+            s = format_support.html_to_plain_text(s, ctx.ctx, ctx.services.get("config"))
+        s = _normalize_search_string_for_find(s)
+        if not s:
+            return self._tool_error("old_content is empty after normalization.")
+        # Mirror the EDIT path's option handling exactly — a preview that uses a different
+        # matcher than the commit it previews is worse than none. regex patterns stay raw
+        # (no markup/normalize munging), same as the edit path.
+        use_regex = bool(kwargs.get("regex"))
+        case_opt = kwargs.get("case_sensitive")
+        try:
+            if use_regex or case_opt is not None:
+                ranges = _find_ranges_regex_case(
+                    ctx.doc, old_stripped if use_regex else s, use_regex,
+                    bool(case_opt) if case_opt is not None else False, all_matches=True)
+            else:
+                ranges = _find_all_ranges(ctx.doc, s)
+        except Exception as e:
+            return self._tool_error("dry_run search failed: %s" % e)
+        matches = []
+        for found in ranges[:20]:
+            try:
+                loc = search_mod._describe_match_location(found, ctx.doc)
+            except Exception:
+                loc = "body"
+            try:
+                snippet = found.getString()
+            except Exception:
+                snippet = ""
+            matches.append({"location": loc, "text": snippet[:160]})
+        return {"status": "ok", "dry_run": True, "count": len(ranges), "matches": matches}
+
     def execute(self, ctx, **kwargs):
+        if kwargs.get("dry_run"):
+            return self._dry_run_preview(ctx, **kwargs)
         wait_seconds = self._review_wait_seconds(ctx.ctx)
         on_main = threading.current_thread() is threading.main_thread()
         if get_agent_edit_review_mode(ctx.ctx) != "wait" or on_main:
@@ -916,7 +1188,7 @@ class ApplyDocumentContent(ToolBase):
                 else:
                     from plugin.framework.queue_executor import execute_on_main_thread
                     result, _ = execute_on_main_thread(_do_edit, timeout=60.0)
-                return result
+                return self._annotate_review_status(ctx.ctx, result)
             finally:
                 if session_box:
                     if on_main:
@@ -1007,6 +1279,18 @@ class ApplyDocumentContent(ToolBase):
         if target == "search" and old_content is None:
             return self._tool_error("target='search' requires old_content."), None
 
+        # position is a search-only refinement; validate it up front (silently ignoring it on an
+        # insert target would teach the model a parameter that "works" by accident).
+        position = str(kwargs.get("position") or "replace").strip().lower()
+        if position not in ("replace", "before", "after"):
+            return self._tool_error("position must be 'replace', 'before' or 'after'."), None
+        if position != "replace" and target != "search":
+            return self._tool_error(
+                "position='before'/'after' requires target='search' (it inserts next to an old_content match)."), None
+        if position != "replace" and kwargs.get("all_matches", False):
+            return self._tool_error(
+                "position='before'/'after' inserts at a single match; drop all_matches or use position='replace'."), None
+
         # Normalize content:
         # - If the model (or caller) serialized a list as a JSON string,
         #   parse it back to a real list first so commas/brackets do not
@@ -1078,21 +1362,29 @@ class ApplyDocumentContent(ToolBase):
                 session.record_mutation(
                     lambda: format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "end", config_svc=config_svc),
                     proposed_preview=_plain_preview(content))
-            return {"status": "ok", "message": "Inserted content at end."}, session
+            return _attach_edited_context(
+                {"status": "ok", "message": "Inserted content at end."},
+                _collapsed_anchor(ctx.doc.getText().getEnd())), session
         if target == "selection":
+            # Anchor BEFORE the edit: the selection insert clears the selection first, so only a
+            # collapsed position (not the selection range itself) survives the replace.
+            anchor = _selection_anchor(ctx.doc)
             with session:
                 # Selection insert clears the selection first, then imports -> atomic (full_document above).
                 _record_html_atomically(
                     session, ctx.doc,
                     lambda: format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "selection", config_svc=config_svc),
                     track_reviewable, proposed_preview=_plain_preview(content))
-            return {"status": "ok", "message": "Inserted content at selection."}, session
+            return _attach_edited_context(
+                {"status": "ok", "message": "Inserted content at selection."}, anchor), session
         if target == "beginning":
             with session:
                 session.record_mutation(
                     lambda: format_support.insert_content_at_position(ctx.doc, ctx.ctx, content, "beginning", config_svc=config_svc),
                     proposed_preview=_plain_preview(content))
-            return {"status": "ok", "message": "Inserted content at beginning."}, session
+            return _attach_edited_context(
+                {"status": "ok", "message": "Inserted content at beginning."},
+                _collapsed_anchor(ctx.doc.getText().getStart())), session
 
         # target == "search" from here on — old_content must be a findable substring, not the full body.
         # Whole-document replace: target='full_document' (no search, no old_content).
@@ -1112,10 +1404,22 @@ class ApplyDocumentContent(ToolBase):
         # no-op surfaced as a failure), N>0 -> "ok". No matched_count/warning/partial-replace:
         # if a replace raises mid-all_matches the existing abort behavior stands.
         # TODO(follow-up): share search-path return dicts with string_eval_tools.py to avoid drift.
+        # Explicit regex / case control (opt-in): a direct SearchDescriptor find that bypasses the
+        # default lenient matcher, so "search with options then replace" agrees with search_in_document.
+        _regex_opt = bool(kwargs.get("regex"))
+        _case_opt = kwargs.get("case_sensitive")
+        _use_opts = _regex_opt or _case_opt is not None
+        _opts_pattern = old_stripped if _regex_opt else search_string
+        _opts_cs = bool(_case_opt) if _case_opt is not None else False
+
         all_matches = kwargs.get("all_matches", False)
         if all_matches:
-            ranges = _find_all_ranges(doc, search_string)
+            ranges = (_find_ranges_regex_case(doc, _opts_pattern, _regex_opt, _opts_cs, all_matches=True)
+                      if _use_opts else _find_all_ranges(doc, search_string))
             count = 0
+            # Anchor at the FIRST match in document order; the echo shows that occurrence's
+            # neighborhood after the edit (positions survive the replaces, content ranges don't).
+            anchor = _collapsed_anchor(ranges[0]) if ranges else None
             # Replace from last to first so earlier character offsets stay valid after edits.
             # One record_mutation per match: each replaced occurrence is its own reviewable
             # change with its own accept/reject outcome.
@@ -1137,12 +1441,109 @@ class ApplyDocumentContent(ToolBase):
             msg = "Replaced %d occurrence(s)." % count
             if use_preserve:
                 msg += " (formatting preserved)"
-            return {"status": "ok", "message": msg, "replaced_count": count}, session
-        found = _find_first_range(doc, search_string)
+            if count > 1:
+                msg += " edited_context shows the first occurrence's neighborhood."
+            return _attach_edited_context(
+                {"status": "ok", "message": msg, "replaced_count": count}, anchor), session
+        found = (_find_ranges_regex_case(doc, _opts_pattern, _regex_opt, _opts_cs, all_matches=False)
+                 if _use_opts else _find_first_range(doc, search_string))
         if found is None:
+            # Search covers body/table cells/text frames but not drawing-layer shapes. If the text
+            # lives only inside such a floating box, say so (actionable) instead of a bare not-found
+            # -- otherwise the agent retries blindly or assumes failure where a shapes-toolset edit
+            # is needed (note 7).
+            shape = _drawing_shape_object_containing(doc, search_string)
+            if shape is not None:
+                shape_name = (getattr(shape, "Name", "") or "").strip() or "(unnamed shape)"
+                if track_reviewable:
+                    # Review modes (record/wait) require edits to become reviewable tracked changes,
+                    # but drawing-shape text can't carry redlines and editing it directly would bypass
+                    # the review/session machinery. Route to the shapes toolset rather than silently
+                    # applying an UNtracked edit while the caller believes review is engaged.
+                    return {"status": "error",
+                            "message": ("old_content is only inside a drawing shape / floating text box "
+                                        f"('{shape_name}'). In review mode it cannot be edited as a tracked "
+                                        "change; edit it via the shapes toolset "
+                                        "(delegate_to_specialized_writer_toolset domain='shapes')."),
+                            "replaced_count": 0}, session
+                # Review off: the text lives only inside a floating drawing shape, which findFirst/
+                # replace can't reach. Edit the shape's own text directly (note 7), preserving format.
+                new_text = _plain_preview(content)
+                undo = None
+                try:
+                    undo = doc.getUndoManager()
+                    undo.enterUndoContext("Edit drawing-shape text")
+                except Exception:
+                    undo = None
+                try:
+                    edited = _replace_text_in_shape(shape, search_string, new_text)
+                finally:
+                    if undo is not None:
+                        try:
+                            undo.leaveUndoContext()
+                        except Exception:
+                            pass
+                if edited:
+                    return {"status": "ok",
+                            "message": ("Replaced 1 occurrence inside drawing shape '%s' (edited the "
+                                        "shape's own text directly — NOT a tracked change; surrounding "
+                                        "formatting preserved)." % shape_name),
+                            "replaced_count": 1}, session
+                # Couldn't edit in place -> fall back to the actionable routing message.
+                return {"status": "error",
+                        "message": ("old_content was found only inside a drawing shape / floating text box "
+                                    f"('{shape_name}'), which normal search/replace cannot edit and the direct "
+                                    "shape edit did not apply. Edit it via the shapes toolset "
+                                    "(delegate_to_specialized_writer_toolset domain='shapes')."),
+                        "replaced_count": 0}, session
             return {"status": "error", "message": "old_content not found in document. Try a shorter, unique substring.",
                     "replaced_count": 0}, session
+        if position in ("before", "after"):
+            # INSERT next to the match instead of replacing it: the single most common petition
+            # edit ("add a paragraph after clause X") previously forced resending the clause
+            # itself in content — which in record/wait rendered as a tracked delete+reinsert of
+            # text nobody touched. Collapse a cursor at the match edge and run the normal
+            # HTML-import insert there; only the genuinely new text enters the review record.
+            #
+            # Two guarded gaps (clear error beats an opaque failure; the atomic wrapper would
+            # roll back either way): the mixed-math importer appends later segments at the
+            # DOCUMENT END (format.py per-segment goto-end), and the HTML import path is not
+            # cell-safe (same nested-XText hazard the replace path detects).
+            if format_support.html_fragment_contains_mixed_math(str(content)):
+                return self._tool_error(
+                    "position='before'/'after' does not support content with math segments yet "
+                    "(later segments would land at the document end); use position='replace' "
+                    "including the math, or target='end'."), session
+            try:
+                in_cell = found.getText().createTextCursorByRange(
+                    found.getStart()).getPropertyValue("TextTable") is not None
+            except Exception:
+                in_cell = False
+            if in_cell:
+                return self._tool_error(
+                    "position='before'/'after' next to a match inside a table cell is not "
+                    "supported yet; use position='replace' with plain text, or rewrite the "
+                    "cell content."), session
+            try:
+                edge = found.getStart() if position == "before" else found.getEnd()
+                insert_cursor = found.getText().createTextCursorByRange(edge)
+            except Exception as e:
+                return self._tool_error("Could not anchor the %s-match insert: %s" % (position, e)), session
+            anchor = _collapsed_anchor(found)
+            with session:
+                _record_html_atomically(
+                    session, doc,
+                    lambda: format_support._insert_mixed_or_plain_html(doc, ctx.ctx, insert_cursor, content, config_svc=config_svc, apply_styles=False),
+                    track_reviewable, proposed_preview=_plain_preview(content))
+            return _attach_edited_context(
+                {"status": "ok",
+                 "message": "Inserted content %s the old_content match (matched text left untouched)." % position,
+                 "inserted": True, "position": position}, anchor), session
+
         original = found.getString()
+        # Anchor BEFORE the mutation: the found range's content is replaced (HTML path even
+        # deletes-then-imports), but a collapsed position at its start survives.
+        anchor = _collapsed_anchor(found)
         with session:
             if use_preserve:
                 _record_preserve_replace(session, doc, found, raw_content, ctx.ctx, track_reviewable)
@@ -1154,7 +1555,8 @@ class ApplyDocumentContent(ToolBase):
         msg = "Replaced 1 occurrence (by old_content)."
         if use_preserve:
             msg += " (formatting preserved)"
-        return {"status": "ok", "message": msg, "replaced_count": 1}, session
+        return _attach_edited_context(
+            {"status": "ok", "message": msg, "replaced_count": 1}, anchor), session
 
 
 # ------------------------------------------------------------------

--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -1037,7 +1037,7 @@ class ApplyDocumentContent(ToolBase):
     parameters = {
         "type": "object",
         "properties": {
-            "content": {"type": "array", "items": {"type": "string"}, "description": ("List of HTML fragments or plain-text fragments (one per block); shape and math per the APPLY_DOCUMENT_CONTENT AND HTML rules — get_guidance('editing-html') serves them if they are not in your context. No Markdown.")},
+            "content": {"type": "array", "items": {"type": "string"}, "description": ("List of HTML fragments or plain-text fragments (one per block); shape and math per the APPLY_DOCUMENT_CONTENT AND HTML rules — the editing-html guidance covers them if they are not already in your context. No Markdown.")},
             "target": {"type": "string", "enum": ["beginning", "end", "selection", "full_document", "search"], "description": "Where to apply the content."},
             "old_content": {"type": "string", "description": ("Substring to find when target='search'. Not for whole-document replace — use target='full_document' instead.")},
             "all_matches": {"type": "boolean", "description": "Replace all occurrences (true) or first only. Default false. Only for target='search' with position='replace'."},

--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -856,18 +856,28 @@ def insert_content_at_position(model, ctx, content, position, config_svc=None):
     elif position == "end":
         cursor.gotoEnd(False)
     elif position == "selection":
+        # Resolve the target FIRST, in the selection's OWN text object: a selection inside a
+        # table cell / frame is a different XText, and gotoRange on a body cursor raises. The
+        # old blanket `except: cursor.gotoEnd(False)` meant a failure DELETED the selection and
+        # appended the content at the document end while reporting ok. Never fall back silently.
         try:
             controller = model.getCurrentController()
-            sel = controller.getSelection()
-            if sel and hasattr(sel, "getCount") and sel.getCount() > 0:
-                rng = sel.getByIndex(0)
-                rng.setString("")
-                cursor.gotoRange(rng.getStart(), False)
-            else:
-                vc = controller.getViewCursor()
-                cursor.gotoRange(vc.getStart(), False)
-        except Exception:
-            cursor.gotoEnd(False)
+            sel = controller.getSelection() if controller else None
+            rng = None
+            if sel and hasattr(sel, "getCount"):
+                try:
+                    if int(sel.getCount()) > 0:
+                        rng = sel.getByIndex(0)
+                except Exception:
+                    rng = None
+            if rng is None:
+                rng = controller.getViewCursor()
+            cursor = rng.getText().createTextCursorByRange(rng.getStart())
+            rng.setString("")  # clear the selection only AFTER the insert cursor is anchored
+        except Exception as e:
+            raise ToolExecutionError(
+                "Could not resolve the current selection (%s). Select text first, or use "
+                "target='search' with old_content, or call set_selection." % e)
     else:
         raise ToolExecutionError("Unknown position: %s" % position)
 
@@ -916,6 +926,15 @@ def replace_single_range_with_content(model, text_range, content, ctx, config_sv
     prepared = html_mod.unescape(content)
     text_obj = text_range.getText()
 
+    # Detect a table-cell target up front (the cursor's TextTable property is set inside a cell).
+    # Block/rich HTML import into a cell's nested XText can raise an empty RuntimeException (see the
+    # FOLLOW-UP above); we use this to turn that opaque failure into a clear, actionable message.
+    in_table_cell = False
+    try:
+        in_table_cell = text_obj.createTextCursorByRange(text_range.getStart()).getPropertyValue("TextTable") is not None
+    except Exception:
+        in_table_cell = False
+
     # Preserve the target paragraph style for INLINE replacements. The StarWriter
     # HTML import resets the paragraph to a default body style, silently demoting
     # headings (e.g. "Heading 3" -> "Text body"). For inline-only content (no
@@ -958,7 +977,19 @@ def replace_single_range_with_content(model, text_range, content, ctx, config_sv
     else:
         # apply_styles=False: a search/replace splits the matched paragraph, so applying a
         # data-lo-style here would restyle the surrounding text. Styled writes use full_document.
-        _insert_mixed_or_plain_html(model, ctx, cursor, prepared, config_svc=config_svc, apply_styles=False)
+        try:
+            _insert_mixed_or_plain_html(model, ctx, cursor, prepared, config_svc=config_svc, apply_styles=False)
+        except Exception as e:
+            # Block/rich HTML into a table cell can raise an empty RuntimeException from the StarWriter
+            # HTML import (nested-XText cursor mapping). Surface a clear, actionable message instead of
+            # the opaque error; the atomic wrapper rolls back the partial edit either way.
+            if in_table_cell and _content_has_block_markup(prepared):
+                raise RuntimeError(
+                    "Rich/block HTML can't be inserted inside a table cell yet (the LibreOffice HTML "
+                    "import mishandles nested cell text). Use plain text or inline tags only inside "
+                    "table cells, or place block/rich content outside the table."
+                ) from e
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/plugin/writer/inline_review.py
+++ b/plugin/writer/inline_review.py
@@ -249,6 +249,67 @@ def _all_redlines_are_agent(model: Any) -> bool:
     return snap.foreign_reliable and len(snap.foreign_ids) == 0
 
 
+# --- Agent-self-resolution guard (used by the agent-facing track_changes_* tools) -------------
+# BUG (reported): the agent accepted its OWN edits. wa-review changes are recorded for the HUMAN
+# to accept/reject in the review UI; the agent must never resolve them. HOW IT HAPPENED:
+# tracking.py's accept/reject tools drive the native .uno:Accept/Reject(All)TrackedChanges, which
+# is blind to the wa-review token, and they are reachable by the LLM (domain='tracking'), so a tool
+# call could resolve the very changes the same turn just made. WHY THIS FIXES IT: these two
+# token-scoped, fail-closed gates let the tools refuse the agent's own changes while still allowing
+# the user's own redlines to be resolved on request.
+
+_BULK_UNRELIABLE_MSG = (
+    "Couldn't read this document's tracked changes reliably, so accept/reject-all is blocked to "
+    "avoid resolving agent edits that are awaiting your review. Resolve changes in LibreOffice "
+    "(Edit > Track Changes > Manage)."
+)
+_BULK_AGENT_PRESENT_MSG = (
+    "This document has %d agent edit(s) awaiting your review (WriterAgent tracked changes). The "
+    "agent must not accept or reject its own edits -- you resolve those in the review popup or "
+    "Edit > Track Changes > Manage. accept-all / reject-all run only when no agent changes are pending."
+)
+
+
+def redline_is_agent_change(redline: Any) -> tuple[bool, bool]:
+    """``(is a wa-review agent change, comment_readable)`` for ONE redline.
+
+    Used by the single-index accept/reject tools. A redline whose RedlineComment can't be read
+    returns ``(False, False)`` so the caller fails CLOSED (refuse rather than risk resolving an
+    agent change we couldn't classify)."""
+    from plugin.writer.edit_review import TOKEN_PREFIX
+    try:
+        comment = str(redline.getPropertyValue("RedlineComment"))
+    except Exception:
+        return False, False
+    return comment.startswith(TOKEN_PREFIX), True
+
+
+def agent_self_resolution_block_reason(model: Any) -> str | None:
+    """Refusal message if a BULK accept/reject must NOT run, else ``None``.
+
+    A blanket AcceptAll/RejectAll would resolve the agent's own wa-review changes, which only the
+    human may do, so refuse whenever the document holds (or might hold) any agent change. Fail
+    CLOSED: a document that exposes redlines but can't be scanned reliably is treated as "agent
+    changes may be present". A document with NO redline table (or an empty one) is allowed -- the
+    native dispatch is a harmless no-op and there is nothing of the user's to clobber. A document
+    whose only redlines are the USER's own is allowed (the agent may resolve those on request);
+    only the agent's own edits are protected."""
+    try:
+        if not hasattr(model, "getRedlines"):
+            return None
+        count = int(model.getRedlines().getCount())
+    except Exception:
+        return _BULK_UNRELIABLE_MSG
+    if count <= 0:
+        return None
+    snap = _agent_and_foreign_redline_snapshot(model)
+    if not snap.tokens_reliable:
+        return _BULK_UNRELIABLE_MSG
+    if snap.agent_tokens:
+        return _BULK_AGENT_PRESENT_MSG % len(snap.agent_tokens)
+    return None
+
+
 def _foreign_redline_ids(model: Any) -> tuple[set, bool]:
     """``(identifiers of non-agent redlines, reliable)``. The identifiers are the user's OWN tracked
     changes (plus any we can't classify, counted as foreign). ``reliable`` is False when the snapshot

--- a/plugin/writer/page.py
+++ b/plugin/writer/page.py
@@ -435,31 +435,74 @@ class SetPageColumns(ToolWriterPageBase):
 
 
 class InsertPageBreak(ToolWriterPageBase):
-    """Insert a page break at the current cursor position."""
+    """Insert a page break at a text anchor (before_text/after_text) or at the view cursor."""
 
     name = "insert_page_break"
-    description = "Insert a page break at the current cursor position."
-    parameters = {"type": "object", "properties": {}, "required": []}
+    description = (
+        "Start a new page. With no anchor, breaks at the user's cursor (arbitrary over MCP). "
+        "Pass before_text or after_text to break the page at a specific passage instead, so a "
+        "headless client can place it deterministically (e.g. before_text of the signature block)."
+    )
+    parameters = {"type": "object", "properties": {
+        "before_text": {"type": "string", "description": "Break so this passage starts a new page (page break on the match's paragraph)."},
+        "after_text": {"type": "string", "description": "Break the page right after this passage's paragraph."},
+        "occurrence": {"type": "integer", "description": "0-based match to use when the anchor text repeats (default 0)."},
+        "case_sensitive": {"type": "boolean", "description": "Case-sensitive anchor match (default true)."},
+    }, "required": []}
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
+        before_text = kwargs.get("before_text")
+        after_text = kwargs.get("after_text")
+        if before_text and after_text:
+            return self._tool_error("Pass only one of before_text / after_text.")
 
         try:
+            if before_text or after_text:
+                anchor = str(before_text or after_text)
+                try:
+                    occurrence = int(kwargs.get("occurrence", 0) or 0)
+                except (TypeError, ValueError):
+                    return self._tool_error("occurrence must be an integer.")
+                if occurrence < 0:
+                    return self._tool_error("occurrence must be non-negative.")
+                sd = doc.createSearchDescriptor()
+                sd.SearchString = anchor
+                sd.SearchRegularExpression = False
+                sd.SearchCaseSensitive = bool(kwargs.get("case_sensitive", True))
+                found = doc.findFirst(sd)
+                for _ in range(occurrence):
+                    if found is None:
+                        break
+                    found = doc.findNext(found.getEnd(), sd)
+                if found is None:
+                    return self._tool_error("Anchor text '%s' not found%s." % (anchor, (" at occurrence %d" % occurrence) if occurrence else ""))
+                from com.sun.star.style.BreakType import PAGE_BEFORE
+                text = found.getText()
+                # BreakType is a PARAGRAPH property. before_text -> the match's own paragraph;
+                # after_text -> the paragraph that FOLLOWS the match.
+                para = text.createTextCursorByRange(found.getStart() if before_text else found.getEnd())
+                if after_text and not para.gotoNextParagraph(False):
+                    # At the LAST paragraph there is nothing after the anchor; silently breaking
+                    # on the anchor's own paragraph would push the anchor itself to a new page
+                    # (the opposite of what was asked) while reporting ok.
+                    return self._tool_error(
+                        "The anchor is in the document's last paragraph; there is nothing after it "
+                        "to start a new page with. Use before_text, or append content first.")
+                para.setPropertyValue("BreakType", PAGE_BEFORE)
+                return {"status": "ok", "message": "Page break inserted %s the anchor." % ("before" if before_text else "after")}
+
             view_cursor = doc.getCurrentController().getViewCursor()
             if not view_cursor:
                 return self._tool_error("Could not obtain view cursor.")
 
+            from com.sun.star.style.BreakType import PAGE_BEFORE
             text = view_cursor.getText()
             cursor = text.createTextCursorByRange(view_cursor)
-
-            from com.sun.star.style.BreakType import PAGE_BEFORE
-
             cursor.setPropertyValue("BreakType", PAGE_BEFORE)
-
             # Optionally insert a paragraph break so the break actually applies cleanly
             text.insertControlCharacter(cursor, 0, False)  # 0 = PARAGRAPH_BREAK
-
             return {"status": "ok", "message": "Page break inserted."}
         except Exception as e:
             return self._tool_error(f"Error inserting page break: {e}")

--- a/plugin/writer/search.py
+++ b/plugin/writer/search.py
@@ -19,7 +19,6 @@
 import logging
 
 from plugin.framework.tool import ToolBase, ToolBaseDummy
-from plugin.writer.paragraph_search import search_paragraph_texts
 from plugin.doc.document_helpers import get_string_without_tracked_deletions
 from . import format as format_support
 
@@ -27,16 +26,235 @@ from . import format as format_support
 log = logging.getLogger("writeragent.writer")
 
 
+def _safe_name(obj):
+    """Best-effort name of a UNO object (getName() then .Name); '' if unavailable."""
+    if obj is None:
+        return ""
+    try:
+        return obj.getName()
+    except Exception:
+        try:
+            return getattr(obj, "Name", "") or ""
+        except Exception:
+            return ""
+
+
+def _prop(obj, name):
+    """obj.getPropertyValue(name) or attribute, '' / None-safe."""
+    if obj is None:
+        return None
+    try:
+        return obj.getPropertyValue(name)
+    except Exception:
+        return getattr(obj, name, None)
+
+
+def _cell_name(cur, text):
+    """Cell address ('A1', 'B2') for a match inside a table cell. A Writer cell exposes it via the
+    CellProperties 'CellName' property (not XNamed.getName), so try that on the cell text object and
+    on the cursor's Cell."""
+    for obj in (text, cur, _prop(cur, "Cell")):
+        v = _prop(obj, "CellName")
+        if v:
+            return v
+    return _safe_name(_prop(cur, "Cell"))
+
+
+def _header_footer_label(text_obj, doc=None):
+    """"header (page style 'X')" / "footer (...)" when *text_obj* is a page-style header/footer
+    text, else None.
+
+    Header/footer text objects are SwXHeadFootText -- findFirst/findNext DOES reach them, but the
+    cursor's TextTable/TextFrame properties don't apply there, so their matches were mislabeled
+    'body' (verified live 2026-07-02). The page-style walk pins down the region and style name; if
+    it fails we still say 'header or footer' rather than misreport 'body'."""
+    try:
+        if getattr(text_obj, "ImplementationName", "") != "SwXHeadFootText":
+            return None
+    except Exception:
+        return None
+    if doc is not None:
+        try:
+            styles = doc.getStyleFamilies().getByName("PageStyles")
+            for i in range(int(styles.getCount())):
+                st = styles.getByIndex(i)
+                try:
+                    if not st.isInUse():
+                        continue
+                except Exception:
+                    pass
+                for attr, region in (
+                    ("HeaderText", "header"), ("HeaderTextLeft", "header"), ("HeaderTextRight", "header"),
+                    ("FooterText", "footer"), ("FooterTextLeft", "footer"), ("FooterTextRight", "footer"),
+                ):
+                    try:
+                        if getattr(st, attr, None) == text_obj:
+                            name = _safe_name(st)
+                            return "%s (page style '%s')" % (region, name) if name else region
+                    except Exception:
+                        continue
+        except Exception:
+            pass
+    return "header or footer"
+
+
+def _describe_match_location(found, doc=None):
+    """Where a found range lives: 'body', "table 'X' cell B2", "text box 'Y'", or a header/footer.
+
+    Uses the cursor's TextTable / Cell / TextFrame properties (the same ones the cell-aware edit
+    path relies on), then the header/footer check. Fails open to 'body' so a match is never
+    dropped over a location quirk."""
+    try:
+        text = found.getText()
+        cur = text.createTextCursorByRange(found.getStart())
+    except Exception:
+        return "body"
+    try:
+        tt = cur.getPropertyValue("TextTable")
+    except Exception:
+        tt = None
+    if tt is not None:
+        tname = _safe_name(tt)
+        cname = _cell_name(cur, text)
+        if tname and cname:
+            return "table '%s' cell %s" % (tname, cname)
+        return "table '%s'" % tname if tname else "a table"
+    try:
+        tf = cur.getPropertyValue("TextFrame")
+    except Exception:
+        tf = None
+    if tf is not None:
+        name = _safe_name(tf)
+        return "text box '%s'" % name if name else "a text box"
+    hf = _header_footer_label(text, doc)
+    if hf:
+        return hf
+    return "body"
+
+
+def _enclosing_paragraph_text(found):
+    """Text of the paragraph containing the match (context); '' on failure."""
+    try:
+        text = found.getText()
+        cur = text.createTextCursorByRange(found.getStart())
+        cur.gotoStartOfParagraph(False)
+        cur.gotoEndOfParagraph(True)
+        return get_string_without_tracked_deletions(cur)
+    except Exception:
+        try:
+            return found.getString()
+        except Exception:
+            return ""
+
+
+def _iter_draw_shapes(container):
+    """Yield every shape on a draw-page container, recursing into group shapes.
+
+    ``doc.findAll`` searches the text model (body, cells, frames, and AS_CHARACTER-anchored shape
+    text that flows inline) but NOT floating drawing-layer shapes. This walks getDrawPage() so the
+    caller can reach text that lives only inside a floating text box / custom shape (note 7)."""
+    try:
+        n = int(container.getCount())
+    except Exception:
+        return
+    for i in range(n):
+        try:
+            shape = container.getByIndex(i)
+        except Exception:
+            continue
+        try:
+            is_group = shape.supportsService("com.sun.star.drawing.GroupShape")
+        except Exception:
+            is_group = False
+        if is_group:
+            yield from _iter_draw_shapes(shape)
+        else:
+            yield shape
+
+
+def _shape_is_as_character(shape):
+    """True if the shape is anchored AS_CHARACTER — its text already flows inline in the body, so
+    the text search covers it. We skip those in the draw-page sweep to avoid reporting them twice."""
+    try:
+        from com.sun.star.text.TextContentAnchorType import AS_CHARACTER
+        return shape.getPropertyValue("AnchorType") == AS_CHARACTER
+    except Exception:
+        return False
+
+
+def _shape_is_text_box(shape):
+    """True if the shape is a Writer 'text box' (Insert > Text Box) whose text lives in a linked
+    text frame. The findFirst/findNext text search already reaches that frame, so we skip the shape
+    in the draw sweep to avoid reporting the same text twice (once as frame, once as shape)."""
+    try:
+        return bool(shape.getPropertyValue("TextBox"))
+    except Exception:
+        return False
+
+
+def _shape_text_hits(shape_text, pattern, use_regex, case_sensitive):
+    """Matched substrings of *pattern* inside *shape_text* (actual-case), [] if none."""
+    if not shape_text or not pattern:
+        return []
+    if use_regex:
+        import re as _re
+        flags = 0 if case_sensitive else _re.IGNORECASE
+        try:
+            return [m.group(0) for m in _re.finditer(pattern, shape_text, flags) if m.group(0)]
+        except Exception:
+            return []
+    hay = shape_text if case_sensitive else shape_text.lower()
+    needle = pattern if case_sensitive else pattern.lower()
+    hits = []
+    step = len(needle) or 1
+    idx = hay.find(needle)
+    while idx != -1:
+        hits.append(shape_text[idx:idx + len(pattern)])
+        idx = hay.find(needle, idx + step)  # non-overlapping, matching LO's native text search
+    return hits
+
+
+def _comment_matches(doc, pattern, use_regex, case_sensitive):
+    """Yield (hit_text, author, content) for pattern matches inside comment (annotation) fields.
+
+    Comments live in text FIELDS, not in the searchable text model -- findFirst/findNext never
+    reaches them (verified live 2026-07-02: a marker inside a comment returned count 0), so text
+    that exists only in a comment was invisible to search. Matching reuses _shape_text_hits (plain
+    substring / regex over the comment's Content). Fully defensive on any UNO failure."""
+    try:
+        fields = doc.getTextFields().createEnumeration()
+    except Exception:
+        return
+    while True:
+        try:
+            if not fields.hasMoreElements():
+                return
+            field = fields.nextElement()
+        except Exception:
+            return
+        try:
+            if not field.supportsService("com.sun.star.text.textfield.Annotation"):
+                continue
+            content = getattr(field, "Content", "") or ""
+            author = (getattr(field, "Author", "") or "").strip()
+        except Exception:
+            continue
+        for hit in _shape_text_hits(content, pattern, use_regex, case_sensitive):
+            yield hit, author, content
+
+
 class SearchInDocument(ToolBase):
-    """Search for text in a document with paragraph context."""
+    """Search for text anywhere in a document (body, tables, text boxes) and report where."""
 
     name = "search_in_document"
     description = (
-        "Search for text in the document using LibreOffice native search. Returns matches with "
-        "surrounding paragraph text for context. IMPORTANT: each match's paragraph_index is an "
-        "INTERNAL addressing index — NEVER cite paragraph numbers to the user (they don't see them "
-        "and they shift as the document changes). When pointing the user to a match or an edit, "
-        "quote the first few words of its text instead (e.g. \"the sentence starting 'The Amazon…'\")."
+        "Search for text ANYWHERE in the document using LibreOffice native search — body paragraphs "
+        "and headings, table cells, text boxes / frames, floating drawing shapes, page headers/footers, "
+        "AND comments (annotations) are all covered. Each match reports WHERE it was found (location, "
+        "e.g. \"body\", \"table 'Table1' cell B2\", \"text box 'Frame1'\", \"shape 'Shape 1'\", "
+        "\"header (page style 'Standard')\", \"comment by 'Ana'\") plus the surrounding paragraph (or "
+        "shape/comment text) for context. When pointing the user to a match, quote the first few words "
+        "of its text and its location rather than any internal index."
     )
     parameters = {
         "type": "object",
@@ -45,8 +263,7 @@ class SearchInDocument(ToolBase):
             "regex": {"type": "boolean", "description": "Use regular expression (default: false)."},
             "case_sensitive": {"type": "boolean", "description": "Case-sensitive search (default: false)."},
             "max_results": {"type": "integer", "description": "Maximum results to return (default: 20)."},
-            "context_paragraphs": {"type": "integer", "description": ("Number of paragraphs of context around each match (default: 1).")},
-            "return_offsets": {"type": "boolean", "description": ("If true, returns {start, end, text} character offsets instead of paragraph context. (Regex not supported).")},
+            "return_offsets": {"type": "boolean", "description": ("If true, returns {start, end, text} character offsets instead of located matches. (Regex not supported).")},
         },
         "required": ["pattern"],
     }
@@ -62,41 +279,114 @@ class SearchInDocument(ToolBase):
         use_regex = kwargs.get("regex", False)
         case_sensitive = kwargs.get("case_sensitive", False)
         max_results = kwargs.get("max_results", 20)
-        context_paragraphs = kwargs.get("context_paragraphs", 1)
         return_offsets = kwargs.get("return_offsets", False)
 
         if return_offsets:
             ranges = format_support.find_text_ranges(ctx.doc, ctx.ctx, pattern, start=0, limit=max_results, case_sensitive=case_sensitive)
             return {"status": "ok", "ranges": ranges}
 
+        # Iterate findFirst/findNext (one range at a time) rather than findAll: findAll's bulk
+        # SwXTextRanges::Create can SIGABRT-crash LibreOffice on documents that contain floating
+        # drawing shapes (observed 2026-07-01 on a real petition). findFirst/findNext covers the
+        # same scope — body, table cells, and text boxes / frames — one match at a time, and is
+        # exactly what the edit path uses without crashing. For each hit we report WHERE it lives.
         doc = ctx.doc
-        doc_svc = ctx.services.document
-        para_ranges = doc_svc.get_paragraph_ranges(doc)
-
-        # Read paragraph texts once
-        para_texts = []
-        for para in para_ranges:
-            try:
-                if para.supportsService("com.sun.star.text.Paragraph"):
-                    para_texts.append(get_string_without_tracked_deletions(para))
-                else:
-                    para_texts.append("")
-            except Exception:
-                para_texts.append("")
-
         try:
-            matches, total_count = search_paragraph_texts(
-                pattern,
-                para_texts,
-                regex=use_regex,
-                case_sensitive=case_sensitive,
-                max_results=max_results,
-                context_paragraphs=context_paragraphs,
-            )
-        except ValueError as e:
-            return {"status": "error", "error": str(e)}
+            sd = doc.createSearchDescriptor()
+            sd.SearchString = pattern
+            sd.SearchRegularExpression = bool(use_regex)
+            sd.SearchCaseSensitive = bool(case_sensitive)
+            found = doc.findFirst(sd)
+        except Exception as e:
+            return {"status": "error", "error": "search failed: %s" % e}
 
-        return {"status": "ok", "matches": matches, "count": total_count}
+        matches = []
+        total_count = 0
+        guard = 0
+        while found is not None and guard < 10000:
+            guard += 1
+            try:
+                hit_text = found.getString()
+            except Exception:
+                hit_text = pattern
+            if hit_text == "":
+                # Zero-width match (e.g. a zero-width regex): getEnd()==getStart() would make
+                # findNext restart in place and spin. Stop rather than emit empty hits / loop.
+                break
+            total_count += 1
+            if len(matches) < max_results:
+                matches.append({
+                    "text": hit_text,
+                    "location": _describe_match_location(found, doc),
+                    "context": _enclosing_paragraph_text(found),
+                })
+            try:
+                found = doc.findNext(found.getEnd(), sd)
+            except Exception:
+                break
+
+        # Draw-layer sweep: floating shapes (text boxes / custom shapes anchored to page or paragraph)
+        # are NOT reached by findAll, so text living only inside one is otherwise reported "not found"
+        # (note 7). Walk the draw page (recursing into groups) and report those hits with a 'shape'
+        # location. AS_CHARACTER shapes are skipped — findAll already covers their inline text.
+        # Every hit is COUNTED (count = total matches in the document, like the text search above);
+        # only the first max_results are returned in matches.
+        if hasattr(doc, "getDrawPage"):
+            try:
+                draw_shapes = list(_iter_draw_shapes(doc.getDrawPage()))
+            except Exception:
+                draw_shapes = []
+            for shape in draw_shapes:
+                try:
+                    if _shape_is_as_character(shape) or _shape_is_text_box(shape):
+                        continue
+                    shape_text = shape.getString() if hasattr(shape, "getString") else ""
+                except Exception:
+                    continue
+                hits = _shape_text_hits(shape_text, pattern, use_regex, case_sensitive)
+                if not hits:
+                    continue
+                sname = (getattr(shape, "Name", "") or "").strip() or "(unnamed shape)"
+                for hit in hits:
+                    total_count += 1
+                    if len(matches) < max_results:
+                        matches.append({
+                            "text": hit,
+                            "location": "shape '%s'" % sname,
+                            "context": shape_text.strip(),
+                        })
+
+        # Comment (annotation) sweep: comments are text fields outside the searchable text model,
+        # so the text search above never sees them. Report matches with the comment's author and
+        # the full comment text as context. Same counting contract as above.
+        for hit, author, content in _comment_matches(doc, pattern, use_regex, case_sensitive):
+            total_count += 1
+            if len(matches) < max_results:
+                matches.append({
+                    "text": hit,
+                    "location": "comment by '%s'" % (author or "unknown"),
+                    "context": content.strip(),
+                })
+
+        # Zero hits with regex=true: a malformed pattern finds nothing SILENTLY (LibreOffice's
+        # SearchDescriptor does not raise, and the Python re sweeps swallow compile errors), which
+        # is indistinguishable from "text not in document". Diagnose it: if the pattern does not
+        # even compile, say so instead of reporting a clean miss. (A pattern that found something
+        # never reaches this check, so ICU-only syntax that Python cannot parse is not rejected.)
+        if total_count == 0 and use_regex:
+            import re as _re
+
+            try:
+                _re.compile(pattern)
+            except _re.error as rex:
+                return {
+                    "status": "error",
+                    "code": "INVALID_REGEX",
+                    "message": ("0 matches, and the pattern does not parse as a regular expression "
+                                "(%s). Fix the pattern, or set regex=false for a literal search." % rex),
+                    "count": 0,
+                }
+        return {"status": "ok", "matches": matches, "count": total_count, "returned": len(matches)}
 
 
 class AdvancedSearch(ToolBaseDummy):

--- a/plugin/writer/selection.py
+++ b/plugin/writer/selection.py
@@ -1,0 +1,102 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""set_selection — select a passage so the user sees it highlighted and target='selection' can
+act on it. Headless MCP clients have no way to set a selection otherwise, which made
+target='selection' a trap (see the target_resolver fix). Selection is view state and transient,
+so for headless flows set_selection and the follow-up edit should be consecutive."""
+from typing import Any
+
+from plugin.framework.tool import ToolBase
+
+
+class SetSelection(ToolBase):
+    name = "set_selection"
+    tier = "core"
+    is_mutation = False
+    uno_services = ["com.sun.star.text.TextDocument"]
+    description = (
+        "Select a passage in the document (highlights it for the user and lets a following "
+        "apply_document_content/apply_style with target='selection' act on it). Select by "
+        "search_text (with occurrence and case_sensitive) or by character range (char_start/"
+        "char_end). Selection is transient view state, so pair it with the edit that uses it. "
+        "Returns the selected text and its character range."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "search_text": {"type": "string", "description": "Text to select (first match unless occurrence is set)."},
+            "occurrence": {"type": "integer", "description": "0-based match to select when search_text repeats (default 0)."},
+            "case_sensitive": {"type": "boolean", "description": "Case-sensitive search_text match (default true)."},
+            "char_start": {"type": "integer", "description": "Alternative to search_text: 0-based start character offset (body text)."},
+            "char_end": {"type": "integer", "description": "End character offset (exclusive), required with char_start."},
+        },
+        "required": [],
+    }
+
+    def execute(self, ctx: Any, **kwargs: Any) -> dict[str, Any]:
+        doc = ctx.doc
+        search_text = kwargs.get("search_text")
+        char_start = kwargs.get("char_start")
+        char_end = kwargs.get("char_end")
+
+        try:
+            controller = doc.getCurrentController()
+            if controller is None:
+                return self._tool_error("No document view is available to hold a selection.")
+        except Exception as e:
+            return self._tool_error("No document view available: %s" % e)
+
+        # --- resolve the range to select ---
+        if search_text:
+            try:
+                occurrence = int(kwargs.get("occurrence", 0) or 0)
+            except (TypeError, ValueError):
+                return self._tool_error("occurrence must be an integer.")
+            if occurrence < 0:
+                return self._tool_error("occurrence must be non-negative.")
+            case_sensitive = bool(kwargs.get("case_sensitive", True))
+            try:
+                sd = doc.createSearchDescriptor()
+                sd.SearchString = str(search_text)
+                sd.SearchRegularExpression = False
+                sd.SearchCaseSensitive = case_sensitive
+                found = doc.findFirst(sd)
+                for _ in range(occurrence):
+                    if found is None:
+                        break
+                    found = doc.findNext(found.getEnd(), sd)
+            except Exception as e:
+                return self._tool_error("Search failed: %s" % e)
+            if found is None:
+                return self._tool_error(
+                    "No match for search_text '%s'%s." % (search_text, (" at occurrence %d" % occurrence) if occurrence else ""))
+            target_range = found
+        elif char_start is not None or char_end is not None:
+            if char_start is None or char_end is None:
+                return self._tool_error("char_start and char_end must both be provided.")
+            from plugin.doc.document_helpers import get_text_cursor_at_range
+
+            target_range = get_text_cursor_at_range(doc, int(char_start), int(char_end))
+            if target_range is None:
+                return self._tool_error("Could not build a cursor for that character range.")
+        else:
+            return self._tool_error("Provide search_text or char_start/char_end.")
+
+        # --- apply the selection in the view ---
+        try:
+            controller.select(target_range)
+        except Exception as e:
+            return self._tool_error("Could not set the selection: %s" % e)
+
+        selected = ""
+        try:
+            selected = target_range.getString()
+        except Exception:
+            pass
+        result = {"status": "ok", "selected_text": selected, "length": len(selected)}
+        # Report the character range when we can measure it (offset path already knows it).
+        if search_text is None and char_start is not None and char_end is not None:
+            result["char_start"], result["char_end"] = int(char_start), int(char_end)
+        return result

--- a/plugin/writer/specialized/bookmarks.py
+++ b/plugin/writer/specialized/bookmarks.py
@@ -91,13 +91,11 @@ class BookmarkService(ServiceBase):
             text.insertTextContent(cursor, bookmark, False)
             bookmark_map[para_idx] = bm_name
 
-        if needs_bookmark:
-            try:
-                if doc.hasLocation():
-                    doc.store()
-            except Exception:
-                pass
-
+        # Deliberately NO doc.store() here: this runs inside READ tools (get_document_tree,
+        # proximity reads), and saving would silently persist the user's unsaved manual edits
+        # and pending tracked changes to disk. The bookmarks live in the document model and are
+        # persisted whenever the USER next saves; on a discarded session they vanish with the
+        # rest of the unsaved state, which is exactly what not-saving means.
         return bookmark_map
 
     def find_nearest_heading_bookmark(self, para_index, bookmark_map):
@@ -127,12 +125,8 @@ class BookmarkService(ServiceBase):
                         removed += 1
                     except Exception:
                         pass
-            if removed:
-                try:
-                    if doc.hasLocation():
-                        doc.store()
-                except Exception:
-                    pass
+            # No doc.store() (same reason as ensure_heading_bookmarks: a maintenance path must
+            # never persist the user's unsaved work as a side effect).
         except Exception:
             log.exception("Failed to cleanup bookmarks")
         return removed

--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -71,43 +71,69 @@ class AddComment(ToolBase):
 
     name = "add_comment"
     intent = "review"
-    description = "Add a comment/annotation. Anchor the comment to text matching search_text."
-    parameters = {"type": "object", "properties": {"content": {"type": "string", "description": "The comment text."}, "search_text": {"type": "string", "description": "Anchor the comment to text containing this string."}}, "required": ["content", "search_text"]}
+    description = (
+        "Add a comment/annotation anchored to text matching search_text. The comment SPANS the "
+        "matched passage (the user sees which text it covers). Use occurrence to target a later "
+        "match and author to sign it."
+    )
+    parameters = {"type": "object", "properties": {
+        "content": {"type": "string", "description": "The comment text."},
+        "search_text": {"type": "string", "description": "Anchor the comment to text matching this string."},
+        "occurrence": {"type": "integer", "description": "0-based match to comment on when search_text repeats (default 0)."},
+        "author": {"type": "string", "description": "Comment author (default 'WriterAgent')."},
+    }, "required": ["content", "search_text"]}
     uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
         content = kwargs.get("content", "")
         search_text = kwargs.get("search_text")
-        author = "WriterAgent"
+        author = (kwargs.get("author") or "WriterAgent").strip() or "WriterAgent"
 
         if not search_text:
             return self._tool_error("Provide search_text.")
+        try:
+            occurrence = int(kwargs.get("occurrence", 0) or 0)
+        except (TypeError, ValueError):
+            return self._tool_error("occurrence must be an integer.")
+        if occurrence < 0:
+            return self._tool_error("occurrence must be non-negative.")
 
         doc = ctx.doc
-        doc_text = doc.getText()
 
-        # Determine anchor position
+        # Find the requested occurrence.
         sd = doc.createSearchDescriptor()
         sd.SearchString = search_text
         sd.SearchRegularExpression = False
         found = doc.findFirst(sd)
+        for _ in range(occurrence):
+            if found is None:
+                break
+            found = doc.findNext(found.getEnd(), sd)
         if found is None:
             # status="error" (not "not_found"): an anchor miss is a failure, so the chat FSM and
             # MCP host don't treat a no-op as success. anchor_text is returned on success only.
-            return {"status": "error", "message": "Text '%s' not found." % search_text, "matched": False, "comment_added": False}
-        anchor_range = found.getStart()
+            where = (" at occurrence %d" % occurrence) if occurrence else ""
+            return {"status": "error", "message": "Text '%s' not found%s." % (search_text, where), "matched": False, "comment_added": False}
 
         annotation = doc.createInstance("com.sun.star.text.textfield.Annotation")
         annotation.setPropertyValue("Author", author)
         annotation.setPropertyValue("Content", content)
         _set_annotation_date(annotation)
-        cursor = doc_text.createTextCursorByRange(anchor_range)
-        doc_text.insertTextContent(cursor, annotation, False)
+        # Insert SPANNING the match (absorb=True over a cursor covering found), so the annotation
+        # highlights the passage instead of a zero-width point. Anchor in the match's own text
+        # object (cell/frame safe).
+        anchor_text = ""
+        try:
+            anchor_text = found.getString()
+        except Exception:
+            pass
+        match_text = found.getText()
+        cursor = match_text.createTextCursorByRange(found.getStart())
+        cursor.gotoRange(found.getEnd(), True)
+        match_text.insertTextContent(cursor, annotation, True)
 
-        # TODO(follow-up): anchor_text echoes search_text (the argument), not the matched document
-        # span — slice found.getString() if agents need to verify first-match disambiguation.
-        return {"status": "ok", "message": "Comment added.", "author": author, "matched": True, "comment_added": True, "anchor_text": search_text}
+        return {"status": "ok", "message": "Comment added.", "author": author, "matched": True, "comment_added": True, "anchor_text": anchor_text or search_text}
 
 
 class DeleteComment(ToolWriterCommentBase):
@@ -148,6 +174,14 @@ class DeleteComment(ToolWriterCommentBase):
                 to_delete.append(field)
             elif author and field_author == author:
                 to_delete.append(field)
+
+        if not to_delete:
+            # A miss must be an ERROR: "ok, deleted: 0" reads as success and the agent then
+            # reports a deletion that never happened.
+            what = ("comment_name '%s'" % comment_name) if comment_name else ("author '%s'" % author)
+            return {"status": "error", "code": "COMMENT_NOT_FOUND",
+                    "message": "No comment matched %s. Call list_comments to see the current names and authors." % what,
+                    "deleted": 0}
 
         for field in to_delete:
             text_obj.removeTextContent(field)
@@ -420,13 +454,32 @@ def _read_annotation(field, para_ranges, text_obj, doc_svc):
     except Exception:
         entry["date"] = ""
 
-    # Paragraph index and anchor preview.
+    # Paragraph index and anchor preview. An annotation field's getAnchor().getString() often
+    # comes back EMPTY (the field anchor reads as a point even for spanning comments), which left
+    # anchor_preview blank — the agent could not tell which passage a comment is about. Fall back
+    # to the ENCLOSING PARAGRAPH's text and say so via anchor_is_paragraph_context.
+    anchor = None
     try:
         anchor = field.getAnchor()
         entry["paragraph_index"] = doc_svc.find_paragraph_for_range(anchor, para_ranges, text_obj)
-        entry["anchor_preview"] = anchor.getString()[:80]
     except Exception:
         entry["paragraph_index"] = 0
-        entry["anchor_preview"] = ""
+    preview = ""
+    if anchor is not None:
+        try:
+            preview = anchor.getString()[:80]
+        except Exception:
+            preview = ""
+        if not preview:
+            try:
+                from plugin.writer.search import _enclosing_paragraph_text
+
+                ptxt = (_enclosing_paragraph_text(anchor) or "").strip()
+                if ptxt:
+                    preview = ptxt[:120]
+                    entry["anchor_is_paragraph_context"] = True
+            except Exception:
+                pass
+    entry["anchor_preview"] = preview
 
     return entry

--- a/plugin/writer/styles.py
+++ b/plugin/writer/styles.py
@@ -291,6 +291,8 @@ class ApplyStyle(FrameworkToolBase):
             "family": {"type": "string", "enum": ["ParagraphStyles", "CharacterStyles"], "description": ("Style family. Default: ParagraphStyles.")},
             "target": {"type": "string", "enum": ["beginning", "end", "selection", "full_document", "search"], "description": "Where to apply the style."},
             "old_content": {"type": "string", "description": "Text to find and apply style to if target = 'search'."},
+            "all_matches": {"type": "boolean", "description": "For target='search': apply to EVERY occurrence of old_content (default false = first only)."},
+            "occurrence": {"type": "integer", "description": "For target='search': apply to this single 0-based occurrence instead of the first."},
         },
         "required": ["style_name"],
     }
@@ -299,6 +301,12 @@ class ApplyStyle(FrameworkToolBase):
 
     # Maps family to the UNO property that holds the style name.
     _PROPERTY_MAP = {"ParagraphStyles": "ParaStyleName", "CharacterStyles": "CharStyleName"}
+
+    def _apply_one(self, ctx, family, uno_prop, uno_value, cursor):
+        if family == "ParagraphStyles":
+            apply_paragraph_style_preserving_direct_char(ctx.doc, cursor, uno_value)
+        else:
+            cursor.setPropertyValue(uno_prop, uno_value)
 
     def execute(self, ctx, **kwargs):
         style_name = (kwargs.get("style_name") or "").strip()
@@ -314,8 +322,73 @@ class ApplyStyle(FrameworkToolBase):
         # CharStyleName to an empty string.
         uno_value = "" if (family == "CharacterStyles" and style_name == "No Character Style") else style_name
 
+        # Validate the style EXISTS before touching the document: a near-miss name ('heading 1',
+        # 'Body Text') used to dead-end in a raw UNO IllegalArgumentException with no hint. Offer
+        # the case-insensitive match when there is one, plus a sample of valid names.
+        if uno_value:
+            try:
+                fam = ctx.doc.getStyleFamilies().getByName(family)
+                if not fam.hasByName(uno_value):
+                    names = [str(n) for n in fam.getElementNames()]
+                    low = uno_value.lower()
+                    # Best hint first: exact case-insensitive, then prefix, then substring —
+                    # shortest name wins ('body text' -> 'Body Text 2', not 'Body Text Indent 2').
+                    exact = [n for n in names if n.lower() == low]
+                    prefix = sorted((n for n in names if n.lower().startswith(low)), key=len)
+                    contains = sorted((n for n in names if low in n.lower()), key=len)
+                    close = exact or prefix or contains
+                    hint = (" Did you mean '%s'?" % close[0]) if close else ""
+                    sample = ", ".join(sorted(names)[:15])
+                    return self._tool_error(
+                        "Style '%s' not found in %s.%s Available styles include: %s." % (style_name, family, hint, sample))
+            except Exception:
+                pass  # can't enumerate styles (exotic doc) -> let the apply path report
+
         target = kwargs.get("target", "selection")
         old_content = kwargs.get("old_content")
+
+        # Multi-occurrence styling (target='search' only). resolve_target_cursor styles only the
+        # first match; all_matches / occurrence let a defined term or repeated quote lead be
+        # styled everywhere. Each match gets a cursor in its OWN text object (cell/frame safe).
+        all_matches = bool(kwargs.get("all_matches"))
+        occ_raw = kwargs.get("occurrence")
+        if target == "search" and (all_matches or occ_raw is not None):
+            from plugin.writer.content import _find_all_ranges, _normalize_search_string_for_find
+            from plugin.writer.format import content_has_markup, html_to_plain_text
+
+            s = str(old_content).strip() if old_content is not None else ""
+            if not s:
+                return {"status": "error", "message": "target='search' requires old_content.", "applied": False, "matched": False}
+            if content_has_markup(s):
+                s = html_to_plain_text(s, ctx.ctx, ctx.services.get("config"))
+            s = _normalize_search_string_for_find(s)
+            ranges = _find_all_ranges(ctx.doc, s) if s else []
+            if not ranges:
+                return {"status": "error", "message": "old_content not found in document.", "target": "search", "applied": False, "matched": False}
+            if occ_raw is not None:
+                try:
+                    occ = int(occ_raw)
+                except (TypeError, ValueError):
+                    return self._tool_error("occurrence must be an integer.")
+                if occ < 0 or occ >= len(ranges):
+                    return self._tool_error("occurrence %s out of range (found %d match(es), use 0..%d)." % (occ_raw, len(ranges), len(ranges) - 1))
+                ranges = [ranges[occ]]
+            applied = 0
+            for found in ranges:
+                try:
+                    ftext = found.getText()
+                    c = ftext.createTextCursorByRange(found.getStart())
+                    c.gotoRange(found.getEnd(), True)
+                    self._apply_one(ctx, family, uno_prop, uno_value, c)
+                    applied += 1
+                except Exception as e:
+                    return self._tool_error("Applied to %d of %d; failed on one match: %s" % (applied, len(ranges), e))
+            result = {"status": "ok", "message": "Applied style '%s' (%s) to %d match(es)." % (style_name, family, applied),
+                      "style_name": style_name, "family": family, "target": "search", "applied": True, "matched": True, "applied_count": applied}
+            from plugin.writer.edit_review import review_recording_enabled
+            if review_recording_enabled(ctx.ctx):
+                result["style_unreviewed"] = True
+            return result
 
         try:
             cursor = resolve_target_cursor(ctx, target, old_content)
@@ -332,10 +405,7 @@ class ApplyStyle(FrameworkToolBase):
             return self._tool_error("Failed to resolve target location.")
 
         try:
-            if family == "ParagraphStyles":
-                apply_paragraph_style_preserving_direct_char(ctx.doc, cursor, uno_value)
-            else:
-                cursor.setPropertyValue(uno_prop, uno_value)
+            self._apply_one(ctx, family, uno_prop, uno_value, cursor)
         except Exception as e:
             return self._tool_error("Could not apply style: %s" % e)
         result = {"status": "ok", "message": "Applied style '%s' (%s) to %s." % (style_name, family, target),

--- a/plugin/writer/target_resolver.py
+++ b/plugin/writer/target_resolver.py
@@ -25,20 +25,43 @@ def resolve_target_cursor(ctx, target, old_content):
         cursor.gotoEnd(False)
         return cursor
     elif target == "selection":
+        # Resolve the explicit selection, else the view cursor. NEVER silently fall back to the end
+        # of the document (the old `except: gotoEnd` appended edits at the very end and still
+        # reported ok). Only when BOTH are unavailable do we raise a clear error, so a headless MCP
+        # client that never set a selection is told to use set_selection / target='search'.
+        controller = None
         try:
             controller = doc.getCurrentController()
-            sel = controller.getSelection()
-            if sel and hasattr(sel, "getCount") and sel.getCount() > 0:
-                rng = sel.getByIndex(0)
-                cursor.gotoRange(rng.getStart(), False)
-                cursor.gotoRange(rng.getEnd(), True)
-            else:
-                vc = controller.getViewCursor()
-                cursor.gotoRange(vc.getStart(), False)
-                cursor.gotoRange(vc.getEnd(), True)
         except Exception:
-            cursor.gotoEnd(False)
-        return cursor
+            controller = None
+        rng = None
+        if controller is not None:
+            try:
+                sel = controller.getSelection()
+                if sel and hasattr(sel, "getCount") and int(sel.getCount()) > 0:
+                    rng = sel.getByIndex(0)
+            except Exception:
+                rng = None
+            if rng is None:
+                try:
+                    rng = controller.getViewCursor()
+                except Exception:
+                    rng = None
+        if rng is None:
+            raise ValueError(
+                "Could not resolve the current selection. Select text first, or use "
+                "target='search' with old_content, or call set_selection.")
+        # Build the cursor in the SELECTION's own text object: a selection inside a table cell or
+        # text frame is a different XText, and gotoRange on a body cursor raises a raw UNO
+        # RuntimeException that escapes callers expecting ValueError. Same pattern as the search
+        # branch below.
+        try:
+            scursor = rng.getText().createTextCursorByRange(rng.getStart())
+            scursor.gotoRange(rng.getEnd(), True)
+            return scursor
+        except Exception as e:
+            raise ValueError("Could not span the current selection (%s). Use target='search' "
+                             "with old_content, or call set_selection." % e)
     elif target == "beginning":
         cursor.gotoStart(False)
         return cursor
@@ -64,6 +87,10 @@ def resolve_target_cursor(ctx, target, old_content):
     if found is None:
         raise ValueError("old_content not found in document. Try a shorter, unique substring.")
 
-    cursor.gotoRange(found.getStart(), False)
-    cursor.gotoRange(found.getEnd(), True)
-    return cursor
+    # Build the cursor in the MATCH's own text object, not the body: a match inside a table cell
+    # or text frame is a different XText, and gotoRange across text objects raises (format.py
+    # documents this). createTextCursorByRange on found.getText() keeps the cursor in-scope.
+    ftext = found.getText()
+    fcursor = ftext.createTextCursorByRange(found.getStart())
+    fcursor.gotoRange(found.getEnd(), True)
+    return fcursor

--- a/plugin/writer/tracking.py
+++ b/plugin/writer/tracking.py
@@ -92,8 +92,24 @@ class TrackChangesList(WriterAgentSpecialTracking, ToolCalcSpecialTracking):
 
     uno_services = _TRACK_CHANGES_UNO_SERVICES
     name = "track_changes_list"
-    description = "List all tracked changes (redlines) in the document, including type, author, date, and comment."
+    description = (
+        "List all tracked changes (redlines) in the document, including type, author, date, text "
+        "and location. NOTE the two flags: 'recording' is the DOCUMENT's own track-changes toggle; "
+        "'agent_review_mode' (off/record/wait) is the user's review setting for AGENT edits — in "
+        "record/wait your edits become redlines even while recording is false."
+    )
     parameters = {"type": "object", "properties": {}, "required": []}
+
+    @staticmethod
+    def _agent_review_mode(uno_ctx):
+        """Best-effort agent review mode, so 'recording: false' is never read as 'my edits are
+        not being tracked' while record/wait mode is active."""
+        try:
+            from plugin.writer.edit_review import get_agent_edit_review_mode
+
+            return get_agent_edit_review_mode(uno_ctx)
+        except Exception:
+            return None
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -102,17 +118,28 @@ class TrackChangesList(WriterAgentSpecialTracking, ToolCalcSpecialTracking):
             recording = doc.getPropertyValue("RecordChanges")
         except Exception:
             pass
+        agent_mode = self._agent_review_mode(getattr(ctx, "ctx", None))
 
         if not hasattr(doc, "getRedlines"):
-            return {"status": "ok", "recording": recording, "changes": [], "count": 0, "message": "Document does not expose redlines API."}
+            result = {"status": "ok", "recording": recording, "changes": [], "count": 0, "message": "Document does not expose redlines API."}
+            if agent_mode is not None:
+                result["agent_review_mode"] = agent_mode
+            return result
 
         try:
             redlines = doc.getRedlines()
             enum = redlines.createEnumeration()
-            changes = []
-            index = 0
+            # Materialize the enumeration FIRST. Calling getAnchor() (which walks the text model)
+            # mid-enumeration conflicts with the live iterator, so accept/reject only touches the
+            # anchor after the loop -- we do the same by collecting the redlines up front.
+            redline_objs = []
             while enum.hasMoreElements():
-                redline = enum.nextElement()
+                redline_objs.append(enum.nextElement())
+
+            from plugin.writer.search import _describe_match_location
+
+            changes = []
+            for index, redline in enumerate(redline_objs):
                 entry: dict[str, Any] = {"index": index}
                 for prop in ("RedlineType", "RedlineAuthor", "RedlineComment", "RedlineIdentifier"):
                     try:
@@ -124,10 +151,46 @@ class TrackChangesList(WriterAgentSpecialTracking, ToolCalcSpecialTracking):
                     entry["date"] = "%04d-%02d-%02d %02d:%02d" % (dt.Year, dt.Month, dt.Day, dt.Hours, dt.Minutes)
                 except Exception:
                     pass
+                # Text + location: accept/reject take this index, so the model needs to know WHICH
+                # change is which. Without them, mapping "reject the change to clause 4.2" onto an
+                # index is guesswork. Redline objects from getRedlines() are property sets (no
+                # getAnchor) with RedlineStart/RedlineEnd (XTextRange) and RedlineText (deleted
+                # content). Each field is best-effort so one failure never drops the other.
+                start = None
+                try:
+                    start = redline.getPropertyValue("RedlineStart")
+                except Exception:
+                    start = None
+                if start is not None:
+                    try:
+                        entry["location"] = _describe_match_location(start, doc)
+                    except Exception:
+                        pass
+                # Text: for an insertion the live span RedlineStart..RedlineEnd holds it; for a
+                # deletion that span is collapsed, so fall back to RedlineText (the removed text).
+                txt = ""
+                try:
+                    end = redline.getPropertyValue("RedlineEnd")
+                    stext = start.getText()
+                    cur = stext.createTextCursorByRange(start)
+                    cur.gotoRange(end, True)
+                    txt = cur.getString() or ""
+                except Exception:
+                    txt = ""
+                if not txt:
+                    try:
+                        rt = redline.getPropertyValue("RedlineText")
+                        txt = (rt.getString() if hasattr(rt, "getString") else str(rt)) if rt is not None else ""
+                    except Exception:
+                        txt = ""
+                if txt:
+                    entry["text"] = txt if len(txt) <= 300 else txt[:299] + "…"
                 changes.append(entry)
-                index += 1
 
-            return {"status": "ok", "recording": recording, "changes": changes, "count": len(changes)}
+            result = {"status": "ok", "recording": recording, "changes": changes, "count": len(changes)}
+            if agent_mode is not None:
+                result["agent_review_mode"] = agent_mode
+            return result
         except Exception as e:
             return self._tool_error(f"Failed to list tracked changes: {e}")
 
@@ -170,6 +233,12 @@ class TrackChangesAcceptAll(WriterAgentSpecialTracking, ToolCalcSpecialTracking)
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
+        # Guard: never let the agent bulk-resolve its OWN (wa-review) edits -- those are the human's
+        # to review. Allowed when no agent changes are pending (see agent_self_resolution_block_reason).
+        from plugin.writer.inline_review import agent_self_resolution_block_reason
+        blocked = agent_self_resolution_block_reason(ctx.doc)
+        if blocked:
+            return self._tool_error(blocked)
         try:
             smgr = ctx.ctx.ServiceManager
             dispatcher = smgr.createInstanceWithContext("com.sun.star.frame.DispatchHelper", ctx.ctx)
@@ -191,6 +260,12 @@ class TrackChangesRejectAll(WriterAgentSpecialTracking, ToolCalcSpecialTracking)
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
+        # Guard: never let the agent bulk-resolve its OWN (wa-review) edits -- those are the human's
+        # to review. Allowed when no agent changes are pending (see agent_self_resolution_block_reason).
+        from plugin.writer.inline_review import agent_self_resolution_block_reason
+        blocked = agent_self_resolution_block_reason(ctx.doc)
+        if blocked:
+            return self._tool_error(blocked)
         try:
             smgr = ctx.ctx.ServiceManager
             dispatcher = smgr.createInstanceWithContext("com.sun.star.frame.DispatchHelper", ctx.ctx)
@@ -229,14 +304,38 @@ class _TrackChangesSingleAction(WriterAgentSpecialTracking, ToolCalcSpecialTrack
             if not target_redline:
                 return self._tool_error(f"No tracked change found at index {index}.")
 
-            # To accept/reject a specific change, we select its text range then use the dispatcher
+            # Guard: refuse to resolve the agent's OWN edit (a wa-review change). Those are recorded
+            # for the human to accept/reject in the review UI; the agent must not do it itself.
+            # Fail closed when the change's metadata can't be read.
+            from plugin.writer.inline_review import redline_is_agent_change
+            is_agent, readable = redline_is_agent_change(target_redline)
+            if not readable:
+                return self._tool_error(
+                    "Couldn't read this change's metadata, so it can't be resolved from here. "
+                    "Use Edit > Track Changes > Manage in LibreOffice."
+                )
+            if is_agent:
+                return self._tool_error(
+                    "This is an agent edit awaiting your review (WriterAgent tracked change). The "
+                    "agent must not accept or reject its own edits -- resolve it in the review popup "
+                    "or Edit > Track Changes > Manage."
+                )
+
+            # To accept/reject a specific change, we select its text range then use the dispatcher.
+            # Redline objects from getRedlines() have NO getAnchor() (live probe: AttributeError) —
+            # they are property sets exposing RedlineStart/RedlineEnd (XTextRange). The old
+            # getAnchor() call meant every real change died here with "Failed to select".
             try:
-                # XRedline inherits from XTextContent, which has an anchor we can select
-                anchor = target_redline.getAnchor()
-                if anchor:
-                    ctx.doc.getCurrentController().select(anchor)
+                start = target_redline.getPropertyValue("RedlineStart")
+                cur = start.getText().createTextCursorByRange(start)
+                try:
+                    end = target_redline.getPropertyValue("RedlineEnd")
+                    if end is not None:
+                        cur.gotoRange(end, True)
+                except Exception:
+                    pass  # collapsed span (e.g. a deletion) — selecting the start point suffices
+                ctx.doc.getCurrentController().select(cur)
             except Exception as e:
-                # Fallback if getAnchor fails, might happen on deleted ranges
                 return self._tool_error(f"Failed to select tracked change for processing: {e}")
 
             smgr = ctx.ctx.ServiceManager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,7 +181,9 @@ setattr(task, "XJob", MockBase)
 
 @pytest.fixture(autouse=True)
 def _setup_grammar_persistence_test_env():
-    """Isolate grammar persistence for every test to avoid leaking files into mock paths."""
+    """Isolate grammar persistence AND the config path for every test, so no test can leak
+    files into mock-derived paths."""
+    from plugin.framework import config as config_mod
     from plugin.writer.locale import grammar_persistence
     import shutil
     import tempfile
@@ -191,8 +193,19 @@ def _setup_grammar_persistence_test_env():
     grammar_persistence._doc_persistence_instances.clear()
 
     tmp_dir = tempfile.mkdtemp()
-    with patch("plugin.framework.config.user_config_dir", return_value=tmp_dir):
-        yield
+    # Seed the resolved-config-path cache too. Patching the user_config_dir attribute below does
+    # NOT reach callers that bound it via `from plugin.framework.config import user_config_dir`
+    # (e.g. plugin/chatbot/memory.py) — those still resolve the path from the mocked UNO ctx, and
+    # MagicMock's default __fspath__ yields a relative "MagicMock/<name>/<id>" path that
+    # MemoryStore's makedirs then creates inside the repo. Seeding the module-level cache routes
+    # every resolver through this per-test temp dir instead.
+    old_resolved = config_mod._resolved_config_path
+    config_mod._resolved_config_path = os.path.join(tmp_dir, "writeragent.json")
+    try:
+        with patch("plugin.framework.config.user_config_dir", return_value=tmp_dir):
+            yield
+    finally:
+        config_mod._resolved_config_path = old_resolved
 
     # Clean up
     grammar_persistence._doc_persistence_instances.clear()
@@ -201,10 +214,15 @@ def _setup_grammar_persistence_test_env():
 
 
 def pytest_sessionstart(session):
-    """Clean up any 'MagicMock' directories created by accidental mock stringification in previous runs."""
+    """Clean up any 'MagicMock' directories created by accidental mock stringification in previous runs.
+
+    (Belt and suspenders: the autouse config-path isolation above prevents new ones; this sweeps
+    litter left by older runs. tests/conftest.py sits one level below the repo root, so ONE
+    dirname past this file's directory is the repo — the previous triple dirname pointed at the
+    repo's PARENT and never cleaned anything.)"""
     import os
     import shutil
-    root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    root = os.path.dirname(os.path.dirname(__file__))
     magic_mock_dir = os.path.join(root, "MagicMock")
     if os.path.isdir(magic_mock_dir):
         shutil.rmtree(magic_mock_dir, ignore_errors=True)

--- a/tests/doc/test_collect_tracked_changes.py
+++ b/tests/doc/test_collect_tracked_changes.py
@@ -1,0 +1,98 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""T2 (R3): collect_tracked_changes walks text portions and reports pending insertions/deletions
+with their text, so a reader can tell new-vs-old and that changes await review. No LibreOffice
+required (drives the portion walk with light fakes). Inline live behavior is verified separately."""
+from unittest.mock import MagicMock
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.doc.document_helpers import collect_tracked_changes
+
+
+def _enum(items):
+    e = MagicMock()
+    st = {"i": 0}
+    e.hasMoreElements.side_effect = lambda: st["i"] < len(items)
+
+    def _nxt():
+        v = items[st["i"]]
+        st["i"] += 1
+        return v
+
+    e.nextElement.side_effect = _nxt
+    return e
+
+
+class _Range:  # not a Mock, so the helper's mock-guard doesn't short-circuit
+    def __init__(self, paras):
+        self._paras = paras
+
+    def createEnumeration(self):
+        return _enum(self._paras)
+
+
+class _Para:
+    def __init__(self, portions):
+        self._portions = portions
+
+    def createEnumeration(self):
+        return _enum(self._portions)
+
+
+def _portion(ptype, rtype=None, s=""):
+    p = MagicMock()
+
+    def _gpv(k):
+        if k == "TextPortionType":
+            return ptype
+        if k == "RedlineType":
+            return rtype
+        raise KeyError(k)
+
+    p.getPropertyValue.side_effect = _gpv
+    p.getString.return_value = s
+    return p
+
+
+def _ins_open():
+    return _portion("Redline", "Insert")
+
+
+def _del_open():
+    return _portion("Redline", "Delete")
+
+
+def test_replace_yields_insertion_then_deletion():
+    # A replace records an inserted run and a deleted run (each bracketed by Redline portions).
+    para = _Para([
+        _ins_open(), _portion("Text", s="novo texto"), _ins_open(),
+        _del_open(), _portion("Text", s="texto velho"), _del_open(),
+    ])
+    out = collect_tracked_changes(_Range([para]))
+    assert out == [
+        {"type": "insertion", "text": "novo texto"},
+        {"type": "deletion", "text": "texto velho"},
+    ]
+
+
+def test_plain_text_no_changes():
+    para = _Para([_portion("Text", s="só texto normal")])
+    assert collect_tracked_changes(_Range([para])) == []
+
+
+def test_only_insertion():
+    para = _Para([_ins_open(), _portion("Text", s="adicionado"), _ins_open()])
+    assert collect_tracked_changes(_Range([para])) == [{"type": "insertion", "text": "adicionado"}]
+
+
+def test_only_deletion():
+    para = _Para([_del_open(), _portion("Text", s="removido"), _del_open()])
+    assert collect_tracked_changes(_Range([para])) == [{"type": "deletion", "text": "removido"}]
+
+
+def test_mock_range_short_circuits_to_empty():
+    assert collect_tracked_changes(MagicMock()) == []

--- a/tests/framework/test_uno_context.py
+++ b/tests/framework/test_uno_context.py
@@ -61,12 +61,13 @@ def test_get_ctx_with_uno():
     mock_uno = MagicMock()
     mock_ctx = MagicMock()
     mock_uno.getComponentContext.return_value = mock_ctx
-    sys.modules['uno'] = mock_uno
-    try:
+    # patch.dict RESTORES the previous sys.modules['uno'] (the session-wide mock installed by
+    # setup_uno_mocks). The old pop('uno') left the whole run without a 'uno' module, so any
+    # later test that imports uno lazily hit the real uno.py -> "No module named 'pyuno'"
+    # (this is what broke tests/mcp/test_long_running_concurrency.py in combined runs).
+    with patch.dict(sys.modules, {'uno': mock_uno}):
         assert (get_ctx() == mock_ctx)
         mock_uno.getComponentContext.assert_called_once()
-    finally:
-        sys.modules.pop('uno', None)
 
 def test_get_ctx_fallback():
     mock_fallback = MagicMock()
@@ -86,14 +87,14 @@ def test_get_ctx_fallback():
 def test_get_ctx_fallback_uno_returns_none():
     mock_uno = MagicMock()
     mock_uno.getComponentContext.return_value = None
-    sys.modules['uno'] = mock_uno
-    try:
-        mock_fallback = MagicMock()
-        set_fallback_ctx(mock_fallback)
-        assert (get_ctx() == mock_fallback)
-    finally:
-        sys.modules.pop('uno', None)
-        set_fallback_ctx(None)
+    mock_fallback = MagicMock()
+    # patch.dict restores the session-wide uno mock afterwards (see test_get_ctx_with_uno).
+    with patch.dict(sys.modules, {'uno': mock_uno}):
+        try:
+            set_fallback_ctx(mock_fallback)
+            assert (get_ctx() == mock_fallback)
+        finally:
+            set_fallback_ctx(None)
 
 
 def test_focus_preserved_restores_focus_window():

--- a/tests/writer/math/test_math_preservation.py
+++ b/tests/writer/math/test_math_preservation.py
@@ -67,6 +67,10 @@ class TestWriterMathPreservation(unittest.TestCase):
         tool = ApplyDocumentContent()
         ctx = MagicMock()
         ctx.doc = MagicMock()
+        # The edit path is atomic in ALL modes now (R4 fix): it opens a grouped undo context and
+        # refuses when the undo manager is unusable/locked — a bare MagicMock's isLocked() would be
+        # truthy, so pin a usable manager for the fake document.
+        ctx.doc.getUndoManager.return_value.isLocked.return_value = False
         ctx.ctx = MagicMock()
         ctx.services = MagicMock()
         

--- a/tests/writer/specialized/test_fields.py
+++ b/tests/writer/specialized/test_fields.py
@@ -99,9 +99,12 @@ def test_fields_insert(mock_ctx):
     doc.createInstance.assert_called_with("com.sun.star.text.textfield.PageNumber")
     assert mock_field.setPropertyValue.call_count == 2
 
-    # Text insertion uses the cursor returned by resolve_target_cursor (doc.getText().createTextCursor)
-    mock_cursor = doc.getText().createTextCursor()
-    mock_cursor.getText().insertTextContent.assert_called_with(mock_cursor, mock_field, False)
+    # Text insertion uses the cursor returned by resolve_target_cursor. Since the cell-safe fix,
+    # the selection cursor is built in the SELECTION's own text object (rng.getText()), not the
+    # body — the old body-cursor pin validated the cross-text bug.
+    rng = mock_controller.getSelection().getByIndex()
+    used_cursor = rng.getText().createTextCursorByRange()
+    used_cursor.getText().insertTextContent.assert_called_with(used_cursor, mock_field, False)
 
 
 def test_fields_delete(mock_ctx):

--- a/tests/writer/test_cell_block_html_gate.py
+++ b/tests/writer/test_cell_block_html_gate.py
@@ -1,0 +1,31 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""R3: pins the block-vs-inline classification that gates the clear "rich HTML in a table cell"
+error in replace_single_range_with_content. Inline content takes the in-cell path that works;
+block/rich content is what triggers the nested-XText RuntimeException, so only it should get the
+clear-error treatment. No LibreOffice required (pure markup classification)."""
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.writer.format import _content_has_block_markup
+
+
+def test_plain_text_is_not_block():
+    assert _content_has_block_markup("hello world") is False
+
+
+def test_inline_tags_are_not_block():
+    # <b>/<span>/<i> are inline -> they go through the in-cell path that works; the cell-error
+    # gate must NOT fire for them.
+    assert _content_has_block_markup("<b>bold</b> text") is False
+
+
+def test_paragraph_is_block():
+    # <p> is block -> the path that can raise inside a table cell; the clear-error gate fires here.
+    assert _content_has_block_markup("<p>a paragraph</p>") is True
+
+
+def test_heading_is_block():
+    assert _content_has_block_markup("<h1>title</h1>") is True

--- a/tests/writer/test_content_search.py
+++ b/tests/writer/test_content_search.py
@@ -1,6 +1,7 @@
 # Unit tests for apply_document_content search helpers (no LibreOffice required).
 from plugin.writer.content import (
     _all_start_indices,
+    _drawing_shape_containing,
     _escape_for_lo_regex,
     _HORIZONTAL_SPACE_CLASS,
     _normalize_search_string_for_find,
@@ -43,4 +44,75 @@ def test_escape_for_lo_regex_normalizes_exotic_spaces_in_needle():
 def test_escape_for_lo_regex_escapes_regex_metacharacters():
     assert _escape_for_lo_regex("a.b") == r"a\.b"
     assert _escape_for_lo_regex("(test)") == r"\(test\)"
+
+
+# --- _drawing_shape_containing (C7): actionable "text is inside a shape" diagnostic -----------
+
+class _FakeShape:
+    def __init__(self, text, name="", raise_on_get=False):
+        self._text = text
+        self.Name = name
+        self._raise = raise_on_get
+
+    def getString(self):
+        if self._raise:
+            raise RuntimeError("shape getString boom")
+        return self._text
+
+
+class _FakeDrawPage:
+    def __init__(self, shapes, raise_count=False):
+        self._shapes = shapes
+        self._raise_count = raise_count
+
+    def getCount(self):
+        if self._raise_count:
+            raise RuntimeError("count boom")
+        return len(self._shapes)
+
+    def getByIndex(self, i):
+        return self._shapes[i]
+
+
+class _FakeDocWithShapes:
+    def __init__(self, shapes, raise_count=False):
+        self._dp = _FakeDrawPage(shapes, raise_count=raise_count)
+
+    def getDrawPage(self):
+        return self._dp
+
+
+def test_drawing_shape_containing_returns_name():
+    doc = _FakeDocWithShapes([_FakeShape("body of box", name="Caixa de Texto 8")])
+    assert _drawing_shape_containing(doc, "of box") == "Caixa de Texto 8"
+
+
+def test_drawing_shape_containing_unnamed_shape():
+    doc = _FakeDocWithShapes([_FakeShape("<O QUE ORIGINOU A DEMANDA?>", name="")])
+    assert _drawing_shape_containing(doc, "ORIGINOU") == "(unnamed shape)"
+
+
+def test_drawing_shape_containing_not_found_returns_none():
+    doc = _FakeDocWithShapes([_FakeShape("something else")])
+    assert _drawing_shape_containing(doc, "missing") is None
+
+
+def test_drawing_shape_containing_empty_needle_returns_none():
+    doc = _FakeDocWithShapes([_FakeShape("anything")])
+    assert _drawing_shape_containing(doc, "   ") is None
+
+
+def test_drawing_shape_containing_no_draw_page_returns_none():
+    assert _drawing_shape_containing(object(), "x") is None
+
+
+def test_drawing_shape_containing_skips_failing_shape():
+    # A shape whose getString raises must be skipped, not abort the scan -- the match is in the next.
+    doc = _FakeDocWithShapes([_FakeShape("", raise_on_get=True), _FakeShape("here is the marker")])
+    assert _drawing_shape_containing(doc, "marker") == "(unnamed shape)"
+
+
+def test_drawing_shape_containing_fails_safe_on_count_error():
+    doc = _FakeDocWithShapes([_FakeShape("marker")], raise_count=True)
+    assert _drawing_shape_containing(doc, "marker") is None
 

--- a/tests/writer/test_edited_context.py
+++ b/tests/writer/test_edited_context.py
@@ -1,0 +1,140 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""edited_context: successful apply_document_content edits echo the touched paragraph(s).
+
+The echo must be right or absent, never wrong: _paragraph_window_text returns None whenever the
+paragraph walk fails, and _attach_edited_context only adds the field when a snippet came back.
+No LibreOffice required — fakes implement the minimal XText/XParagraphCursor protocol."""
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.writer.content import (
+    _EDITED_CONTEXT_MAX_CHARS,
+    _attach_edited_context,
+    _collapsed_anchor,
+    _paragraph_window_text,
+)
+
+
+class FakeCursor:
+    """Minimal XTextCursor + XParagraphCursor stand-in over a paragraph list."""
+
+    def __init__(self, text, para, at_end=False):
+        self.text = text
+        self.para = para          # paragraph index of the position
+        self.at_end = at_end      # False -> at paragraph start
+        self.span_from = None     # set by gotoRange(expand=True)
+
+    # --- XTextRange-ish ---
+    def getText(self):
+        return self.text
+
+    def getStart(self):
+        return FakeCursor(self.text, self.para, at_end=False if self.span_from is None else False)
+
+    def getEnd(self):
+        return FakeCursor(self.text, self.para, at_end=True)
+
+    # --- XParagraphCursor ---
+    def gotoStartOfParagraph(self, expand):
+        self.at_end = False
+        return True
+
+    def gotoEndOfParagraph(self, expand):
+        self.at_end = True
+        return True
+
+    def gotoPreviousParagraph(self, expand):
+        if self.para == 0:
+            return False
+        self.para -= 1
+        return True
+
+    def gotoNextParagraph(self, expand):
+        if self.para >= len(self.text.paragraphs) - 1:
+            return False
+        self.para += 1
+        return True
+
+    def gotoRange(self, other, expand):
+        assert expand is True
+        self.span_from = min(self.para, self.para)
+        self.span_to = other.para
+        return True
+
+    def getString(self):
+        if self.span_from is None:
+            return self.text.paragraphs[self.para]
+        return "\n".join(self.text.paragraphs[self.para:self.span_to + 1])
+
+
+class FakeText:
+    def __init__(self, paragraphs):
+        self.paragraphs = paragraphs
+
+    def createTextCursorByRange(self, rng):
+        return FakeCursor(self, rng.para, at_end=rng.at_end)
+
+
+def _anchor_at(text, para):
+    return FakeCursor(text, para)
+
+
+def test_window_is_paragraph_plus_neighbors():
+    text = FakeText(["P0", "P1-EDITED", "P2", "P3"])
+    s = _paragraph_window_text(_anchor_at(text, 1))
+    assert s == "P0\nP1-EDITED\nP2"
+
+
+def test_window_clamps_at_document_edges():
+    text = FakeText(["FIRST", "SECOND"])
+    assert _paragraph_window_text(_anchor_at(text, 0)) == "FIRST\nSECOND"
+    assert _paragraph_window_text(_anchor_at(text, 1)) == "FIRST\nSECOND"
+
+
+def test_window_truncates_around_the_middle():
+    text = FakeText(["A" * 600, "B" * 600, "C" * 600])
+    s = _paragraph_window_text(_anchor_at(text, 1))
+    assert len(s) <= _EDITED_CONTEXT_MAX_CHARS
+    assert " [...] " in s
+    assert s.startswith("A") and s.endswith("C")
+
+
+def test_failure_yields_none_not_garbage():
+    assert _paragraph_window_text(None) is None
+
+    class Broken:
+        def getText(self):
+            raise RuntimeError("nested exotic text")
+
+    assert _paragraph_window_text(Broken()) is None
+
+
+def test_blank_window_yields_none():
+    text = FakeText(["", "", ""])
+    assert _paragraph_window_text(_anchor_at(text, 1)) is None
+
+
+def test_attach_only_when_snippet_exists():
+    text = FakeText(["P0", "P1", "P2"])
+    ok = _attach_edited_context({"status": "ok"}, _anchor_at(text, 1))
+    assert ok["edited_context"] == "P0\nP1\nP2"
+    no = _attach_edited_context({"status": "ok"}, None)
+    assert "edited_context" not in no
+
+
+def test_collapsed_anchor_is_best_effort():
+    class NoCursorText:
+        def createTextCursorByRange(self, rng):
+            raise RuntimeError("unsupported")
+
+    class Range:
+        def getText(self):
+            return NoCursorText()
+
+        def getStart(self):
+            return self
+
+    assert _collapsed_anchor(Range()) is None

--- a/tests/writer/test_inline_review_guards.py
+++ b/tests/writer/test_inline_review_guards.py
@@ -26,6 +26,8 @@ from plugin.writer.inline_review import (
     _foreign_redline_in_span,
     _other_agent_redline_in_span,
     _span_contains_point,
+    agent_self_resolution_block_reason,
+    redline_is_agent_change,
     resolve_agent_change,
 )
 from plugin.writer.edit_review import TOKEN_PREFIX
@@ -571,3 +573,49 @@ def test_agent_redlines_does_not_hang_on_mock_enumeration():
     doc.getRedlines.return_value.createEnumeration.return_value = enum
     assert agent_changes(doc) == []
     assert pending_agent_change_count(doc) == 0
+
+
+# --------------------------------------------------- agent-self-resolution guard (B3 fix)
+
+def test_block_reason_none_when_no_redlines_api():
+    # An object with no getRedlines() -> nothing to clobber -> bulk dispatch (a no-op) is allowed.
+    assert agent_self_resolution_block_reason(object()) is None
+
+
+def test_block_reason_none_on_empty_document():
+    assert agent_self_resolution_block_reason(FakeModel(FakeRedlines([]))) is None
+
+
+def test_block_reason_blocks_when_agent_change_present():
+    model = FakeModel(FakeRedlines([_agent_rl()]))
+    reason = agent_self_resolution_block_reason(model)
+    assert reason is not None and "agent edit" in reason.lower()
+
+
+def test_block_reason_allows_user_only_redlines():
+    # The user's own tracked changes (no token) may be bulk-resolved on request.
+    assert agent_self_resolution_block_reason(FakeModel(FakeRedlines([_user_rl()]))) is None
+
+
+def test_block_reason_fails_closed_on_silent_truncation():
+    # Redlines present but the scan can't be trusted -> assume an agent change might hide in the tail.
+    model = FakeModel(FakeRedlines([_user_rl()], count=2))
+    assert agent_self_resolution_block_reason(model) is not None
+
+
+def test_block_reason_fails_closed_on_count_error():
+    model = FakeModel(FakeRedlines([_user_rl()], raise_count=True))
+    assert agent_self_resolution_block_reason(model) is not None
+
+
+def test_redline_is_agent_change_true_for_token():
+    assert redline_is_agent_change(_agent_rl()) == (True, True)
+
+
+def test_redline_is_agent_change_false_for_user():
+    assert redline_is_agent_change(_user_rl()) == (False, True)
+
+
+def test_redline_is_agent_change_unreadable_fails_closed():
+    rl = FakeRedline("", 0, 0, raise_on={"RedlineComment"})
+    assert redline_is_agent_change(rl) == (False, False)

--- a/tests/writer/test_paragraph_index_directive.py
+++ b/tests/writer/test_paragraph_index_directive.py
@@ -14,7 +14,10 @@ from plugin.writer.search import SearchInDocument
 from plugin.writer.structural import GetPageObjects
 
 # Model-facing tools whose results expose a paragraph index to the model.
-_INDEX_TOOLS = (GetPageObjects, GetDocumentTree, GetHeadingChildren, SearchInDocument)
+# NOTE: SearchInDocument no longer belongs here — its results carry {text, location, context}
+# (no paragraph_index anymore) and its description instructs quoting the match text + location
+# instead of any internal index. Pinned separately below so the intent can't silently regress.
+_INDEX_TOOLS = (GetPageObjects, GetDocumentTree, GetHeadingChildren)
 
 
 def test_index_tools_warn_against_citing_paragraph_numbers():
@@ -26,3 +29,12 @@ def test_index_tools_warn_against_citing_paragraph_numbers():
 def test_get_page_objects_uses_the_central_directive_constant():
     # The previously-uncovered tool now carries the canonical constant verbatim (single source).
     assert PARAGRAPH_INDEX_DIRECTIVE in GetPageObjects.description
+
+
+def test_search_reports_locations_instead_of_internal_indexes():
+    # Search's replacement for the directive: no index in results, and the description steers the
+    # model to quote match text + location.
+    desc = (SearchInDocument.description or "").lower()
+    assert "location" in desc
+    assert "internal index" in desc
+    assert "paragraph_index" not in desc

--- a/tests/writer/test_qol_batch_fixes.py
+++ b/tests/writer/test_qol_batch_fixes.py
@@ -1,0 +1,227 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""The 8-point QoL/bug batch (2026-07-02): reads must not save, is_active must be proxy-safe,
+misses must be errors (regex, delete_comment), position='before'/'after' inserts, document echo,
+undo/redo exposure, and recoverable error messages. No LibreOffice required."""
+from unittest.mock import MagicMock
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+
+# ---- 1) reads never doc.store() ----------------------------------------------
+
+def test_ensure_heading_bookmarks_never_stores():
+    import inspect
+
+    from plugin.writer.specialized import bookmarks as bm
+
+    # Strip comments: the fix intentionally documents WHY there is no doc.store() call.
+    code_lines = [line.split("#")[0] for line in inspect.getsource(bm).splitlines()]
+    assert not any("doc.store()" in line for line in code_lines), \
+        "a READ/maintenance path must never persist the user's unsaved work"
+
+
+# (is_active proxy-safe + document echo + multi-doc guidance tests live in the MCP experience PR,
+# tests/mcp/test_mcp_qol_extras.py — they exercise document_research/mcp_protocol/agent_manual.)
+
+# ---- 3) invalid regex is an error, not a clean miss ---------------------------
+
+def _search_zero_hits(pattern, use_regex):
+    """Run SearchInDocument against a doc that finds nothing."""
+    from plugin.writer.search import SearchInDocument
+
+    doc = MagicMock()
+    doc.createSearchDescriptor.return_value = MagicMock()
+    doc.findFirst.return_value = None
+    doc.getDrawPage.return_value = []
+    doc.getTextFields.return_value.createEnumeration.return_value.hasMoreElements.return_value = False
+    ctx = MagicMock()
+    ctx.doc = doc
+    return SearchInDocument().execute(ctx, pattern=pattern, regex=use_regex)
+
+
+def test_invalid_regex_zero_hits_is_error():
+    res = _search_zero_hits("([a-", True)
+    assert res["status"] == "error" and res["code"] == "INVALID_REGEX"
+    assert "regex=false" in res["message"]
+
+
+def test_valid_regex_zero_hits_stays_ok():
+    res = _search_zero_hits("nunca_existe_\\d+", True)
+    assert res["status"] == "ok" and res["count"] == 0
+
+
+def test_literal_zero_hits_stays_ok():
+    res = _search_zero_hits("([a-", False)  # literal search for weird chars is legitimate
+    assert res["status"] == "ok" and res["count"] == 0
+
+
+# ---- 4) delete_comment miss is an error ---------------------------------------
+
+def test_delete_comment_not_found_is_error():
+    from plugin.writer.specialized.comments import DeleteComment
+
+    doc = MagicMock()
+    doc.getTextFields.return_value.createEnumeration.return_value.hasMoreElements.return_value = False
+    ctx = MagicMock()
+    ctx.doc = doc
+    res = DeleteComment().execute(ctx, comment_name="nope")
+    assert res["status"] == "error" and res["code"] == "COMMENT_NOT_FOUND"
+    assert res["deleted"] == 0
+    assert "list_comments" in res["message"]
+
+
+# ---- 5) position='before'/'after' contract ------------------------------------
+
+def test_position_param_validation():
+    from plugin.writer.content import ApplyDocumentContent
+
+    tool = ApplyDocumentContent()
+    ctx = MagicMock()
+    ctx.doc.getUndoManager.return_value.isLocked.return_value = False
+    res = tool.execute(ctx, content=["<p>x</p>"], target="search", old_content="y", position="sideways")
+    assert res["status"] == "error" and "position" in res["message"]
+    res = tool.execute(ctx, content=["<p>x</p>"], target="search", old_content="y",
+                       position="after", all_matches=True)
+    assert res["status"] == "error" and "all_matches" in res["message"]
+    # Silently ignoring position on an insert target would teach a parameter that "works" by
+    # accident — it must be rejected.
+    res = tool.execute(ctx, content=["<p>x</p>"], target="end", position="after")
+    assert res["status"] == "error" and "target='search'" in res["message"]
+
+
+def test_position_after_inserts_at_match_edge_without_replacing():
+    """The Q8 happy path: collapsed cursor at the found range's edge, HTML import WITHOUT
+    styles, result carries inserted=true/position and NO replaced_count."""
+    from unittest.mock import patch
+
+    from plugin.writer import format as format_support
+    from plugin.writer.content import ApplyDocumentContent
+
+    found = MagicMock()
+    found.getText.return_value.createTextCursorByRange.return_value = MagicMock()
+    # Not inside a table cell:
+    found.getText.return_value.createTextCursorByRange.return_value.getPropertyValue.return_value = None
+
+    ctx = MagicMock()
+    ctx.doc.getUndoManager.return_value.isLocked.return_value = False
+
+    with patch("plugin.writer.content._find_first_range", return_value=found), \
+         patch("plugin.writer.content._collapsed_anchor", return_value=None), \
+         patch.object(format_support, "html_fragment_contains_mixed_math", return_value=False), \
+         patch.object(format_support, "_insert_mixed_or_plain_html") as ins:
+        res = ApplyDocumentContent().execute(
+            ctx, content=["<p>novo</p>"], target="search", old_content="clausula", position="after")
+
+    assert res["status"] == "ok" and res["inserted"] is True and res["position"] == "after"
+    assert "replaced_count" not in res
+    ins.assert_called_once()
+    assert ins.call_args.kwargs.get("apply_styles") is False
+    # The match edge used must be getEnd() for 'after'.
+    found.getEnd.assert_called()
+
+
+def test_position_after_rejects_math_and_table_cells():
+    from unittest.mock import patch
+
+    from plugin.writer import format as format_support
+    from plugin.writer.content import ApplyDocumentContent
+
+    ctx = MagicMock()
+    ctx.doc.getUndoManager.return_value.isLocked.return_value = False
+
+    found = MagicMock()
+    with patch("plugin.writer.content._find_first_range", return_value=found), \
+         patch.object(format_support, "html_fragment_contains_mixed_math", return_value=True):
+        res = ApplyDocumentContent().execute(
+            ctx, content=["<p>\\(x^2\\)</p>"], target="search", old_content="c", position="after")
+    assert res["status"] == "error" and "math" in res["message"]
+
+    cell_cursor = MagicMock()
+    cell_cursor.getPropertyValue.return_value = MagicMock()  # TextTable set -> inside a cell
+    found.getText.return_value.createTextCursorByRange.return_value = cell_cursor
+    with patch("plugin.writer.content._find_first_range", return_value=found), \
+         patch.object(format_support, "html_fragment_contains_mixed_math", return_value=False):
+        res = ApplyDocumentContent().execute(
+            ctx, content=["<p>x</p>"], target="search", old_content="c", position="after")
+    assert res["status"] == "error" and "table cell" in res["message"]
+
+
+def test_position_in_schema():
+    from plugin.writer.content import ApplyDocumentContent
+
+    props = ApplyDocumentContent.parameters["properties"]
+    assert props["position"]["enum"] == ["replace", "before", "after"]
+
+
+# ---- 7) undo/redo exposed --------------------------------------------------------
+
+def test_undo_redo_are_real_core_tools():
+    from plugin.framework.tool import ToolBase
+    from plugin.doc.undo import Redo, Undo
+
+    for cls in (Undo, Redo):
+        assert issubclass(cls, ToolBase)
+        assert cls.tier == "core"
+        assert cls.is_mutation is True
+        assert "user" in cls.description.lower()  # the shared-stack caution must be in the description
+
+
+def test_undo_counts_steps_and_reports_stack_state():
+    from plugin.doc.undo import Undo
+
+    um = MagicMock()
+    um.isUndoPossible.side_effect = [True, True, False, False]
+    um.isRedoPossible.return_value = True
+    ctx = MagicMock()
+    ctx.doc.getUndoManager.return_value = um
+    res = Undo().execute(ctx, steps=3)
+    assert res["status"] == "ok" and res["undone"] == 2
+    assert "can_undo" in res and res["can_redo"] is True  # promised by the tool description
+
+
+def test_redo_counts_steps():
+    from plugin.doc.undo import Redo
+
+    um = MagicMock()
+    um.isRedoPossible.side_effect = [True, False, True]
+    ctx = MagicMock()
+    ctx.doc.getUndoManager.return_value = um
+    res = Redo().execute(ctx, steps=2)
+    assert res["status"] == "ok" and res["redone"] == 1
+
+
+# ---- 8) recoverable error messages ----------------------------------------------
+
+def test_apply_style_unknown_style_lists_names_and_suggests():
+    from plugin.writer.styles import ApplyStyle
+
+    fam = MagicMock()
+    fam.hasByName.return_value = False
+    fam.getElementNames.return_value = ["Heading 1", "Heading 2", "Text body", "Quotations"]
+    ctx = MagicMock()
+    ctx.doc.getStyleFamilies.return_value.getByName.return_value = fam
+    res = ApplyStyle().execute(ctx, style_name="heading 1", family="ParagraphStyles")
+    assert res["status"] == "error"
+    assert "Did you mean 'Heading 1'" in res["message"]
+    assert "Text body" in res["message"]
+
+
+def test_truncated_flag_on_get_document_content():
+    from unittest.mock import patch
+
+    from plugin.writer import format as format_support
+    from plugin.writer.content import GetDocumentContent
+
+    ctx = MagicMock()
+    ctx.services.document.get_document_length.return_value = 800
+    with patch.object(format_support, "document_to_content",
+                      return_value="<p>short</p>\n\n[... truncated ...]"):
+        res = GetDocumentContent().execute(ctx, max_chars=10)
+    assert res.get("truncated") is True
+    with patch.object(format_support, "document_to_content", return_value="<p>all</p>"):
+        res = GetDocumentContent().execute(ctx, max_chars=10)
+    assert "truncated" not in res

--- a/tests/writer/test_review_status_annotation.py
+++ b/tests/writer/test_review_status_annotation.py
@@ -1,0 +1,50 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""R1 (robustness): a successful edit result must carry the CURRENT review status per-call, so the
+model is correct even if the initialize manual is stale (manual is sent once at connect; toggling
+the mode later doesn't update it). No LibreOffice required."""
+from unittest.mock import patch
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.writer.content import ApplyDocumentContent
+
+_tool = ApplyDocumentContent()
+
+
+def _annotate(mode, result):
+    with patch("plugin.writer.content.get_agent_edit_review_mode", return_value=mode):
+        return _tool._annotate_review_status(object(), result)
+
+
+def test_off_mode_leaves_result_unchanged():
+    out = _annotate("off", {"status": "ok", "message": "Replaced 1 occurrence."})
+    assert "pending_review" not in out
+    assert "tracked change" not in out["message"]
+
+
+def test_record_mode_marks_pending_and_no_outcome_notice():
+    out = _annotate("record", {"status": "ok", "message": "Replaced 1 occurrence."})
+    assert out["pending_review"] is True
+    assert out["review_mode"] == "record"
+    m = out["message"].lower()
+    assert "tracked change" in m and "do not accept or reject" in m
+    assert "not be notified" in m
+
+
+def test_wait_mode_also_annotated():
+    out = _annotate("wait", {"status": "ok", "message": "x"})
+    assert out["pending_review"] is True and out["review_mode"] == "wait"
+
+
+def test_error_result_not_annotated():
+    out = _annotate("record", {"status": "error", "message": "old_content not found"})
+    assert "pending_review" not in out
+
+
+def test_unknown_mode_not_annotated():
+    out = _annotate("nonsense", {"status": "ok", "message": "x"})
+    assert "pending_review" not in out

--- a/tests/writer/test_search_reach.py
+++ b/tests/writer/test_search_reach.py
@@ -1,0 +1,202 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Search reach beyond the body text model — header/footer labeling and the comment sweep.
+
+Pure control-flow tests with fakes (no LibreOffice). The UNO behavior itself (findFirst reaching
+header/footer text, comments being invisible to it) was verified live; what is testable here is
+the labeling logic of _header_footer_label / _describe_match_location and the matching plus
+defensiveness of _comment_matches."""
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.writer.search import _comment_matches, _describe_match_location, _header_footer_label
+
+
+# ---- fakes ----------------------------------------------------------------
+
+class FakeHeadFootText:
+    ImplementationName = "SwXHeadFootText"
+
+
+class FakeBodyText:
+    ImplementationName = "SwXBodyText"
+
+    def createTextCursorByRange(self, rng):
+        return FakeCursor()
+
+
+class FakeCursor:
+    def getPropertyValue(self, name):
+        return None  # not in a table, not in a frame
+
+
+class FakePageStyle:
+    def __init__(self, name, header=None, footer=None, in_use=True):
+        self._name = name
+        self.HeaderText = header
+        self.FooterText = footer
+        self._in_use = in_use
+
+    def isInUse(self):
+        return self._in_use
+
+    def getName(self):
+        return self._name
+
+
+class FakeStyles:
+    def __init__(self, styles):
+        self._styles = styles
+
+    def getCount(self):
+        return len(self._styles)
+
+    def getByIndex(self, i):
+        return self._styles[i]
+
+
+class FakeDoc:
+    def __init__(self, styles=(), fields=()):
+        self._styles = FakeStyles(list(styles))
+        self._fields = list(fields)
+
+    def getStyleFamilies(self):
+        outer = self
+
+        class Fam:
+            def getByName(self, name):
+                assert name == "PageStyles"
+                return outer._styles
+        return Fam()
+
+    def getTextFields(self):
+        outer = self
+
+        class Fields:
+            def createEnumeration(self):
+                return FakeEnum(outer._fields)
+        return Fields()
+
+
+class FakeEnum:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def hasMoreElements(self):
+        return bool(self._items)
+
+    def nextElement(self):
+        return self._items.pop(0)
+
+
+class FakeAnnotation:
+    def __init__(self, content, author="Ana"):
+        self.Content = content
+        self.Author = author
+
+    def supportsService(self, s):
+        return s == "com.sun.star.text.textfield.Annotation"
+
+
+class FakeOtherField:
+    def supportsService(self, s):
+        return False
+
+
+class FakeRange:
+    def __init__(self, text):
+        self._text = text
+
+    def getText(self):
+        return self._text
+
+    def getStart(self):
+        return object()
+
+
+# ---- _header_footer_label --------------------------------------------------
+
+def test_non_headfoot_text_returns_none():
+    assert _header_footer_label(FakeBodyText(), FakeDoc()) is None
+
+
+def test_header_found_with_style_name():
+    hf = FakeHeadFootText()
+    doc = FakeDoc(styles=[FakePageStyle("Standard", header=hf)])
+    assert _header_footer_label(hf, doc) == "header (page style 'Standard')"
+
+
+def test_footer_found_with_style_name():
+    hf = FakeHeadFootText()
+    doc = FakeDoc(styles=[FakePageStyle("Landscape", footer=hf)])
+    assert _header_footer_label(hf, doc) == "footer (page style 'Landscape')"
+
+
+def test_unused_styles_are_skipped():
+    hf = FakeHeadFootText()
+    unused = FakePageStyle("Old", header=hf, in_use=False)
+    used = FakePageStyle("Standard", footer=hf)
+    doc = FakeDoc(styles=[unused, used])
+    assert _header_footer_label(hf, doc) == "footer (page style 'Standard')"
+
+
+def test_style_walk_failure_still_labels_generically():
+    hf = FakeHeadFootText()
+    assert _header_footer_label(hf, doc=None) == "header or footer"
+    assert _header_footer_label(hf, FakeDoc(styles=[])) == "header or footer"
+
+
+# ---- _describe_match_location with header text ------------------------------
+
+def test_location_reports_header_not_body():
+    class HeadTextWithCursor(FakeHeadFootText):
+        def createTextCursorByRange(self, rng):
+            return FakeCursor()
+
+    hf = HeadTextWithCursor()
+    doc = FakeDoc(styles=[FakePageStyle("Standard", header=hf)])
+    assert _describe_match_location(FakeRange(hf), doc) == "header (page style 'Standard')"
+
+
+def test_location_body_unchanged_without_doc():
+    assert _describe_match_location(FakeRange(FakeBodyText())) == "body"
+
+
+# ---- _comment_matches --------------------------------------------------------
+
+def test_comment_match_yields_hit_author_content():
+    doc = FakeDoc(fields=[FakeAnnotation("please FIX this paragraph", author="Ana")])
+    got = list(_comment_matches(doc, "fix", use_regex=False, case_sensitive=False))
+    assert got == [("FIX", "Ana", "please FIX this paragraph")]
+
+
+def test_comment_no_match_yields_nothing():
+    doc = FakeDoc(fields=[FakeAnnotation("nothing here")])
+    assert list(_comment_matches(doc, "absent", False, False)) == []
+
+
+def test_non_annotation_fields_are_skipped():
+    doc = FakeDoc(fields=[FakeOtherField(), FakeAnnotation("target inside", author="Bo")])
+    got = list(_comment_matches(doc, "target", False, False))
+    assert got == [("target", "Bo", "target inside")]
+
+
+def test_multiple_hits_in_one_comment():
+    doc = FakeDoc(fields=[FakeAnnotation("x a x b x")])
+    got = list(_comment_matches(doc, "x", False, False))
+    assert [g[0] for g in got] == ["x", "x", "x"]
+
+
+def test_comment_regex_matching():
+    doc = FakeDoc(fields=[FakeAnnotation("codes A1 and B2 here")])
+    got = list(_comment_matches(doc, r"[A-Z]\d", use_regex=True, case_sensitive=True))
+    assert [g[0] for g in got] == ["A1", "B2"]
+
+
+def test_enumeration_failure_is_silent():
+    class BrokenDoc:
+        def getTextFields(self):
+            raise RuntimeError("no fields")
+    assert list(_comment_matches(BrokenDoc(), "x", False, False)) == []

--- a/tests/writer/test_selection.py
+++ b/tests/writer/test_selection.py
@@ -1,0 +1,172 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Selection: target='selection' must not silently append at the document end, and set_selection
+lets a headless client pick a passage. No LibreOffice required."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.writer.selection import SetSelection
+from plugin.writer.target_resolver import resolve_target_cursor
+
+
+# ---- C1: target='selection' raises instead of silently going to end ----------
+
+def _ctx_with_controller(controller):
+    text = MagicMock()
+    cursor = MagicMock()
+    text.createTextCursor.return_value = cursor
+    doc = MagicMock()
+    doc.getText.return_value = text
+    doc.getCurrentController.return_value = controller
+    ctx = SimpleNamespace(doc=doc, ctx=MagicMock(), services={"config": MagicMock()})
+    return ctx, cursor
+
+
+def test_selection_raises_when_both_selection_and_viewcursor_fail_not_gotoEnd():
+    controller = MagicMock()
+    controller.getSelection.side_effect = RuntimeError("boom")
+    controller.getViewCursor.side_effect = RuntimeError("no view")
+    ctx, cursor = _ctx_with_controller(controller)
+    with pytest.raises(ValueError) as ei:
+        resolve_target_cursor(ctx, "selection", None)
+    assert "set_selection" in str(ei.value) or "search" in str(ei.value)
+    cursor.gotoEnd.assert_not_called()  # the bug was a silent gotoEnd(False)
+
+
+def test_selection_falls_back_to_view_cursor_never_end():
+    # A selection whose getCount blows up must not fail the call; fall to the view cursor
+    # (spanned in ITS text object), and NEVER append at the document end.
+    controller = MagicMock()
+    bad_sel = MagicMock()
+    bad_sel.getCount.side_effect = RuntimeError("unreadable selection")
+    controller.getSelection.return_value = bad_sel
+    vc_cursor = MagicMock()
+    controller.getViewCursor.return_value.getText.return_value.createTextCursorByRange.return_value = vc_cursor
+    ctx, body_cursor = _ctx_with_controller(controller)
+    result = resolve_target_cursor(ctx, "selection", None)
+    assert result is vc_cursor
+    body_cursor.gotoEnd.assert_not_called()
+
+
+def test_selection_uses_explicit_selection_range():
+    rng = MagicMock()
+    sel_cursor = MagicMock()
+    rng.getText.return_value.createTextCursorByRange.return_value = sel_cursor
+    sel = MagicMock()
+    sel.getCount.return_value = 1
+    sel.getByIndex.return_value = rng
+    controller = MagicMock()
+    controller.getSelection.return_value = sel
+    ctx, body_cursor = _ctx_with_controller(controller)
+    result = resolve_target_cursor(ctx, "selection", None)
+    assert result is sel_cursor           # built in the selection's own text (cell/frame-safe)
+    body_cursor.gotoEnd.assert_not_called()
+
+
+# ---- C2: set_selection -------------------------------------------------------
+
+def _selection_ctx():
+    doc = MagicMock()
+    controller = MagicMock()
+    doc.getCurrentController.return_value = controller
+    ctx = SimpleNamespace(doc=doc)
+    return ctx, doc, controller
+
+
+def test_set_selection_by_search_text_selects_and_reports():
+    ctx, doc, controller = _selection_ctx()
+    found = MagicMock()
+    found.getString.return_value = "clause 3.2"
+    doc.findFirst.return_value = found
+    res = SetSelection().execute(ctx, search_text="clause 3.2")
+    assert res["status"] == "ok" and res["selected_text"] == "clause 3.2"
+    controller.select.assert_called_once_with(found)
+
+
+def test_set_selection_occurrence_walks_findNext():
+    ctx, doc, controller = _selection_ctx()
+    first, second = MagicMock(), MagicMock()
+    second.getString.return_value = "hit2"
+    doc.findFirst.return_value = first
+    doc.findNext.return_value = second
+    res = SetSelection().execute(ctx, search_text="hit", occurrence=1)
+    assert res["status"] == "ok" and res["selected_text"] == "hit2"
+    controller.select.assert_called_once_with(second)
+
+
+def test_set_selection_no_match_errors():
+    ctx, doc, controller = _selection_ctx()
+    doc.findFirst.return_value = None
+    res = SetSelection().execute(ctx, search_text="nope")
+    assert res["status"] == "error" and "No match" in res["message"]
+    controller.select.assert_not_called()
+
+
+def test_set_selection_requires_a_target():
+    ctx, doc, controller = _selection_ctx()
+    res = SetSelection().execute(ctx)
+    assert res["status"] == "error" and "search_text" in res["message"]
+
+
+def test_set_selection_char_range_requires_both():
+    ctx, doc, controller = _selection_ctx()
+    res = SetSelection().execute(ctx, char_start=5)
+    assert res["status"] == "error" and "char_start and char_end" in res["message"]
+
+
+def test_set_selection_by_char_offsets_happy_path():
+    from unittest.mock import patch
+
+    ctx, doc, controller = _selection_ctx()
+    rng = MagicMock()
+    rng.getString.return_value = "faixa"
+    with patch("plugin.doc.document_helpers.get_text_cursor_at_range", return_value=rng):
+        res = SetSelection().execute(ctx, char_start=10, char_end=15)
+    assert res["status"] == "ok" and res["selected_text"] == "faixa"
+    assert res["char_start"] == 10 and res["char_end"] == 15
+    controller.select.assert_called_once_with(rng)
+
+
+def test_selection_target_spans_in_the_ranges_own_text():
+    """A selection inside a table cell/frame lives in a different XText: the resolver must build
+    the cursor there (a body-cursor gotoRange raises a raw UNO RuntimeException that escapes
+    callers expecting ValueError)."""
+    rng = MagicMock()
+    cell_cursor = MagicMock()
+    rng.getText.return_value.createTextCursorByRange.return_value = cell_cursor
+    sel = MagicMock()
+    sel.getCount.return_value = 1
+    sel.getByIndex.return_value = rng
+    controller = MagicMock()
+    controller.getSelection.return_value = sel
+    ctx, body_cursor = _ctx_with_controller(controller)
+    result = resolve_target_cursor(ctx, "selection", None)
+    assert result is cell_cursor          # built via rng.getText(), not the body cursor
+    body_cursor.gotoRange.assert_not_called()
+    body_cursor.gotoEnd.assert_not_called()
+
+
+def test_selection_target_wraps_span_failure_in_valueerror():
+    import pytest as _pytest
+
+    rng = MagicMock()
+    rng.getText.return_value.createTextCursorByRange.side_effect = RuntimeError("cross-text")
+    sel = MagicMock()
+    sel.getCount.return_value = 1
+    sel.getByIndex.return_value = rng
+    controller = MagicMock()
+    controller.getSelection.return_value = sel
+    ctx, _ = _ctx_with_controller(controller)
+    with _pytest.raises(ValueError):
+        resolve_target_cursor(ctx, "selection", None)
+
+
+def test_set_selection_is_core_read_only():
+    assert SetSelection.tier == "core" and SetSelection.is_mutation is False

--- a/tests/writer/test_small_fixes_r5.py
+++ b/tests/writer/test_small_fixes_r5.py
@@ -1,0 +1,360 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""The 6 smaller R5 fixes: dry_run, apply_style all/occurrence, track_changes_list text/location,
+add_comment span/occurrence/author, insert_page_break anchored, regex/case in apply. No LibreOffice."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+
+def _edit_ctx():
+    ctx = MagicMock()
+    ctx.doc.getUndoManager.return_value.isLocked.return_value = False
+    return ctx
+
+
+# ---- D1: dry_run ------------------------------------------------------------
+
+def test_dry_run_reports_matches_without_mutating():
+    from plugin.writer import content as content_mod
+    from plugin.writer.content import ApplyDocumentContent
+
+    r1, r2 = MagicMock(), MagicMock()
+    r1.getString.return_value = "clause 3.2 text"
+    r2.getString.return_value = "clause 3.2 again"
+    ctx = _edit_ctx()
+    with patch.object(content_mod, "_find_all_ranges", return_value=[r1, r2]) as fa, \
+         patch("plugin.writer.search._describe_match_location", return_value="body"), \
+         patch.object(content_mod, "_normalize_search_string_for_find", side_effect=lambda s: s), \
+         patch("plugin.writer.format.content_has_markup", return_value=False):
+        res = ApplyDocumentContent().execute(ctx, content=["x"], target="search", old_content="clause 3.2", dry_run=True)
+    assert res["status"] == "ok" and res["dry_run"] is True and res["count"] == 2
+    assert res["matches"][0]["location"] == "body"
+    # No session/undo context opened for a dry run.
+    ctx.doc.getUndoManager.assert_not_called()
+
+
+def test_dry_run_requires_search_target():
+    from plugin.writer.content import ApplyDocumentContent
+    res = ApplyDocumentContent().execute(_edit_ctx(), content=["x"], target="end", dry_run=True)
+    assert res["status"] == "error" and "search" in res["message"]
+
+
+def test_dry_run_honors_regex_via_the_same_matcher_as_the_edit():
+    """A preview that uses a different matcher than the commit is worse than none: with
+    regex=true, dry_run must route through _find_ranges_regex_case with the RAW pattern."""
+    from plugin.writer import content as content_mod
+    from plugin.writer.content import ApplyDocumentContent
+
+    r = MagicMock()
+    r.getString.return_value = "bravo charlie"
+    ctx = _edit_ctx()
+    with patch.object(content_mod, "_find_ranges_regex_case", return_value=[r]) as frc, \
+         patch.object(content_mod, "_find_all_ranges") as far, \
+         patch("plugin.writer.search._describe_match_location", return_value="body"), \
+         patch("plugin.writer.format.content_has_markup", return_value=False):
+        res = ApplyDocumentContent().execute(
+            ctx, content=["x"], target="search", old_content=r"brav. charl.e", dry_run=True, regex=True)
+    assert res["status"] == "ok" and res["count"] == 1
+    far.assert_not_called()
+    args = frc.call_args[0]
+    assert args[1] == r"brav. charl.e" and args[2] is True  # raw pattern, regex on
+
+
+# ---- D5: page break happy paths + last-paragraph edge ------------------------
+
+def _pagebreak_doc(found_next=True):
+    import types as _types
+    import sys as _sys
+    bt = _types.ModuleType("com.sun.star.style.BreakType")
+    bt.PAGE_BEFORE = "PAGE_BEFORE"
+    _sys.modules["com.sun.star.style.BreakType"] = bt
+    doc = MagicMock()
+    found = MagicMock()
+    para = MagicMock()
+    para.gotoNextParagraph.return_value = found_next
+    found.getText.return_value.createTextCursorByRange.return_value = para
+    doc.findFirst.return_value = found
+    return doc, para
+
+
+def test_page_break_before_text_sets_break_on_match_paragraph():
+    from plugin.writer.page import InsertPageBreak
+
+    doc, para = _pagebreak_doc()
+    res = InsertPageBreak().execute(SimpleNamespace(doc=doc), before_text="Assinaturas")
+    assert res["status"] == "ok" and "before" in res["message"]
+    para.setPropertyValue.assert_called_once_with("BreakType", "PAGE_BEFORE")
+    para.gotoNextParagraph.assert_not_called()
+
+
+def test_page_break_after_text_breaks_on_following_paragraph():
+    from plugin.writer.page import InsertPageBreak
+
+    doc, para = _pagebreak_doc(found_next=True)
+    res = InsertPageBreak().execute(SimpleNamespace(doc=doc), after_text="clausula")
+    assert res["status"] == "ok" and "after" in res["message"]
+    para.gotoNextParagraph.assert_called_once()
+    para.setPropertyValue.assert_called_once_with("BreakType", "PAGE_BEFORE")
+
+
+def test_page_break_after_text_last_paragraph_errors_instead_of_wrong_direction():
+    from plugin.writer.page import InsertPageBreak
+
+    doc, para = _pagebreak_doc(found_next=False)
+    res = InsertPageBreak().execute(SimpleNamespace(doc=doc), after_text="assinatura final")
+    assert res["status"] == "error" and "last paragraph" in res["message"]
+    para.setPropertyValue.assert_not_called()  # never the wrong-direction silent break
+
+
+# ---- D2: apply_style all_matches / occurrence -------------------------------
+
+def _style_ctx():
+    ctx = MagicMock()
+    fam = MagicMock()
+    fam.hasByName.return_value = True
+    ctx.doc.getStyleFamilies.return_value.getByName.return_value = fam
+    return ctx
+
+
+def test_apply_style_all_matches_applies_to_each():
+    from plugin.writer.styles import ApplyStyle
+
+    ranges = [MagicMock(), MagicMock(), MagicMock()]
+    with patch("plugin.writer.content._find_all_ranges", return_value=ranges), \
+         patch("plugin.writer.content._normalize_search_string_for_find", side_effect=lambda s: s), \
+         patch("plugin.writer.format.content_has_markup", return_value=False), \
+         patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char") as ap, \
+         patch("plugin.writer.edit_review.review_recording_enabled", return_value=False):
+        res = ApplyStyle().execute(_style_ctx(), style_name="Heading 1", target="search",
+                                   old_content="Title", all_matches=True)
+    assert res["status"] == "ok" and res["applied_count"] == 3
+    assert ap.call_count == 3
+
+
+def test_apply_style_occurrence_out_of_range():
+    from plugin.writer.styles import ApplyStyle
+
+    with patch("plugin.writer.content._find_all_ranges", return_value=[MagicMock()]), \
+         patch("plugin.writer.content._normalize_search_string_for_find", side_effect=lambda s: s), \
+         patch("plugin.writer.format.content_has_markup", return_value=False):
+        res = ApplyStyle().execute(_style_ctx(), style_name="Heading 1", target="search",
+                                   old_content="Title", occurrence=5)
+    assert res["status"] == "error" and "out of range" in res["message"]
+
+
+# ---- D3: track_changes_list text + location ---------------------------------
+
+def test_track_changes_list_adds_text_and_location():
+    from plugin.writer.tracking import TrackChangesList
+
+    # Redlines from getRedlines() are property sets: RedlineStart/RedlineEnd (XTextRange) and
+    # RedlineText (removed content) — NOT getAnchor. For an insertion the live span carries the text.
+    start = MagicMock()
+    span_cursor = MagicMock()
+    span_cursor.getString.return_value = "inserted clause"
+    start.getText.return_value.createTextCursorByRange.return_value = span_cursor
+    props = {"RedlineType": "Insert", "RedlineAuthor": "X", "RedlineStart": start, "RedlineEnd": MagicMock()}
+    redline = MagicMock()
+    redline.getPropertyValue.side_effect = lambda p: props.get(p, "")
+    enum = MagicMock()
+    enum.hasMoreElements.side_effect = [True, False]
+    enum.nextElement.return_value = redline
+    doc = MagicMock()
+    doc.getPropertyValue.return_value = True
+    doc.getRedlines.return_value.createEnumeration.return_value = enum
+    ctx = SimpleNamespace(doc=doc)
+    with patch("plugin.writer.search._describe_match_location", return_value="body"):
+        res = TrackChangesList().execute(ctx)
+    assert res["status"] == "ok" and res["count"] == 1
+    e = res["changes"][0]
+    assert e["text"] == "inserted clause" and e["location"] == "body"
+
+
+def test_track_changes_list_deletion_falls_back_to_redlinetext():
+    from plugin.writer.tracking import TrackChangesList
+
+    start = MagicMock()
+    # Deletion: the live span is collapsed (empty), so RedlineText supplies the removed text.
+    start.getText.return_value.createTextCursorByRange.return_value.getString.return_value = ""
+    rtext = MagicMock()
+    rtext.getString.return_value = "removed words"
+    props = {"RedlineType": "Delete", "RedlineStart": start, "RedlineEnd": MagicMock(), "RedlineText": rtext}
+    redline = MagicMock()
+    redline.getPropertyValue.side_effect = lambda p: props.get(p, "")
+    enum = MagicMock()
+    enum.hasMoreElements.side_effect = [True, False]
+    enum.nextElement.return_value = redline
+    doc = MagicMock()
+    doc.getPropertyValue.return_value = True
+    doc.getRedlines.return_value.createEnumeration.return_value = enum
+    with patch("plugin.writer.search._describe_match_location", return_value="body"):
+        res = TrackChangesList().execute(SimpleNamespace(doc=doc))
+    assert res["changes"][0]["text"] == "removed words"
+
+
+# ---- list_comments: paragraph-context fallback for empty anchor previews ----
+
+def test_read_annotation_falls_back_to_paragraph_context():
+    from plugin.writer.specialized.comments import _read_annotation
+
+    anchor = MagicMock()
+    anchor.getString.return_value = ""  # annotation anchors read as empty points
+    field = MagicMock()
+    field.getAnchor.return_value = anchor
+    field.getPropertyValue.side_effect = lambda p: {"Author": "Rev", "Content": "note"}.get(p, "")
+    doc_svc = MagicMock()
+    doc_svc.find_paragraph_for_range.return_value = 7
+    with patch("plugin.writer.search._enclosing_paragraph_text", return_value="  the clause the comment covers  "):
+        e = _read_annotation(field, [], MagicMock(), doc_svc)
+    assert e["anchor_preview"] == "the clause the comment covers"
+    assert e["anchor_is_paragraph_context"] is True
+    assert e["paragraph_index"] == 7
+
+
+def test_read_annotation_keeps_real_span_when_present():
+    from plugin.writer.specialized.comments import _read_annotation
+
+    anchor = MagicMock()
+    anchor.getString.return_value = "covered words"
+    field = MagicMock()
+    field.getAnchor.return_value = anchor
+    field.getPropertyValue.side_effect = lambda p: {"Author": "Rev"}.get(p, "")
+    e = _read_annotation(field, [], MagicMock(), MagicMock())
+    assert e["anchor_preview"] == "covered words"
+    assert "anchor_is_paragraph_context" not in e
+
+
+# ---- track_changes_list: agent_review_mode alongside the doc toggle ----------
+
+def test_track_changes_list_reports_agent_review_mode():
+    from plugin.writer.tracking import TrackChangesList
+
+    enum = MagicMock()
+    enum.hasMoreElements.return_value = False
+    doc = MagicMock()
+    doc.getPropertyValue.return_value = False  # document toggle off...
+    doc.getRedlines.return_value.createEnumeration.return_value = enum
+    ctx = SimpleNamespace(doc=doc, ctx=MagicMock())
+    with patch("plugin.writer.edit_review.get_agent_edit_review_mode", return_value="record"):
+        res = TrackChangesList().execute(ctx)
+    assert res["recording"] is False
+    assert res["agent_review_mode"] == "record"  # ...but agent edits ARE being tracked
+
+
+# ---- accept/reject select via RedlineStart/End (redlines have no getAnchor) --
+
+def test_accept_selects_via_redline_start_end_not_getanchor():
+    from plugin.writer.tracking import TrackChangesAccept
+
+    start = MagicMock(spec=["getText"])
+    span = MagicMock()
+    start.getText.return_value.createTextCursorByRange.return_value = span
+    props = {"RedlineStart": start, "RedlineEnd": MagicMock(), "RedlineComment": "user change"}
+    # spec-limited: no getAnchor attribute at all, like the real UNO redline property set.
+    redline = MagicMock(spec=["getPropertyValue"])
+    redline.getPropertyValue.side_effect = lambda p: props.get(p, "")
+    enum = MagicMock()
+    enum.hasMoreElements.side_effect = [True, False]
+    enum.nextElement.return_value = redline
+    doc = MagicMock()
+    doc.getRedlines.return_value.createEnumeration.return_value = enum
+    ctx = MagicMock()
+    ctx.doc = doc
+    with patch("plugin.writer.inline_review.redline_is_agent_change", return_value=(False, True)):
+        res = TrackChangesAccept().execute(ctx, index=0)
+    assert res["status"] == "ok", res
+    doc.getCurrentController.return_value.select.assert_called_once_with(span)
+    span.gotoRange.assert_called_once()  # expanded to RedlineEnd
+
+
+def test_accept_still_refuses_agent_own_changes():
+    from plugin.writer.tracking import TrackChangesAccept
+
+    redline = MagicMock(spec=["getPropertyValue"])
+    redline.getPropertyValue.return_value = "wa-review:abc:0"
+    enum = MagicMock()
+    enum.hasMoreElements.side_effect = [True, False]
+    enum.nextElement.return_value = redline
+    ctx = MagicMock()
+    ctx.doc.getRedlines.return_value.createEnumeration.return_value = enum
+    with patch("plugin.writer.inline_review.redline_is_agent_change", return_value=(True, True)):
+        res = TrackChangesAccept().execute(ctx, index=0)
+    assert res["status"] == "error" and "must not accept" in res["message"]
+    ctx.doc.getCurrentController.return_value.select.assert_not_called()
+
+
+# ---- D4: add_comment span / occurrence / author -----------------------------
+
+def test_add_comment_occurrence_author_and_span():
+    from plugin.writer.specialized.comments import AddComment
+
+    doc = MagicMock()
+    first, second = MagicMock(), MagicMock()
+    second.getString.return_value = "second hit"
+    second.getText.return_value = mtext = MagicMock()
+    doc.findFirst.return_value = first
+    doc.findNext.return_value = second
+    ctx = SimpleNamespace(doc=doc)
+    with patch("plugin.writer.specialized.comments._set_annotation_date"):
+        res = AddComment().execute(ctx, content="note", search_text="hit", occurrence=1, author="Rev")
+    assert res["status"] == "ok" and res["author"] == "Rev" and res["anchor_text"] == "second hit"
+    # Spans the match: insertTextContent called with absorb=True.
+    assert mtext.insertTextContent.call_args[0][2] is True
+
+
+def test_add_comment_not_found_at_occurrence():
+    from plugin.writer.specialized.comments import AddComment
+
+    doc = MagicMock()
+    doc.findFirst.return_value = MagicMock()
+    doc.findNext.return_value = None
+    res = AddComment().execute(SimpleNamespace(doc=doc), content="n", search_text="x", occurrence=3)
+    assert res["status"] == "error" and res["comment_added"] is False
+
+
+# ---- D5: insert_page_break anchored -----------------------------------------
+
+def test_page_break_both_anchors_rejected():
+    from plugin.writer.page import InsertPageBreak
+    res = InsertPageBreak().execute(SimpleNamespace(doc=MagicMock()), before_text="a", after_text="b")
+    assert res["status"] == "error" and "only one" in res["message"]
+
+
+def test_page_break_anchor_not_found():
+    from plugin.writer.page import InsertPageBreak
+    doc = MagicMock()
+    doc.findFirst.return_value = None
+    # com.sun.star.style.BreakType is a mocked module; the import inside execute resolves via the uno mock.
+    res = InsertPageBreak().execute(SimpleNamespace(doc=doc), before_text="Signature")
+    assert res["status"] == "error" and "not found" in res["message"]
+
+
+# ---- D6: regex / case in the edit path --------------------------------------
+
+def test_find_ranges_regex_case_builds_descriptor():
+    from plugin.writer.content import _find_ranges_regex_case
+
+    doc = MagicMock()
+    sd = MagicMock()
+    doc.createSearchDescriptor.return_value = sd
+    doc.findFirst.return_value = None
+    _find_ranges_regex_case(doc, r"cl\w+", True, False, all_matches=False)
+    assert sd.SearchString == r"cl\w+"
+    assert sd.SearchRegularExpression is True and sd.SearchCaseSensitive is False
+
+
+def test_find_ranges_regex_case_all_matches_walks_next():
+    from plugin.writer.content import _find_ranges_regex_case
+
+    doc = MagicMock()
+    doc.createSearchDescriptor.return_value = MagicMock()
+    a, b = MagicMock(), MagicMock()
+    doc.findFirst.return_value = a
+    doc.findNext.side_effect = [b, None]
+    out = _find_ranges_regex_case(doc, "x", False, True, all_matches=True)
+    assert out == [a, b]

--- a/tests/writer/test_surgical_offset_guard.py
+++ b/tests/writer/test_surgical_offset_guard.py
@@ -617,16 +617,35 @@ def test_html_atomic_refuses_when_undo_manager_locked():
     assert session.changes == []
 
 
-def test_html_not_recording_runs_directly_without_context():
-    # No review contract -> run the mutation directly (today's behaviour), never touching the undo
-    # manager and never refusing.
-    class NoUndoDoc:
-        def getUndoManager(self):
-            raise AssertionError("must not be consulted when not recording")
-
+def test_html_not_recording_is_still_atomic_on_success():
+    # R4 atomicity fix: the delete-then-import path can strand a deletion in ANY mode, so review
+    # OFF also runs inside the grouped undo context (before, it ran directly with no rollback and a
+    # failing import left the document modified while reporting an error).
+    um = FakeUndoManager()
     session = FakeSession()
     calls = {"n": 0}
-    _record_html_atomically(session, NoUndoDoc(), lambda: calls.__setitem__("n", calls["n"] + 1),
-                            False, proposed_preview="x")
+
+    def ok_mutate():
+        calls["n"] += 1
+        um.record_action()
+
+    _record_html_atomically(session, FakeDoc(um), ok_mutate, False, proposed_preview="x")
     assert calls["n"] == 1
+    assert len(um.entered) == 1 and um.leaves == 1 and um.undos == 0
     assert len(session.changes) == 1
+
+
+def test_html_not_recording_rolls_back_partial_on_failure():
+    # Review OFF + the import throws after the delete landed -> the whole batch is undone and no
+    # change record survives: status error must mean "document untouched".
+    um = FakeUndoManager()
+    session = FakeSession()
+
+    def failing_mutate():
+        um.record_action()                        # the delete landed...
+        raise RuntimeError("import blew up")      # ...then the HTML import throws
+
+    with pytest.raises(RuntimeError):
+        _record_html_atomically(session, FakeDoc(um), failing_mutate, False, proposed_preview="x")
+    assert um.undos == 1                          # the stranded deletion was rolled back
+    assert session.changes == []

--- a/tests/writer/test_tracking.py
+++ b/tests/writer/test_tracking.py
@@ -33,7 +33,11 @@ def _create_mock_ctx():
         return props[name]
     doc.setPropertyValue.side_effect = _set_prop
     doc.getPropertyValue.side_effect = _get_prop
-    
+
+    # Default: empty redline table. The agent-self-resolution guard reads getCount() first; 0 means
+    # "no changes pending" so bulk accept/reject is allowed (the pre-guard behavior for empty docs).
+    doc.getRedlines.return_value.getCount.return_value = 0
+
     ctx.doc = doc
     
     # Mock dispatcher and frame for accept/reject tests
@@ -174,44 +178,49 @@ def test_track_changes_reject_all():
     assert res["status"] == "ok"
     dispatcher.executeDispatch.assert_called_with(frame, ".uno:RejectAllTrackedChanges", "", 0, ())
 
+def _redline_property_set():
+    """A redline like the real UNO one: a property set with RedlineStart/RedlineEnd and NO
+    getAnchor (the old tests pinned select(getAnchor()) — a method MagicMock fabricated but the
+    real object never had, which is exactly why accept/reject by index was broken)."""
+    start = MagicMock()
+    span_cursor = MagicMock()
+    start.getText.return_value.createTextCursorByRange.return_value = span_cursor
+    props = {"RedlineStart": start, "RedlineEnd": MagicMock(), "RedlineComment": "user edit"}
+    redline_mock = MagicMock(spec=["getPropertyValue"])
+    redline_mock.getPropertyValue.side_effect = lambda p: props.get(p, "")
+    return redline_mock, span_cursor
+
+
 def test_track_changes_accept():
     ctx, dispatcher, frame, _ = _create_mock_ctx()
     tool = TrackChangesAccept()
-    
-    # Mock redlines
-    redline_mock = MagicMock()
-    anchor_mock = MagicMock()
-    redline_mock.getAnchor.return_value = anchor_mock
-    
+
+    redline_mock, span_cursor = _redline_property_set()
     enum_mock = MagicMock()
     enum_mock.hasMoreElements.side_effect = [True, False]
     enum_mock.nextElement.return_value = redline_mock
-    
+
     ctx.doc.getRedlines.return_value.createEnumeration.return_value = enum_mock
-    
+
     res = tool.execute(ctx, index=0)
     assert res["status"] == "ok"
-    ctx.doc.getCurrentController().select.assert_called_with(anchor_mock)
+    ctx.doc.getCurrentController().select.assert_called_with(span_cursor)
     dispatcher.executeDispatch.assert_called_with(frame, ".uno:AcceptTrackedChange", "", 0, ())
 
 def test_track_changes_reject():
     ctx, dispatcher, frame, _ = _create_mock_ctx()
     tool = TrackChangesReject()
-    
-    # Mock redlines
-    redline_mock = MagicMock()
-    anchor_mock = MagicMock()
-    redline_mock.getAnchor.return_value = anchor_mock
-    
+
+    redline_mock, span_cursor = _redline_property_set()
     enum_mock = MagicMock()
     enum_mock.hasMoreElements.side_effect = [True, False]
     enum_mock.nextElement.return_value = redline_mock
-    
+
     ctx.doc.getRedlines.return_value.createEnumeration.return_value = enum_mock
-    
+
     res = tool.execute(ctx, index=0)
     assert res["status"] == "ok"
-    ctx.doc.getCurrentController().select.assert_called_with(anchor_mock)
+    ctx.doc.getCurrentController().select.assert_called_with(span_cursor)
     dispatcher.executeDispatch.assert_called_with(frame, ".uno:RejectTrackedChange", "", 0, ())
 
 # --- Comment Tests ---
@@ -291,3 +300,111 @@ def test_comment_delete():
     res = tool.execute(ctx, index=0)
     assert res["status"] == "ok"
     comment_mock.dispose.assert_called_once()
+
+
+# --- Agent-self-resolution guard (B3): the agent must never accept/reject its OWN edits --------
+
+from plugin.writer.edit_review import TOKEN_PREFIX
+
+_AGENT_COMMENT = TOKEN_PREFIX + "sess123:0"
+
+
+def _fake_redline(comment, raise_comment=False):
+    rl = MagicMock()
+    props = {"RedlineComment": comment, "RedlineIdentifier": f"id:{comment}",
+             # Real redlines expose these (and no getAnchor); the accept/reject selection uses them.
+             "RedlineStart": MagicMock(), "RedlineEnd": MagicMock()}
+
+    def _get(name):
+        if raise_comment and name == "RedlineComment":
+            raise RuntimeError("comment read boom")
+        return props[name]
+
+    rl.getPropertyValue.side_effect = _get
+    return rl
+
+
+def _install_redlines(ctx, items, count=None):
+    """Wire ctx.doc.getRedlines() to enumerate *items* (count override simulates a truncated scan)."""
+    rls = ctx.doc.getRedlines.return_value
+    rls.getCount.return_value = len(items) if count is None else count
+
+    def _mk_enum(*_a, **_k):
+        seq = list(items)
+        enum = MagicMock()
+        enum.hasMoreElements.side_effect = lambda: len(seq) > 0
+        enum.nextElement.side_effect = lambda: seq.pop(0)
+        return enum
+
+    rls.createEnumeration.side_effect = _mk_enum
+    return rls
+
+
+def test_accept_all_blocked_when_agent_change_pending():
+    ctx, dispatcher, _frame, _ = _create_mock_ctx()
+    _install_redlines(ctx, [_fake_redline(_AGENT_COMMENT)])
+    res = TrackChangesAcceptAll().execute(ctx)
+    assert res["status"] == "error"
+    assert "agent edit" in res["message"].lower()
+    dispatcher.executeDispatch.assert_not_called()
+
+
+def test_reject_all_blocked_when_agent_change_pending():
+    ctx, dispatcher, _frame, _ = _create_mock_ctx()
+    _install_redlines(ctx, [_fake_redline(_AGENT_COMMENT)])
+    res = TrackChangesRejectAll().execute(ctx)
+    assert res["status"] == "error"
+    dispatcher.executeDispatch.assert_not_called()
+
+
+def test_accept_all_allowed_with_only_user_redlines():
+    # The user's OWN tracked changes (no wa-review token) may be bulk-resolved on request.
+    ctx, dispatcher, frame, _ = _create_mock_ctx()
+    _install_redlines(ctx, [_fake_redline("")])
+    res = TrackChangesAcceptAll().execute(ctx)
+    assert res["status"] == "ok"
+    dispatcher.executeDispatch.assert_called_with(frame, ".uno:AcceptAllTrackedChanges", "", 0, ())
+
+
+def test_accept_all_blocked_when_scan_unreliable():
+    # Redlines present (count=2) but only 1 enumerates -> can't prove no agent change -> fail closed.
+    ctx, dispatcher, _frame, _ = _create_mock_ctx()
+    _install_redlines(ctx, [_fake_redline("")], count=2)
+    res = TrackChangesAcceptAll().execute(ctx)
+    assert res["status"] == "error"
+    dispatcher.executeDispatch.assert_not_called()
+
+
+def test_single_accept_blocked_on_agent_redline():
+    ctx, dispatcher, _frame, _ = _create_mock_ctx()
+    _install_redlines(ctx, [_fake_redline(_AGENT_COMMENT)])
+    res = TrackChangesAccept().execute(ctx, index=0)
+    assert res["status"] == "error"
+    assert "agent edit" in res["message"].lower()
+    dispatcher.executeDispatch.assert_not_called()
+    ctx.doc.getCurrentController().select.assert_not_called()
+
+
+def test_single_reject_blocked_on_agent_redline():
+    ctx, dispatcher, _frame, _ = _create_mock_ctx()
+    _install_redlines(ctx, [_fake_redline(_AGENT_COMMENT)])
+    res = TrackChangesReject().execute(ctx, index=0)
+    assert res["status"] == "error"
+    dispatcher.executeDispatch.assert_not_called()
+
+
+def test_single_accept_allowed_on_user_redline():
+    ctx, dispatcher, frame, _ = _create_mock_ctx()
+    _install_redlines(ctx, [_fake_redline("")])
+    res = TrackChangesAccept().execute(ctx, index=0)
+    assert res["status"] == "ok"
+    dispatcher.executeDispatch.assert_called_with(frame, ".uno:AcceptTrackedChange", "", 0, ())
+
+
+def test_single_accept_blocked_when_comment_unreadable():
+    # Fail closed: if we can't read the change's metadata we can't prove it isn't an agent change.
+    ctx, dispatcher, _frame, _ = _create_mock_ctx()
+    _install_redlines(ctx, [_fake_redline("", raise_comment=True)])
+    res = TrackChangesAccept().execute(ctx, index=0)
+    assert res["status"] == "error"
+    dispatcher.executeDispatch.assert_not_called()


### PR DESCRIPTION
> **Companion PRs — coordinated set.** One improvement split into 4 for review. Recommended merge order: **#363 tables → #364 images → #365 search & edit → #366 mcp** (mcp last: its single-source manual describes tools/behaviors from the others — `get_image`, search-anywhere, tracked-changes-in-reads — though code-wise each PR stands alone). The only file two PRs share is `mcp_protocol.py` (#364 + #366), which 3-way-merges cleanly.
>
> - #363 — Tables
> - #364 — Images
> - #365 — Search & edit reliability
> - #366 — MCP experience

---

Per your note, B9 rides with the rest of the bug fixes here.

- **Search** — B1 `search_in_document` finds text anywhere (table cells, text boxes, shapes, headers/footers, comments) via findFirst/findNext (avoids the `doc.findAll` crash on floating shapes); B7 invalid regex → clear error; Q17 regex/case_sensitive.
- **Edit path** — B2 edit floating-shape text in place or route to shapes; B3 atomic delete+import in all modes (grouped undo + rollback); B10 `target='selection'` fails loudly instead of appending at doc end; Q7 edited-context echo; Q8 before/after insert; Q12 dry_run; Q13 apply_style all_matches/occurrence (cell-safe).
- **Tracked changes & comments** — B11 accept/reject select the change's live span (RedlineStart..RedlineEnd; the old `getAnchor` never existed); Q14 list carries text + location; Q1 reads surface pending changes; Q2 edit results carry review status; B8 delete_comment miss is an error; Q15 add_comment spans the passage and list_comments shows it.
- **Reads/nav** — B5 reads no longer silently save; Q16 page break can anchor to text; F4 undo/redo; F6 set_selection.
- **B9** test-suite isolation: one test swapped and deleted the shared uno mock; restore with patch.dict and route mocked config writes to a temp dir. The full suite stops leaking failures / a MagicMock folder.

Docs: `writer-tracking-api-reference.md` (single accept/reject + list payload). Tests: 216 pass standalone; the full suite adds no failures beyond the pre-existing environmental baseline.

Covers **B1, B2, B3, B5, B7, B8, B9, B10, B11, Q1, Q2, Q7, Q8, Q12, Q13, Q14, Q15, Q16, Q17, F4, F6**.
