### PR TITLE
Clean up quant status ok, ydata import name, ops.py docs, and html_import callers

### DIFF
--- a/docs/numpy-domains.md
+++ b/docs/numpy-domains.md
@@ -43,7 +43,7 @@ uv pip install numpy pandas scipy scikit-learn statsmodels ydata-profiling panda
 | `numpy`, `pandas` | All helpers (coercion, tables, aggregates) |
 | `scipy` | `detect_outliers` (IQR, z-score) |
 | `scikit-learn` | `detect_outliers` (`isolation_forest`), `cluster_numeric` |
-| [ydata-profiling](https://github.com/ydataai/ydata-profiling) (`data_profiling`) | `describe_data` |
+| [ydata-profiling](https://github.com/ydataai/ydata-profiling) (`ydata_profiling`) | `describe_data` |
 | `statsmodels` | `run_regression`, [`forecast_time_series` / `decompose_time_series`](../plugin/scripting/forecast.py) |
 | [pandas-montecarlo](https://github.com/ranaroussi/pandas-montecarlo) | `monte_carlo` |
 

--- a/docs/writer_tools_analysis.md
+++ b/docs/writer_tools_analysis.md
@@ -13,7 +13,6 @@
 | [images.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/images.py) | ImageGenerate, EditImage | 123 | 3.6K |
 | [images_doc.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/images_doc.py) | ImageList, ImageGetInfo, ImageSetProperties, ImageDownload, ImageInsert, ImageDelete, ImageReplace | 729 | 24.1K |
 | [navigation.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/navigation.py) | NavHeading, NavSurroundings | 90 | 3.1K |
-| [ops.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/ops.py) | *(helper module, no tools)* | 125 | 3.8K |
 | [outline.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/outline.py) | GetDocumentOutline, GetHeadingContent | 181 | 5.6K |
 | [search.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/search.py) | SearchInDocument, ReplaceInDocument | 241 | 8.1K |
 | [stats.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/stats.py) | GetDocumentStats | 83 | 2.3K |
@@ -134,7 +133,7 @@ Implemented as `ManageTrackedChanges` in [tracking.py](file:///home/keithcu/Desk
 > The big content files ([content.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/content.py) at 1032 lines, [comments.py](../../plugin/writer/comments.py) at 548 lines, [images_doc.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/images_doc.py) at 729 lines) are already large. The proposed merges keep them from getting unwieldy — the largest merge adds ~160 lines to [search.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/search.py) for fulltext.
 
 > [!IMPORTANT]
-> The [format.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/format.py) and [ops.py](file:///home/keithcu/Desktop/Python/writeragent/plugin/writer/ops.py) helper modules (705 lines combined) are not tool files and should remain as-is. They provide shared utilities used across multiple tool files.
+> The format.py and html_import.py helper modules are not tool files and should remain as-is. They provide shared utilities used across multiple tool files.
 
 ## Not Recommended
 

--- a/plugin/chatbot/rich_text.py
+++ b/plugin/chatbot/rich_text.py
@@ -226,7 +226,7 @@ def _tighten_list_indent(body_range):
 
 def _insert_html_at_cursor(doc, cursor, html_fragment):
     """Import an HTML fragment into *doc* at *cursor* using Writer's HTML filter."""
-    from plugin.writer.format import insert_html_fragment_at_cursor
+    from plugin.writer.html_import import insert_html_fragment_at_cursor
 
     insert_html_fragment_at_cursor(cursor, html_fragment, extra_css=_SIDEBAR_LIST_CSS)
 

--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -644,7 +644,7 @@ def _append_markdown_cell(doc: Any, source: str, *, lead_break: bool) -> None:
         if lead_break and _doc_body_nonempty(doc):
             text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
             cursor.gotoEnd(False)
-        from plugin.writer.format import insert_html_fragment_at_cursor
+        from plugin.writer.html_import import insert_html_fragment_at_cursor
 
         try:
             insert_html_fragment_at_cursor(cursor, _wrap_html_fragment(display), wrap=False)

--- a/plugin/scripting/venv/quant.py
+++ b/plugin/scripting/venv/quant.py
@@ -77,7 +77,7 @@ def fetch_historical_data(params: dict[str, Any], context: dict[str, Any]) -> di
         records = data.values.tolist()
         
         return {
-            "status": "success",
+            "status": "ok",
             "helper": "fetch_historical_data",
             "table": {
                 "columns": columns,
@@ -118,7 +118,7 @@ def technical_analysis(params: dict[str, Any], data: Any, context: dict[str, Any
             df[col] = df[col].astype(str)
             
         return {
-            "status": "success",
+            "status": "ok",
             "helper": "technical_analysis",
             "table": {
                 "columns": list(df.columns),
@@ -225,7 +225,7 @@ def efficient_frontier(params: dict[str, Any], data: Any, context: dict[str, Any
         cleaned_weights = ef.clean_weights()
         
         return {
-            "status": "success",
+            "status": "ok",
             "helper": "efficient_frontier",
             "weights": cleaned_weights
         }

--- a/plugin/vision/vision_egress.py
+++ b/plugin/vision/vision_egress.py
@@ -201,7 +201,7 @@ def insert_vision_result_into_writer(
     params: dict[str, Any] | None = None,
 ) -> None:
     """Insert formatted vision HTML immediately after the selected graphic anchor."""
-    from plugin.writer.format import insert_html_at_cursor
+    from plugin.writer.html_import import insert_html_at_cursor
 
     html = vision_html_from_result(result)
     if not html.strip():

--- a/plugin/writer/specialized/forms.py
+++ b/plugin/writer/specialized/forms.py
@@ -344,7 +344,7 @@ Output ONLY the HTML content. No explanations. No Markdown like # Header.
             shape.setString(plain)
             return
 
-        from ..format import insert_html_fragment_at_cursor
+        from ..html_import import insert_html_fragment_at_cursor
 
         vc = doc.getCurrentController().getViewCursor()
         cursor = doc.getText().createTextCursorByRange(vc)

--- a/tests/chatbot/test_rich_text.py
+++ b/tests/chatbot/test_rich_text.py
@@ -581,7 +581,7 @@ class ChatThemeAndImporterTests(unittest.TestCase):
         from plugin.chatbot import rich_text
 
         cursor = MockTextCursor()
-        with patch("plugin.writer.format.insert_html_fragment_at_cursor") as mock_insert:
+        with patch("plugin.writer.html_import.insert_html_fragment_at_cursor") as mock_insert:
             rich_text._insert_html_at_cursor(MockDoc(), cursor, "<p>Hi</p>")
         mock_insert.assert_called_once_with(
             cursor,

--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -379,7 +379,7 @@ def test_import_ipynb_markdown_html_uses_insert_html(tmp_path, monkeypatch):
         html_calls.append(html)
         return True
 
-    monkeypatch.setattr("plugin.writer.format.insert_html_fragment_at_cursor", fake_insert_html)
+    monkeypatch.setattr("plugin.writer.html_import.insert_html_fragment_at_cursor", fake_insert_html)
 
     stats = import_ipynb_to_writer(doc, str(ipynb))
 

--- a/tests/vision/test_vision_egress.py
+++ b/tests/vision/test_vision_egress.py
@@ -108,7 +108,7 @@ def test_insert_vision_result_calc_structured(mock_structured, mock_html):
 
 
 @patch("plugin.writer.edit_review.review_recording_enabled", return_value=False)
-@patch("plugin.writer.format.insert_html_at_cursor")
+@patch("plugin.writer.html_import.insert_html_at_cursor")
 @patch("plugin.vision.vision_egress.prepare_vision_writer_insert")
 def test_insert_vision_result_into_writer_uses_prepare_and_insert(mock_prepare, mock_insert, _review):
     from plugin.vision.vision_egress import insert_vision_result_into_writer
@@ -125,7 +125,7 @@ def test_insert_vision_result_into_writer_uses_prepare_and_insert(mock_prepare, 
     mock_insert.assert_called_once_with(doc, ctx, cursor, "<p>line</p>", apply_styles=False)
 
 
-@patch("plugin.writer.format.insert_html_at_cursor")
+@patch("plugin.writer.html_import.insert_html_at_cursor")
 @patch("plugin.vision.vision_egress.prepare_vision_writer_insert")
 def test_insert_vision_result_into_writer_without_edit_review(mock_prepare, mock_insert):
     """LibrePy omits edit_review; OCR insert must still apply HTML directly."""

--- a/tests/writer/test_ops_uno.py
+++ b/tests/writer/test_ops_uno.py
@@ -5,7 +5,7 @@ from plugin.doc.document_helpers import (
     find_paragraph_for_range,
     get_selection_range,
 )
-from plugin.writer.format import insert_html_fragment_at_cursor
+from plugin.writer.html_import import insert_html_fragment_at_cursor
 from plugin.testing_runner import native_test
 from plugin.tests.testing_utils import with_native_doc
 

--- a/tests/writer/test_vision_graphic_insert_uno.py
+++ b/tests/writer/test_vision_graphic_insert_uno.py
@@ -12,7 +12,7 @@ from plugin.doc.visual_helpers import list_graphic_objects
 from plugin.testing_runner import native_test
 from plugin.tests.testing_utils import with_native_doc
 from plugin.vision.vision_egress import prepare_vision_writer_insert
-from plugin.writer.format import insert_html_at_cursor
+from plugin.writer.html_import import insert_html_at_cursor
 from plugin.writer.images.image_tools import insert_image_at_locator
 
 _VISION_HTML_FIXTURE = "<p>Vision OCR line after image.</p>"


### PR DESCRIPTION
Completed all 4 maintainability items in one PR:
1. Updated quant helper status returns from 'success' to 'ok' in plugin/scripting/venv/quant.py.
2. Corrected ydata import name in docs/numpy-domains.md.
3. Removed deleted ops.py from docs/writer_tools_analysis.md inventory and note.
4. Updated direct callers and test patch targets of insert_html_* to import from plugin.writer.html_import while maintaining wrappers in format.py.

---
*PR created automatically by Jules for task [12389944560339986013](https://jules.google.com/task/12389944560339986013) started by @KeithCu*