### PR TITLE
build: tolerate pre-1980 mtimes when zipping OXTs

### DIFF
--- a/scripts/build_libreharper_oxt.py
+++ b/scripts/build_libreharper_oxt.py
@@ -150,7 +150,11 @@ def zip_libreharper_bundle(base_dir: str, output: str) -> int:
     count = 0
     import zipfile
 
-    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+    # strict_timestamps=False: freshly vendored wheels and reused Cloud Agent
+    # snapshot checkouts can carry pre-1980 (epoch-0) mtimes, which the default
+    # rejects with "ZIP does not support timestamps before 1980" and aborts the
+    # build. False clamps such entries to 1980-01-01 instead of failing.
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED, strict_timestamps=False) as zf:
         for root, dirs, filenames in os.walk(bundle_path):
             dirs[:] = [d for d in dirs if not should_exclude(d, with_tests=True)]
             for fn in filenames:

--- a/scripts/build_librepy_oxt.py
+++ b/scripts/build_librepy_oxt.py
@@ -252,7 +252,11 @@ def zip_librepy_bundle(base_dir: str, output: str) -> int:
     count = 0
     import zipfile
 
-    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+    # strict_timestamps=False: freshly vendored wheels and reused Cloud Agent
+    # snapshot checkouts can carry pre-1980 (epoch-0) mtimes, which the default
+    # rejects with "ZIP does not support timestamps before 1980" and aborts the
+    # build. False clamps such entries to 1980-01-01 instead of failing.
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED, strict_timestamps=False) as zf:
         for root, dirs, filenames in os.walk(bundle_path):
             dirs[:] = [d for d in dirs if not should_exclude(d, with_tests=True)]
             for fn in filenames:

--- a/scripts/build_oxt.py
+++ b/scripts/build_oxt.py
@@ -355,7 +355,11 @@ def zip_bundle(base_dir, output, bundle_dir=BUNDLE_DIR):
         os.remove(output_path)
 
     count = 0
-    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+    # strict_timestamps=False: freshly vendored wheels and reused Cloud Agent
+    # snapshot checkouts can carry pre-1980 (epoch-0) mtimes, which the default
+    # rejects with "ZIP does not support timestamps before 1980" and aborts the
+    # build. False clamps such entries to 1980-01-01 instead of failing.
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED, strict_timestamps=False) as zf:
         for root, dirs, filenames in os.walk(bundle_path):
             dirs[:] = [d for d in dirs if not should_exclude(d, with_tests=True)]
             for fn in filenames:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`make build` / `make deploy` can abort with:

```
ValueError: ZIP does not support timestamps before 1980
```

Python's `zipfile` refuses to add files whose mtime is before 1980. Two common situations produce such files:

- Freshly vendored wheels — `uv`/pip extract many wheel files with an epoch-0 (`1970-01-01`) mtime.
- Reused Cloud Agent snapshot checkouts — the snapshot restore resets `/workspace` file mtimes to `1970-01-01`.

When any bundled file carries a pre-1980 mtime, the OXT zip step aborts mid-write, leaving a truncated (22-byte) `build/WriterAgent.oxt`, which then fails `unopkg add` and blocks hot-deploy.

## Fix

Pass `strict_timestamps=False` to the three OXT `zipfile.ZipFile(...)` writers (WriterAgent, LibrePy, LibreHarper). With this flag, `zipfile` clamps out-of-range timestamps to `1980-01-01` instead of raising, so packaging never fails on restored/normalized timestamps. Contents are unchanged; only the stored zip entry timestamp is clamped.

## Testing

Set a bundled source file to an epoch-0 mtime and rebuilt:

- `touch -d @0 plugin/main.py`
- `make build` → **succeeds**: `Created build/WriterAgent.oxt with 1345 files` (previously aborted with the pre-1980 error).
- OXT integrity: `ZipFile.testzip()` → OK; the `plugin/main.py` entry `date_time` is clamped to `(1980, 1, 1, 0, 0, 0)`.
- `unopkg add build/WriterAgent.oxt` → registers `org.extension.writeragent` cleanly.
- `make build` runs `ty` + `ruff` first and completed, so the change is type/lint clean.

## Why it helps

This removes the root cause behind the Cloud Agent mtime workarounds (per-boot `start` mtime normalization and pre-baking `vendor/`), so those environment scripts can be simplified back to lock-cleanup only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86666315-c87f-43ce-8b41-69b64ad8588b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86666315-c87f-43ce-8b41-69b64ad8588b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

