### PR TITLE
Make librarian onboarding non-blocking — ask exactly once (fixes #346)

### DIFF
--- a/docs/chat-librarian-onboarding.md
+++ b/docs/chat-librarian-onboarding.md
@@ -51,6 +51,33 @@ On the UI thread before each librarian turn, [`plugin/chatbot/librarian.py`](plu
 Generic placeholders (`user`, `root`, `administrator`, …) are filtered out. The hint is injected as `[SUGGESTED USER NAME]` in agent instructions; the model **confirms** before calling `upsert_memory` with key `"name"`. If the user prefers another name or declines, the agent respects that.
 
 
+## Shipped behavior (2026-08): Onboarding is non-blocking
+
+**Problem** ([#346](https://github.com/KeithCu/writeragent/issues/346)): the entry gate in
+`panel._do_send` routed **every** message to the Librarian until `USER.md` existed, and the only
+exit was the model calling `switch_to_document_mode`. Weak models never called it, so users were
+trapped in an interrogation loop across sessions with no skip option.
+
+**Fix**: a deterministic pre-step, no model involvement:
+
+1. **Seeding** — `seed_user_profile_if_missing()` in [`plugin/chatbot/librarian.py`](../plugin/chatbot/librarian.py)
+   runs before the gate on each send. When no profile exists, it writes a provisional `USER.md`
+   from `get_suggested_user_name()` (LibreOffice User Data, then OS login). Document work starts
+   on message #1; the blocking path is unreachable for new installs.
+2. **Guidance prompt** — while the profile carries the auto-detected marker, the main chat receives
+   `USER_PROFILE_SEED_GUIDANCE` ([`prompts.py`](../plugin/framework/prompts.py)): the first reply
+   confirms the auto-detected name, asks once about favorite colors (they personalize document
+   formatting), saving answers with `upsert_memory`, and ends by offering a tour.
+3. **Asked exactly once** — saving key `name` clears the marker automatically, so later sessions
+   never re-ask.
+4. **On-demand tour** — messages asking for a tour (`is_tour_request()` in `librarian.py`:
+   "tour", "show me around", …) route into the original `LibrarianOnboardingTool` flow any time,
+   so the full teaching experience stays available on request.
+
+Everything else in this document — personality, goals, memory format, teaching tips — still applies
+whenever the Librarian flow runs (it remains reachable by removing `USER.md`).
+
+
 ## Reply language and localized UI
 
 ### What we learned (ship-ready behavior)
@@ -500,6 +527,6 @@ def _init_chat_session(self):
 ---
 
 **Approved**: ⬜️  **In Progress**: ⬜️  **Completed**: ⬜️
-**Last Updated**: 2026-05-09
+**Last Updated**: 2026-08-23
 **Priority**: High 🚀
 **Approach**: Agent-Driven Conversation ✨

--- a/plugin/chatbot/librarian.py
+++ b/plugin/chatbot/librarian.py
@@ -4,12 +4,13 @@
 # This program is free software.
 
 import getpass
+import json
 import logging
 import re
 from typing import Any, Iterable, cast
 
 from plugin.framework.tool import ToolBase
-from plugin.chatbot.memory import format_upsert_memory_chat_line_from_arguments
+from plugin.chatbot.memory import MemoryStore, format_upsert_memory_chat_line_from_arguments
 
 log = logging.getLogger(__name__)
 
@@ -80,6 +81,76 @@ def get_os_login_name() -> str | None:
 def get_suggested_user_name(ctx: Any) -> str | None:
     """Best-effort name for librarian confirmation: LO profile first, then OS login."""
     return get_libreoffice_user_display_name(ctx) or get_os_login_name()
+
+
+def seed_user_profile_if_missing(ctx: Any) -> bool:
+    """Create a provisional USER.md from OS/LO data when no profile exists yet.
+
+    Why: the onboarding gate in panel._do_send routes EVERY message to the Librarian
+    until USER.md exists, and the only exit is the model calling switch_to_document_mode
+    / upsert_memory. Weak models often never call those tools, trapping users in an
+    endless interrogation (issue #346). Seeding here makes the profile exist
+    deterministically so document work is never blocked; the name remains a suggestion
+    the main chat can confirm or correct via upsert_memory.
+
+    Returns True when a new profile was created.
+    """
+    try:
+        store = MemoryStore(ctx)
+    except Exception as e:
+        log.debug("seed_user_profile_if_missing: MemoryStore unavailable: %s", e)
+        return False
+
+    from plugin.chatbot.memory import _MEMORY_RW_LOCK
+
+    # Same lock as MemoryTool.execute: seeding races a concurrent upsert otherwise.
+    with _MEMORY_RW_LOCK:
+        try:
+            if str(store.read("user") or "").strip():
+                return False
+        except OSError as e:
+            log.debug("seed_user_profile_if_missing: could not read existing profile: %s", e)
+            return False
+
+        suggested_name = get_suggested_user_name(ctx)
+        profile: dict[str, str] = {
+            "name_source": "auto-detected from LibreOffice User Data or OS login; not yet confirmed by the user",
+            "favorite_colors": "",
+        }
+        if suggested_name:
+            profile["name"] = suggested_name
+
+        try:
+            store.write("user", json.dumps(profile, indent=2, ensure_ascii=False))
+        except OSError as e:
+            log.debug("seed_user_profile_if_missing: could not write profile: %s", e)
+            return False
+    log.info("Seeded provisional user profile (suggested_name=%r)", suggested_name)
+    return True
+
+
+# ── On-demand Librarian tour ─────────────────────────────────────────────────
+# Requests are matched deterministically (any session, not just the first) and
+# routed to the original LibrarianOnboardingTool flow via panel._do_send.
+
+_TOUR_REQUEST_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(grand\s+)?tour\b",
+        r"\bshow\s?(?:me|us)\s?(?:a)?round\b",
+        r"\bshow\s?me\s?the\s?ropes\b",
+        r"\b(?:give|take)\s?me\s?(?:a|the)\s?tour\b",
+        r"\bteach\s?me\s?(?:how\s?to\s?use\s)?writeragent\b",
+        r"\bintroduce\s?me\s?to\s?writeragent\b",
+        r"\bwhat\s?(?:else\s)?can\s(?:you|writeragent)\sdo\b",
+    )
+)
+
+
+def is_tour_request(text: str) -> bool:
+    """True when the message clearly asks for the Librarian tour."""
+    normalized = str(text or "").strip().lower()
+    return any(pattern.search(normalized) for pattern in _TOUR_REQUEST_PATTERNS)
 
 
 class SwitchToDocumentModeTool(ToolBase):

--- a/plugin/chatbot/memory.py
+++ b/plugin/chatbot/memory.py
@@ -1,5 +1,7 @@
 import os
 import logging
+import tempfile
+import threading
 from typing import Any, Mapping, cast
 
 from plugin.framework.tool import ToolBase
@@ -7,6 +9,12 @@ from plugin.framework.config import user_config_dir
 from plugin.framework.errors import ConfigError
 
 log = logging.getLogger(__name__)
+
+# Serializes read-modify-write cycles on the memory files. Models may emit several
+# upsert_memory calls in one turn (e.g. name + favorite color); without this lock
+# the concurrent writes raced: last writer clobbered sibling keys and the shorter
+# payload left torn JSON tail bytes on disk (observed 2026-08-23, USER.md 150B).
+_MEMORY_RW_LOCK = threading.Lock()
 
 
 from plugin.framework.deal_shim import deal
@@ -39,8 +47,20 @@ class MemoryStore:
     def write(self, target: str, content: str) -> bool:
         # crosshair: off
         path = self._get_path(target)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(content)
+        # Atomic replace (same directory → same filesystem): a reader or concurrent
+        # writer can never observe a half-written file, even if this process crashes
+        # mid-write.
+        fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path), prefix=".memory-", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+            os.replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
         return True
 
 
@@ -131,36 +151,45 @@ class MemoryTool(ToolBase):
             return self._tool_error(f"Failed to initialize memory store: {e}")
 
         target = "user"
-        try:
-            current = store.read(target)
-        except OSError as e:
-            return self._tool_error(f"Failed to read existing memory: {e}")
+        # Hold the lock across the whole read-modify-write: parallel tool calls for
+        # the same user message must merge, not race (torn JSON + lost keys).
+        with _MEMORY_RW_LOCK:
+            try:
+                current = store.read(target)
+            except OSError as e:
+                return self._tool_error(f"Failed to read existing memory: {e}")
 
-        try:
-            parsed = json.loads(current) if current.strip() else {}
-            if not isinstance(parsed, dict):
-                # Not a JSON object: start over so the librarian can rebuild memory.
+            try:
+                parsed = json.loads(current) if current.strip() else {}
+                if not isinstance(parsed, dict):
+                    # Not a JSON object: start over so the librarian can rebuild memory.
+                    parsed = {}
+            except json.JSONDecodeError:
+                # Invalid JSON (e.g. legacy YAML): start over.
                 parsed = {}
-        except json.JSONDecodeError:
-            # Invalid JSON (e.g. legacy YAML): start over.
-            parsed = {}
 
-        # Nested update
-        parts = key.split(".")
-        current_dict = parsed
-        for part in parts[:-1]:
-            if part not in current_dict or not isinstance(current_dict[part], dict):
-                current_dict[part] = {}
-            current_dict = current_dict[part]
+            # Nested update
+            parts = key.split(".")
+            current_dict = parsed
+            for part in parts[:-1]:
+                if part not in current_dict or not isinstance(current_dict[part], dict):
+                    current_dict[part] = {}
+                current_dict = current_dict[part]
 
-        current_dict[parts[-1]] = content
+            current_dict[parts[-1]] = content
 
-        new_content = json.dumps(parsed, indent=2, ensure_ascii=False)
-        if new_content == current:
-            return {"status": "ok", "message": f"Memory for '{key}' is already up to date."}
+            # Once a real name lands, the seed marker has served its purpose.
+            # Leaving it in place made the seed-guidance re-ask name/color in
+            # every future session (only-once guarantee, #346).
+            if key == "name":
+                parsed.pop("name_source", None)
 
-        try:
-            store.write(target, new_content)
-            return {"status": "ok", "message": f"Upserted key '{key}' in memory."}
-        except OSError as e:
-            return self._tool_error(f"Failed to write memory: {e}")
+            new_content = json.dumps(parsed, indent=2, ensure_ascii=False)
+            if new_content == current:
+                return {"status": "ok", "message": f"Memory for '{key}' is already up to date."}
+
+            try:
+                store.write(target, new_content)
+                return {"status": "ok", "message": f"Upserted key '{key}' in memory."}
+            except OSError as e:
+                return self._tool_error(f"Failed to write memory: {e}")

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -1020,12 +1020,36 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
         except Exception:
             log.exception("_do_send: agent backend check failed")
 
+        # On-demand Librarian tour: route explicit requests into the original
+        # onboarding flow, any session (#346 follow-up). Matched deterministically
+        # so no model goodwill is required to reach Keith's tour.
+        try:
+            from plugin.chatbot.librarian import is_tour_request
+
+            if is_tour_request(query_text):
+                self._in_librarian_mode = True
+                log.info("_do_send: starting librarian tour (user requested)")
+                self._run_librarian(query_text, model)
+                return
+        except Exception:
+            log.exception("_do_send: tour request routing failed")
+
         if self._in_librarian_mode:
             log.info("_do_send: continuing librarian onboarding agent")
             self._run_librarian(query_text, model)
             return
 
-        # Check if USER.md exists for Librarian Onboarding entry
+        # Check if USER.md exists for Librarian Onboarding entry.
+        # Seed a provisional profile from OS/LO data first: a missing profile used to
+        # route every message into onboarding until the model called
+        # switch_to_document_mode, which weak models never do (#346).
+        try:
+            from plugin.chatbot.librarian import seed_user_profile_if_missing
+
+            seed_user_profile_if_missing(self.ctx)
+        except Exception:
+            log.exception("_do_send: seeding user profile failed")
+
         user_md_exists = False
         from plugin.chatbot.memory import MemoryStore
 

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -278,6 +278,26 @@ WHEN TO SAVE (do this proactively, don't wait to be asked):
 - You discover something about the environment.
 Prioritize what reduces future user steering."""
 
+# Appended to the [USER PROFILE / MEMORY] injection when the profile was auto-seeded
+# (see librarian.seed_user_profile_if_missing): first reply must ask both profile
+# questions explicitly, offer the on-demand tour once, and never block work.
+USER_PROFILE_SEED_GUIDANCE = (
+    "The profile above was auto-created: 'name' comes from LibreOffice User Data or the OS login, "
+    "and the user never chose it. Requirements:\n"
+    "1) If 'name_source' says not yet confirmed, your first reply MUST ask \"Should I call you <name>?\". "
+    "If they prefer a different name, save it via upsert_memory (key 'name'); the app clears "
+    "'name_source' automatically once a real name is saved.\n"
+    "2) If 'favorite_colors' is empty, ask once whether they have a favorite color or colors. Explain "
+    "ultra concisely that these are used to make nicer looking tables and documents. Save whatever "
+    "they give via upsert_memory (key 'favorite_colors').\n"
+    "3) End that same reply by offering a tour: \"Let me know if you'd ever like a tour around — otherwise "
+    "let's get straight to work.\" If they ask for one in a later message, a separate guided tour takes "
+    "over automatically — do not try to give it yourself.\n"
+    "Tone: warm, friendly, and playful — like a welcoming host meeting someone new. Emojis are welcome "
+    "here. These questions should feel like friendly getting-to-know-you chat, not paperwork.\n"
+    "Answer tasks immediately; never delay or withhold document work behind these questions."
+)
+
 # Writer sidebar modes — not exposed on delegate_to_specialized_writer_toolset (user picks from dropdown).
 WRITER_SIDEBAR_ONLY_DOMAINS = frozenset({"brainstorming", "writing_plan", "deep_research"})
 
@@ -824,6 +844,8 @@ def get_chat_system_prompt_for_document(model, additional_instructions="", ctx=N
             user_mem = store.read("user")
             if user_mem:
                 base += "\n\n[USER PROFILE / MEMORY]\n" + user_mem.strip() + "\n"
+                if "name_source" in user_mem:
+                    base += "\n" + USER_PROFILE_SEED_GUIDANCE + "\n"
         except Exception as e:
             import logging
 

--- a/scripts/fix_uno_import.py
+++ b/scripts/fix_uno_import.py
@@ -188,6 +188,8 @@ def find_system_uno(*, venv_py: tuple[int, int] | None = None):
             "/usr/lib/python3.12/site-packages",
             "/usr/lib64/python3.14/site-packages",
             "/usr/lib64/python3.13/site-packages",
+            # Snap installs ship uno.py inside the read-only snap tree (no distro site-packages).
+            "/snap/libreoffice/current/lib/libreoffice/program",
         ]
         for p in search_paths:
             if os.path.exists(os.path.join(p, "uno.py")):
@@ -212,6 +214,8 @@ def find_system_uno(*, venv_py: tuple[int, int] | None = None):
             "/usr/lib/libreoffice/program",
             "/usr/lib64/libreoffice/program",
             "/opt/libreoffice/program",
+            # Snap LibreOffice (pyuno.so lives next to uno.py in the snap tree).
+            "/snap/libreoffice/current/lib/libreoffice/program",
         ]
         for p in search_libs:
             if os.path.exists(os.path.join(p, "pyuno.so")):

--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -17,6 +17,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # shellcheck source=lo_paths.sh
 source "$SCRIPT_DIR/lo_paths.sh"
+
+# Pin unopkg to the profile LibreOffice actually reads (snap installs need this).
+PROFILE_ARGS="$(unopkg_profile_args)"
 BUILD_DIR="$PROJECT_ROOT/build"
 OXT_FILE="$BUILD_DIR/WriterAgent.oxt"
 
@@ -137,12 +140,12 @@ install_extension() {
 
     # Remove previous version
     echo "[*] Removing previous version (if any)..."
-    $unopkg remove "$EXTENSION_ID" 2>&1 || true
+    $unopkg $PROFILE_ARGS remove "$EXTENSION_ID" 2>&1 || true
     sleep 2
 
     # Install new version
     echo "[*] Installing $OXT_FILE ..."
-    if ! $unopkg add "$OXT_FILE" 2>&1; then
+    if ! $unopkg $PROFILE_ARGS add "$OXT_FILE" 2>&1; then
         echo "[X] unopkg add failed"
         echo "    Troubleshooting:"
         echo "    1. Make sure LibreOffice is fully closed"
@@ -155,7 +158,7 @@ install_extension() {
 
     sleep 2
     echo "[*] Verifying installation..."
-    if $unopkg list 2>&1 | grep -q "$EXTENSION_ID"; then
+    if $unopkg $PROFILE_ARGS list 2>&1 | grep -q "$EXTENSION_ID"; then
         echo "[OK] Extension verified: $EXTENSION_ID is registered"
     else
         echo "[!!] Could not verify via unopkg list (often OK, LO will load it on start)"
@@ -172,7 +175,7 @@ uninstall_extension() {
     ensure_lo_stopped || return 1
 
     echo "[*] Removing extension $EXTENSION_ID ..."
-    if $unopkg remove "$EXTENSION_ID" 2>&1 | grep -qiE "not deployed|no such|aucune"; then
+    if $unopkg $PROFILE_ARGS remove "$EXTENSION_ID" 2>&1 | grep -qiE "not deployed|no such|aucune"; then
         echo "    Extension was not installed"
     else
         echo "[OK] Extension removed"
@@ -183,7 +186,7 @@ uninstall_extension() {
 
 extension_registered() {
     local unopkg="$1"
-    $unopkg list 2>&1 | grep -q "$EXTENSION_ID"
+    $unopkg $PROFILE_ARGS list 2>&1 | grep -q "$EXTENSION_ID"
 }
 
 install_to_cache() {

--- a/scripts/lo_paths.sh
+++ b/scripts/lo_paths.sh
@@ -7,6 +7,26 @@
 [[ -n "${_LO_PATHS_LOADED:-}" ]] && return 0
 _LO_PATHS_LOADED=1
 
+# Snap installs keep the real program dir inside the read-only snap tree; the
+# /snap/bin entries are wrappers that do not include unopkg/soffice. Direct CLI
+# tools from that dir also need the snap's bundled libraries on the loader path,
+# and they must target the snap profile explicitly: without confinement HOME
+# stays $HOME, so unopkg would register into ~/.config which snap LibreOffice
+# never reads (issue: dev-deploy silently installed into a dead profile).
+_LO_SNAP_PROGRAM_DIR="/snap/libreoffice/current/lib/libreoffice/program"
+if [[ -x "$_LO_SNAP_PROGRAM_DIR/unopkg" || -x "$_LO_SNAP_PROGRAM_DIR/soffice" ]]; then
+    export LD_LIBRARY_PATH="$_LO_SNAP_PROGRAM_DIR:/snap/libreoffice/current/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+# Extra unopkg arguments pinning it to the LibreOffice profile that is actually
+# used. Empty for deb/rpm installs (default profile discovery is correct).
+unopkg_profile_args() {
+    local snap_conf="$HOME/snap/libreoffice/current/.config/libreoffice/4"
+    if [[ -x "$_LO_SNAP_PROGRAM_DIR/unopkg" && -d "$snap_conf/user" ]]; then
+        printf -- '-env:UserInstallation=file://%s' "$snap_conf"
+    fi
+}
+
 _lo_macos_program_dir() {
     local macos_bin="/Applications/LibreOffice.app/Contents/MacOS"
     if [[ -d "$macos_bin" ]]; then
@@ -68,6 +88,7 @@ find_soffice() {
         /usr/lib64/libreoffice/program/soffice \
         /opt/libreoffice*/program/soffice \
         /snap/bin/libreoffice.soffice \
+        "$_LO_SNAP_PROGRAM_DIR/soffice" \
         /usr/local/bin/soffice; do
         for c in $candidate; do
             if [[ -x "$c" ]]; then
@@ -92,7 +113,8 @@ find_unopkg() {
         /usr/lib/libreoffice/program/unopkg \
         /usr/lib64/libreoffice/program/unopkg \
         /opt/libreoffice*/program/unopkg \
-        /snap/bin/libreoffice.unopkg; do
+        /snap/bin/libreoffice.unopkg \
+        "$_LO_SNAP_PROGRAM_DIR/unopkg"; do
         for c in $candidate; do
             if [[ -x "$c" ]]; then
                 echo "$c"

--- a/tests/chatbot/test_librarian.py
+++ b/tests/chatbot/test_librarian.py
@@ -1,0 +1,97 @@
+# Tests for librarian.seed_user_profile_if_missing (issue #346: onboarding must never block work).
+
+import json
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from plugin.chatbot.librarian import is_tour_request, seed_user_profile_if_missing
+from plugin.chatbot.memory import MemoryStore
+
+
+class DummyCtx:
+    def __init__(self, tmp_dir):
+        self.tmp_dir = tmp_dir
+
+    # Mocking getServiceManager so user_config_dir resolves here
+    def getServiceManager(self):
+        sm = Mock()
+        path_settings = Mock()
+        path_settings.UserConfig = f"file://{self.tmp_dir}"
+        sm.createInstanceWithContext.return_value = path_settings
+        return sm
+
+
+class TestSeedUserProfile(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.ctx = DummyCtx(self.tmp_dir)
+        self.store = MemoryStore(self.ctx)
+
+    def test_seed_creates_profile_with_suggested_name(self):
+        with patch("plugin.chatbot.librarian.get_suggested_user_name", return_value="Keith"):
+            created = seed_user_profile_if_missing(self.ctx)
+
+        self.assertTrue(created)
+        raw = self.store.read("user")
+        self.assertTrue(raw.strip(), "seeded profile must be non-empty so the onboarding gate passes")
+        data = json.loads(raw)
+        self.assertEqual(data.get("name"), "Keith")
+        self.assertIn("auto-detected", data.get("name_source", ""))
+
+    def test_seed_without_suggested_name_still_unblocks_gate(self):
+        with patch("plugin.chatbot.librarian.get_suggested_user_name", return_value=None):
+            created = seed_user_profile_if_missing(self.ctx)
+
+        self.assertTrue(created)
+        raw = self.store.read("user")
+        self.assertTrue(raw.strip())
+        data = json.loads(raw)
+        self.assertNotIn("name", data)
+        self.assertIn("name_source", data)
+
+    def test_seed_never_overwrites_existing_profile(self):
+        original = json.dumps({"name": "Existing"}, indent=2)
+        self.store.write("user", original)
+
+        with patch("plugin.chatbot.librarian.get_suggested_user_name", return_value="Keith"):
+            created = seed_user_profile_if_missing(self.ctx)
+
+        self.assertFalse(created)
+        self.assertEqual(self.store.read("user"), original)
+
+    def test_second_seed_is_a_no_op(self):
+        with patch("plugin.chatbot.librarian.get_suggested_user_name", return_value="Keith"):
+            self.assertTrue(seed_user_profile_if_missing(self.ctx))
+            self.assertFalse(seed_user_profile_if_missing(self.ctx))
+
+        seeded = json.loads(self.store.read("user"))
+        self.assertEqual(seeded.get("name"), "Keith")
+
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestTourRequestMatcher(unittest.TestCase):
+    def test_clear_tour_requests_match(self):
+        for text in (
+            "give me a tour",
+            "Show me around!",
+            "Can I take the grand tour?",
+            "what can WriterAgent do?",
+            "teach me how to use WriterAgent",
+            "introduce me to WriterAgent",
+        ):
+            self.assertTrue(is_tour_request(text), text)
+
+    def test_normal_messages_do_not_match(self):
+        for text in (
+            "hello",
+            "make a table",
+            "tutorial please",  # 'tour' inside 'tutorial' must not match
+            "yes, André is fine, and my favourite color is yellow",
+            "",
+        ):
+            self.assertFalse(is_tour_request(text), text)

--- a/tests/chatbot/test_memory.py
+++ b/tests/chatbot/test_memory.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import tempfile
@@ -161,6 +162,79 @@ class TestMemoryTool(unittest.TestCase):
         self.assertIn("editor:", content)
         self.assertIn("vim: Yes", content)
 '''
+
+class TestMemoryWriteConcurrency(unittest.TestCase):
+    """Regression: parallel upsert_memory calls raced and tore USER.md (2026-08-23).
+
+    Two calls in one model turn (name + favorite color) interleaved their
+    open/write cycles: shorter payload won the head of the file, the longer
+    write's stale tail survived, and the sibling key was lost.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.ctx = DummyCtx(self.tmp_dir)
+        self.store = MemoryStore(self.ctx)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_parallel_upserts_merge_without_corruption(self):
+        import threading
+
+        from plugin.chatbot.memory import MemoryTool
+
+        tool = MemoryTool()
+
+        def run(key, content):
+            res = tool.execute(self.ctx, key=key, content=content)
+            assert res.get("status") == "ok", res
+
+        t1 = threading.Thread(target=run, args=("name", "Andre"))
+        t2 = threading.Thread(target=run, args=("favorite_colors", "dark blue"))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        data = json.loads(self.store.read("user"))  # must be valid JSON
+        self.assertEqual(data["name"], "Andre")
+        self.assertEqual(data["favorite_colors"], "dark blue")
+
+    def test_write_is_atomic_and_cleans_temp_files(self):
+        import os
+
+        self.store.write("user", json.dumps({"name": "Andre"}))
+        self.assertEqual(json.loads(self.store.read("user")), {"name": "Andre"})
+        leftovers = [f for f in os.listdir(self.tmp_dir) if f.startswith(".memory-")]
+        self.assertEqual(leftovers, [], "atomic-write temp files must not leak")
+
+    def test_upserting_name_clears_seed_marker(self):
+        # After the user confirms their name, the seed guidance must stop
+        # injecting — otherwise every new session re-asks name/color.
+        seeded = {
+            "name_source": "auto-detected from LibreOffice User Data or OS login; not yet confirmed by the user",
+            "favorite_colors": "",
+            "name": "andre",
+        }
+        self.store.write("user", json.dumps(seeded))
+
+        res = MemoryTool().execute(self.ctx, key="name", content="André")
+        self.assertEqual(res["status"], "ok")
+
+        data = json.loads(self.store.read("user"))
+        self.assertNotIn("name_source", data)
+        self.assertEqual(data["name"], "André")
+
+    def test_color_upsert_alone_keeps_seed_marker(self):
+        seeded = {"name_source": "auto-detected", "favorite_colors": "", "name": "andre"}
+        self.store.write("user", json.dumps(seeded))
+
+        MemoryTool().execute(self.ctx, key="favorite_colors", content="blue")
+
+        data = json.loads(self.store.read("user"))
+        self.assertIn("name_source", data)  # name still unconfirmed → keep asking once
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/chatbot/test_smol_agent.py
+++ b/tests/chatbot/test_smol_agent.py
@@ -803,8 +803,11 @@ def test_do_send_enters_librarian_when_user_memory_missing():
     ), patch("plugin.chatbot.config_ui_helpers.sync_sidebar_text_model"), patch(
         "plugin.chatbot.memory.MemoryStore"
     ) as mock_store:
-        mock_store.return_value.read.return_value = ""
-        SendButtonListener._do_send(listener)
+        # Seed reads through librarian's own import binding too; keep it deterministic
+        # against the global config-path cache instead of a real profile directory.
+        with patch("plugin.chatbot.librarian.MemoryStore", mock_store):
+            mock_store.return_value.read.return_value = ""
+            SendButtonListener._do_send(listener)
 
     assert listener._in_librarian_mode is True
     listener._run_librarian.assert_called_once()
@@ -843,8 +846,9 @@ def test_do_send_uses_document_chat_after_librarian_flag_clears():
     ), patch("plugin.chatbot.config_ui_helpers.sync_sidebar_text_model"), patch(
         "plugin.chatbot.memory.MemoryStore"
     ) as mock_store:
-        mock_store.return_value.read.return_value = '{"name": "Keith"}'
-        SendButtonListener._do_send(listener)
+        with patch("plugin.chatbot.librarian.MemoryStore", mock_store):
+            mock_store.return_value.read.return_value = '{"name": "Keith"}'
+            SendButtonListener._do_send(listener)
 
     assert listener._in_librarian_mode is False
     listener._run_librarian.assert_not_called()


### PR DESCRIPTION
## Problem

#346: the onboarding gate routed **every** message to the Librarian until `USER.md` existed, and the only exit was the model calling `switch_to_document_mode`. Weak models never call it, so users were stuck in an interrogation loop across sessions — asked their name and favorite colors instead of getting work done. Reproduced concretely with `deepseek-chat`: repeated *"MAKE A TABLE NOW"* got name questions all session.

## Fix — deterministic, keeps the Librarian fully intact

- `seed_user_profile_if_missing()` writes a provisional `USER.md` from LibreOffice User Data / OS login (the June 17 direction in #346) before the gate, so document work starts on message #1. The blocking path is unreachable for new installs.
- First-reply guidance: explicitly confirm the auto-detected name (only re-saved if the user corrects it) and ask once about favorite colors with a one-line explanation that they make nicer looking tables. Saved via `upsert_memory`. Never delays document work.
- Saving key `name` clears the seed marker automatically, so the questions are asked **exactly once**, across sessions.
- Messages asking for a tour (`"tour"`, `"show me around"`, … — deterministic phrase match) route into the existing `LibrarianOnboardingTool` flow, so the full teaching experience stays available on demand, any session.

## Bonus bug found while validating

Two `upsert_memory` calls in one model turn (name + color) raced their read-modify-write on `USER.md`: torn JSON tail bytes on disk and a lost key — reproduced live. Fixed with an atomic write (`tempfile` + `os.replace`) and a lock around the read-modify-write cycle.

## Testing

- 587 pytest tests pass, including new regression suites (seeding, tour-request matcher, parallel-upsert merge, marker cleanup); `make typecheck` clean
- Manually verified end-to-end twice on true virgin profiles (empty settings surviving restarts): first-run seeding, single ask, answers persisting across restarts, spreadsheet edits from message #1, and the full six-tip tour via the phrase trigger
- Functional changes are platform-neutral Python/UNO. The snap-tooling commit is Linux-only and purely additive (all existing paths untouched). Not exercised on macOS/Windows — happy for a maintainer CI run.
