### PR TITLE
Fix matplotlib chart sheet placement for Calc =PYTHON formulas

### DIFF
--- a/plugin/calc/python/formula_locator_cache.py
+++ b/plugin/calc/python/formula_locator_cache.py
@@ -19,9 +19,9 @@ MAX_FORMULAS_PER_DOC = 4096
 DEFAULT_DOC_CACHE_TTL_SECONDS = 300.0  # 5 minutes idle TTL
 
 # Regex to extract code string literal from =PY("...") or =PYTHON("...", ...) formulas.
-# Handles Calc-escaped double-quotes ("") inside string literals.
+# Handles Calc-escaped double-quotes ("") inside string literals and supports optional add-in namespaces.
 _PY_FORMULA_CODE_REGEX = re.compile(
-    r'(?:ORG\.EXTENSION\.WRITERAGENT\.PYTHONFUNCTION\.)?(?:PY|PYTHON)\s*\(\s*"((?:[^"]|"")*)"',
+    r'(?:ORG\.EXTENSION\.[A-Z0-9_.]+\.)?(?:PY|PYTHON)\s*\(\s*"((?:[^"]|"")*)"',
     re.IGNORECASE,
 )
 
@@ -195,7 +195,14 @@ def is_matching_py_formula(formula: str, code_str: str) -> bool:
     upper = formula.upper()
     if "PYTHON" not in upper and "PY" not in upper:
         return False
-    return extract_code_from_py_formula(formula) == code_str
+    extracted = extract_code_from_py_formula(formula)
+    if extracted is None:
+        return False
+    if extracted == code_str:
+        return True
+    ext_norm = extracted.replace("\r\n", "\n").strip()
+    code_norm = code_str.replace("\r\n", "\n").strip()
+    return ext_norm == code_norm
 
 
 def search_sheet_for_formula(
@@ -316,8 +323,16 @@ def locate_formula_cell_in_doc(
             count = sheets.getCount() if hasattr(sheets, "getCount") else 0
             for i in range(count):
                 sheet = sheets.getByIndex(i)
-                if active_sheet is not None and sheet == active_sheet:
-                    continue
+                try:
+                    if (
+                        active_sheet is not None
+                        and hasattr(sheet, "getName")
+                        and hasattr(active_sheet, "getName")
+                        and sheet.getName() == active_sheet.getName()
+                    ):
+                        continue
+                except Exception:
+                    pass
                 res = search_sheet_for_formula(sheet, code_str, doc_url=doc_url, cache=active_cache)
                 if res is not None:
                     cell, r, c = res

--- a/plugin/calc/python/image_egress.py
+++ b/plugin/calc/python/image_egress.py
@@ -105,6 +105,16 @@ def _insert_image_result_on_sheet_impl(ctx: Any, payload: dict[str, Any], code: 
             except Exception:
                 log.debug("insert_image_result_on_sheet: locate_formula_cell_in_doc failed", exc_info=True)
 
+            if sheet is None or target_cell is None:
+                # Bugfix (#385/#389): When formula code is provided (=PYTHON / =PY), failing to locate
+                # the formula cell must NOT fall back to the controller's active sheet or active selection.
+                # Falling back causes plots to be inserted on whatever sheet/cell is active (e.g. analysis!A1
+                # during Ctrl+Shift+F9 recalc).
+                log.warning(
+                    "insert_image_result_on_sheet: could not locate formula cell for formula code; aborting egress to prevent wrong-sheet placement"
+                )
+                return
+
         ctrl = doc.getCurrentController() if hasattr(doc, "getCurrentController") else None
 
         if sheet is None:

--- a/tests/calc/python/test_formula_locator_cache.py
+++ b/tests/calc/python/test_formula_locator_cache.py
@@ -257,6 +257,26 @@ def test_opportunistic_batch_caching_warms_all_sheet_formulas():
     assert located_3[2] == (10, 4)
 
 
+def test_locate_formula_cell_in_doc_secondary_sheet_when_active_sheet_differs():
+    """Formula cell on secondary sheet (viz) is located even when controller active sheet is analysis."""
+    sheet_analysis = CalcSheetStub("analysis")
+    sheet_viz = CalcSheetStub("viz")
+    doc = CalcDocStub(sheets=[sheet_analysis, sheet_viz], url="file:///test_demo.ods", active_sheet="analysis")
+    ctx = _ctx_with_doc(doc)
+
+    code = "import matplotlib.pyplot as plt; plt.plot([1, 2, 3]); plt.plot([3, 2, 1])"
+    # Formula is on viz sheet at B2 (col=1, row=1)
+    sheet_viz.getCellByPosition(1, 1).setFormula(
+        f'=ORG.EXTENSION.WRITERAGENT.PYTHONFUNCTION.PYTHON("{code}")'
+    )
+
+    located = locate_formula_cell_in_doc(ctx, doc, code)
+    assert located is not None
+    found_sheet, found_cell, (r, c) = located
+    assert found_sheet.getName() == "viz"
+    assert (r, c) == (1, 1)
+
+
 def test_untitled_docs_do_not_share_formula_cache():
     """Empty getURL() must not collide; RuntimeUID (lifecycle key) isolates unsaved books."""
     cache = FormulaLocationCache(max_formulas_per_doc=10)

--- a/tests/calc/python/test_venv_image.py
+++ b/tests/calc/python/test_venv_image.py
@@ -30,6 +30,7 @@ def test_calc_image_result_inserts_on_sheet():
             side_effect=lambda fn, *args, **kwargs: fn(*args, **kwargs),
         ) as main_thread,
         patch("plugin.calc.python.image_egress.insert_image_result_on_sheet") as insert,
+        patch("plugin.scripting.config_limits.configured_python_max_data_cells", return_value=10000),
     ):
         out = tool.execute(ctx, code="import matplotlib.pyplot as plt\nplt.plot([1])")
 
@@ -51,6 +52,7 @@ def test_writer_image_result_returns_path_only():
         patch("plugin.calc.python.venv.run_code_in_user_venv", return_value={"status": "ok", "result": _IMAGE_PAYLOAD}),
         patch("plugin.calc.python.venv.write_image_payload_to_temp", return_value="/tmp/plot.svg"),
         patch("plugin.calc.python.image_egress.insert_image_result_on_sheet") as insert,
+        patch("plugin.scripting.config_limits.configured_python_max_data_cells", return_value=10000),
     ):
         out = tool.execute(ctx, code="import matplotlib.pyplot as plt\nplt.plot([1])")
 
@@ -104,6 +106,31 @@ def test_insert_image_result_on_sheet_background_thread_marshaling():
         insert_image_result_on_sheet(ctx, _IMAGE_PAYLOAD)
 
     assert exec_main.call_count == 1
+
+
+def test_insert_image_result_on_sheet_aborts_when_formula_location_fails_for_code():
+    """When code is supplied and formula cell location fails, image egress aborts without inserting on active sheet."""
+    ctx = MagicMock()
+    doc = MagicMock()
+    ctrl = MagicMock()
+    active_sheet = MagicMock()
+    draw_page = MagicMock()
+    active_sheet.DrawPage = draw_page
+    ctrl.getActiveSheet.return_value = active_sheet
+    doc.getCurrentController.return_value = ctrl
+
+    code = "import matplotlib.pyplot as plt; plt.plot([1, 2, 3])"
+
+    with (
+        patch("plugin.scripting.document_scripts.get_calc_document_from_ctx", return_value=doc),
+        patch("plugin.calc.python.formula_locator_cache.locate_formula_cell_in_doc", return_value=None),
+        patch("plugin.calc.python.image_egress.write_image_payload_to_temp") as mock_write,
+    ):
+        insert_image_result_on_sheet(ctx, _IMAGE_PAYLOAD, code=code)
+
+    # Must abort before writing temp file or adding shape to active sheet's DrawPage
+    mock_write.assert_not_called()
+    draw_page.add.assert_not_called()
 
 
 def test_shape_anchor_matches_by_address_not_identity():


### PR DESCRIPTION
Fixes matplotlib chart sheet placement bug where plots from =PYTHON() formulas were incorrectly inserted on whatever sheet was active (e.g., analysis!A1) when recalculating from another sheet or during hard recalc.

---
*PR created automatically by Jules for task [17329243132825593004](https://jules.google.com/task/17329243132825593004) started by @KeithCu*