### PR TITLE
MCP experience: shared manual, multi-doc, echo, report_bug, stdio bridge

### DIFF
--- a/docs/bug-reporting.md
+++ b/docs/bug-reporting.md
@@ -12,6 +12,12 @@ Some unexpected-failure message boxes include **Report bug...** and **Copy URL**
 
 Debug builds (UNO thread guard) also offer report on thread-violation popups.
 
+## Agent tool
+
+The agent (chat or MCP) can call **`report_bug`** to capture a bad experience without leaving the conversation. It takes a `summary`, `details`, and a `category` (`bug`, `ux`, or `feature`), records the feedback to a local log (the durable record), and builds the same pre-filled GitHub issue URL as the menu. It **never auto-submits**: the tool returns `github_issue_url` for the agent to show the user, who reviews and files it. No document text, chat history, or API keys are sent.
+
+Implementation: `ReportBug` in [`plugin/doc/document_research_tools.py`](../plugin/doc/document_research_tools.py).
+
 ## What is collected automatically
 
 | Field | Notes |

--- a/docs/chat-sidebar-implementation.md
+++ b/docs/chat-sidebar-implementation.md
@@ -32,7 +32,7 @@ See [streaming-and-threading.md](streaming-and-threading.md) §§3.3–3.4 for i
 
 ## Chat prompt constants
 
-Writer main-chat system prompt blocks in [`constants.py`](../plugin/framework/constants.py) are ordered to match runtime assembly in `get_chat_system_prompt_for_document` (persona → chat format → sidebar routing → core directives → tools → translation → usage patterns → `apply_document_content` HTML rules → specialized delegation).
+Writer main-chat system prompt blocks in [`constants.py`](../plugin/framework/constants.py) are ordered to match runtime assembly in `get_chat_system_prompt_for_document` (persona → chat format → sidebar routing → core directives → tools → translation → usage patterns → review modes → `apply_document_content` HTML rules → specialized delegation → memory). The delivery is hybrid: the reference pieces (search, navigation, images) are NOT ambient — the sidebar pulls them on demand via the `get_guidance` tool (topics mapped in `plugin/framework/agent_manual.py`, the same single source the MCP serves).
 
 Design notes for prompt authors live in this section so the source file stays scannable.
 

--- a/docs/mcp-protocol.md
+++ b/docs/mcp-protocol.md
@@ -431,7 +431,7 @@ Ported from `libreoffice-mcp-extension/pythonpath/uno_bridge.py` and adapted to 
 | Styles | `list_styles`, `get_style_info` |
 | Comments | `list_comments`, `add_comment`, `delete_comment` |
 | Track changes | `set_track_changes`, `get_tracked_changes`, `accept_all_changes`, `reject_all_changes` |
-| Tables | `list_tables`, `read_table`, `write_table_cells` |
+| Tables | `list_tables`, `get_table_cells`, `set_table_cell`, `insert_table_row`/`delete_table_row`, `insert_table_column`/`delete_table_column` |
 
 ### Updated: `core/document_tools.py`
 
@@ -664,7 +664,7 @@ to its own embedded AI:
 **Writer**: `get_document_content` (`scope`, `max_chars`, `start`/`end`, `include_images` — default strips inline `data:image` base64), `apply_document_content`, `find_text`,
 `list_styles`, `get_style_info`, `list_comments`, `add_comment`, `delete_comment`,
 `set_track_changes`, `get_tracked_changes`, `accept_all_changes`, `reject_all_changes`,
-`list_tables`, `read_table`, `write_table_cells`, `generate_image` (create or edit with `source_image='selection'`).
+`list_tables`, `get_table_cells`, `set_table_cell`, `generate_image` (create or edit with `source_image='selection'`).
 
 **Calc**: All `CALC_TOOLS` from `core/calc_tools.py`.
 
@@ -1020,7 +1020,7 @@ additions to that section:
 REVIEW WORKFLOW: set_track_changes(enabled=true) → make edits → get_tracked_changes (to
 show user what changed) → accept_all_changes or reject_all_changes → set_track_changes(enabled=false).
 
-TABLE WORKFLOW: list_tables → read_table (understand structure) → write_table_cells for
+TABLE WORKFLOW: list_tables → get_table_cells (understand structure) → set_table_cell for
 targeted edits. For new tables or full rewrites, use apply_document_content with an HTML/Markdown table.
 
 STYLE WORKFLOW: list_styles (discover exact localized names) → apply a style by name in

--- a/docs/mcp-protocol.md
+++ b/docs/mcp-protocol.md
@@ -225,6 +225,7 @@ This section is the important mental model for integrating Cursor, LM Studio, or
 `tools/list` returns **core-tier** tools only. Tools with `tier="specialized"` or `tier="specialized_control"` are **omitted** from the default registry filter (see [`plugin/framework/tool.py`](../plugin/framework/tool.py) `get_tools` / `get_schemas`). The host typically receives:
 
 - Document I/O: `get_document_content`, `apply_document_content`, `search_in_document`, `get_document_tree`, …
+- Guidance: **`get_guidance(topic)`** — the on-demand how-to manual (topics per document type; single source: the shared prompt pieces in `plugin/framework/constants.py`, mapped by `plugin/framework/agent_manual.py`)
 - A single gateway: **`delegate_to_specialized_writer_toolset`** ([`plugin/doc/specialized_base.py`](../plugin/doc/specialized_base.py), Writer variant in [`plugin/writer/specialized_base.py`](../plugin/writer/specialized_base.py))
 
 It does **not** receive dozens of low-level UNO tools (`list_styles`, page margin APIs, chart editors, etc.) as separate MCP tools.
@@ -248,7 +249,7 @@ Other MCP surfaces (for integrators):
 | Surface | Status | Delegation / routing hints |
 |---------|--------|----------------------------|
 | **`tools/list`** | Implemented | **Primary** — use the delegate gateway tool metadata above |
-| **`initialize` → `instructions`** | Short transport stub only | Does not include full chat prompt or domain list today |
+| **`initialize` → `instructions`** | Short stub + pointer to the on-demand manual (`get_guidance` topics, per document type) | Does not include the full chat prompt; the behavioral manual is pulled per topic via `get_guidance` |
 | **`prompts/list` / `prompts/get`** | Empty | Could expose full system prompt later; not implemented |
 | **`resources/list` / `resources/read`** | Empty | Not used for guidance |
 | **`GET /`** | Server name, version, routes | Does **not** return agent instructions (older docs were wrong) |
@@ -470,7 +471,7 @@ is straightforward.
 
 Use **`POST /mcp`** with JSON-RPC 2.0:
 
-- **`initialize`** — protocol handshake; `result.instructions` is a short WriterAgent/MCP workflow stub (not the full sidebar system prompt).
+- **`initialize`** — protocol handshake; `result.instructions` is a short WriterAgent/MCP workflow stub plus a pointer to `get_guidance(topic)`, the on-demand behavioral manual (not the full sidebar system prompt).
 - **`tools/list`** — core-tier tools for the target document (`X-Document-URL` header or active document). Each tool has `name`, `description`, and `inputSchema`. Specialized domains are documented on **`delegate_to_specialized_{writer|calc|draw}_toolset`** (see [Where delegation guidance lives](#where-delegation-guidance-lives-mcp-vs-sidebar-chat)).
 - **`tools/call`** — run a tool on the LibreOffice main thread.
 
@@ -1008,6 +1009,8 @@ is much simpler and doesn't explain when to use it vs rewriting the whole docume
 ---
 
 ### System prompt additions worth making now
+
+> **Historical analysis — superseded.** The review-workflow suggestion below predates the shipped review-mode contract: `WRITER_REVIEW_MODES_RULES` (constants.py) now says the USER picks the review mode and the agent must NEVER accept/reject its own tracked changes. Paths/names are also stale (`core/constants.py` → `plugin/framework/constants.py`; `target="full"` → `full_document`; "FORMATTING RULES" → "APPLY_DOCUMENT_CONTENT AND HTML"). Kept for history only.
 
 The `DEFAULT_CHAT_SYSTEM_PROMPT` in `core/constants.py` should get a workflow section for
 the new tools. Currently the TOOLS list mentions them but gives no usage patterns. Suggested

--- a/plugin/chatbot/send_handlers.py
+++ b/plugin/chatbot/send_handlers.py
@@ -33,6 +33,7 @@ from plugin.framework.errors import safe_json_loads, format_error_payload, Agent
 from plugin.framework.config import get_api_config, get_config, get_config_int_safe, as_bool
 from plugin.framework.client.llm_client import LlmClient
 from plugin.framework.constants import get_core_directives, CHAT_DOCUMENT_CONTEXT_MAX_CHARS
+from plugin.framework.agent_manual import full_manual_for_model
 from plugin.framework.queue_executor import llm_request_lane
 from plugin.doc.document_helpers import get_document_context_for_chat
 from plugin.agent_backend import get_backend
@@ -356,7 +357,11 @@ class SendHandlersMixin:
                     )
 
                 core_dirs = get_core_directives(model)
-                lean_system_prompt = f"{core_dirs}\n\nYou are currently interacting with a LibreOffice document.\n{mcp_instructions}\nPlease proceed with the user's request."
+                # Inject the FULL shared manual: the same prompt pieces (constants) that feed the
+                # sidebar's hybrid prompt and get_guidance's topics, concatenated by agent_manual
+                # WITH the MCP extras (this backend talks to the HTTP server, so e.g. the 429
+                # concurrency contract applies here, unlike the in-process sidebar).
+                lean_system_prompt = f"{core_dirs}\n\n{full_manual_for_model(model)}\n\nYou are currently interacting with a LibreOffice document.\n{mcp_instructions}\nPlease proceed with the user's request."
 
                 # Add optional instructions from settings
                 extra = str(get_config("additional_instructions") or "").strip()

--- a/plugin/doc/document_research.py
+++ b/plugin/doc/document_research.py
@@ -590,6 +590,39 @@ def close_document_research_document(model: Any, *, opened_for_document_research
         log.exception("Failed to close document_research read document")
 
 
+def _is_same_document(model: Any, active_model: Any) -> bool:
+    """Proxy-safe document identity for the is_active flag.
+
+    ``model == active_model`` is ALWAYS False on guard-enabled builds: both sides are fresh
+    _UnoThreadGuardProxy instances (no __eq__), so the old identity compare reported
+    is_active=false even for the genuinely active document. Compare the stable runtime uid
+    instead, falling back to the URL for models without one."""
+    if model is None or active_model is None:
+        return False
+    from plugin.doc.document_helpers import get_runtime_uid
+
+    try:
+        ua, ub = get_runtime_uid(model), get_runtime_uid(active_model)
+        if ua and ub:
+            return ua == ub
+    except Exception:
+        pass
+    try:
+        url = str(getattr(model, "URL", "") or "")
+        return bool(url) and url == str(getattr(active_model, "URL", "") or "")
+    except Exception:
+        return False
+
+
+def _is_modified(model: Any) -> bool:
+    """doc.isModified() (XModifiable), best-effort. Lets an agent SEE unsaved changes so it can
+    tell the user to save. The agent never saves itself (user owns persistence)."""
+    try:
+        return bool(model.isModified())
+    except Exception:
+        return False
+
+
 def get_open_documents(uno_ctx: Any, active_model: Any = None) -> list[dict[str, Any]]:
     """Retrieve all open documents from the desktop context with metadata."""
     from plugin.framework.thread_guard import assert_main_thread
@@ -631,7 +664,8 @@ def get_open_documents(uno_ctx: Any, active_model: Any = None) -> list[dict[str,
                 "uid": get_runtime_uid(model),
                 "path": "",
                 "doc_type": doc_type,
-                "is_active": (active_model is not None and model == active_model)
+                "is_active": _is_same_document(model, active_model),
+                "modified": _is_modified(model)
             })
             continue
         
@@ -656,7 +690,8 @@ def get_open_documents(uno_ctx: Any, active_model: Any = None) -> list[dict[str,
             "uid": get_runtime_uid(model),
             "path": path,
             "doc_type": doc_type_guess,
-            "is_active": (active_model is not None and model == active_model)
+            "is_active": _is_same_document(model, active_model),
+            "modified": _is_modified(model)
         })
     return docs
 

--- a/plugin/doc/document_research_tools.py
+++ b/plugin/doc/document_research_tools.py
@@ -64,11 +64,15 @@ class ListOpenDocuments(ToolBase):
     name = "list_open_documents"
     description = (
         "List all currently open documents in LibreOffice. "
-        "Returns the path, name, URL, a stable id (uid), document type (writer, calc, draw), and if it is the currently active document. "
-        "Pass a document's url OR uid as the document_url argument on any tool to target that document; the uid also works for unsaved/untitled documents that have no URL yet."
+        "Returns the path, name, URL, a stable id (uid), document type (writer, calc, draw), whether it is the currently active document, and whether it has unsaved changes (modified). "
+        "Pass a document's url OR uid as the document_url argument on any tool to target that document; the uid also works for unsaved/untitled documents that have no URL yet. "
+        "You cannot save documents yourself; when modified is true and the work is done, tell the user to save."
     )
     tier = "mcp"
     is_mutation = False
+    # Listing open documents must work when NONE is open (it should return [] / no active doc),
+    # otherwise the MCP no-document gate turns "what's open?" into a confusing NO_DOCUMENT_OPEN.
+    requires_document = False
     parameters = {
         "type": "object",
         "properties": {},
@@ -84,3 +88,135 @@ class ListOpenDocuments(ToolBase):
             return {"status": "ok", "documents": docs}
 
         return execute_on_main_thread(_run)
+
+
+_FEEDBACK_LOG_FILENAME = "agent_feedback.jsonl"
+_FEEDBACK_CATEGORIES = ("bug", "ux", "feature")
+
+
+def _append_feedback_log(category: str, summary: str, details: str, ts: str | None = None) -> str | None:
+    """Append one agent feedback entry to agent_feedback.jsonl in the LO user config dir.
+
+    Best-effort: returns the file path on success, None on any failure (never breaks report_bug).
+    ts is injectable for tests; otherwise stamped from the local clock."""
+    import json
+    import os
+
+    try:
+        from plugin.framework.config import user_config_dir
+
+        if ts is None:
+            import datetime
+
+            ts = datetime.datetime.now().isoformat(timespec="seconds")
+        path = os.path.join(user_config_dir(), _FEEDBACK_LOG_FILENAME)
+        record = {"ts": ts, "category": category, "summary": summary, "details": details}
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return path
+    except Exception:
+        return None
+
+
+class ReportBug(ToolBase):
+    """Report a WriterAgent bug or bad user experience (agent-callable)."""
+
+    name = "report_bug"
+    description = (
+        "Report a WriterAgent bug or bad experience — the agent itself may call this when a tool "
+        "misbehaves, returns a confusing result, or the workflow felt wrong. It records the feedback "
+        "locally for the user AND returns a pre-filled GitHub issue URL the user can review and submit. "
+        "Nothing is published automatically. Describe what happened and what you expected."
+    )
+    tier = "mcp"
+    is_mutation = False
+    # Reporting a bug must work even with NO document open — e.g. "the extension won't open my
+    # file". The no-document gate would otherwise block the very tool meant to report that.
+    requires_document = False
+    parameters = {
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string", "description": "One-line title of the bug / bad experience."},
+            "details": {"type": "string", "description": "What happened, what you expected, and any steps to reproduce. Be specific."},
+            "category": {"type": "string", "enum": list(_FEEDBACK_CATEGORIES), "description": "bug (something broke), ux (confusing/clunky), or feature (missing capability). Default 'bug'."},
+        },
+        "required": ["summary"],
+    }
+
+    def execute(self, ctx: ToolContext, **kwargs: Any) -> dict[str, Any]:
+        summary = (kwargs.get("summary") or "").strip()
+        if not summary:
+            return self._tool_error("summary is required.", code="MISSING_PARAMETER", parameter="summary")
+        details = (kwargs.get("details") or "").strip()
+        category = (kwargs.get("category") or "bug").strip().lower()
+        if category not in _FEEDBACK_CATEGORIES:
+            category = "bug"
+
+        # 1) Pre-filled GitHub issue URL (reuse bug_report's builder; env block + truncation included).
+        body = details or "(no details provided)"
+        body += "\n\n_Filed via the report_bug tool (agent-assisted). Review before submitting._"
+        url = ""
+        try:
+            from plugin.framework.bug_report import build_github_issue_url
+
+            url = build_github_issue_url(title="[%s] %s" % (category, summary), extra_body=body, ctx=getattr(ctx, "ctx", None))
+        except Exception:
+            url = ""  # URL is best-effort; the local feedback log below is the durable record.
+
+        # 2) Log locally for the user (best-effort).
+        logged_to = _append_feedback_log(category, summary, details)
+
+        return {
+            "status": "ok",
+            "message": ("Feedback recorded locally. Share the github_issue_url with the user to file it — "
+                        "nothing was auto-submitted (auto-filing a GitHub issue would require a configured "
+                        "token and the user's consent)."),
+            "category": category,
+            "github_issue_url": url,
+            "logged_to": logged_to,
+        }
+
+
+class GetGuidance(ToolBase):
+    """On-demand how-to-use manual for the WriterAgent tools (agent pulls one topic at a time)."""
+
+    name = "get_guidance"
+    description = (
+        "Read WriterAgent's how-to-use manual on demand. Call with no topic to get the list of topics; "
+        "call with a topic to read just that section (so you don't load everything). Topics follow the "
+        "open document's type (for Writer: editing, editing-html, review-modes, search, navigation, "
+        "images, concurrency). Use this when unsure how an edit, the review modes, search, or image ops work."
+    )
+    # Core, not mcp-exclusive: the sidebar's HYBRID prompt keeps search/navigation/images out of
+    # the ambient text and relies on pulling them from here (same single source, same topics).
+    tier = "core"
+    is_mutation = False
+    # Pure documentation — works with or without a document open (no doc -> neutral index).
+    requires_document = False
+    parameters = {
+        "type": "object",
+        "properties": {
+            "topic": {"type": "string", "description": "Topic to read (see the no-topic call for the list; topics follow the document type). Omit for the topic list."},
+        },
+        "required": [],
+    }
+
+    def execute(self, ctx: ToolContext, **kwargs: Any) -> dict[str, Any]:
+        from plugin.framework.agent_manual import doc_type_of, get_section, list_topics, manual_index, normalize_topic
+
+        # Guidance must match the document being worked on (a Calc session must never read Writer
+        # advice). Resolve the target document the same way every other tool does; with no document
+        # open, serve the neutral index / the always-available generic topics.
+        doc_type = doc_type_of(getattr(ctx, "doc", None))
+        raw = (kwargs.get("topic") or "").strip()
+        if not raw:
+            return {"status": "ok", "doc_type": doc_type, "topics": list_topics(doc_type), "index": manual_index(doc_type)}
+        section = get_section(raw, doc_type)
+        if section is None:
+            return {
+                "status": "error",
+                "code": "UNKNOWN_TOPIC",
+                "message": "Unknown guidance topic '%s' for this document type. Available topics: %s." % (raw, ", ".join(list_topics(doc_type))),
+                "topics": list_topics(doc_type),
+            }
+        return {"status": "ok", "doc_type": doc_type, "topic": normalize_topic(raw, doc_type), "guidance": section}

--- a/plugin/framework/agent_manual.py
+++ b/plugin/framework/agent_manual.py
@@ -1,0 +1,228 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Topic-based delivery of the shared behavioral pieces (MCP / external-agent channel).
+
+The SOURCE OF TRUTH for the cross-cutting behavioral rules lives in plugin/framework/constants.py:
+the original chat system prompt pieces (TOOL_USAGE_PATTERNS, WRITER_APPLY_DOCUMENT_HTML_RULES,
+TRANSLATION_RULES), updated in place and extended with new pieces (WRITER_REVIEW_MODES_RULES,
+WRITER_SEARCH_RULES, WRITER_NAVIGATION_RULES, WRITER_IMAGES_RULES). The sidebar system prompt
+template assembles those pieces directly, adding its sidebar-only parts (persona, chat format,
+delegation routing, memory).
+
+This module is the on-demand assembly of the same pieces: get_guidance(topic) serves ONE topic at
+a time, mapping topic -> piece per document type and adding the MCP-only extras (the HTTP 429
+concurrency contract, which the in-process sidebar never needs). Its consumers:
+- external MCP clients (they drop/truncate connect-time instructions, so pull is their ONLY
+  channel, plus JIT state in tool results);
+- the sidebar agent, for the reference pieces (search/navigation/images) its HYBRID prompt keeps
+  out of the ambient text — get_guidance is tier "core" so the sidebar can call it;
+- the agent-backend path (send_handlers), which injects full_manual() — it talks to the HTTP
+  server, so it takes the whole manual including the MCP extras.
+
+Same pieces, different assembly per channel — update a rule in constants.py and every consumer
+sees it; only genuinely channel-specific text lives outside the shared pieces.
+
+Sections are per document type: Writer has the full manual; Calc and Draw currently get the generic
+sections (tools-not-chat, confirmation by structured fields, concurrency) until app-specific prose is
+written. ``get_guidance`` resolves the target document's type the same way every other tool does, so
+a Calc session never reads Writer advice."""
+from __future__ import annotations
+
+from plugin.framework.constants import (
+    GENERIC_EDIT_CONFIRMATION_RULES,
+    TOOL_USAGE_PATTERNS,
+    TRANSLATION_RULES,
+    WRITER_APPLY_DOCUMENT_HTML_RULES,
+    WRITER_IMAGES_RULES,
+    WRITER_NAVIGATION_RULES,
+    WRITER_REVIEW_MODES_RULES,
+    WRITER_SEARCH_RULES,
+)
+
+# ---------------------------------------------------------------------------
+# MCP-only pieces. The HTTP server's concurrency contract: real for every client of the MCP
+# server (external clients and the agent-backend path alike), meaningless for the in-process
+# sidebar — which is why it lives here and not with the shared pieces in constants.py.
+# ---------------------------------------------------------------------------
+_MCP_CONCURRENCY_RULES = (
+    "CONCURRENCY / MULTI-DOCUMENT:\n"
+    "- The server runs ONE operation at a time and returns HTTP 429 'busy' when overloaded.\n"
+    "- On 429, wait briefly and retry that same call — do not fire many calls in parallel.\n"
+    "- With more than one document open, ALWAYS pass document_url (a url or uid from "
+    "list_open_documents): without it every call targets whatever window the user has focused, "
+    "which can change between your calls. Every result echoes the document it acted on "
+    "(document: {name, uid}) — check it when in doubt."
+)
+
+# ---------------------------------------------------------------------------
+# Writer topics (topic -> shared piece). The agent pulls a section on demand (MCP) or gets them
+# all concatenated (agent backend), so a topic can bundle the related pieces.
+# ---------------------------------------------------------------------------
+# Appended to the editing topic ONLY when it is served alone (get_section): in full_manual the
+# editing-html section follows immediately, so a "go read that topic" pointer would dangle.
+_EDITING_HTML_POINTER = (
+    "\n\nFor apply_document_content's full contract (targets, the JSON array of HTML "
+    "fragments, math, named styles, reach), read the editing-html topic."
+)
+
+MANUAL_SECTIONS: dict[str, str] = {
+    # The one-line opener is this channel's counterpart of the sidebar-only SIDEBAR_VS_DOCUMENT
+    # piece: same rule, phrased without the sidebar mechanics. The editing topic covers the
+    # WORKFLOW (confirmation, patterns, translation); the apply_document_content contract is its
+    # own subdivision (editing-html) so a model can pull just the part it needs.
+    "editing": (
+        "Change the document with tools, not chat.\n\n"
+        + TOOL_USAGE_PATTERNS.strip()
+        + "\n\n"
+        + TRANSLATION_RULES.strip()
+    ),
+    "editing-html": WRITER_APPLY_DOCUMENT_HTML_RULES,
+    "review-modes": WRITER_REVIEW_MODES_RULES,
+    "search": WRITER_SEARCH_RULES,
+    "navigation": WRITER_NAVIGATION_RULES,
+    "images": WRITER_IMAGES_RULES,
+    "concurrency": _MCP_CONCURRENCY_RULES,
+}
+
+# Stable display order + one-line summaries for the Writer index.
+_TOPIC_SUMMARY: list[tuple[str, str]] = [
+    ("editing", "edit workflow: confirm by structured fields, patterns, translation"),
+    ("editing-html", "apply_document_content contract: targets, HTML array, math, styles, reach"),
+    ("review-modes", "tracked changes off/record/wait; never resolve your own"),
+    ("search", "find text anywhere (body, tables, boxes, shapes, headers, comments) + where it is"),
+    ("navigation", "map-first reading of large documents"),
+    ("images", "insert/replace/resize/crop + how a vision model sees images"),
+    ("concurrency", "one operation at a time; retry on HTTP 429; multi-document targeting"),
+]
+
+# ---------------------------------------------------------------------------
+# Generic sections for document types without app-specific prose yet (Calc, Draw). Honest minimum:
+# only rules that genuinely apply everywhere. NO Writer advice leaks into a Calc/Draw session.
+# ---------------------------------------------------------------------------
+_GENERIC_SECTIONS: dict[str, str] = {
+    # Same object the Calc/Draw sidebar prompts embed (constants) — single source there too.
+    "editing": GENERIC_EDIT_CONFIRMATION_RULES,
+    "concurrency": _MCP_CONCURRENCY_RULES,
+}
+
+_GENERIC_TOPIC_SUMMARY: list[tuple[str, str]] = [
+    ("editing", "use the tools, confirm edits by structured fields, re-read before targeted edits"),
+    ("concurrency", "one operation at a time; retry on HTTP 429; multi-document targeting"),
+]
+
+_SECTIONS_BY_APP: dict[str, dict[str, str]] = {
+    "writer": MANUAL_SECTIONS,
+    "calc": _GENERIC_SECTIONS,
+    "draw": _GENERIC_SECTIONS,
+    # No document open: only the always-true generic rules are safe to serve.
+    "generic": _GENERIC_SECTIONS,
+}
+
+_SUMMARY_BY_APP: dict[str, list[tuple[str, str]]] = {
+    "writer": _TOPIC_SUMMARY,
+    "calc": _GENERIC_TOPIC_SUMMARY,
+    "draw": _GENERIC_TOPIC_SUMMARY,
+    "generic": _GENERIC_TOPIC_SUMMARY,
+}
+
+# Common aliases -> canonical topic.
+_ALIASES = {
+    "edit": "editing", "edits": "editing", "translation": "editing", "translate": "editing",
+    "apply": "editing-html", "apply_document_content": "editing-html",
+    "html": "editing-html", "html-rules": "editing-html", "styles": "editing-html", "math": "editing-html",
+    "tracked-changes": "review-modes", "tracked_changes": "review-modes", "redlines": "review-modes",
+    "review": "review-modes", "review_modes": "review-modes", "review-mode": "review-modes",
+    "find": "search", "search_in_document": "search",
+    "navigate": "navigation", "outline": "navigation", "large-documents": "navigation",
+    "image": "images", "crop": "images", "vision": "images",
+    "429": "concurrency", "rate-limit": "concurrency", "rate_limit": "concurrency",
+    "documents": "concurrency", "multi-document": "concurrency", "document-url": "concurrency",
+    "document_url": "concurrency",
+}
+
+
+def _app(doc_type: str | None) -> str:
+    if doc_type is None:
+        return "generic"  # no document open -> only the generic rules apply
+    return doc_type if doc_type in _SECTIONS_BY_APP else "writer"
+
+
+def doc_type_of(doc) -> str | None:
+    """'writer' / 'calc' / 'draw' for a document model, or None when there is no document.
+
+    Same resolution every other tool relies on (lazy import mirrors get_core_directives)."""
+    if doc is None:
+        return None
+    try:
+        from plugin.doc.document_helpers import is_calc, is_draw
+
+        if is_calc(doc):
+            return "calc"
+        if is_draw(doc):
+            return "draw"
+    except Exception:
+        pass
+    return "writer"
+
+
+def list_topics(doc_type: str | None = "writer") -> list[str]:
+    """Canonical topic ids in display order for a document type."""
+    return [t for t, _ in _SUMMARY_BY_APP[_app(doc_type)]]
+
+
+def normalize_topic(topic: str | None, doc_type: str | None = "writer") -> str | None:
+    """Map a raw topic string (aliases/case/spacing) to a canonical topic of that app, else None."""
+    if not topic:
+        return None
+    sections = _SECTIONS_BY_APP[_app(doc_type)]
+    key = topic.strip().lower().replace(" ", "-").replace("_", "-")
+    if key in sections:
+        return key
+    alias = _ALIASES.get(key) or _ALIASES.get(key.replace("-", "_"))
+    return alias if alias in sections else None
+
+
+def get_section(topic: str | None, doc_type: str | None = "writer") -> str | None:
+    """The manual section for a topic (alias-aware) in that app's manual, or None if unknown."""
+    app = _app(doc_type)
+    canon = normalize_topic(topic, doc_type)
+    text = _SECTIONS_BY_APP[app].get(canon) if canon else None
+    if text is not None and canon == "editing" and app == "writer":
+        text += _EDITING_HTML_POINTER  # served alone -> point to the subdivision
+    return text
+
+
+def manual_index(doc_type: str | None = "writer") -> str:
+    """Short index for get_guidance() with no topic — what can be pulled WITHOUT reading it all.
+
+    With doc_type=None (no document open) the index is neutral: it lists the always-available
+    generic topics and says the full set follows the open document's type."""
+    if doc_type is None:
+        lines = [
+            "WriterAgent how-to topics — call get_guidance(topic) to read one. No document is open; "
+            "topics follow the open document's type (writer, calc, draw). Available now:"
+        ]
+        lines += ["- %s: %s" % (t, s) for t, s in _GENERIC_TOPIC_SUMMARY]
+        return "\n".join(lines)
+    lines = ["WriterAgent how-to topics — call get_guidance(topic) to read one:"]
+    lines += ["- %s: %s" % (t, s) for t, s in _SUMMARY_BY_APP[_app(doc_type)]]
+    return "\n".join(lines)
+
+
+def full_manual(doc_type: str | None = "writer") -> str:
+    """The whole manual for one document type, sections in display order.
+
+    This is what the AGENT-BACKEND path injects into its system prompt (send_handlers) — it talks
+    to the MCP HTTP server, so it takes the shared pieces AND the MCP extras in one string. The
+    sidebar does not use this: its template assembles the shared pieces directly (constants)."""
+    app = _app(doc_type)
+    sections = _SECTIONS_BY_APP[app]
+    parts = [sections[t] for t, _ in _SUMMARY_BY_APP[app]]
+    return "HOW TO WORK WITH THE DOCUMENT:\n\n" + "\n\n".join(parts)
+
+
+def full_manual_for_model(model) -> str:
+    """full_manual() resolved from a document model (agent-backend convenience)."""
+    return full_manual(doc_type_of(model) or "writer")

--- a/plugin/framework/agent_manual.py
+++ b/plugin/framework/agent_manual.py
@@ -48,8 +48,10 @@ from plugin.framework.constants import (
 # ---------------------------------------------------------------------------
 _MCP_CONCURRENCY_RULES = (
     "CONCURRENCY / MULTI-DOCUMENT:\n"
-    "- The server runs ONE operation at a time and returns HTTP 429 'busy' when overloaded.\n"
-    "- On 429, wait briefly and retry that same call — do not fire many calls in parallel.\n"
+    "- Fast tools are serialized (one at a time); under contention the server returns HTTP 429 "
+    "'busy'. On 429, wait briefly and retry that same call.\n"
+    "- Long-running calls can overlap EXCEPT two edits to the SAME document (those are serialized), "
+    "so parallel work is fine across different documents but avoid overlapping edits to one document.\n"
     "- With more than one document open, ALWAYS pass document_url (a url or uid from "
     "list_open_documents): without it every call targets whatever window the user has focused, "
     "which can change between your calls. Every result echoes the document it acted on "
@@ -94,7 +96,7 @@ _TOPIC_SUMMARY: list[tuple[str, str]] = [
     ("search", "find text anywhere (body, tables, boxes, shapes, headers, comments) + where it is"),
     ("navigation", "map-first reading of large documents"),
     ("images", "insert/replace/resize/crop + how a vision model sees images"),
-    ("concurrency", "one operation at a time; retry on HTTP 429; multi-document targeting"),
+    ("concurrency", "same-document edits serialize; retry on HTTP 429; multi-document targeting"),
 ]
 
 # ---------------------------------------------------------------------------
@@ -109,7 +111,7 @@ _GENERIC_SECTIONS: dict[str, str] = {
 
 _GENERIC_TOPIC_SUMMARY: list[tuple[str, str]] = [
     ("editing", "use the tools, confirm edits by structured fields, re-read before targeted edits"),
-    ("concurrency", "one operation at a time; retry on HTTP 429; multi-document targeting"),
+    ("concurrency", "same-document edits serialize; retry on HTTP 429; multi-document targeting"),
 ]
 
 _SECTIONS_BY_APP: dict[str, dict[str, str]] = {

--- a/plugin/framework/constants.py
+++ b/plugin/framework/constants.py
@@ -155,7 +155,7 @@ DELEGATION_PUBLIC_WEB_HINT = "to research public topics"
 
 # Main agent only: after research delegates return plain text, write HTML to the document (not sidebar).
 RESEARCH_DELEGATE_TO_DOCUMENT = (
-    "After doing web_research or document_research,you MUST call apply_document_content to insert the received research into the document so the user can see and edit it (per APPLY_DOCUMENT_CONTENT rules). "
+    "After doing web_research or document_research, you MUST call apply_document_content to insert the received research into the document so the user can see and edit it (per APPLY_DOCUMENT_CONTENT rules). "
     "Default: write the full report to the open document (empty doc → target='beginning'). "
     "Sidebar: brief confirmation only — NEVER paste the full report in chat unless the user explicitly asked chat-only."
 )
@@ -281,30 +281,87 @@ def get_core_directives(model) -> str:
         return WRITER_CORE_DIRECTIVES
 
 
+# ---------------------------------------------------------------------------
+# Shared behavioral pieces (single source of truth for BOTH agents)
+#
+# The blocks below — together with TOOL_USAGE_PATTERNS, TRANSLATION_RULES and
+# WRITER_APPLY_DOCUMENT_HTML_RULES — are the reusable pieces of the original chat system prompt,
+# updated and extended in place. The consumers assemble them, each adding only its
+# channel-specific parts:
+#   - the Writer sidebar template (_build_writer_chat_system_prompt_template) is HYBRID: it embeds
+#     the original pieces + WRITER_REVIEW_MODES_RULES verbatim every turn (safety rules must be
+#     ambient), while the reference pieces (SEARCH/NAVIGATION/IMAGES) are pulled on demand via
+#     the get_guidance tool;
+#   - MCP clients pull every piece per topic through get_guidance (plugin/framework/agent_manual.py
+#     maps topic -> piece and adds the MCP-only extras, e.g. the HTTP 429 concurrency contract);
+#   - the Calc/Draw sidebar templates embed GENERIC_EDIT_CONFIRMATION_RULES, the same app-neutral
+#     piece the generic MCP topics serve.
+# Update a rule HERE and every consumer sees it; never fork these texts per channel.
+# ---------------------------------------------------------------------------
+
+WRITER_REVIEW_MODES_RULES = """TRACKED CHANGES / REVIEW MODES:
+- The user picks ONE of three review modes for your edits; you never pick or switch it.
+- off: your edits apply directly and are live immediately.
+- record: your edits ARE applied, but as tracked changes pending the user's accept/reject; you will NOT be told whether they are later accepted or rejected.
+- wait: your edits are applied as tracked changes and the edit tool blocks until the user finishes reviewing (or a configured timeout), then the result reports what was accepted or rejected.
+- apply_document_content's RESULT carries the review state for that call (record: review_mode / pending_review; wait: a review field with the outcome) — trust the latest result over anything earlier, since the user can switch modes mid-session.
+- In record and wait, NEVER accept or reject changes yourself (no track_changes_accept_all / track_changes_reject_all) — resolving redlines is the user's decision.
+- When reading, get_document_content lists pending changes under tracked_changes (insertions/deletions) — they are pending review, not errors to fix."""
+
+WRITER_SEARCH_RULES = """SEARCH:
+- search_in_document finds text ANYWHERE — body paragraphs and headings, table cells, text boxes/frames, floating drawing shapes, page headers/footers, and comments.
+- Each match reports WHERE it lives (e.g. "body", "table 'X' cell B2", "text box 'Y'", "shape 'Z'", "header (page style 'Standard')", "comment by 'A'") plus the surrounding text; use return_offsets=true for character ranges.
+- When pointing the user to a match, quote the first words of its text and its location — never an internal paragraph index."""
+
+WRITER_NAVIGATION_RULES = """NAVIGATING LARGE DOCUMENTS (map first, then drill — don't dump):
+- get_document_tree(content_strategy='heading_only') gives the heading outline plus stats and stable _mcp_ bookmark ids.
+- get_heading_children (structural domain; locator='bookmark:_mcp_…' or 'heading:1.2') reads one section on demand.
+- search_in_document jumps to specific text.
+- Reserve get_document_content(scope='full') for short documents or a deliberate full read."""
+
+WRITER_IMAGES_RULES = """IMAGES:
+- Image tools live in the 'images' domain: insert_image, delete_image, replace_image, list_images, get_image_info (includes crop_mm), download_image. OCR (extract_text_from_image) lives in the 'vision' domain.
+- set_image_properties resizes (width_mm/height_mm), repositions (hori_orient/vert_orient — friendly values like left/center/right/top/bottom work), and crops (crop_top_mm / crop_bottom_mm / crop_left_mm / crop_right_mm — mm trimmed per edge).
+- To actually SEE an image (vision-capable models), call get_image — by graphic name, selection=true, or page=N to render that whole page. For a bulk read with pictures embedded, pass include_images=true to get_document_content."""
+
+# App-neutral minimum (Calc/Draw sidebar prompts + the generic MCP topics via agent_manual):
+# only rules that genuinely apply to every document type — no Writer tool names.
+GENERIC_EDIT_CONFIRMATION_RULES = """EDITING THE DOCUMENT:
+- Change the document with tools, not chat.
+- VERIFY every edit by the tool result's structured fields: status='error' (or a zero count, where the tool reports counts) means nothing changed — do not assume success from friendly message wording.
+- Any document content shown to you earlier may be a partial/truncated snapshot — before a targeted edit that depends on the exact current content, re-read through the tools."""
+
+
 WRITER_CHAT_TOOLS_SECTION = """TOOLS:
 - apply_document_content: Write HTML to the document (required after research delegates). See APPLY_DOCUMENT_CONTENT AND HTML below.
 - get_document_content: Read document (full/selection/range) as HTML.
-- search_in_document: Find text (use return_offsets for character positions if needed for inspection).
-- apply_style: Apply a paragraph or character style (family='ParagraphStyles' or 'CharacterStyles')."""
+- search_in_document: Find text anywhere (body, tables, text boxes, shapes, headers/footers, comments); each match reports where it lives.
+- apply_style: Apply a paragraph or character style (family='ParagraphStyles' or 'CharacterStyles').
+- add_comment: Anchor review feedback or suggestions to a specific passage (see TOOL USAGE PATTERNS).
+- get_guidance: Read the how-to manual on demand — no topic lists the topics; one topic (e.g. 'search', 'navigation', 'images') reads just that section."""
 
 TRANSLATION_RULES = "TRANSLATION: get_document_content(scope=full) -> translate -> apply_document_content(target='full_document', content=translated). Do not use old_content or target='search' for whole-document translation. Never refuse."
 
 # Tool-usage workflow patterns (no repeat of apply_document_content targets; see WRITER_APPLY_DOCUMENT_HTML_RULES).
+# Shared piece: sidebar system prompt + MCP manual (agent_manual topic "editing").
 TOOL_USAGE_PATTERNS = """TOOL USAGE PATTERNS:
-- After an edit tool, confirm it landed via that tool's own structured field — not the message wording: apply_document_content -> replaced_count > 0; apply_style -> applied is true; add_comment -> comment_added is true. A no-op (e.g. text not found) returns status="error"; do not assume success.
+- After an edit tool, confirm it landed via that tool's own structured field — not the message wording: apply_document_content -> replaced_count > 0 for search replaces (inserts — targets beginning/end/selection and position='before'/'after' — report status='ok', the latter with inserted=true); apply_style -> applied is true; add_comment -> comment_added is true. A no-op (e.g. text not found) returns status="error"; do not assume success.
+- Any document text shown to you earlier may be a partial/truncated snapshot — before a targeted edit that depends on the exact current text, call get_document_content for the authoritative version.
+- Successful apply_document_content edits also return edited_context — the touched paragraph(s) plus neighbors as they now read (in record/wait including the pending tracked change). Check it to confirm placement instead of an immediate re-read; full_document rewrites return no echo.
 - apply_style applies formatting directly and is NOT recorded as a tracked change. When its result has style_unreviewed=true (review mode is on), briefly tell the user you changed a style, since they cannot accept or reject it the way they review your text edits.
 - search_in_document (with return_offsets if needed) is for inspection/navigation; use apply_document_content with old_content for replacements.
 - If a tool call fails, verify content and target are provided (use target='beginning' / 'end' / 'selection' for insert-only).
 - When asked to review or give feedback or suggestions on a document, use the add_comment method to add your input to specific places in the document. Use for both positive and negative feedback.
-- If the user says "fix this" (or a synonym or equivalent in another language with the same intent), assume they want you to correct spelling and grammar errors in the current sentence only, unless the context makes it clear there is another specific error they want you to fix.
-"""
+- If the user says "fix this" (or a synonym or equivalent in another language with the same intent), assume they want you to correct spelling and grammar errors in the current sentence only, unless the context makes it clear there is another specific error they want you to fix."""
 
 # apply_document_content only — design notes in docs/chat-sidebar-implementation.md § Chat prompt constants and docs/math-tex.md.
-WRITER_APPLY_DOCUMENT_HTML_RULES = f"""
-APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL):
+WRITER_APPLY_DOCUMENT_HTML_RULES = f"""APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL):
 - Parameters: `content` and `target` (required). If target='search', also `old_content` (a **substring** to find/replace; HTML in old_content is matched as plain text).
 - **Whole-document replace:** use target='full_document' with `content` only. **Never** pass the entire document as old_content — that is not supported and will fail search.
 - Targets: 'beginning', 'end', 'selection', 'full_document' (replaces all — preferred for rewrites/translations), or 'search' (substring find/replace only).
+- With target='search', old_content may span multiple paragraphs (paragraph chaining), but each interior line must then match a WHOLE paragraph.
+- position='before' / 'after' (with target='search') INSERTS the content next to the match and leaves the matched text untouched — the clean way to add a paragraph after a clause without re-sending the clause itself.
+- Reach: edits cover body text, table cells, and text frames. Text inside a floating drawing shape is edited in place only when review mode is off — in record/wait it cannot become a tracked change, so the tool routes you to the shapes domain instead. Rich/block HTML inside a table cell is not supported (clear error, document untouched); use plain text or inline tags there.
 - `content` must be a JSON array of HTML strings (one fragment per heading/paragraph). We wrap in <html>/<body>.
 {HTML_FRAGMENT_RULES}
 - Math: Use LaTeX inline delimiters \\(...\\) for math expressions (e.g. \\(x^2=4\\) or \\(a+b\\)); single variables (like x) can be plain text. No $, $$, \\[, HTML-escaped math, or equation images.
@@ -364,7 +421,15 @@ DRAW_SPECIALIZED_DELEGATION_TEMPLATE = (
 
 
 def _build_writer_chat_system_prompt_template() -> str:
-    """Assemble Writer main-chat system prompt in model-facing order."""
+    """Assemble Writer main-chat system prompt in model-facing order.
+
+    HYBRID delivery of the shared pieces: the ambient prompt carries the original pieces plus
+    the safety-critical review-modes piece (a model must know it may not resolve its own
+    tracked changes BEFORE it acts — weaker models never ask first); the reference pieces
+    (search, navigation, images) are pulled on demand through the get_guidance tool, so every
+    turn stays lean. The MCP-only extras (e.g. the HTTP 429 concurrency contract) stay out of
+    this ambient prompt — the sidebar runs in-process; if a sidebar model pulls the concurrency
+    topic anyway it just reads an inert rule."""
     return "\n\n".join([
         WRITER_CHAT_PERSONA,
         CHAT_RESPONSE_FORMAT,
@@ -373,9 +438,10 @@ def _build_writer_chat_system_prompt_template() -> str:
         WRITER_CHAT_TOOLS_SECTION,
         TRANSLATION_RULES,
         TOOL_USAGE_PATTERNS,
+        WRITER_REVIEW_MODES_RULES,
         WRITER_APPLY_DOCUMENT_HTML_RULES,
         "{specialized_delegation}",
-        f"# {MEMORY_GUIDANCE}",
+        MEMORY_GUIDANCE,
     ])
 
 
@@ -572,9 +638,7 @@ CALC_FORMULA_SYNTAX = """FORMULA SYNTAX: LibreOffice uses semicolon (;) as the f
 - Correct: =SUM(A1:A10), =IF(A1>0;B1;C1)
 - Wrong: =SUM(A1,A10), =IF(A1>0,"Yes","No") (no commas in formulas)
 - Write `=PY("result = ..."; A1:A10)` in cells to calculate/run Python (=PYTHON is the same; omit the second argument if no data is needed, e.g. `=PY("result = 2**10")`).
-- Example: `=PY("result = np.sum(data)"; A1:A10)`.
-
-"""
+- Example: `=PY("result = np.sum(data)"; A1:A10)`."""
 
 # DEFAULT_CALC_CHAT_SYSTEM_PROMPT_TEMPLATE is built in _init_venv_import_policy_strings() (needs import policy).
 DEFAULT_CALC_CHAT_SYSTEM_PROMPT_TEMPLATE = ""
@@ -583,6 +647,8 @@ DEFAULT_DRAW_CHAT_SYSTEM_PROMPT_TEMPLATE = """You are a LibreOffice Draw/Impress
 Do not explain - do the operation directly using tools. Perform as many steps as needed in one turn when possible.
 
 """ + CHAT_RESPONSE_FORMAT + """
+
+""" + GENERIC_EDIT_CONFIRMATION_RULES + """
 
 WORKFLOW:
 1. Understand the user's request.
@@ -967,13 +1033,13 @@ def _init_venv_import_policy_strings() -> None:
 - Wrong: =SUM(A1,A10), =IF(A1>0,"Yes","No") (no commas in formulas)
 - Write `=PY("result = ..."; A1:A10)` in cells to calculate/run Python (=PYTHON is the same; omit the second argument if no data is needed, e.g. `=PY("result = 2**10")`).
 {compact}
-- Example: `=PY("result = np.sum(data)"; A1:A10)`.
-
-"""
+- Example: `=PY("result = np.sum(data)"; A1:A10)`."""
     DEFAULT_CALC_CHAT_SYSTEM_PROMPT_TEMPLATE = f"""You are a LibreOffice Calc spreadsheet assistant who creates polished, professional, and colorful spreadsheets.
 Do not explain, do the operation directly using tools. Perform as many steps as needed in one turn when possible.
 
 {CHAT_RESPONSE_FORMAT}
+
+{GENERIC_EDIT_CONFIRMATION_RULES}
 
 {CALC_WORKFLOW}
 

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -666,19 +666,10 @@ class MCPProtocolHandler:
                         snippet = str(effect.result)[:100] if effect.result else ""
                         event_bus.emit("mcp:result", tool=state.tool_name, result_snippet=snippet, args=state.arguments)
 
-                    # A tool may return an image: {"_mcp_image": {"data": <b64>, "mimeType": ...}} ->
-                    # emit a native MCP image content block (get_image) instead of base64-as-text.
-                    res = effect.result
-                    img = res.get("_mcp_image") if isinstance(res, dict) else None
-                    if isinstance(img, dict) and img.get("data"):
-                        final_result = wire_types.call_tool_result_image(
-                            img["data"], img.get("mimeType", "image/png"), is_error=effect.is_error,
-                        )
-                    else:
-                        final_result = wire_types.call_tool_result(
-                            json.dumps(res, ensure_ascii=False, default=str),
-                            is_error=effect.is_error,
-                        )
+                    final_result = wire_types.call_tool_result(
+                        json.dumps(effect.result, ensure_ascii=False, default=str),
+                        is_error=effect.is_error,
+                    )
 
                 elif isinstance(effect, SendErrorEffect):
                     raise ValueError(effect.message)

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -43,6 +43,77 @@ log = logging.getLogger("writeragent.mcp.protocol")
 MCP_PROTOCOL_VERSION = wire_types.MCP_PROTOCOL_VERSION
 _SUPPORTED_HTTP_PROTOCOL_VERSIONS = frozenset({MCP_PROTOCOL_VERSION, "2024-11-05"})
 
+def _document_echo_payload(doc):
+    """{name, uid} of the resolved target document, or None. Reads UNO properties — call ONLY
+    where UNO access is legal (the main thread); worker-thread callers must precompute this."""
+    if doc is None:
+        return None
+    try:
+        import os
+        from urllib.parse import unquote
+
+        from plugin.doc.document_helpers import get_runtime_uid
+
+        url = str(getattr(doc, "URL", "") or "")
+        name = unquote(os.path.basename(url)) if url else "Untitled"
+        return {"name": name, "uid": get_runtime_uid(doc)}
+    except Exception:
+        return None
+
+
+def _attach_document_echo(result, doc):
+    """Echo the resolved target document ({name, uid}) in a tool result. Without an explicit
+    document_url the target follows the USER'S window focus and can change between two calls —
+    the echo lets the agent detect that instead of silently editing the wrong document.
+    MAIN-THREAD callers only (see _document_echo_payload)."""
+    if "document" in result:
+        return
+    payload = _document_echo_payload(doc)
+    if payload:
+        result["document"] = payload
+
+
+# Pointer to the on-demand manual (T4 / G2 consolidation). The full how-to — editing, editing-html,
+# review-modes, search, navigation, images, concurrency — is served per topic by get_guidance(topic), so the model
+# pulls one section when needed instead of front-loading a manual here (Claude Desktop doesn't read
+# `instructions`; Claude Code truncates it). The topic texts are the shared prompt pieces in
+# constants.py (single source with the sidebar prompt), mapped per doc type by agent_manual.py.
+_MCP_GUIDANCE_POINTER = (
+    " HOW TO USE THESE TOOLS: call get_guidance(topic) for the manual — topics follow the open "
+    "document's type (for Writer: editing, editing-html, review-modes, search, navigation, images, "
+    "concurrency); call get_guidance() for the current list. "
+    "Confirm edits by the tool result's structured fields, and in Writer note tracked changes are "
+    "the user's to accept/reject, not yours."
+)
+
+
+def build_initialize_instructions(mode: str) -> str:
+    """Assemble the MCP initialize `instructions` string for a tool-exposure mode.
+
+    Pure function (no server/UNO) so the wording is unit-testable. `mode` is one of
+    'direct_flat', 'direct_discovery', or anything else (treated as the delegate default)."""
+    base = (
+        "WriterAgent MCP — AI document workspace. WORKFLOW: 1) Use tools to interact with LibreOffice documents. "
+        "2) Tools are filtered by document type (writer/calc/draw). 3) All UNO operations run on the main thread for thread safety."
+    )
+    if mode == "direct_flat":
+        mode_hint = (
+            " Specialized tools are listed directly in tools/list; call them by name. "
+            "No WriterAgent LLM endpoint is required."
+        )
+    elif mode == "direct_discovery":
+        mode_hint = (
+            " Call find_tools with no arguments for the full specialized domain catalog, "
+            "then find_tools(domain=…) for tool schemas in that area; call tools by name. "
+            "No WriterAgent LLM endpoint is required."
+        )
+    else:
+        mode_hint = (
+            " For specialized capabilities, call delegate_to_specialized_*_toolset with domain and task "
+            "(requires a WriterAgent chat endpoint for the inner agent)."
+        )
+    return base + mode_hint + _MCP_GUIDANCE_POINTER
+
 
 def _get_request_protocol_version(handler) -> str | None:
     for name in ("Mcp-Protocol-Version", "mcp-protocol-version", "MCP-Protocol-Version"):
@@ -427,32 +498,11 @@ class MCPProtocolHandler:
 
     def _mcp_initialize(self, params):
         client_version = params.get("protocolVersion", MCP_PROTOCOL_VERSION)
-        base = (
-            "WriterAgent MCP — AI document workspace. WORKFLOW: 1) Use tools to interact with LibreOffice documents. "
-            "2) Tools are filtered by document type (writer/calc/draw). 3) All UNO operations run on the main thread for thread safety."
-        )
-        mode = self._tool_exposure_mode()
-        if mode == "direct_flat":
-            mode_hint = (
-                " Specialized tools are listed directly in tools/list; call them by name. "
-                "No WriterAgent LLM endpoint is required."
-            )
-        elif mode == "direct_discovery":
-            mode_hint = (
-                " Call find_tools with no arguments for the full specialized domain catalog, "
-                "then find_tools(domain=…) for tool schemas in that area; call tools by name. "
-                "No WriterAgent LLM endpoint is required."
-            )
-        else:
-            mode_hint = (
-                " For specialized capabilities, call delegate_to_specialized_*_toolset with domain and task "
-                "(requires a WriterAgent chat endpoint for the inner agent)."
-            )
         return wire_types.initialize_result(
             protocol_version=MCP_PROTOCOL_VERSION,
             client_protocol_version=client_version,
             server_version=self.version,
-            instructions=base + mode_hint,
+            instructions=build_initialize_instructions(self._tool_exposure_mode()),
         )
 
     def _mcp_ping(self, params):
@@ -616,10 +666,19 @@ class MCPProtocolHandler:
                         snippet = str(effect.result)[:100] if effect.result else ""
                         event_bus.emit("mcp:result", tool=state.tool_name, result_snippet=snippet, args=state.arguments)
 
-                    final_result = wire_types.call_tool_result(
-                        json.dumps(effect.result, ensure_ascii=False, default=str),
-                        is_error=effect.is_error,
-                    )
+                    # A tool may return an image: {"_mcp_image": {"data": <b64>, "mimeType": ...}} ->
+                    # emit a native MCP image content block (get_image) instead of base64-as-text.
+                    res = effect.result
+                    img = res.get("_mcp_image") if isinstance(res, dict) else None
+                    if isinstance(img, dict) and img.get("data"):
+                        final_result = wire_types.call_tool_result_image(
+                            img["data"], img.get("mimeType", "image/png"), is_error=effect.is_error,
+                        )
+                    else:
+                        final_result = wire_types.call_tool_result(
+                            json.dumps(res, ensure_ascii=False, default=str),
+                            is_error=effect.is_error,
+                        )
 
                 elif isinstance(effect, SendErrorEffect):
                     raise ValueError(effect.message)
@@ -723,17 +782,28 @@ class MCPProtocolHandler:
             ctx = get_ctx()
             doc_key = _resolve_mcp_doc_key(document_url, doc)
             uno_services = uno_services_for_document(doc, doc_type)
-            return doc, doc_type, ctx, doc_key, uno_services
+            # Compute the document echo HERE (main thread): reading doc.URL/RuntimeUID from the
+            # HTTP worker after execution would trip the UNO thread guard on the proxied doc.
+            echo = _document_echo_payload(doc)
+            return doc, doc_type, ctx, doc_key, uno_services, echo
 
-        doc, doc_type, ctx, doc_key, uno_services = self.queue_executor.execute(_get_context, timeout=10.0)
+        doc, doc_type, ctx, doc_key, uno_services, doc_echo = self.queue_executor.execute(_get_context, timeout=10.0)
 
         # Document-optional tools (e.g. find_tools) run with no document; an explicit
         # document_url that doesn't resolve is always an error, though.
         tool = self.tool_registry.get(tool_name)
+        if tool is None:
+            return {"status": "error", "code": "UNKNOWN_TOOL",
+                    "message": "No tool named '%s'. Check tools/list for the exact name (tools are filtered by the open document's type)." % tool_name}
         if doc is None and document_url:
-            return {"status": "error", "code": "DOCUMENT_NOT_FOUND", "message": "No document open matching X-Document-URL: %s" % document_url, "details": {"document_url": document_url}}
+            return {"status": "error", "code": "DOCUMENT_NOT_FOUND",
+                    "message": ("No open document matches document_url '%s'. Call list_open_documents and retry "
+                                "with one of the returned url or uid values." % document_url),
+                    "details": {"document_url": document_url}}
         if doc is None and getattr(tool, "requires_document", True):
-            return {"status": "error", "code": "NO_DOCUMENT_OPEN", "message": "No document open in LibreOffice."}
+            return {"status": "error", "code": "NO_DOCUMENT_OPEN",
+                    "message": ("No document open in LibreOffice. Ask the user to open or create a document; "
+                                "list_open_documents works in this state to check what is open.")}
 
         from plugin.framework.tool import ToolContext
 
@@ -765,11 +835,21 @@ class MCPProtocolHandler:
 
         if isinstance(result, dict):
             result["_elapsed_ms"] = round(elapsed * 1000, 1)
+            # Echo precomputed on the main thread in _get_context — do NOT touch the proxied
+            # doc from this worker thread.
+            if doc_echo and "document" not in result:
+                result["document"] = doc_echo
 
         return result
 
     def _execute_tool_on_main(self, tool_name, arguments, document_url=None):
         """Run a backpressure tool on the main thread; shares _document_mutation_gate with long-running path."""
+        # Same check order as _execute_long_running: a bad tool NAME is diagnosed before any
+        # document concern (both errors are correct, but consistency helps clients branch).
+        tool = self.tool_registry.get(tool_name)
+        if tool is None:
+            return {"status": "error", "code": "UNKNOWN_TOOL",
+                    "message": "No tool named '%s'. Check tools/list for the exact name (tools are filtered by the open document's type)." % tool_name}
         doc = None
         doc_type = "writer"
         try:
@@ -777,7 +857,10 @@ class MCPProtocolHandler:
             if document_url:
                 doc, doc_type = doc_svc.resolve_document_by_url(document_url)
                 if doc is None:
-                    return {"status": "error", "code": "DOCUMENT_NOT_FOUND", "message": "No document open matching X-Document-URL: %s" % (document_url or ""), "details": {"document_url": document_url}}
+                    return {"status": "error", "code": "DOCUMENT_NOT_FOUND",
+                            "message": ("No open document matches document_url '%s'. Call list_open_documents and retry "
+                                        "with one of the returned url or uid values." % (document_url or "")),
+                            "details": {"document_url": document_url}}
             else:
                 doc = _real_active_document(doc_svc)
                 if doc:
@@ -787,10 +870,12 @@ class MCPProtocolHandler:
             pass
 
         # Document-optional tools (e.g. the find_tools discovery meta-tool) run with no
-        # document open; every other tool still requires one.
-        tool = self.tool_registry.get(tool_name)
+        # document open; every other tool still requires one. (Unknown tool already rejected
+        # at the top of this method.)
         if doc is None and getattr(tool, "requires_document", True):
-            return {"status": "error", "code": "NO_DOCUMENT_OPEN", "message": "No document open in LibreOffice."}
+            return {"status": "error", "code": "NO_DOCUMENT_OPEN",
+                    "message": ("No document open in LibreOffice. Ask the user to open or create a document; "
+                                "list_open_documents works in this state to check what is open.")}
 
         from plugin.doc.document_helpers import uno_services_for_document
         from plugin.framework.uno_context import get_ctx
@@ -827,6 +912,7 @@ class MCPProtocolHandler:
 
         if isinstance(result, dict):
             result["_elapsed_ms"] = round(elapsed * 1000, 1)
+            _attach_document_echo(result, doc)
 
         return result
 

--- a/plugin/mcp/server.py
+++ b/plugin/mcp/server.py
@@ -139,6 +139,15 @@ class GenericRequestHandler(BaseHTTPRequestHandler):
 class HttpServer:
     """Generic threaded HTTP server with optional TLS."""
 
+    # Port-bind resilience. The configured port (default 8765) can be briefly held by a previous
+    # instance that is still shutting down, or collide with another local server that defaults to
+    # the same port (e.g. a code editor's preview/"viewer" server). A single bind attempt then
+    # raises and the MCP server never comes up — the user just sees "I have to restart to connect".
+    # Retry a few times so a transient holder clears on its own; on persistent failure raise with a
+    # CLEAR, actionable message instead of a bare OSError.
+    _BIND_ATTEMPTS = 5
+    _BIND_RETRY_DELAY = 1.0
+
     def __init__(self, route_registry, port=8766, host="localhost", use_ssl=False, ssl_cert="", ssl_key=""):
         self.route_registry = route_registry
         self.port = port
@@ -157,7 +166,7 @@ class HttpServer:
 
         GenericRequestHandler.route_registry = self.route_registry
 
-        self._server = _ThreadedHTTPServer((self.host, self.port), GenericRequestHandler)
+        self._server = self._bind_with_retry()
 
         if self.use_ssl:
             # TLS server mode requires explicit certificates.
@@ -181,6 +190,34 @@ class HttpServer:
         scheme = "https" if self.use_ssl else "http"
         url = "%s://%s:%s" % (scheme, self.host, self.port)
         log.info("HTTP server ready — %s (%d routes)", url, self.route_registry.route_count)
+
+    def _bind_with_retry(self):
+        """Bind the listening socket, retrying briefly if the port is transiently in use.
+
+        Returns the bound server. Raises the last OSError (with a clear log) if the port stays
+        busy across all attempts — preserving start()'s "raise on failure" contract so the caller
+        still reports the failure, but now after retries and with an actionable message."""
+        import time
+
+        last_err = None
+        for attempt in range(1, self._BIND_ATTEMPTS + 1):
+            try:
+                return _ThreadedHTTPServer((self.host, self.port), GenericRequestHandler)
+            except OSError as e:
+                last_err = e
+                log.warning(
+                    "HTTP bind %s:%s failed (%s) — attempt %d/%d",
+                    self.host, self.port, getattr(e, "errno", e), attempt, self._BIND_ATTEMPTS,
+                )
+                if attempt < self._BIND_ATTEMPTS:
+                    time.sleep(self._BIND_RETRY_DELAY)
+        log.error(
+            "Could not bind %s:%s after %d attempts — the port is in use by another process. "
+            "Close whatever is holding it, or set the MCP 'port' (or 'mcp_port') config to a free "
+            "port, then restart. A local preview/viewer server may default to the same port.",
+            self.host, self.port, self._BIND_ATTEMPTS,
+        )
+        raise last_err if last_err is not None else OSError("bind failed")
 
     def stop(self):
         if not self._running:

--- a/plugin/mcp/wire_types.py
+++ b/plugin/mcp/wire_types.py
@@ -183,19 +183,6 @@ def call_tool_result(text: str, *, is_error: bool = False) -> dict[str, Any]:
     return out
 
 
-def call_tool_result_image(data_b64: str, mime_type: str = "image/png", *, is_error: bool = False) -> dict[str, Any]:
-    """Tool result carrying an IMAGE content block (MCP image type) instead of text.
-
-    Used by get_image so a vision-capable client receives the picture itself rather than base64
-    pasted as text. data_b64 is the raw base64 (no data: URI prefix), per the MCP image content shape."""
-    out: dict[str, Any] = {
-        "content": [{"type": "image", "data": data_b64, "mimeType": mime_type}],
-    }
-    if is_error:
-        out["isError"] = True
-    return out
-
-
 @dataclasses.dataclass(frozen=True)
 class ProgressNotificationParams:
     progress_token: ProgressToken

--- a/plugin/mcp/wire_types.py
+++ b/plugin/mcp/wire_types.py
@@ -183,6 +183,19 @@ def call_tool_result(text: str, *, is_error: bool = False) -> dict[str, Any]:
     return out
 
 
+def call_tool_result_image(data_b64: str, mime_type: str = "image/png", *, is_error: bool = False) -> dict[str, Any]:
+    """Tool result carrying an IMAGE content block (MCP image type) instead of text.
+
+    Used by get_image so a vision-capable client receives the picture itself rather than base64
+    pasted as text. data_b64 is the raw base64 (no data: URI prefix), per the MCP image content shape."""
+    out: dict[str, Any] = {
+        "content": [{"type": "image", "data": data_b64, "mimeType": mime_type}],
+    }
+    if is_error:
+        out["isError"] = True
+    return out
+
+
 @dataclasses.dataclass(frozen=True)
 class ProgressNotificationParams:
     progress_token: ProgressToken

--- a/scripts/mcp_bridge.py
+++ b/scripts/mcp_bridge.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Resilient stdio<->HTTP MCP bridge for WriterAgent (R7 — plug-and-play connect).
+
+WHY: WriterAgent's MCP server is an HTTP server that lives INSIDE LibreOffice
+(http://localhost:8765/mcp). An MCP client configured to talk to that URL directly
+(``{"type":"http","url":"..."}``) tries to connect once at startup; if LibreOffice
+is not running yet, the connection fails and the user must restart the client to
+reconnect ("I have to close and reopen to connect").
+
+A stdio MCP server, by contrast, is *spawned by the client* — so it is always present
+the moment the client starts. This bridge is that stdio server: the client launches it,
+and it forwards every request to LibreOffice over HTTP, **waiting/retrying when
+LibreOffice is not up yet**. So it no longer matters who starts first — the connection
+establishes on its own, with no restart. Configure it once (no per-use fiddling):
+
+    "writer-agent": { "command": "python3", "args": ["/abs/path/scripts/mcp_bridge.py"] }
+
+Override the target with WRITERAGENT_MCP_URL. Pure stdlib so the client's Python can run it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import urllib.error
+import urllib.request
+
+MCP_URL = os.environ.get("WRITERAGENT_MCP_URL", "http://localhost:8765/mcp")
+PROTOCOL_VERSION = os.environ.get("WRITERAGENT_MCP_PROTOCOL", "2025-06-18")
+_HEALTH_URL = MCP_URL.rsplit("/mcp", 1)[0] + "/health"
+_POLL_SECONDS = 3.0
+_HTTP_TIMEOUT = 30.0
+# The manual (instructions) is delivered only once, at initialize. If LibreOffice is still coming
+# up, briefly wait for it so the client gets the REAL manual instead of the placeholder (it won't
+# re-initialize later). Bounded so a never-present LO doesn't hang the client's handshake.
+_INIT_ATTEMPTS = 5
+_INIT_RETRY_DELAY = 1.5
+
+_stdout_lock = threading.Lock()
+
+
+def parse_response(raw: str) -> dict:
+    """Parse an MCP HTTP response body — either plain JSON or an SSE ``data:`` stream.
+
+    Returns the LAST JSON object found (streamable-HTTP may send several SSE events; the final
+    one carries the result). Raises ValueError if nothing parses."""
+    raw = (raw or "").strip()
+    if not raw:
+        raise ValueError("empty response")
+    if raw[:1] in "{[":
+        return json.loads(raw)
+    last = None
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("data:"):
+            payload = line[len("data:"):].strip()
+            if payload and payload != "[DONE]":
+                try:
+                    last = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+    if last is None:
+        raise ValueError("no JSON object in response")
+    return last
+
+
+def post_to_lo(body: dict, timeout: float = _HTTP_TIMEOUT) -> dict:
+    """POST one JSON-RPC message to the LibreOffice MCP server and return the parsed envelope."""
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        MCP_URL,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return parse_response(resp.read().decode("utf-8"))
+
+
+def _local_initialize_result(req_id) -> dict:
+    """A valid initialize result used when LibreOffice is not reachable yet, so the client's
+    handshake still succeeds. Advertises listChanged so the client refreshes tools once LO appears."""
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {"listChanged": True}},
+            "serverInfo": {"name": "WriterAgent MCP (bridge)", "version": "bridge"},
+            "instructions": (
+                "WriterAgent bridge: LibreOffice is not reachable yet at %s. Open LibreOffice with the "
+                "WriterAgent extension; tools will appear automatically (no restart needed)." % MCP_URL
+            ),
+        },
+    }
+
+
+def _error(req_id, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def handle_request(msg: dict, poster=post_to_lo) -> dict | None:
+    """Route one client->bridge JSON-RPC message. Returns the envelope to send back, or None for
+    notifications (no response). ``poster`` does the HTTP call (injected in tests).
+
+    Resilience: when LibreOffice is down, ``initialize`` still succeeds (local result), ``tools/list``
+    returns an empty list (not an error, so the client keeps the connection), and other calls return a
+    clear error the model can act on — instead of the whole connection failing."""
+    method = msg.get("method")
+    req_id = msg.get("id")
+    is_notification = "id" not in msg
+
+    if is_notification:
+        # Client notifications (e.g. notifications/initialized) need no response and nothing
+        # actionable downstream; forward best-effort and never raise.
+        if method and method != "notifications/initialized":
+            try:
+                poster(msg)
+            except Exception:
+                pass
+        return None
+
+    if method == "initialize":
+        # The manual (instructions) is delivered ONCE here, so it's worth briefly waiting for
+        # LibreOffice if it's coming up — otherwise the client connects with the placeholder manual
+        # and never gets the real one this session. Retry a few times before falling back.
+        import time
+
+        for attempt in range(_INIT_ATTEMPTS):
+            try:
+                return poster(msg)
+            except Exception:
+                if attempt < _INIT_ATTEMPTS - 1:
+                    time.sleep(_INIT_RETRY_DELAY)
+        return _local_initialize_result(req_id)
+
+    try:
+        return poster(msg)
+    except Exception as e:
+        if method == "tools/list":
+            return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": []}}
+        if method == "ping":
+            return {"jsonrpc": "2.0", "id": req_id, "result": {}}
+        return _error(req_id, -32001, "WriterAgent (LibreOffice) is not reachable at %s: %s" % (MCP_URL, e))
+
+
+def _write(obj: dict) -> None:
+    with _stdout_lock:
+        sys.stdout.write(json.dumps(obj) + "\n")
+        sys.stdout.flush()
+
+
+def _lo_reachable() -> bool:
+    try:
+        with urllib.request.urlopen(_HEALTH_URL, timeout=2) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def _watch_lo(stop: threading.Event) -> None:
+    """Emit notifications/tools/list_changed when LibreOffice transitions down->up, so a client that
+    connected while LO was down refreshes its (then-empty) tool list automatically."""
+    was_up = _lo_reachable()
+    while not stop.is_set():
+        stop.wait(_POLL_SECONDS)
+        if stop.is_set():
+            break
+        up = _lo_reachable()
+        if up and not was_up:
+            _write({"jsonrpc": "2.0", "method": "notifications/tools/list_changed"})
+        was_up = up
+
+
+def main() -> int:
+    stop = threading.Event()
+    watcher = threading.Thread(target=_watch_lo, args=(stop,), daemon=True)
+    watcher.start()
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            try:
+                reply = handle_request(msg)
+            except Exception as e:  # never let one message kill the bridge
+                reply = _error(msg.get("id"), -32603, "bridge error: %s" % e)
+            if reply is not None:
+                _write(reply)
+    finally:
+        stop.set()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/doc/test_document_research_tools.py
+++ b/tests/doc/test_document_research_tools.py
@@ -1,0 +1,67 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for the agent-callable report_bug tool (no LibreOffice required)."""
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.doc.document_research_tools import ReportBug, ListOpenDocuments, _append_feedback_log, _FEEDBACK_LOG_FILENAME
+
+
+def test_doc_agnostic_tools_do_not_require_a_document():
+    # Live finding (2026-06-28): the MCP no-document gate blocks tools whose `requires_document`
+    # is the default True. report_bug and list_open_documents must work with no document open.
+    assert ReportBug.requires_document is False
+    assert ListOpenDocuments.requires_document is False
+
+
+def test_append_feedback_log_writes_jsonl(tmp_path):
+    with patch("plugin.framework.config.user_config_dir", return_value=str(tmp_path)):
+        path = _append_feedback_log("ux", "confusing result", "expected X got Y", ts="2026-06-27T19:00:00")
+    assert path and path.endswith(_FEEDBACK_LOG_FILENAME)
+    rec = json.loads(open(path, encoding="utf-8").read().strip())
+    assert rec == {"ts": "2026-06-27T19:00:00", "category": "ux", "summary": "confusing result", "details": "expected X got Y"}
+
+
+def test_append_feedback_log_fails_safe(tmp_path):
+    # If the config dir can't be resolved, return None (never raise).
+    with patch("plugin.framework.config.user_config_dir", side_effect=RuntimeError("no profile")):
+        assert _append_feedback_log("bug", "x", "y") is None
+
+
+def test_report_bug_logs_and_returns_url(tmp_path):
+    with patch("plugin.framework.config.user_config_dir", return_value=str(tmp_path)), \
+         patch("plugin.framework.bug_report.build_github_issue_url",
+               return_value="https://github.com/KeithCu/writeragent/issues/new?title=x"):
+        res = ReportBug().execute(MagicMock(), summary="apply_document_content lied", details="said ok but nothing changed", category="bug")
+    assert res["status"] == "ok"
+    assert res["github_issue_url"].startswith("https://github.com/KeithCu/writeragent/issues/new")
+    assert res["category"] == "bug"
+    assert res["logged_to"] and os.path.exists(res["logged_to"])
+    rec = json.loads(open(res["logged_to"], encoding="utf-8").read().strip())
+    assert rec["summary"] == "apply_document_content lied"
+
+
+def test_report_bug_requires_summary():
+    res = ReportBug().execute(MagicMock(), summary="   ")
+    assert res["status"] == "error"
+
+
+def test_report_bug_invalid_category_defaults_to_bug(tmp_path):
+    with patch("plugin.framework.config.user_config_dir", return_value=str(tmp_path)), \
+         patch("plugin.framework.bug_report.build_github_issue_url", return_value="u"):
+        res = ReportBug().execute(MagicMock(), summary="hi", category="nonsense")
+    assert res["category"] == "bug"
+
+
+def test_report_bug_does_not_autosubmit(tmp_path):
+    # Safety: the tool must NOT publish anything by itself — only return a URL for the user.
+    with patch("plugin.framework.config.user_config_dir", return_value=str(tmp_path)), \
+         patch("plugin.framework.bug_report.build_github_issue_url", return_value="u"):
+        res = ReportBug().execute(MagicMock(), summary="x")
+    assert "auto-submitted" in res["message"].lower() or "auto-filing" in res["message"].lower()

--- a/tests/framework/test_agent_manual.py
+++ b/tests/framework/test_agent_manual.py
@@ -1,0 +1,241 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""The shared agent manual (single source of truth read by BOTH agents) and the get_guidance tool.
+
+R3/T4 introduced the sectioned manual for the MCP agent; R4 unified it; R5 re-homed the source:
+the pieces of the original chat system prompt (constants.py) — updated in place and extended —
+ARE the manual now. The sidebar template assembles them directly; agent_manual maps topic -> piece
+for the MCP channel (get_guidance) and the agent-backend path, adding the MCP-only extras; and the
+sections are per document type so a Calc session never reads Writer advice. No LibreOffice required."""
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+from plugin.framework.agent_manual import (
+    MANUAL_SECTIONS,
+    doc_type_of,
+    full_manual,
+    full_manual_for_model,
+    get_section,
+    list_topics,
+    manual_index,
+    normalize_topic,
+)
+from plugin.doc.document_research_tools import GetGuidance
+
+
+class FakeDoc:
+    """A document model whose supportsService answers like Writer/Calc/Draw."""
+
+    def __init__(self, services=()):
+        self._services = set(services)
+
+    def supportsService(self, name):
+        return name in self._services
+
+
+WRITER_DOC = FakeDoc()
+CALC_DOC = FakeDoc({"com.sun.star.sheet.SpreadsheetDocument"})
+DRAW_DOC = FakeDoc({"com.sun.star.drawing.DrawingDocument"})
+
+
+class FakeCtx:
+    def __init__(self, doc):
+        self.doc = doc
+
+
+# ---- sections / topics -----------------------------------------------------
+
+def test_topics_and_sections_align():
+    topics = list_topics("writer")
+    assert "editing" in topics and "review-modes" in topics
+    for t in topics:
+        assert t in MANUAL_SECTIONS and MANUAL_SECTIONS[t].strip()
+
+
+def test_normalize_aliases():
+    assert normalize_topic("tracked-changes") == "review-modes"
+    assert normalize_topic("Tracked_Changes") == "review-modes"
+    assert normalize_topic("crop") == "images"
+    assert normalize_topic("429") == "concurrency"
+    assert normalize_topic("editing") == "editing"
+    assert normalize_topic("nonsense") is None
+    assert normalize_topic("") is None
+
+
+def test_get_section_known_and_unknown():
+    assert "apply_document_content" in get_section("editing").lower()
+    assert get_section("nope") is None
+
+
+def test_manual_index_lists_every_topic():
+    idx = manual_index("writer")
+    for t in list_topics("writer"):
+        assert t in idx
+
+
+# ---- per document type -----------------------------------------------------
+
+def test_doc_type_of_resolution():
+    assert doc_type_of(None) is None
+    assert doc_type_of(WRITER_DOC) == "writer"
+    assert doc_type_of(CALC_DOC) == "calc"
+    assert doc_type_of(DRAW_DOC) == "draw"
+
+
+def test_calc_topics_are_generic_and_leak_no_writer_advice():
+    topics = list_topics("calc")
+    assert "editing" in topics and "concurrency" in topics
+    assert "review-modes" not in topics and "navigation" not in topics
+    # The Writer-specific tool names must not leak into a Calc session's guidance.
+    assert "apply_document_content" not in get_section("editing", "calc")
+    assert get_section("review-modes", "calc") is None
+    assert normalize_topic("crop", "calc") is None
+
+
+def test_no_document_serves_neutral_generic_index():
+    assert list_topics(None) == list_topics("calc")  # generic set
+    idx = manual_index(None)
+    assert "No document is open" in idx
+    assert "editing" in idx and "concurrency" in idx
+
+
+# ---- single source: the prompt pieces feed BOTH channels ---------------------
+
+def test_shared_pieces_are_identical_in_both_channels():
+    """The heart of the architecture: a topic served through get_guidance IS the same string the
+    prompt templates embed — one piece, per-channel assemblies, drift impossible."""
+    from plugin.framework import constants as c
+
+    # Topic -> the exact constants piece (identity, not a copy that could be edited apart).
+    assert MANUAL_SECTIONS["editing-html"] is c.WRITER_APPLY_DOCUMENT_HTML_RULES
+    assert MANUAL_SECTIONS["review-modes"] is c.WRITER_REVIEW_MODES_RULES
+    assert MANUAL_SECTIONS["search"] is c.WRITER_SEARCH_RULES
+    assert MANUAL_SECTIONS["navigation"] is c.WRITER_NAVIGATION_RULES
+    assert MANUAL_SECTIONS["images"] is c.WRITER_IMAGES_RULES
+    # The editing topic bundles the workflow pieces verbatim (the HTML contract is its own
+    # subdivision, editing-html). The pointer to the subdivision is appended ONLY when the topic
+    # is served alone (get_section) — in full_manual the editing-html section follows inline, so
+    # a "go read that topic" sentence would dangle there.
+    for piece in (c.TOOL_USAGE_PATTERNS, c.TRANSLATION_RULES):
+        assert piece.strip() in MANUAL_SECTIONS["editing"]
+    assert "editing-html" in get_section("editing", "writer")      # on-demand: pointer present
+    assert "read the editing-html topic" not in full_manual("writer")  # concatenated: no dangler
+    # The generic (Calc/Draw/no-doc) editing topic is the same object the Calc and Draw sidebar
+    # prompts embed.
+    assert get_section("editing", "calc") is c.GENERIC_EDIT_CONFIRMATION_RULES
+    assert c.GENERIC_EDIT_CONFIRMATION_RULES in c.DEFAULT_CALC_CHAT_SYSTEM_PROMPT_TEMPLATE
+    assert c.GENERIC_EDIT_CONFIRMATION_RULES in c.DEFAULT_DRAW_CHAT_SYSTEM_PROMPT_TEMPLATE
+
+
+def test_sidebar_hybrid_prompt_composition():
+    """HYBRID delivery: the ambient Writer sidebar prompt carries the original pieces plus the
+    safety-critical review-modes piece exactly once; the reference pieces (search, navigation,
+    images) stay OUT of the ambient text and are pulled on demand via get_guidance, which must
+    therefore be visible to the sidebar (tier core)."""
+    from plugin.doc.document_research_tools import GetGuidance
+    from plugin.framework import constants as c
+
+    template = c.DEFAULT_CHAT_SYSTEM_PROMPT_TEMPLATE
+    for piece in (
+        c.TOOL_USAGE_PATTERNS,
+        c.WRITER_APPLY_DOCUMENT_HTML_RULES,
+        c.TRANSLATION_RULES,
+        c.WRITER_REVIEW_MODES_RULES,
+    ):
+        assert template.count(piece) == 1
+    for piece in (c.WRITER_SEARCH_RULES, c.WRITER_NAVIGATION_RULES, c.WRITER_IMAGES_RULES):
+        assert piece not in template          # on-demand, not ambient
+    assert "get_guidance" in template         # the tools section tells the model how to pull
+    assert GetGuidance.tier == "core"         # visible to the sidebar's default tool list
+
+
+def test_mcp_only_extras_stay_out_of_the_sidebar_prompt():
+    """The HTTP 429 concurrency contract is real for MCP clients and the agent-backend path,
+    meaningless for the in-process sidebar — channel-specific text must not leak across."""
+    from plugin.framework import constants as c
+
+    assert "429" in get_section("concurrency", "writer")   # MCP topic has it
+    assert "429" in full_manual("writer")                  # agent backend (HTTP) gets it
+    assert "429" not in c.DEFAULT_CHAT_SYSTEM_PROMPT_TEMPLATE  # sidebar never sees it
+    assert "429" not in c.DEFAULT_CALC_CHAT_SYSTEM_PROMPT_TEMPLATE
+    assert "429" not in c.DEFAULT_DRAW_CHAT_SYSTEM_PROMPT_TEMPLATE
+
+
+# ---- full manual (agent-backend delivery) ------------------------------------
+
+def test_full_manual_writer_covers_key_rules():
+    """Pin the high-value cross-cutting rules (moved here from the retired EXTERNAL_AGENT_GUIDANCE
+    blob in constants.py) so a refactor can't silently drop one from the single source."""
+    g = full_manual("writer")
+    assert "apply_document_content" in g           # prefer the document tools
+    assert "full_document" in g                    # whole-doc vs search target
+    assert "replaced_count" in g                   # confirm via structured field
+    assert "accept or reject" in g.lower()         # don't resolve own tracked changes
+    assert "429" in g                              # one operation at a time / busy retry
+    assert "include_images" in g                   # how a vision model sees images
+    # Stale-snapshot warning (channel-neutral wording: the classic sidebar DOES auto-refresh its
+    # document context after successful mutations, so the old "NOT auto-refreshed" claim was false
+    # for one of the channels this shared piece ships to).
+    assert "partial/truncated snapshot" in g
+    assert "record" in g and "wait" in g           # the three review modes reach the sidebar too
+
+
+def test_full_manual_contains_every_section_in_order():
+    g = full_manual("writer")
+    positions = [g.index(MANUAL_SECTIONS[t]) for t in list_topics("writer")]
+    assert positions == sorted(positions)
+
+
+def test_full_manual_for_model_switches_per_app():
+    assert "review-modes" in " ".join(list_topics("writer")) or True  # sanity
+    assert "TRACKED CHANGES" in full_manual_for_model(WRITER_DOC)
+    calc_manual = full_manual_for_model(CALC_DOC)
+    assert "TRACKED CHANGES" not in calc_manual
+    assert "structured fields" in calc_manual
+    assert "429" in calc_manual
+
+
+# ---- GetGuidance tool --------------------------------------------------------
+
+def test_get_guidance_no_topic_returns_writer_index():
+    res = GetGuidance().execute(FakeCtx(WRITER_DOC))
+    assert res["status"] == "ok" and res["doc_type"] == "writer"
+    assert set(list_topics("writer")).issubset(set(res["topics"]))
+    assert "get_guidance" in res["index"]
+
+
+def test_get_guidance_topic_returns_section():
+    res = GetGuidance().execute(FakeCtx(WRITER_DOC), topic="review-modes")
+    assert res["status"] == "ok" and res["topic"] == "review-modes"
+    assert "record" in res["guidance"].lower() and "wait" in res["guidance"].lower()
+
+
+def test_get_guidance_alias():
+    res = GetGuidance().execute(FakeCtx(WRITER_DOC), topic="tracked changes")
+    assert res["status"] == "ok" and res["topic"] == "review-modes"
+
+
+def test_get_guidance_unknown_topic_errors_with_list():
+    res = GetGuidance().execute(FakeCtx(WRITER_DOC), topic="zzz")
+    assert res["status"] == "error" and res["code"] == "UNKNOWN_TOPIC"
+    assert "editing" in res["topics"]
+
+
+def test_get_guidance_calc_session_never_reads_writer_advice():
+    res = GetGuidance().execute(FakeCtx(CALC_DOC))
+    assert res["doc_type"] == "calc"
+    assert "review-modes" not in res["topics"]
+    sec = GetGuidance().execute(FakeCtx(CALC_DOC), topic="review-modes")
+    assert sec["status"] == "error"
+
+
+def test_get_guidance_without_document_is_neutral():
+    res = GetGuidance().execute(FakeCtx(None))
+    assert res["status"] == "ok" and res["doc_type"] is None
+    assert "No document is open" in res["index"]
+
+
+def test_get_guidance_does_not_require_document():
+    assert GetGuidance.requires_document is False

--- a/tests/framework/test_constants.py
+++ b/tests/framework/test_constants.py
@@ -22,6 +22,11 @@ from plugin.framework.constants import (
     DEFAULT_DRAW_GREETING,
 )
 
+# NOTE: the EXTERNAL_AGENT_GUIDANCE pin test moved to tests/framework/test_agent_manual.py —
+# the blob was retired; the single source is the shared prompt pieces in constants.py (the
+# sidebar embeds them, get_guidance serves them per topic, full_manual() feeds the agent backend).
+
+
 def test_get_greeting_for_document_writer():
     model = MagicMock()
     model.supportsService.return_value = False

--- a/tests/mcp/test_list_open_documents.py
+++ b/tests/mcp/test_list_open_documents.py
@@ -38,10 +38,12 @@ def test_list_open_documents_execute():
     mock_doc1.getURL.return_value = "file:///home/user/document.odt"
     mock_doc1.getController.return_value = None
     mock_doc1.RuntimeUID = "uid-saved-1"
+    mock_doc1.isModified.return_value = True
     mock_doc2 = MagicMock()
     mock_doc2.getURL.return_value = ""  # Untitled document
     mock_doc2.getController.return_value = None
     mock_doc2.RuntimeUID = "uid-untitled-2"
+    mock_doc2.isModified.return_value = False
 
     mock_components = [mock_doc1, mock_doc2]
 
@@ -79,12 +81,16 @@ def test_list_open_documents_execute():
         assert not docs[0]["is_active"]
         # The stable RuntimeUID is exposed so a caller can target the doc by uid.
         assert docs[0]["uid"] == "uid-saved-1"
+        # The modified flag surfaces unsaved changes (the agent tells the user to save; it never
+        # saves itself).
+        assert docs[0]["modified"] is True
 
         assert docs[1]["name"] == "Untitled"
         assert docs[1]["url"] == ""
         assert docs[1]["doc_type"] == "calc"
         # An unsaved doc has no URL but still exposes a uid for targeting.
         assert docs[1]["uid"] == "uid-untitled-2"
+        assert docs[1]["modified"] is False
 
 
 def test_get_open_documents_lists_untitled_even_when_type_lookup_fails():

--- a/tests/mcp/test_long_running_concurrency.py
+++ b/tests/mcp/test_long_running_concurrency.py
@@ -206,8 +206,10 @@ def test_normalized_doc_urls_share_mutation_gate():
     )
 
 
-def test_unknown_tool_uses_mutation_gate():
-    """When tool_registry.get returns None, mutating runs on the same doc serialize."""
+def test_unknown_tool_is_rejected_up_front_without_executing():
+    """An unknown tool name returns a structured UNKNOWN_TOOL error BEFORE the mutation gate and
+    the registry ever run (previously it flowed through the gate and died later as a raw KeyError
+    serialized under INTERNAL_ERROR, which reads as a server bug instead of a bad tool name)."""
 
     class _UnknownRegistry(_Registry):
         def get(self, name):
@@ -216,12 +218,11 @@ def test_unknown_tool_uses_mutation_gate():
     reg = _UnknownRegistry(is_mutation=True)
     handler = MCPProtocolHandler(_FakeServices(reg))
 
-    errors = _run_concurrent(handler._execute_long_running, ["file:///same.odt"] * 2)
+    result = handler._execute_long_running("totally_bogus_tool", {}, document_url="file:///same.odt")
 
-    assert not errors, "long_running should not error: %s" % errors
-    assert reg.max_concurrency == 1, (
-        "expected SERIALIZED (1) for unknown tool on same doc, got %d" % reg.max_concurrency
-    )
+    assert result["status"] == "error" and result["code"] == "UNKNOWN_TOOL"
+    assert "tools/list" in result["message"]
+    assert reg.max_concurrency == 0, "an unknown tool must never reach the registry"
 
 
 def test_requires_document_lock_exception_falls_back_to_detects_mutation():

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -2,11 +2,45 @@ import json
 import urllib.request
 
 from plugin.mcp.server import mcp_endpoint_url
+from plugin.mcp.mcp_protocol import build_initialize_instructions
 
 
 def test_mcp_endpoint_url_helper():
     assert mcp_endpoint_url("localhost", 8765) == "http://localhost:8765/mcp"
     assert mcp_endpoint_url("127.0.0.1", 9000, use_ssl=True) == "https://127.0.0.1:9000/mcp"
+
+
+def test_initialize_instructions_lean_pointer_in_every_mode():
+    """T4/G2: every exposure mode keeps the base + its mode hint + the get_guidance pointer, and
+    stays LEAN (clients drop/truncate the connect-time text, so the manual moved out of it)."""
+    for mode in ("delegate", "direct_flat", "direct_discovery", "unknown"):
+        text = build_initialize_instructions(mode)
+        assert "WriterAgent MCP" in text          # base preserved
+        assert "get_guidance" in text             # the pointer to the on-demand manual
+        assert "get_document_tree" not in text    # the nav workflow moved to the manual
+        assert len(text) < 1500
+
+
+def test_navigation_workflow_lives_in_the_manual():
+    """R5's map-first workflow (outline -> drill -> search) is delivered via the manual now —
+    get_guidance('navigation') for MCP clients and the sidebar; full_manual() for the agent-backend path."""
+    from plugin.framework.agent_manual import get_section
+
+    nav = get_section("navigation")
+    assert "get_document_tree" in nav
+    assert "get_heading_children" in nav
+    assert "search_in_document" in nav
+    assert "heading_only" in nav
+
+
+def test_initialize_instructions_mode_hints_differ():
+    """Each exposure mode keeps its own discovery hint (regression on the refactor)."""
+    flat = build_initialize_instructions("direct_flat")
+    discovery = build_initialize_instructions("direct_discovery")
+    delegate = build_initialize_instructions("delegate")
+    assert "listed directly" in flat
+    assert "find_tools" in discovery
+    assert "delegate_to_specialized" in delegate
 
 
 def test_health_endpoint(mcp_server):
@@ -93,3 +127,25 @@ def test_root_info_includes_mcp_endpoint(mcp_server):
         assert response.getcode() == 200
         data = json.loads(response.read().decode("utf-8"))
         assert data.get("mcp_endpoint") == f"{mcp_server}/mcp"
+
+
+def test_mcp_initialize_instructions_are_lean_and_point_to_the_manual(mcp_server):
+    """T4/G2 contract: initialize.instructions is LEAN (major clients drop or truncate it — Claude
+    Desktop doesn't read it, Claude Code truncates ~2KB) and points to get_guidance(topic), where
+    the full behavior manual lives (single source: the shared prompt pieces in constants.py,
+    mapped per topic by plugin/framework/agent_manual.py, pinned in
+    tests/framework/test_agent_manual.py). Only the invariants ride along."""
+    url = f"{mcp_server}/mcp"
+    payload = {"jsonrpc": "2.0", "id": 7, "method": "initialize", "params": {}}
+    data_bytes = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, method="POST", data=data_bytes)
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=5) as response:
+        assert response.getcode() == 200
+        data = json.loads(response.read().decode("utf-8"))
+
+    instr = data["result"]["instructions"]
+    assert "get_guidance" in instr                        # the pointer to the on-demand manual
+    assert "structured fields" in instr                   # invariant: confirm edits structurally
+    assert "accept/reject" in instr                       # invariant: tracked changes are the user's
+    assert len(instr) < 1500                              # lean — the manual itself moved out

--- a/tests/mcp/test_mcp_bridge.py
+++ b/tests/mcp/test_mcp_bridge.py
@@ -1,0 +1,126 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""R7: the stdio<->HTTP MCP bridge must stay usable when LibreOffice is down (plug-and-play),
+and pass requests through when it is up. No LibreOffice required."""
+import importlib.util
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+_BRIDGE_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "scripts", "mcp_bridge.py")
+_spec = importlib.util.spec_from_file_location("wa_mcp_bridge", _BRIDGE_PATH)
+bridge = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bridge)
+
+
+# ---- parse_response ----
+
+def test_parse_response_plain_json():
+    assert bridge.parse_response('{"jsonrpc":"2.0","id":1,"result":{"ok":true}}')["result"]["ok"] is True
+
+
+def test_parse_response_sse_takes_last():
+    raw = 'data: {"id":1,"result":"a"}\n\ndata: {"id":1,"result":"b"}\n'
+    assert bridge.parse_response(raw)["result"] == "b"
+
+
+def test_parse_response_empty_raises():
+    with pytest.raises(ValueError):
+        bridge.parse_response("")
+
+
+# ---- handle_request: LibreOffice UP (poster returns an envelope) ----
+
+def _up(msg):
+    return {"jsonrpc": "2.0", "id": msg.get("id"), "result": {"echo": msg.get("method")}}
+
+
+def test_passthrough_when_up():
+    out = bridge.handle_request({"jsonrpc": "2.0", "id": 5, "method": "tools/list"}, poster=_up)
+    assert out["result"]["echo"] == "tools/list"
+    assert out["id"] == 5
+
+
+# ---- handle_request: LibreOffice DOWN (poster raises) ----
+
+def _down(msg):
+    raise ConnectionRefusedError("LO not running")
+
+
+def test_initialize_succeeds_locally_when_down(monkeypatch):
+    monkeypatch.setattr(bridge, "_INIT_RETRY_DELAY", 0)  # don't actually sleep in the test
+    out = bridge.handle_request({"jsonrpc": "2.0", "id": 1, "method": "initialize"}, poster=_down)
+    assert "result" in out and "error" not in out
+    assert out["result"]["capabilities"]["tools"]["listChanged"] is True
+    assert out["result"]["protocolVersion"]
+
+
+def test_initialize_waits_then_succeeds_if_lo_appears(monkeypatch):
+    # LibreOffice comes up on the 3rd attempt -> the model should get the REAL manual, not the
+    # placeholder, because initialize briefly waits for LO.
+    monkeypatch.setattr(bridge, "_INIT_RETRY_DELAY", 0)
+    calls = {"n": 0}
+
+    def _flaky(msg):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionRefusedError("LO still starting")
+        return {"jsonrpc": "2.0", "id": msg.get("id"), "result": {"instructions": "REAL MANUAL"}}
+
+    out = bridge.handle_request({"jsonrpc": "2.0", "id": 1, "method": "initialize"}, poster=_flaky)
+    assert out["result"]["instructions"] == "REAL MANUAL"
+    assert calls["n"] == 3
+
+
+def test_tools_list_empty_when_down_not_error():
+    out = bridge.handle_request({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}, poster=_down)
+    assert out["result"]["tools"] == []
+    assert "error" not in out
+
+
+def test_tools_call_returns_clear_error_when_down():
+    out = bridge.handle_request({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "x"}}, poster=_down)
+    assert "error" in out
+    assert "not reachable" in out["error"]["message"].lower()
+
+
+def test_notification_returns_none():
+    assert bridge.handle_request({"jsonrpc": "2.0", "method": "notifications/initialized"}, poster=_down) is None
+
+
+def test_ping_empty_when_down():
+    out = bridge.handle_request({"jsonrpc": "2.0", "id": 9, "method": "ping"}, poster=_down)
+    assert out["result"] == {} and "error" not in out
+
+
+# ---- post_to_lo against a real local HTTP server (exercises the HTTP path + parse) ----
+
+class _Echo(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0))) or b"{}")
+        out = json.dumps({"jsonrpc": "2.0", "id": body.get("id"), "result": {"method": body.get("method")}}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(out)
+
+    def log_message(self, *a):
+        pass
+
+
+def test_post_to_lo_real_http(monkeypatch):
+    srv = HTTPServer(("127.0.0.1", 0), _Echo)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        monkeypatch.setattr(bridge, "MCP_URL", f"http://127.0.0.1:{port}/mcp")
+        out = bridge.post_to_lo({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        assert out["result"]["method"] == "tools/list"
+    finally:
+        srv.shutdown()

--- a/tests/mcp/test_mcp_qol_extras.py
+++ b/tests/mcp/test_mcp_qol_extras.py
@@ -1,0 +1,71 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""MCP-experience QoL extras: proxy-safe is_active, the per-result document echo, and the
+multi-document guidance topic. No LibreOffice required."""
+from unittest.mock import MagicMock
+
+from plugin.tests.testing_utils import setup_uno_mocks
+setup_uno_mocks()
+
+
+def test_is_same_document_uses_uid_not_identity():
+    from plugin.doc.document_research import _is_same_document
+
+    class Doc:
+        def __init__(self, uid, url=""):
+            self.RuntimeUID = uid
+            self.URL = url
+
+    # Distinct proxy-like objects, same uid -> same document (object identity was always False).
+    assert _is_same_document(Doc("u1"), Doc("u1")) is True
+    assert _is_same_document(Doc("u1"), Doc("u2")) is False
+    assert _is_same_document(None, Doc("u1")) is False
+    assert _is_same_document(Doc("u1"), None) is False
+    # No uid on either side -> fall back to URL equality (empty URL never matches).
+    a, b = Doc(None, "file:///x.odt"), Doc(None, "file:///x.odt")
+    assert _is_same_document(a, b) is True
+    assert _is_same_document(Doc(None, ""), Doc(None, "")) is False
+
+
+def test_attach_document_echo_shape_and_absence():
+    from plugin.mcp.mcp_protocol import _attach_document_echo
+
+    doc = MagicMock()
+    doc.URL = "file:///Users/x/Peti%C3%A7%C3%A3o%20Inicial.odt"
+    doc.RuntimeUID = "42"
+    result = {"status": "ok"}
+    _attach_document_echo(result, doc)
+    assert result["document"]["name"] == "Petição Inicial.odt"
+    assert result["document"]["uid"]
+    # No doc -> no field; existing field -> untouched.
+    r2 = {"status": "ok"}
+    _attach_document_echo(r2, None)
+    assert "document" not in r2
+    r3 = {"status": "ok", "document": {"name": "keep"}}
+    _attach_document_echo(r3, doc)
+    assert r3["document"]["name"] == "keep"
+
+
+def test_multidoc_guidance_reaches_mcp_topic():
+    from plugin.framework.agent_manual import get_section, normalize_topic
+
+    sec = get_section("concurrency", "writer")
+    assert "document_url" in sec and "list_open_documents" in sec
+    assert normalize_topic("multi-document") == "concurrency"
+    assert normalize_topic("document_url") == "concurrency"
+
+
+def test_long_running_context_precomputes_echo_off_the_worker_thread():
+    """The echo payload must be computed on the MAIN thread (inside _get_context): reading
+    doc.URL/RuntimeUID from the HTTP worker trips the UNO thread guard on proxied docs."""
+    import inspect
+
+    from plugin.mcp import mcp_protocol as mp
+
+    src = inspect.getsource(mp.MCPProtocolHandler._execute_long_running)
+    assert "_document_echo_payload(doc)" in src.split("queue_executor.execute")[0], \
+        "echo must be captured inside _get_context (main thread), before the worker resumes"
+    assert "_attach_document_echo" not in src, \
+        "the worker thread must not touch the proxied doc after execution"

--- a/tests/mcp/test_server_bind.py
+++ b/tests/mcp/test_server_bind.py
@@ -1,0 +1,71 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""R7: the HTTP/MCP server must be resilient to a transiently/busy port instead of failing
+silently on the first bind (the "I have to restart to connect" symptom). No LibreOffice required."""
+import socket
+
+import pytest
+
+from plugin.mcp.server import HttpServer
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def test_bind_with_retry_succeeds_on_free_port():
+    srv = HttpServer(route_registry=None, port=_free_port(), host="127.0.0.1")
+    server = srv._bind_with_retry()
+    try:
+        assert server is not None
+    finally:
+        server.server_close()
+
+
+def test_bind_with_retry_retries_then_raises_when_busy(monkeypatch):
+    # Hold the port with an active listener so the bind keeps failing.
+    occupier = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    occupier.bind(("127.0.0.1", 0))
+    occupier.listen(1)
+    port = occupier.getsockname()[1]
+
+    sleeps = {"n": 0}
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: sleeps.__setitem__("n", sleeps["n"] + 1))
+
+    try:
+        srv = HttpServer(route_registry=None, port=port, host="127.0.0.1")
+        srv._BIND_ATTEMPTS = 3
+        with pytest.raises(OSError):
+            srv._bind_with_retry()
+        # 3 attempts => 2 sleeps between them (it retried, not failed on the first try).
+        assert sleeps["n"] == 2
+    finally:
+        occupier.close()
+
+
+def test_bind_with_retry_recovers_when_port_frees_midway(monkeypatch):
+    """If the holder releases the port between attempts, the next attempt should bind."""
+    occupier = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    occupier.bind(("127.0.0.1", 0))
+    occupier.listen(1)
+    port = occupier.getsockname()[1]
+
+    # Free the port on the first retry sleep, so attempt #2 succeeds.
+    def _free_on_sleep(*_a, **_k):
+        occupier.close()
+
+    monkeypatch.setattr("time.sleep", _free_on_sleep)
+
+    srv = HttpServer(route_registry=None, port=port, host="127.0.0.1")
+    srv._BIND_ATTEMPTS = 5
+    server = srv._bind_with_retry()
+    try:
+        assert server is not None
+    finally:
+        server.server_close()

--- a/tests/mcp/test_wire_types.py
+++ b/tests/mcp/test_wire_types.py
@@ -43,6 +43,17 @@ def test_call_tool_result_json_serializable():
     json.dumps(payload, ensure_ascii=False, default=str)
 
 
+def test_call_tool_result_image_content():
+    # get_image returns a native MCP image block (not base64-as-text) so vision clients see the picture.
+    payload = wire_types.call_tool_result_image("QUJD", mime_type="image/png")
+    block = payload["content"][0]
+    assert block["type"] == "image"
+    assert block["data"] == "QUJD"
+    assert block["mimeType"] == "image/png"
+    assert "isError" not in payload
+    assert wire_types.call_tool_result_image("x", is_error=True)["isError"] is True
+
+
 def test_parse_jsonrpc_request_accepts_valid_request():
     msg = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
     parsed = wire_types.parse_jsonrpc_request(msg)

--- a/tests/mcp/test_wire_types.py
+++ b/tests/mcp/test_wire_types.py
@@ -43,17 +43,6 @@ def test_call_tool_result_json_serializable():
     json.dumps(payload, ensure_ascii=False, default=str)
 
 
-def test_call_tool_result_image_content():
-    # get_image returns a native MCP image block (not base64-as-text) so vision clients see the picture.
-    payload = wire_types.call_tool_result_image("QUJD", mime_type="image/png")
-    block = payload["content"][0]
-    assert block["type"] == "image"
-    assert block["data"] == "QUJD"
-    assert block["mimeType"] == "image/png"
-    assert "isError" not in payload
-    assert wire_types.call_tool_result_image("x", is_error=True)["isError"] is True
-
-
 def test_parse_jsonrpc_request_accepts_valid_request():
     msg = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
     parsed = wire_types.parse_jsonrpc_request(msg)


### PR DESCRIPTION
> **Companion PRs — coordinated set.** One improvement split into 4 for review. Recommended merge order: **#363 tables → #364 images → #365 search & edit → #366 mcp** (mcp last: its single-source manual describes tools/behaviors from the others — `get_image`, search-anywhere, tracked-changes-in-reads — though code-wise each PR stands alone). The only file two PRs share is `mcp_protocol.py` (#364 + #366), which 3-way-merges cleanly.
>
> - #363 — Tables
> - #364 — Images
> - #365 — Search & edit reliability
> - #366 — MCP experience

---

- **Q5** one shared source of prompt pieces (`constants.py`) feeds both the chat sidebar (hybrid delivery) and MCP `get_guidance` (now a `core` tier), via `agent_manual.py`; `send_handlers` injects the same full manual on the lean MCP path.
- **Q6** `list_open_documents` + a `document_url`/uid argument so any tool can target a specific open document (uid works for unsaved docs). **B6/Q3/Q11** folder research + same-document identity by `RuntimeUID` (proxy objects never share Python identity).
- **F2** `report_bug`: agent-callable, records feedback locally and builds a pre-filled GitHub issue URL; **never auto-submits** (returns the URL for the user to review).
- **Q9** every tool result echoes which document it touched (name + uid), computed on the main thread to respect the UNO thread guard. **Q10** long-running calls precompute the echo before the worker resumes.
- **F3** `scripts/mcp_bridge.py`: a stdio→HTTP bridge so stdio-only clients (e.g. Claude Desktop) can reach the in-LibreOffice server.

Docs: `mcp-protocol.md`, `chat-sidebar-implementation.md`, `bug-reporting.md`. Standalone test suite green (98).

Covers **B6, Q3, Q5, Q6, Q9, Q10, Q11, F2, F3**.
