### PR TITLE
Fix portfolio_tearsheet returns grid handling and DatetimeIndex

### DIFF
--- a/plugin/scripting/venv/quant.py
+++ b/plugin/scripting/venv/quant.py
@@ -132,27 +132,66 @@ def technical_analysis(params: dict[str, Any], data: Any, context: dict[str, Any
 
 def portfolio_tearsheet(params: dict[str, Any], data: Any, context: dict[str, Any]) -> dict[str, Any]:
     try:
+        import pandas as pd
         import quantstats as qs  # type: ignore
     except ImportError:
         return _missing_package_error("portfolio_tearsheet", "quantstats")
-        
+
     res = _resolve_df(data)
     df = res.df
-    
-    try:
-        if df.shape[1] > 1:
-            prices = df.iloc[:, 1]
-            returns = prices.pct_change().dropna()
+
+    if df.empty:
+        return _error_result("INVALID_DATA", "Input data is empty.", helper="portfolio_tearsheet")
+
+    date_col = next((c for c in df.columns if str(c).strip().lower() in ("date", "datetime", "timestamp")), None)
+    dates = None
+    if date_col is not None:
+        dates = pd.to_datetime(df[date_col], errors="coerce")
+        df = df.drop(columns=[date_col])
+
+    numeric_df = df.apply(pd.to_numeric, errors="coerce")
+    numeric_df = numeric_df.dropna(how="all")
+
+    if numeric_df.empty or numeric_df.shape[1] == 0:
+        return _error_result("INVALID_DATA", "No numeric data columns found for portfolio tearsheet.", helper="portfolio_tearsheet")
+
+    col_param = params.get("column") if isinstance(params, dict) else None
+    if col_param and col_param in numeric_df.columns:
+        returns = numeric_df[col_param].dropna()
+        if dates is not None:
+            dates = dates.loc[returns.index]
+    else:
+        if numeric_df.shape[1] == 1:
+            returns = numeric_df.iloc[:, 0].dropna()
+            if dates is not None:
+                dates = dates.loc[returns.index]
         else:
-            returns = df.iloc[:, 0].dropna()
-            
+            returns = numeric_df.mean(axis=1).dropna()
+            if dates is not None:
+                dates = dates.loc[returns.index]
+
+    returns = pd.to_numeric(returns, errors="coerce").dropna()
+    if returns.empty:
+        return _error_result("INVALID_DATA", "No valid numeric returns found.", helper="portfolio_tearsheet")
+
+    if dates is not None and not dates.dropna().empty:
+        returns.index = dates
+    else:
+        returns.index = pd.date_range("2024-01-01", periods=len(returns), freq="D")
+
+    try:
         metrics = qs.reports.metrics(returns, display=False)
-        metrics_dict = metrics.to_dict()
-        
+        if hasattr(metrics, "iloc") and metrics.shape[1] >= 1:
+            metrics_dict = {str(k): v for k, v in metrics.iloc[:, 0].to_dict().items()}
+        elif isinstance(metrics, dict):
+            metrics_dict = metrics
+        else:
+            metrics_dict = metrics.to_dict()
+
         return {
-            "status": "success",
+            "status": "ok",
             "helper": "portfolio_tearsheet",
-            "metrics": metrics_dict
+            "metrics": metrics_dict,
         }
     except Exception as e:
         log.exception("Error in portfolio_tearsheet")

--- a/tests/scripting/test_quant.py
+++ b/tests/scripting/test_quant.py
@@ -90,3 +90,49 @@ def test_client_run_quant_worker_error(ctx):
 def test_helper_names_cover_templates():
     for helper in HELPER_NAMES:
         assert get_quant_template(helper) is not None
+
+
+def test_portfolio_tearsheet_portfolio_returns_grid():
+    grid = [
+        ["AAPL", "MSFT", "GOOG"],
+        [0.01, 0.008, 0.012],
+        [0.02, -0.01, 0.025],
+        [-0.005, 0.015, 0.01],
+        [0.012, 0.005, -0.008],
+        [0.008, 0.02, 0.015],
+        [0.015, -0.005, 0.02],
+        [-0.01, 0.012, 0.005],
+        [0.02, 0.008, 0.018],
+        [0.005, 0.015, -0.002],
+        [0.01, 0.01, 0.01],
+    ]
+    result = venv_run_quant({"helper": "portfolio_tearsheet", "params": {}}, data=grid)
+    assert result["status"] == "ok"
+    assert result["helper"] == "portfolio_tearsheet"
+    assert "metrics" in result
+    assert isinstance(result["metrics"], dict)
+    assert "Cumulative Return" in result["metrics"] or len(result["metrics"]) > 0
+
+
+def test_portfolio_tearsheet_with_date_column_and_single_column_param():
+    grid = [
+        ["Date", "AAPL", "MSFT"],
+        ["2024-01-01", 0.01, 0.02],
+        ["2024-01-02", 0.02, -0.01],
+        ["2024-01-03", -0.005, 0.015],
+    ]
+    result = venv_run_quant({"helper": "portfolio_tearsheet", "params": {"column": "MSFT"}}, data=grid)
+    assert result["status"] == "ok"
+    assert "metrics" in result
+
+
+def test_portfolio_tearsheet_invalid_data():
+    grid = [
+        ["HeaderA", "HeaderB"],
+        ["text1", "text2"],
+        ["text3", "text4"],
+    ]
+    result = venv_run_quant({"helper": "portfolio_tearsheet", "params": {}}, data=grid)
+    assert result["status"] == "error"
+    assert result["code"] == "INVALID_DATA"
+    assert result["helper"] == "portfolio_tearsheet"


### PR DESCRIPTION
Fixed portfolio_tearsheet helper in plugin/scripting/venv/quant.py to correctly treat grid inputs as periodic returns without invoking .pct_change(), calculate equal-weighted mean across multi-column return grids, handle date columns or generate a fallback DatetimeIndex to avoid quantstats AttributeError, and return status 'ok' with flat metrics or INVALID_DATA error. Added unit tests in tests/scripting/test_quant.py.

---
*PR created automatically by Jules for task [4947644229363214898](https://jules.google.com/task/4947644229363214898) started by @KeithCu*