### PR TITLE
Fix Calc auto-spill collision detection when spill targets are overwritten

### DIFF
--- a/plugin/calc/python/function.py
+++ b/plugin/calc/python/function.py
@@ -302,7 +302,49 @@ def scalar_for_list_result(ctx: Any, code: str, result: Any, *, worker_data: Any
 # Key: (doc_url, sheet_name, formula_row, formula_col)
 # Value: list of (spilled_row, spilled_col) coordinates
 SPILL_REGISTRY: dict[tuple[str, str, int, int], list[tuple[int, int]]] = {}
+# The spill value registry tracks expected spilled values for each target coordinate.
+# Key: (doc_url, sheet_name, formula_row, formula_col)
+# Value: dict mapping (spilled_row, spilled_col) -> coerced_calc_value
+SPILL_VALUE_REGISTRY: dict[tuple[str, str, int, int], dict[tuple[int, int], Any]] = {}
 LOADED_DOCUMENTS: set[str] = set()
+
+
+def _cell_matches_spilled_value(cell: Any, expected_val: Any) -> bool:
+    """True if cell's current UNO content matches expected spilled value."""
+    try:
+        from com.sun.star.table.CellContentType import EMPTY, FORMULA, TEXT, VALUE
+    except ImportError:
+        EMPTY = cast("Any", 0)
+        VALUE = cast("Any", 1)
+        TEXT = cast("Any", 2)
+        FORMULA = cast("Any", 3)
+
+    ctype = cell.getType()
+    if ctype == EMPTY:
+        return expected_val == "" or expected_val is None
+
+    if ctype == FORMULA:
+        # User formula in a spill target cell is always a collision
+        return False
+
+    if ctype == VALUE:
+        if isinstance(expected_val, (int, float)) and not isinstance(expected_val, bool):
+            try:
+                val = cell.getValue()
+                return math.isclose(val, float(expected_val), rel_tol=1e-9, abs_tol=1e-9)
+            except Exception:
+                return False
+        return False
+
+    if ctype == TEXT:
+        if isinstance(expected_val, str):
+            try:
+                return cell.getString() == expected_val
+            except Exception:
+                return False
+        return False
+
+    return False
 
 import unohelper
 from com.sun.star.util import XModifyListener
@@ -401,6 +443,7 @@ class CalcSpillModifyListener(unohelper.Base, XModifyListener):
                 if to_remove:
                     for key in to_remove:
                         SPILL_REGISTRY.pop(key, None)
+                        SPILL_VALUE_REGISTRY.pop(key, None)
                     if doc is not None:
                         save_spill_registry_for_doc(doc)
         except Exception:
@@ -417,19 +460,34 @@ def load_spill_registry_for_doc(doc: Any) -> None:
         from plugin.doc.udprops import get_document_property
         import json
         raw = get_document_property(doc, "WriterAgentSpillRegistry", None)
-        if not isinstance(raw, str) or not raw.strip():
-            return
-        data = json.loads(raw)
         doc_url = getattr(doc, "getURL", lambda: "")() or ""
-        for key, value in data.items():
-            parts = key.split(":")
-            if len(parts) == 2:
-                sheet_name, coords = parts
-                row_col = coords.split(",")
-                if len(row_col) == 2:
-                    frow, fcol = int(row_col[0]), int(row_col[1])
-                    spill_coords = [(int(r), int(c)) for r, c in value]
-                    SPILL_REGISTRY[(doc_url, sheet_name, frow, fcol)] = spill_coords
+        if isinstance(raw, str) and raw.strip():
+            data = json.loads(raw)
+            for key, value in data.items():
+                parts = key.split(":")
+                if len(parts) == 2:
+                    sheet_name, coords = parts
+                    row_col = coords.split(",")
+                    if len(row_col) == 2:
+                        frow, fcol = int(row_col[0]), int(row_col[1])
+                        spill_coords = [(int(r), int(c)) for r, c in value]
+                        SPILL_REGISTRY[(doc_url, sheet_name, frow, fcol)] = spill_coords
+
+        raw_values = get_document_property(doc, "WriterAgentSpillValueRegistry", None)
+        if isinstance(raw_values, str) and raw_values.strip():
+            val_data = json.loads(raw_values)
+            for key, value in val_data.items():
+                parts = key.split(":")
+                if len(parts) == 2:
+                    sheet_name, coords = parts
+                    row_col = coords.split(",")
+                    if len(row_col) == 2:
+                        frow, fcol = int(row_col[0]), int(row_col[1])
+                        val_map = {}
+                        for rc_str, val in value.items():
+                            r_str, c_str = rc_str.split(",")
+                            val_map[(int(r_str), int(c_str))] = val
+                        SPILL_VALUE_REGISTRY[(doc_url, sheet_name, frow, fcol)] = val_map
     except Exception:
         log.exception("Failed to load spill registry from document property")
 
@@ -441,11 +499,18 @@ def save_spill_registry_for_doc(doc: Any) -> None:
         import json
         doc_url = getattr(doc, "getURL", lambda: "")() or ""
         doc_spills = {}
+        doc_spill_values = {}
         for key, value in SPILL_REGISTRY.items():
             k_url, sheet_name, frow, fcol = key
             if k_url == doc_url:
-                doc_spills[f"{sheet_name}:{frow},{fcol}"] = value
+                prop_key = f"{sheet_name}:{frow},{fcol}"
+                doc_spills[prop_key] = value
+                if key in SPILL_VALUE_REGISTRY:
+                    doc_spill_values[prop_key] = {
+                        f"{r},{c}": val for (r, c), val in SPILL_VALUE_REGISTRY[key].items()
+                    }
         set_document_property(doc, "WriterAgentSpillRegistry", json.dumps(doc_spills))
+        set_document_property(doc, "WriterAgentSpillValueRegistry", json.dumps(doc_spill_values))
     except Exception:
         log.exception("Failed to save spill registry to document property")
 
@@ -596,6 +661,7 @@ def perform_deferred_spill(
             num_cols = max(len(row) for row in grid) if num_rows > 0 else 0
             if num_rows == 0 or num_cols == 0:
                 SPILL_REGISTRY[reg_key] = []
+                SPILL_VALUE_REGISTRY[reg_key] = {}
                 save_spill_registry_for_doc(doc)
                 return
 
@@ -642,13 +708,18 @@ def perform_deferred_spill(
                 remaining_range.setDataArray(tuple(tuple(row) for row in coerced_grid[1:]))
 
             new_spills = []
+            new_spill_values = {}
             for r_offset in range(num_rows):
                 for c_offset in range(num_cols):
                     if (r_offset, c_offset) == (0, 0):
                         continue
-                    new_spills.append((formula_row + r_offset, formula_col + c_offset))
+                    r_coord = formula_row + r_offset
+                    c_coord = formula_col + c_offset
+                    new_spills.append((r_coord, c_coord))
+                    new_spill_values[(r_coord, c_coord)] = coerced_grid[r_offset][c_offset]
 
             SPILL_REGISTRY[reg_key] = new_spills
+            SPILL_VALUE_REGISTRY[reg_key] = new_spill_values
             save_spill_registry_for_doc(doc)
 
             # 5. Apply NumberFormats for any temporal cells (dates, datetimes, times, durations)
@@ -807,6 +878,7 @@ def finalize_python_return(
                         reg_key = (doc_url, sheet_name, formula_row, formula_col)
                         previous_spills = SPILL_REGISTRY.get(reg_key, [])
                         prev_spill_set = set(previous_spills)
+                        prev_spill_values = SPILL_VALUE_REGISTRY.get(reg_key, {})
 
                         log.debug("Spill: previous spills for cell %r: %r", reg_key, previous_spills)
 
@@ -827,13 +899,13 @@ def finalize_python_return(
                                     break
                                 if (target_r, target_c) == (formula_row, formula_col):
                                     continue
-                                if (target_r, target_c) in prev_spill_set:
-                                    continue
                                 cell = sheet.getCellByPosition(target_c, target_r)
                                 cell_type = cell.getType()
-                                if cell_type != EMPTY:
+                                if cell_type == EMPTY:
+                                    continue
+                                if (target_r, target_c) not in prev_spill_set:
                                     log.debug(
-                                        "Spill: collision: cell at %r (type=%s, val=%r, formula=%r) is not empty",
+                                        "Spill: collision: cell at %r (type=%s, val=%r, formula=%r) is not empty and was not previously spilled",
                                         (target_r, target_c),
                                         cell_type,
                                         cell.getValue() or cell.getString(),
@@ -841,10 +913,32 @@ def finalize_python_return(
                                     )
                                     collides = True
                                     break
+                                exp_val = prev_spill_values.get((target_r, target_c))
+                                if not _cell_matches_spilled_value(cell, exp_val):
+                                    log.debug(
+                                        "Spill: collision: cell at %r was modified from expected spilled value %r",
+                                        (target_r, target_c),
+                                        exp_val,
+                                    )
+                                    collides = True
+                                    break
                             if collides:
                                 break
 
                         if collides:
+                            # Clean up old spilled cells that were NOT modified by the user
+                            for r, c in previous_spills:
+                                if (r, c) != (formula_row, formula_col):
+                                    try:
+                                        old_cell = sheet.getCellByPosition(c, r)
+                                        exp_val = prev_spill_values.get((r, c))
+                                        if _cell_matches_spilled_value(old_cell, exp_val):
+                                            old_cell.clearContents(23)
+                                    except Exception:
+                                        pass
+                            SPILL_REGISTRY.pop(reg_key, None)
+                            SPILL_VALUE_REGISTRY.pop(reg_key, None)
+                            save_spill_registry_for_doc(doc)
                             return "#SPILL!"
 
                         from plugin.framework.queue_executor import post_to_main_thread

--- a/tests/calc/python/test_function.py
+++ b/tests/calc/python/test_function.py
@@ -435,18 +435,25 @@ def test_load_and_save_spill_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     import json
 
     saved_payload = None
+    saved_value_payload = None
 
     def mock_get_prop(model, name, default=None):
         if name == "WriterAgentSpillRegistry":
             return json.dumps({
                 "Sheet1:1,1": [[2, 1], [3, 1]]
             })
+        if name == "WriterAgentSpillValueRegistry":
+            return json.dumps({
+                "Sheet1:1,1": {"2,1": 20.0, "3,1": 30.0}
+            })
         return default
 
     def mock_set_prop(model, name, value):
-        nonlocal saved_payload
+        nonlocal saved_payload, saved_value_payload
         if name == "WriterAgentSpillRegistry":
             saved_payload = value
+        elif name == "WriterAgentSpillValueRegistry":
+            saved_value_payload = value
 
     monkeypatch.setattr("plugin.doc.udprops.get_document_property", mock_get_prop)
     monkeypatch.setattr("plugin.doc.udprops.set_document_property", mock_set_prop)
@@ -454,19 +461,94 @@ def test_load_and_save_spill_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     doc = CalcDocStub(url="file:///fake_doc.ods")
 
     python_function.SPILL_REGISTRY.clear()
+    python_function.SPILL_VALUE_REGISTRY.clear()
     python_function.LOADED_DOCUMENTS.clear()
 
     python_function.load_spill_registry_for_doc(doc)
     key = ("file:///fake_doc.ods", "Sheet1", 1, 1)
     assert key in python_function.SPILL_REGISTRY
     assert python_function.SPILL_REGISTRY[key] == [(2, 1), (3, 1)]
+    assert key in python_function.SPILL_VALUE_REGISTRY
+    assert python_function.SPILL_VALUE_REGISTRY[key] == {(2, 1): 20.0, (3, 1): 30.0}
 
     python_function.SPILL_REGISTRY[key] = [(2, 1), (3, 1), (4, 1)]
+    python_function.SPILL_VALUE_REGISTRY[key] = {(2, 1): 20.0, (3, 1): 30.0, (4, 1): 40.0}
     python_function.save_spill_registry_for_doc(doc)
 
     assert saved_payload is not None
     data = json.loads(saved_payload)
     assert data["Sheet1:1,1"] == [[2, 1], [3, 1], [4, 1]]
+
+    assert saved_value_payload is not None
+    val_data = json.loads(saved_value_payload)
+    assert val_data["Sheet1:1,1"] == {"2,1": 20.0, "3,1": 30.0, "4,1": 40.0}
+
+
+def test_spill_target_overwrite_produces_spill_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Overwriting a spilled cell produces #SPILL! on formula re-evaluation (B8 QA requirement)."""
+    doc = CalcDocStub(url="file:///repro_b8.ods", selection="J8")
+    sheet = doc.getSheets().getByName("Sheet1")
+    # Formula cell J8 is col 9, row 7 (0-indexed)
+    sheet.getCellByPosition(9, 7).setFormula('=PYTHON("result = [10, 20, 30]")')
+    ctx = _ctx_with_doc(doc)
+
+    python_function.SPILL_REGISTRY.clear()
+    python_function.SPILL_VALUE_REGISTRY.clear()
+    python_function.LOADED_DOCUMENTS.clear()
+
+    class DummyTimer:
+        def __init__(self, interval, function, args=(), kwargs={}):
+            self.function = function
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self):
+            self.function(*self.args, **self.kwargs)
+
+    monkeypatch.setattr(python_function.threading, "Timer", DummyTimer)
+    monkeypatch.setattr(
+        "plugin.framework.queue_executor.post_to_main_thread",
+        lambda fn, *a, **k: fn(*a, **k),
+    )
+
+    code = "result = [10, 20, 30]"
+    result = [10.0, 20.0, 30.0]
+
+    # 1. Initial evaluation: J8 auto-spills J9 (20) and J10 (30)
+    val1 = finalize_python_return(ctx, code, result)
+    assert val1 == 10.0
+    assert sheet.getCellByPosition(9, 8).getValue() == 20.0  # J9
+    assert sheet.getCellByPosition(9, 9).getValue() == 30.0  # J10
+
+    key = ("file:///repro_b8.ods", "Sheet1", 7, 9)
+    assert key in python_function.SPILL_REGISTRY
+    assert python_function.SPILL_REGISTRY[key] == [(8, 9), (9, 9)]
+    assert python_function.SPILL_VALUE_REGISTRY[key] == {(8, 9): 20.0, (9, 9): 30.0}
+
+    # 2. Simulate user typing "BLOCK" into J9 (col 9, row 8)
+    sheet.getCellByPosition(9, 8).setString("BLOCK")
+
+    # 3. Re-evaluate J8 formula
+    val2 = finalize_python_return(ctx, code, result)
+    assert val2 == "#SPILL!"
+
+    # J9 must retain user text "BLOCK", while unmodified J10 (30) must be cleared
+    assert sheet.getCellByPosition(9, 8).getString() == "BLOCK"
+    EMPTY = 0
+    assert sheet.getCellByPosition(9, 9).getType() == EMPTY
+    assert key not in python_function.SPILL_REGISTRY
+    assert key not in python_function.SPILL_VALUE_REGISTRY
+
+    # 4. User clears J9
+    sheet.getCellByPosition(9, 8).clearContents(23)
+
+    # 5. Re-evaluate J8 formula again -> successfully spills 10, 20, 30
+    val3 = finalize_python_return(ctx, code, result)
+    assert val3 == 10.0
+    assert sheet.getCellByPosition(9, 8).getValue() == 20.0
+    assert sheet.getCellByPosition(9, 9).getValue() == 30.0
+    assert key in python_function.SPILL_REGISTRY
+    assert python_function.SPILL_REGISTRY[key] == [(8, 9), (9, 9)]
 
 
 def test_session_key_and_init_kwargs_recursion_off_main_thread(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
In `plugin/calc/python/function.py`, formula auto-spills previously ignored collision checks for target cells that were previously owned by the formula even if the user had since typed over them.

This change:
1. Adds `SPILL_VALUE_REGISTRY` to store expected spilled values for target coordinates.
2. Persists `SPILL_VALUE_REGISTRY` in document properties via `WriterAgentSpillValueRegistry`.
3. Adds `_cell_matches_spilled_value` helper to verify whether cell content matches expected spilled values.
4. Updates `finalize_python_return` to detect collisions when target cells no longer match expected spilled values, returning `#SPILL!` and clearing unmodified spilled cells.
5. Adds unit tests in `tests/calc/python/test_function.py` covering the bug sequence.

---
*PR created automatically by Jules for task [2071825512657001188](https://jules.google.com/task/2071825512657001188) started by @KeithCu*