### PR TITLE
Fix Google Gemini provider shim image generation logic and model defaults

### DIFF
--- a/plugin/framework/client/google_shim.py
+++ b/plugin/framework/client/google_shim.py
@@ -35,15 +35,21 @@ class GoogleShim(OpenAIShim):
     ) -> tuple[str, str, bytes, dict[str, str]]:
         endpoint = self.client._endpoint()
         key = self.client._resolve_auth().get("api_key", "")
-        model_name = model or "imagen-3.0-generate-002"
+        model_name = model or "imagen-4.0-generate-001"
 
         if model_name.startswith("imagen"):
             url = f"{endpoint}/v1beta/models/{model_name}:predict?key={key}"
             aspect = "1:1"
-            if width > height * 1.5:
-                aspect = "16:9"
-            elif height > width * 1.5:
-                aspect = "9:16"
+            if width and height:
+                ratio = width / height
+                if abs(ratio - (16 / 9)) < 0.15:
+                    aspect = "16:9"
+                elif abs(ratio - (4 / 3)) < 0.1:
+                    aspect = "4:3"
+                elif abs(ratio - (3 / 4)) < 0.1:
+                    aspect = "3:4"
+                elif abs(ratio - (9 / 16)) < 0.15:
+                    aspect = "9:16"
 
             data: dict[str, Any] = {"instances": [{"prompt": prompt}], "parameters": {"sampleCount": 1, "aspectRatio": aspect}}
         else:
@@ -62,16 +68,21 @@ class GoogleShim(OpenAIShim):
 
         if "predictions" in response_data:
             preds = response_data.get("predictions", [])
-            for pr in preds:
-                if b64 := pr.get("bytesBase64Encoded"):
-                    out.append(b64)
+            if isinstance(preds, list):
+                for pr in preds:
+                    if isinstance(pr, dict):
+                        if b64 := pr.get("bytesBase64Encoded"):
+                            out.append(b64)
 
         candidates = response_data.get("candidates", [])
-        if candidates:
-            parts = candidates[0].get("content", {}).get("parts", [])
-            for p in parts:
-                inline = p.get("inlineData", {})
-                if inline and inline.get("data"):
-                    out.append(inline["data"])
+        if candidates and isinstance(candidates, list):
+            cand = candidates[0]
+            if isinstance(cand, dict):
+                parts = cand.get("content", {}).get("parts", [])
+                if isinstance(parts, list):
+                    for p in parts:
+                        if isinstance(p, dict):
+                            inline = p.get("inlineData", {})
+                            if isinstance(inline, dict) and inline.get("data"):
+                                out.append(inline["data"])
         return out
-

--- a/tests/framework/test_client_llm_google.py
+++ b/tests/framework/test_client_llm_google.py
@@ -71,14 +71,21 @@ def test_google_image_completion(mock_ctx):
     shim = client._get_shim()
     assert isinstance(shim, GoogleShim)
 
-    # 1. Test Imagen path (model name starts with imagen)
-    method, path, body, headers = shim.build_image_request("Draw a sunset", model="imagen-3.0-generate-002", width=1792, height=1024)
+    # 1. Test Imagen path default model & aspect ratio 16:9
+    method, path, body, headers = shim.build_image_request("Draw a sunset", model=None, width=1792, height=1024)
     assert method == "POST"
-    assert path == "/v1beta/models/imagen-3.0-generate-002:predict?key=test-key"
+    assert path == "/v1beta/models/imagen-4.0-generate-001:predict?key=test-key"
     data = json.loads(body.decode("utf-8"))
     assert data["parameters"]["aspectRatio"] == "16:9"
 
-    # 2. Test Multimodal path (other models)
+    # 2. Test Imagen aspect ratio 4:3 and 3:4
+    _, _, body_4_3, _ = shim.build_image_request("Draw a cat", model="imagen-4.0-generate-001", width=1024, height=768)
+    assert json.loads(body_4_3.decode("utf-8"))["parameters"]["aspectRatio"] == "4:3"
+
+    _, _, body_3_4, _ = shim.build_image_request("Draw a tower", model="imagen-4.0-generate-001", width=768, height=1024)
+    assert json.loads(body_3_4.decode("utf-8"))["parameters"]["aspectRatio"] == "3:4"
+
+    # 3. Test Multimodal path (other models)
     method, path, body, headers = shim.build_image_request("Generate an image", model="gemini-2.5-flash-image", width=1024, height=1024)
     assert method == "POST"
     assert path == "/v1beta/models/gemini-2.5-flash-image:generateContent?key=test-key"


### PR DESCRIPTION
Validated Google Gemini provider code against Google official API specs. Fixed aspect ratio mapping for 4:3 and 3:4 image sizes, updated default Imagen model fallback to imagen-4.0-generate-001, and added tests.

---
*PR created automatically by Jules for task [2599016157457715290](https://jules.google.com/task/2599016157457715290) started by @KeithCu*