### PR TITLE
docs(AGENTS): add Cursor Cloud environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,16 @@ Usual targets generate `plugin/_manifest.py` when needed. Other Makefile targets
 
 ---
 
+## Cursor Cloud specific instructions
+
+Facts that bit past Cloud Agents on the headless Ubuntu VM (not obvious from the README):
+
+- **Hot-deploy needs `rsync`.** `make deploy` fails with `rsync: command not found` if it is missing (`scripts/dev-deploy.sh` rsyncs the bundle into the LibreOffice cache). Install it: `sudo apt-get install -y rsync`.
+- **OXT zip needs mtimes ≥ 1980.** `scripts/build_oxt.py` (Python `zipfile`) refuses to add files dated before 1980; reused snapshot checkouts often carry epoch-0 mtimes. If `make build`/`make deploy` fails on old timestamps, bump them: `find /workspace -newermt '1970-01-01' ! -newermt '1980-01-02' -exec touch -d '1980-01-02' {} +` (or the equivalent `os.utime` sweep).
+- **`writeragent.json` lives at `~/.config/libreoffice/4/user/config/writeragent.json`** (LibreOffice `PathSettings.UserConfig` — the `user/config/` subdir, **not** `user/`). Writing it to `user/` is silently ignored. Seed `scripting.python_venv_path` to `/workspace/.venv` so `=PY()` uses the project venv instead of `/usr/bin/python3`.
+
+---
+
 ## HTTP / LLM (summary)
 
 Chat and tool calls go through `llm_client` (see its module doc). Persistent connections live in `ai/service`; auth headers in `auth`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Cursor Cloud specific instructions** section to `AGENTS.md` capturing three non-obvious facts that bit Cloud Agents on the headless Ubuntu VM:

- Hot-deploy (`make deploy`) needs `rsync` — otherwise `scripts/dev-deploy.sh` fails with `rsync: command not found`.
- The OXT builder (`scripts/build_oxt.py`, Python `zipfile`) refuses file mtimes before 1980; reused snapshot checkouts often carry epoch-0 timestamps, so they must be bumped.
- `writeragent.json` lives at `~/.config/libreoffice/4/user/config/writeragent.json` (LibreOffice `PathSettings.UserConfig`, the `user/config/` subdir — not `user/`). Setting `scripting.python_venv_path` to `/workspace/.venv` makes `=PY()` use the project venv instead of `/usr/bin/python3`.

Docs-only change; no code or behavior changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86666315-c87f-43ce-8b41-69b64ad8588b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86666315-c87f-43ce-8b41-69b64ad8588b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

