### PR TITLE
LibrePy-safe Writer selection offsets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Rules that apply in many places. Breaking them causes wrong-document bugs, froze
 
 - **Two products, one OXT at a time.** WriterAgent (`make deploy`, `plugin/main.py`) vs LibrePy (`make build-core` / `deploy-core`, `plugin/main_core.py`, `extension-core/`). `deploy-core` removes WriterAgent. Dual-install overlay is **not shipped**. File list: [`scripts/librepy_bundle_paths.py`](scripts/librepy_bundle_paths.py). Packaging: [docs/libreoffice-core-python-extension-split.md](docs/libreoffice-core-python-extension-split.md).
 
-- **LibrePy-safe document helpers.** Linebreaks, tracked-deletion reads, heading trees, and path: `plugin/doc/text_helpers.py`. Type guards: `doc_type.py`. Document properties: `udprops.py`. Do **not** import `document_helpers` from LibrePy paths (it pulls Calc analyzer / chat context). Do **not** re-export the light helpers from `document_helpers`.
+- **LibrePy-safe document helpers.** Linebreaks, tracked-deletion reads, heading trees, path, and Writer selection range / char count: `plugin/doc/text_helpers.py`. Type guards: `doc_type.py`. Document properties: `udprops.py`. Do **not** import `document_helpers` from LibrePy paths (it pulls Calc analyzer / chat context). Do **not** re-export the light helpers from `document_helpers`.
 
 - **`plugin.framework.client` package init is lazy.** HTTP / errors / provider detection load immediately; `LlmClient`, embeddings, and analysis load on attribute access. LibrePy may import `requests` / `provider_detection`. Do not import `llm_client` or embeddings from LibrePy paths.
 

--- a/plugin/doc/document_helpers.py
+++ b/plugin/doc/document_helpers.py
@@ -662,7 +662,7 @@ def get_full_document_text(model, max_chars=CHAT_DOCUMENT_CONTEXT_MAX_CHARS):
             return text
 
         if doc_type == _doc_type.DocumentType.WRITER:
-            doc_len = _writer_char_count(model)
+            doc_len = _text_helpers._writer_char_count(model)
             take = min(doc_len, max_chars)
             excerpt = _read_writer_text_slice(model, 0, take)
             if doc_len > max_chars:
@@ -699,26 +699,6 @@ def get_document_end(model, max_chars=4000):
 _GO_RIGHT_CHUNK = 8192
 
 
-def _writer_char_count(model) -> int:
-    """Writer document character count; prefers O(1) CharacterCount over full getString()."""
-    try:
-        check_disposed(model, "Document Model")
-        count = getattr(model, "CharacterCount", None)
-        if count is not None:
-            return max(0, int(count))
-    except Exception:
-        pass
-    try:
-        text = safe_call(model.getText, "Get document text")
-        cursor = safe_call(text.createTextCursor, "Create text cursor")
-        safe_call(cursor.gotoStart, "Cursor gotoStart", False)
-        safe_call(cursor.gotoEnd, "Cursor gotoEnd", True)
-        return len(_text_helpers.normalize_linebreaks(safe_call(cursor.getString, "Cursor getString")))
-    except UnoObjectError:
-        logging.getLogger(__name__).exception("_writer_char_count failed")
-        return 0
-
-
 def _read_writer_text_slice(model, start_offset: int, length: int) -> str:
     """Read up to *length* characters from *start_offset* without loading the full document."""
     if length <= 0:
@@ -729,67 +709,6 @@ def _read_writer_text_slice(model, start_offset: int, length: int) -> str:
         return ""
     # cursor.getString() concatenates tracked deletions as plain text; enumerate portions instead.
     return _text_helpers.normalize_linebreaks(_text_helpers.get_string_without_tracked_deletions(cursor))
-
-
-def _char_offset_of_position(model, target_start, doc_len: int) -> int:
-    """Character offset of a UNO text position from document start (no prefix getString())."""
-    if doc_len <= 0:
-        return 0
-    try:
-        text = safe_call(model.getText, "Get document text")
-        cursor = safe_call(text.createTextCursor, "Create text cursor")
-        safe_call(cursor.gotoStart, "Cursor gotoStart", False)
-        offset = 0
-        while offset < doc_len:
-            cmp = safe_call(text.compareRegionStarts, "compareRegionStarts", target_start, safe_call(cursor.getStart, "Cursor getStart"))
-            if cmp == 0:
-                return offset
-            if cmp > 0:
-                if offset == 0:
-                    return 0
-                safe_call(cursor.goLeft, "Cursor goLeft", 1, False)
-                offset -= 1
-                continue
-            step = min(_GO_RIGHT_CHUNK, doc_len - offset)
-            if step <= 0:
-                return offset
-            safe_call(cursor.goRight, "Cursor goRight", step, False)
-            offset += step
-            cmp_after = safe_call(text.compareRegionStarts, "compareRegionStarts", target_start, safe_call(cursor.getStart, "Cursor getStart"))
-            if cmp_after >= 0:
-                while offset > 0 and safe_call(text.compareRegionStarts, "compareRegionStarts", target_start, safe_call(cursor.getStart, "Cursor getStart")) > 0:
-                    safe_call(cursor.goLeft, "Cursor goLeft", 1, False)
-                    offset -= 1
-                while safe_call(text.compareRegionStarts, "compareRegionStarts", target_start, safe_call(cursor.getStart, "Cursor getStart")) < 0 and offset < doc_len:
-                    safe_call(cursor.goRight, "Cursor goRight", 1, False)
-                    offset += 1
-                return offset
-        return doc_len
-    except UnoObjectError:
-        logging.getLogger(__name__).exception("_char_offset_of_position failed")
-        return 0
-
-
-def _get_writer_selection_positions(model):
-    """Return (text, sel_start_pos, sel_end_pos) or None when selection unavailable."""
-    try:
-        check_disposed(model, "Document Model")
-        controller = safe_call(model.getCurrentController, "Get current controller")
-        sel = safe_call(controller.getSelection, "Get selection")
-        sel_count = 0
-        if sel and hasattr(sel, "getCount"):
-            sel_count = safe_call(sel.getCount, "Get selection count")
-        if not sel or sel_count == 0:
-            vc = safe_call(controller.getViewCursor, "Get view cursor")
-            rng = vc
-        else:
-            rng = safe_call(sel.getByIndex, "Get selection by index", 0)
-        if not rng or not hasattr(rng, "getStart") or not hasattr(rng, "getEnd"):
-            return None
-        text = safe_call(model.getText, "Get document text")
-        return text, safe_call(rng.getStart, "Get range start"), safe_call(rng.getEnd, "Get range end")
-    except UnoObjectError:
-        return None
 
 
 def _writer_excerpt_overlaps_selection(model, excerpt_start: int, excerpt_end: int, sel_start_pos, sel_end_pos) -> bool:
@@ -819,7 +738,7 @@ def get_document_length(model):
     try:
         check_disposed(model, "Document Model")
         if _doc_type.get_document_type(model) == _doc_type.DocumentType.WRITER:
-            return _writer_char_count(model)
+            return _text_helpers._writer_char_count(model)
         text = safe_call(model.getText, "Get document text")
         cursor = safe_call(text.createTextCursor, "Create text cursor")
         safe_call(cursor.gotoStart, "Cursor gotoStart", False)
@@ -865,25 +784,6 @@ def get_text_cursor_at_range(model, start_offset, end_offset):
 
 
 @main_thread_only
-def get_selection_range(model):
-    """Return (start_offset, end_offset) character positions into the document.
-    Cursor (no selection) = same start and end. Returns (0, 0) on error or no text range."""
-    try:
-        check_disposed(model, "Document Model")
-        sel_positions = _get_writer_selection_positions(model)
-        if sel_positions is None:
-            return (0, 0)
-        _text, sel_start_pos, sel_end_pos = sel_positions
-        doc_len = _writer_char_count(model)
-        start_offset = _char_offset_of_position(model, sel_start_pos, doc_len)
-        end_offset = _char_offset_of_position(model, sel_end_pos, doc_len)
-        return (start_offset, end_offset)
-    except UnoObjectError:
-        logging.getLogger(__name__).exception("get_selection_range failed")
-        return (0, 0)
-
-
-@main_thread_only
 def get_document_context_for_chat(model, max_context=CHAT_DOCUMENT_CONTEXT_MAX_CHARS, include_end=True, include_selection=True, ctx=None):
     """Build a single context string for chat. Handles Writer, Calc and Draw.
     ctx: component context (required for Calc and Draw documents)."""
@@ -900,7 +800,7 @@ def get_document_context_for_chat(model, max_context=CHAT_DOCUMENT_CONTEXT_MAX_C
         if doc_type == _doc_type.DocumentType.WRITER:
             try:
                 check_disposed(model, "Document Model")
-                doc_len = _writer_char_count(model)
+                doc_len = _text_helpers._writer_char_count(model)
             except (UnoObjectError, Exception):
                 logging.getLogger(__name__).exception("get_document_context_for_chat Writer failed, trying fallback to selection-only")
                 sel_text = get_selection_text(model)
@@ -920,9 +820,9 @@ def get_document_context_for_chat(model, max_context=CHAT_DOCUMENT_CONTEXT_MAX_C
 
             start_offset, end_offset = (0, 0)
             if include_selection:
-                sel_positions = _get_writer_selection_positions(model)
+                sel_positions = _text_helpers._get_writer_selection_positions(model)
                 if sel_positions is not None and _writer_selection_overlaps_windows(model, excerpt_windows, sel_positions[1], sel_positions[2]):
-                    start_offset, end_offset = get_selection_range(model)
+                    start_offset, end_offset = _text_helpers.get_selection_range(model)
                     start_offset = max(0, min(start_offset, doc_len))
                     end_offset = max(0, min(end_offset, doc_len))
                     if start_offset > end_offset:

--- a/plugin/doc/text_helpers.py
+++ b/plugin/doc/text_helpers.py
@@ -4,11 +4,12 @@
 # Copyright (c) 2026 LibreCalc AI Assistant (Calc integration features, originally MIT)
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Writer text / path helpers used by LibrePy without ``document_helpers``.
+"""Writer text / path / selection helpers used by LibrePy without ``document_helpers``.
 
-LibrePy Run Python Script, text analytics, and Excel auto-open need linebreak
-normalization, tracked-deletion reads, heading trees, and a file path. Those
-must not load ``document_helpers`` → ``SheetAnalyzer`` / chat context.
+LibrePy Run Python Script, text analytics, Excel auto-open, and Writer selection
+offsets need linebreak normalization, tracked-deletion reads, heading trees, file
+paths, and selection range calculation. Those must not load ``document_helpers`` →
+``SheetAnalyzer`` / chat context.
 """
 
 from __future__ import annotations
@@ -37,6 +38,110 @@ def normalize_linebreaks(text: str | None) -> str:
     # Normalize remaining \r -> \n
     text = text.replace("\r", "\n")
     return text
+
+
+# goRight(nCount, bExpand) takes short; max 32767 per call
+_GO_RIGHT_CHUNK = 8192
+
+
+def _writer_char_count(model) -> int:
+    """Writer document character count; prefers O(1) CharacterCount over full getString()."""
+    try:
+        check_disposed(model, "Document Model")
+        count = getattr(model, "CharacterCount", None)
+        if count is not None:
+            return max(0, int(count))
+    except Exception:
+        pass
+    try:
+        text = safe_call(model.getText, "Get document text")
+        cursor = safe_call(text.createTextCursor, "Create text cursor")
+        safe_call(cursor.gotoStart, "Cursor gotoStart", False)
+        safe_call(cursor.gotoEnd, "Cursor gotoEnd", True)
+        return len(normalize_linebreaks(safe_call(cursor.getString, "Cursor getString")))
+    except UnoObjectError:
+        logging.getLogger(__name__).exception("_writer_char_count failed")
+        return 0
+
+
+def _char_offset_of_position(model, target_start, doc_len: int) -> int:
+    """Character offset of a UNO text position from document start (no prefix getString())."""
+    if doc_len <= 0:
+        return 0
+    try:
+        text = safe_call(model.getText, "Get document text")
+        cursor = safe_call(text.createTextCursor, "Create text cursor")
+        safe_call(cursor.gotoStart, "Cursor gotoStart", False)
+        offset = 0
+        while offset < doc_len:
+            cmp = safe_call(text.compareRegionStarts, "compareRegionStarts", target_start, safe_call(cursor.getStart, "Cursor getStart"))
+            if cmp == 0:
+                return offset
+            if cmp > 0:
+                if offset == 0:
+                    return 0
+                safe_call(cursor.goLeft, "Cursor goLeft", 1, False)
+                offset -= 1
+                continue
+            step = min(_GO_RIGHT_CHUNK, doc_len - offset)
+            if step <= 0:
+                return offset
+            safe_call(cursor.goRight, "Cursor goRight", step, False)
+            offset += step
+            cmp_after = safe_call(text.compareRegionStarts, "compareRegionStarts", target_start, safe_call(cursor.getStart, "Cursor getStart"))
+            if cmp_after >= 0:
+                while offset > 0 and safe_call(text.compareRegionStarts, "compareRegionStarts", target_start, safe_call(cursor.getStart, "Cursor getStart")) > 0:
+                    safe_call(cursor.goLeft, "Cursor goLeft", 1, False)
+                    offset -= 1
+                while safe_call(text.compareRegionStarts, "compareRegionStarts", target_start, safe_call(cursor.getStart, "Cursor getStart")) < 0 and offset < doc_len:
+                    safe_call(cursor.goRight, "Cursor goRight", 1, False)
+                    offset += 1
+                return offset
+        return doc_len
+    except UnoObjectError:
+        logging.getLogger(__name__).exception("_char_offset_of_position failed")
+        return 0
+
+
+def _get_writer_selection_positions(model):
+    """Return (text, sel_start_pos, sel_end_pos) or None when selection unavailable."""
+    try:
+        check_disposed(model, "Document Model")
+        controller = safe_call(model.getCurrentController, "Get current controller")
+        sel = safe_call(controller.getSelection, "Get selection")
+        sel_count = 0
+        if sel and hasattr(sel, "getCount"):
+            sel_count = safe_call(sel.getCount, "Get selection count")
+        if not sel or sel_count == 0:
+            vc = safe_call(controller.getViewCursor, "Get view cursor")
+            rng = vc
+        else:
+            rng = safe_call(sel.getByIndex, "Get selection by index", 0)
+        if not rng or not hasattr(rng, "getStart") or not hasattr(rng, "getEnd"):
+            return None
+        text = safe_call(model.getText, "Get document text")
+        return text, safe_call(rng.getStart, "Get range start"), safe_call(rng.getEnd, "Get range end")
+    except UnoObjectError:
+        return None
+
+
+@main_thread_only
+def get_selection_range(model):
+    """Return (start_offset, end_offset) character positions into the document.
+    Cursor (no selection) = same start and end. Returns (0, 0) on error or no text range."""
+    try:
+        check_disposed(model, "Document Model")
+        sel_positions = _get_writer_selection_positions(model)
+        if sel_positions is None:
+            return (0, 0)
+        _text, sel_start_pos, sel_end_pos = sel_positions
+        doc_len = _writer_char_count(model)
+        start_offset = _char_offset_of_position(model, sel_start_pos, doc_len)
+        end_offset = _char_offset_of_position(model, sel_end_pos, doc_len)
+        return (start_offset, end_offset)
+    except UnoObjectError:
+        logging.getLogger(__name__).exception("get_selection_range failed")
+        return (0, 0)
 
 
 class HeadingTreeNode(TypedDict):

--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -37,8 +37,8 @@ log = logging.getLogger("writeragent.writer")
 
 
 def _selection_range_for_export(model):  # pyright: ignore[reportUnusedFunction]
-    """Resolve selection range for export (lazy import so html_export never names document_helpers)."""
-    from plugin.doc.document_helpers import get_selection_range
+    """Resolve selection range for export (lazy import so html_export never names text_helpers directly or document_helpers)."""
+    from plugin.doc.text_helpers import get_selection_range
 
     return get_selection_range(model)
 

--- a/plugin/writer/html_export.py
+++ b/plugin/writer/html_export.py
@@ -207,7 +207,7 @@ def document_to_content(
 
     if scope == "selection":
         # Import via format so LibrePy (which ships html_export but not document_helpers)
-        # never sees an eager plugin.doc.document_helpers import in this file.
+        # selection path no longer names document_helpers in this file.
         start, end = format_mod._selection_range_for_export(model)
         return _done(
             _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc, include_images=include_images),

--- a/tests/writer/test_document_context_for_chat.py
+++ b/tests/writer/test_document_context_for_chat.py
@@ -41,7 +41,7 @@ def test_inject_markers_no_overlap():
 
 
 @patch("plugin.doc.document_helpers._read_writer_text_slice")
-@patch("plugin.doc.document_helpers._writer_char_count", return_value=20000)
+@patch("plugin.doc.text_helpers._writer_char_count", return_value=20000)
 @patch("plugin.doc.doc_type.get_document_type")
 def test_get_document_context_reads_slices_not_full_doc(mock_doc_type, mock_char_count, mock_read_slice):
     from plugin.doc.doc_type import DocumentType
@@ -57,7 +57,7 @@ def test_get_document_context_reads_slices_not_full_doc(mock_doc_type, mock_char
 
 
 @patch("plugin.doc.document_helpers._read_writer_text_slice")
-@patch("plugin.doc.document_helpers._writer_char_count", return_value=100)
+@patch("plugin.doc.text_helpers._writer_char_count", return_value=100)
 @patch("plugin.doc.doc_type.get_document_type")
 def test_get_document_context_short_doc_single_slice(mock_doc_type, mock_char_count, mock_read_slice):
     from plugin.doc.doc_type import DocumentType

--- a/tests/writer/test_ops_uno.py
+++ b/tests/writer/test_ops_uno.py
@@ -3,6 +3,8 @@ from plugin.doc.document_helpers import (
     get_paragraph_ranges,
     get_text_cursor_at_range,
     find_paragraph_for_range,
+)
+from plugin.doc.text_helpers import (
     get_selection_range,
 )
 from plugin.writer.format import insert_html_fragment_at_cursor

--- a/update-libreharper.xml
+++ b/update-libreharper.xml
@@ -9,7 +9,7 @@
       "update available" without a workable upgrade path if the OXT is missing.
     -->
     <identifier value="org.extension.libreharper" />
-    <version value="0.8.56" />
+    <version value="0.8.60" />
     <update-download>
         <src xlink:href="https://github.com/KeithCu/writeragent/releases/latest/download/LibreHarper.oxt" />
     </update-download>

--- a/update-librepy.xml
+++ b/update-librepy.xml
@@ -9,7 +9,7 @@
       "update available" without a workable upgrade path if the OXT is missing.
     -->
     <identifier value="org.extension.librepy" />
-    <version value="0.8.56" />
+    <version value="0.8.60" />
     <update-download>
         <src xlink:href="https://github.com/KeithCu/writeragent/releases/latest/download/LibrePy.oxt" />
     </update-download>

--- a/update.xml
+++ b/update.xml
@@ -10,7 +10,7 @@
       only shows "update available" without a workable LO-side upgrade path.
     -->
     <identifier value="org.extension.writeragent" />
-    <version value="0.8.56" />
+    <version value="0.8.60" />
     <update-download>
         <src xlink:href="https://github.com/KeithCu/writeragent/releases/latest/download/writeragent.oxt" />
     </update-download>


### PR DESCRIPTION
Moved Writer selection offset helpers (_writer_char_count, _char_offset_of_position, _get_writer_selection_positions, get_selection_range) and _GO_RIGHT_CHUNK constant from document_helpers.py to text_helpers.py. Updated document_helpers.py, format.py, html_export.py, AGENTS.md, test_document_context_for_chat.py, and test_ops_uno.py accordingly.

---
*PR created automatically by Jules for task [17253054914441391093](https://jules.google.com/task/17253054914441391093) started by @KeithCu*