### PR TITLE
Fix CrossHair workflow: use uv dependency group instead of missing extra

### DIFF
--- a/.github/workflows/crosshair-deep.yml
+++ b/.github/workflows/crosshair-deep.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --dev --extra dev
+          uv sync --dev
 
       - name: Create build directory
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On-demand CrossHair workflow run [32677868949](https://github.com/KeithCu/writeragent/actions/runs/32677868949) failed during **Install dependencies**:

```
uv sync --dev --extra dev
error: Extra `dev` is not defined in the `optional-dependencies` table for `writeragent`
```

`pyproject.toml` installs CrossHair via PEP 735 `[dependency-groups]` (`dev`) with `[tool.uv] default-groups = ["dev"]`. There is no `[project.optional-dependencies]` extra named `dev`.

## Change

In `.github/workflows/crosshair-deep.yml`, change:

```
uv sync --dev --extra dev
```

to:

```
uv sync --dev
```

`--dev` is the uv group flag and matches the existing `dev` dependency group (which already includes `crosshair-tool`). No dummy extra was added.

Grep for other stale `--extra dev` usages found only this workflow. The other workflow (`.github/workflows/build-vec-wheels.yml`) does not use `uv sync`.

## Testing

Local `uv` 0.12.5 against this tree:

- `uv sync --dev --extra dev --dry-run` reproduces the CI error: Extra `dev` is not defined
- `uv sync --dev --dry-run` succeeds (lockfile resolves; `crosshair-tool` is in the `dev` group)
- `pyproject.toml` has `[dependency-groups] dev` and no `optional-dependencies`
- YAML parses; no remaining `--extra` in `.github/workflows/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78243c24-7e72-4c8c-9a33-cbb2736cecfc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78243c24-7e72-4c8c-9a33-cbb2736cecfc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

