### PR TITLE
🧪 Add unit tests for resolve_layout_id

### DIFF
--- a/plugin/draw/transform_schema.py
+++ b/plugin/draw/transform_schema.py
@@ -104,7 +104,7 @@ def resolve_layout_id(name_or_id: Any) -> int | None:
         return None
     if isinstance(name_or_id, int):
         return name_or_id
-    if isinstance(name_or_id, float) and name_or_id == int(name_or_id):
+    if isinstance(name_or_id, float) and name_or_id.is_integer():
         return int(name_or_id)
     if not isinstance(name_or_id, str):
         return None

--- a/tests/draw/test_transform_schema.py
+++ b/tests/draw/test_transform_schema.py
@@ -27,6 +27,53 @@ def test_resolve_layout_autolayout_and_alias():
     assert resolve_layout_id(19) == 19
 
 
+def test_resolve_layout_id_comprehensive():
+    # Integers
+    assert resolve_layout_id(0) == 0
+    assert resolve_layout_id(19) == 19
+    assert resolve_layout_id(-1) == -1
+
+    # Floats with/without integer equivalence
+    assert resolve_layout_id(19.0) == 19
+    assert resolve_layout_id(0.0) == 0
+    assert resolve_layout_id(19.5) is None
+    assert resolve_layout_id(float("nan")) is None
+
+    # Booleans (should return None because bool inherits from int in Python)
+    assert resolve_layout_id(True) is None
+    assert resolve_layout_id(False) is None
+
+    # Non-string / non-numeric types
+    assert resolve_layout_id(None) is None
+    assert resolve_layout_id([]) is None
+    assert resolve_layout_id({}) is None
+
+    # Strings: empty or whitespace
+    assert resolve_layout_id("") is None
+    assert resolve_layout_id("   ") is None
+
+    # Strings: AUTOLAYOUT names (case insensitivity and whitespace handling)
+    assert resolve_layout_id("AUTOLAYOUT_TITLE") == 0
+    assert resolve_layout_id("  autolayout_title_2content  ") == 3
+    assert resolve_layout_id("autolayout_title_only") == 19
+
+    # Strings: _LAYOUTS alias names
+    assert resolve_layout_id("title") == 0
+    assert resolve_layout_id("  BLANK  ") == 11
+    assert resolve_layout_id("two_column_text") == 2
+
+    # Strings: Numeric strings
+    assert resolve_layout_id("19") == 19
+    assert resolve_layout_id("  12  ") == 12
+    assert resolve_layout_id("0") == 0
+    assert resolve_layout_id("-5") == -5
+
+    # Strings: Invalid / non-matching names or non-integer numbers
+    assert resolve_layout_id("invalid_layout_name") is None
+    assert resolve_layout_id("AUTOLAYOUT_NON_EXISTENT") is None
+    assert resolve_layout_id("12.34") is None
+
+
 def test_parse_transform_valid():
     payload = {"Transforms": {"SlideCommands": [{"JumpToSlide": 0}]}}
     obj, err = parse_transform_argument(json.dumps(payload))


### PR DESCRIPTION
### 🎯 What
Add comprehensive unit tests for `resolve_layout_id` in `plugin/draw/transform_schema.py` and refine float conversion to avoid exceptions on NaN floats.

### 📊 Coverage
- Integers (0, 19, negative values)
- Floats (integer-equivalent, non-integer, `NaN`)
- Booleans (`True`, `False`)
- Non-string/non-numeric types (`None`, `[]`, `{}`)
- Empty and whitespace-only strings
- Collabora `AUTOLAYOUT_*` layout names (with case-insensitivity and surrounding whitespace)
- WriterAgent `_LAYOUTS` layout aliases (`"title"`, `"blank"`, `"two_column_text"`)
- Numeric strings (`"19"`, `"  12  "`)
- Non-matching layout names and non-integer float strings (`"12.34"`)

### ✨ Result
Improved unit test coverage and robust error handling for `resolve_layout_id`.

---
*PR created automatically by Jules for task [7058298216310004046](https://jules.google.com/task/7058298216310004046) started by @KeithCu*