### PR TITLE
Update WriterAgent eval model list from live OpenRouter catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ For detailed setup instructions, see the **[Install and Troubleshooting Guide](d
 
 An in-LibreOffice **LLM Evaluation Suite** benchmarks models on real Writer, Calc, and Draw tasks and ranks them by **Value (C²/$)** — average correctness squared ÷ average dollars per run, using live OpenRouter pricing.
 
+Apr 2026 snapshot — slugs and prices may be stale. Current default eval models live in [`scripts/prompt_optimization/model_configs.py`](scripts/prompt_optimization/model_configs.py).
+
 | Rank | Model                                  | Avg correctness | Avg score | Avg tokens | Avg cost ($) | Value (C²/$) |
 | ---- | -------------------------------------- | --------------- | --------- | ---------- | ------------ | ------------ |
 | 1    | openai/gpt-oss-120b                    | 0.980           | 0.942     | 3767.1     | 0.00025      | 3827.240     |

--- a/docs/eval-benchmarks.md
+++ b/docs/eval-benchmarks.md
@@ -6,6 +6,8 @@ How to run evals from the repo: [scripts/prompt_optimization/README.md](../scrip
 
 ## Snapshot ranking (Apr 2026)
 
+Apr 2026 snapshot — slugs and prices may be stale. Current default eval models live in [`scripts/prompt_optimization/model_configs.py`](../scripts/prompt_optimization/model_configs.py).
+
 | Rank | Model | Avg correctness | Avg score | Avg tokens | Avg cost ($) | Value (C²/$) |
 | ---- | -------------------------------------- | --------------- | --------- | ---------- | ------------ | ------------ |
 | 1 | openai/gpt-oss-120b | 0.980 | 0.942 | 3767.1 | 0.00025 | 3827.240 |

--- a/scripts/prompt_optimization/README.md
+++ b/scripts/prompt_optimization/README.md
@@ -147,6 +147,8 @@ Use `--out path.json` or `--out path.csv` to write results (format by extension)
 
 ### Benchmark results (best models, combined runs)
 
+Apr 2026 snapshot — slugs and prices may be stale. Current default eval models live in `model_configs.py`.
+
 From multi-model runs on the default 8-evaluation Writer set, ranked by **Corr/USD** (avg correctness ÷ total cost; higher = better value) and/or **correctness**:
 
 - **openai/gpt-oss-120b** — Top value in run 1 (346.8 Corr/USD, 1.0 correctness, ~$0.003 total).

--- a/scripts/prompt_optimization/model_configs.py
+++ b/scripts/prompt_optimization/model_configs.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 Model definitions for multi-model DSPy/OpenRouter benchmarking.
 
 Each model is identified by its **openrouter_id** (e.g. openai/gpt-oss-120b).
-Prices are in USD per 1M tokens.
+Prices are in USD per 1M tokens (OpenRouter ``pricing.prompt`` /
+``pricing.completion`` × 1e6). Context windows are ``context_length``.
 """
 
 from dataclasses import dataclass
@@ -32,141 +33,65 @@ class ModelConfig:
     notes: Optional[str] = None
 
 
+# Prices and context_length from OpenRouter GET /api/v1/models (2026-08-24).
+# Default sweep is US/small-leaning plus China pack; gold-only is excluded
+# from get_default_models() but stays in MODELS for --gold-model.
 MODELS: list[ModelConfig] = [
     ModelConfig(
         openrouter_id="openai/gpt-oss-120b",
         display_name="OpenAI: gpt-oss-120b",
-        context_window_tokens=131_000,
-        input_cost_per_million=0.039,
-        output_cost_per_million=0.19,
-        notes=(
-            "117B-parameter MoE; 5.1B activated per forward; MXFP4; "
-            "high-reasoning, agentic, and general-purpose; native tools."
-        ),
+        context_window_tokens=131_072,
+        input_cost_per_million=0.037,
+        output_cost_per_million=0.17,
+        notes="OpenAI open-weight 117B MoE (5.1B active); high-reasoning agentic default.",
     ),
     ModelConfig(
-        openrouter_id="google/gemini-3-flash-preview",
-        display_name="Google: Gemini 3 Flash",
+        openrouter_id="openai/gpt-oss-20b",
+        display_name="OpenAI: gpt-oss-20b",
+        context_window_tokens=131_072,
+        input_cost_per_million=0.03,
+        output_cost_per_million=0.13,
+        notes="OpenAI open-weight 21B MoE (3.6B active); cheap small sibling of 120B.",
+    ),
+    ModelConfig(
+        openrouter_id="openai/gpt-5.6-luna",
+        display_name="OpenAI: GPT-5.6 Luna",
         context_window_tokens=1_050_000,
-        input_cost_per_million=0.10,
-        output_cost_per_million=0.40,
-        notes=(
-            "Latest Gemini Flash; fast multimodal with strong coding and "
-            "function-calling."
-        ),
+        input_cost_per_million=0.2,
+        output_cost_per_million=1.2,
+        notes="OpenAI GPT-5.6 fast/cheap tier for latency-sensitive agent work.",
     ),
     ModelConfig(
-        openrouter_id="z-ai/glm-5.1",
-        display_name="Z.ai: GLM 5.1",
-        context_window_tokens=203_000,
-        input_cost_per_million=0.95,
-        output_cost_per_million=3.15,
-        notes=(
-            "Latest flagship GLM with enhanced programming capabilities and "
-            "more stable multi-step reasoning / agent execution."
-        ),
+        openrouter_id="google/gemini-3.7-flash",
+        display_name="Google: Gemini 3.7 Flash",
+        context_window_tokens=1_048_576,
+        input_cost_per_million=0.375,
+        output_cost_per_million=1.875,
+        notes="Google Flash for fast agentic/coding work; replaces Gemini 3 Flash Preview.",
     ),
     ModelConfig(
-        openrouter_id="minimax/minimax-m2.7",
-        display_name="MiniMax: MiniMax M2.7",
-        context_window_tokens=197_000,
-        input_cost_per_million=0.30,
-        output_cost_per_million=1.20,
-        notes=(
-            "Released Mar 18, 2026; 2.12T tokens; flagship model optimized for "
-            "office workflows (Word, Excel, PPT); scores 80.2% on SWE-Bench "
-            "Verified; strong planning and agentic capabilities."
-        ),
-    ),
-    ModelConfig(
-        openrouter_id="x-ai/grok-4.1-fast",
-        display_name="xAI: Grok 4.1 Fast",
-        context_window_tokens=2_000_000,
-        input_cost_per_million=0.20,
-        output_cost_per_million=0.50,
-        notes=(
-            "Grok 4.1 Fast; 2M-token context; $0.20/M input, $0.50/M output."
-        ),
-    ),
-    ModelConfig(
-        openrouter_id="qwen/qwen3.5-35b-a3b",
-        display_name="Qwen: Qwen3.5-35B-A3B",
-        context_window_tokens=262_000,
-        input_cost_per_million=0.25,
-        output_cost_per_million=2.00,
-        notes="Vision-language MoE; linear attention; comparable to Qwen3.5-27B.",
-    ),
-    ModelConfig(
-        openrouter_id="qwen/qwen3.5-27b",
-        display_name="Qwen: Qwen3.5-27B",
-        context_window_tokens=262_000,
-        input_cost_per_million=0.30,
-        output_cost_per_million=2.40,
-        notes="Dense VLM with linear attention; comparable to Qwen3.5-122B-A10B.",
-    ),
-    ModelConfig(
-        openrouter_id="qwen/qwen3.5-122b-a10b",
-        display_name="Qwen: Qwen3.5-122B-A10B",
-        context_window_tokens=262_000,
-        input_cost_per_million=0.40,
-        output_cost_per_million=3.20,
-        notes="VLM MoE; second to Qwen3.5-397B-A17B; strong text and visual.",
-    ),
-    ModelConfig(
-        openrouter_id="qwen/qwen3.5-9b",
-        display_name="Qwen: Qwen3.5-9B",
-        context_window_tokens=262_000,
-        input_cost_per_million=0.10,
-        output_cost_per_million=0.15,
-        notes=(
-            "Released Mar 10, 2026; 9B-parameter multimodal foundation model "
-            "from the Qwen3.5 family; strong reasoning, coding, and visual "
-            "understanding via early fusion of multimodal tokens."
-        ),
-    ),
-    ModelConfig(
-        openrouter_id="allenai/olmo-3.1-32b-instruct",
-        display_name="AllenAI: Olmo 3.1 32B Instruct",
-        context_window_tokens=65_536,
-        input_cost_per_million=0.20,
-        output_cost_per_million=0.60,
-        notes="Released Jan 6, 2026; 65K context.",
+        openrouter_id="google/gemini-3.5-flash-lite",
+        display_name="Google: Gemini 3.5 Flash Lite",
+        context_window_tokens=1_048_576,
+        input_cost_per_million=0.3,
+        output_cost_per_million=2.5,
+        notes="Google lite Flash for cheap focused subagent tasks.",
     ),
     ModelConfig(
         openrouter_id="nvidia/nemotron-3-nano-30b-a3b",
         display_name="NVIDIA: Nemotron 3 Nano 30B A3B",
-        context_window_tokens=262_000,
-        input_cost_per_million=0.05,
-        output_cost_per_million=0.20,
-        notes="Small MoE; open-weights; agentic AI; high compute efficiency.",
-    ),
-    ModelConfig(
-        openrouter_id="nvidia/nemotron-3-super-120b-a12b:free",
-        display_name="NVIDIA: Nemotron 3 Super 120B A12B (Free Tier)",
-        context_window_tokens=262_000,
-        input_cost_per_million=0.20,
-        output_cost_per_million=0.80,
-        notes=(
-            "Large Nemotron 3 Super 120B variant on OpenRouter; "
-            "configured here with approximate list pricing so it can "
-            "participate in intelligence-per-dollar benchmarking."
-        ),
-    ),
-    ModelConfig(
-        openrouter_id="mistralai/devstral-2512",
-        display_name="Mistral: Devstral 2 2512",
         context_window_tokens=262_144,
-        input_cost_per_million=0.40,
-        output_cost_per_million=2.00,
-        notes="Released Dec 9, 2025; 262K context.",
+        input_cost_per_million=0.05,
+        output_cost_per_million=0.2,
+        notes="NVIDIA small MoE; paid (not :free) high-efficiency agentic.",
     ),
     ModelConfig(
-        openrouter_id="deepseek/deepseek-v3.2",
-        display_name="DeepSeek V3.2",
-        context_window_tokens=131_072,
-        input_cost_per_million=0.26,
-        output_cost_per_million=0.38,
-        notes="Released Dec 8, 2025; 131K context.",
+        openrouter_id="nvidia/nemotron-3.5-lightning",
+        display_name="NVIDIA: Nemotron 3.5 Lightning",
+        context_window_tokens=262_144,
+        input_cost_per_million=0.08,
+        output_cost_per_million=0.2,
+        notes="NVIDIA 30B/3B-active MoE; paid replacement for the Super :free slot.",
     ),
     ModelConfig(
         openrouter_id="inception/mercury-2",
@@ -174,16 +99,84 @@ MODELS: list[ModelConfig] = [
         context_window_tokens=128_000,
         input_cost_per_million=0.25,
         output_cost_per_million=0.75,
-        notes=(
-            "Released Mar 4, 2026; 9.15B tokens; first reasoning diffusion LLM "
-            "(dLLM); >1,000 tokens/sec; supports tunable reasoning levels, "
-            "native tool use, and schema-aligned JSON output."
-        ),
+        notes="Inception reasoning diffusion LLM; native tools, very high throughput.",
+    ),
+    ModelConfig(
+        openrouter_id="x-ai/grok-4.6",
+        display_name="SpaceXAI: Grok 4.6",
+        context_window_tokens=500_000,
+        input_cost_per_million=2.0,
+        output_cost_per_million=6.0,
+        notes="SpaceXAI Grok 4.6; replaces retired grok-4.1-fast (4.6 only).",
+    ),
+    ModelConfig(
+        openrouter_id="meta/muse-glimmer-30b",
+        display_name="Meta: Muse Glimmer 30B",
+        context_window_tokens=131_072,
+        input_cost_per_million=0.35,
+        output_cost_per_million=1.5,
+        notes="Meta dense 30B multimodal; distilled Spark for consumer-hardware agents.",
+    ),
+    ModelConfig(
+        openrouter_id="meta/muse-spark-1.2-contributor",
+        display_name="Meta: Muse Spark 1.2 Contributor",
+        context_window_tokens=1_048_576,
+        input_cost_per_million=0.1,
+        output_cost_per_million=0.2,
+        notes="Meta Spark 1.2 contributor tier; cheap 1M-context reasoning.",
+    ),
+    ModelConfig(
+        openrouter_id="poolside/laguna-s-2.1",
+        display_name="Poolside: Laguna S 2.1",
+        context_window_tokens=1_048_576,
+        input_cost_per_million=0.09,
+        output_cost_per_million=0.18,
+        notes="Poolside 118B/8B-active coding agent; paid (not :free).",
+    ),
+    ModelConfig(
+        openrouter_id="qwen/qwen3.8-27b",
+        display_name="Qwen: Qwen3.8 27B",
+        context_window_tokens=1_000_000,
+        input_cost_per_million=0.4,
+        output_cost_per_million=3.0,
+        notes="Qwen 3.8 dense 27B VLM; the default-set Qwen (replaces the 3.5 family).",
+    ),
+    ModelConfig(
+        openrouter_id="z-ai/glm-5.3",
+        display_name="Z.ai: GLM 5.3",
+        context_window_tokens=1_048_576,
+        input_cost_per_million=1.4,
+        output_cost_per_million=4.4,
+        notes="Z.ai flagship GLM for long-horizon software/agent work; replaces 5.1.",
+    ),
+    ModelConfig(
+        openrouter_id="minimax/minimax-m3",
+        display_name="MiniMax: MiniMax M3",
+        context_window_tokens=1_048_576,
+        input_cost_per_million=0.3,
+        output_cost_per_million=1.2,
+        notes="MiniMax multimodal 1M-context agent/coding model; replaces M2.7.",
+    ),
+    ModelConfig(
+        openrouter_id="deepseek/deepseek-v4-flash-0731",
+        display_name="DeepSeek: DeepSeek V4 Flash 0731",
+        context_window_tokens=1_310_720,
+        input_cost_per_million=0.14,
+        output_cost_per_million=0.28,
+        notes="DeepSeek 284B/13B-active MoE Flash; replaces V3.2.",
+    ),
+    ModelConfig(
+        openrouter_id="qwen/qwen3.7-flash",
+        display_name="Qwen: Qwen3.7 Flash",
+        context_window_tokens=1_000_000,
+        input_cost_per_million=0.03,
+        output_cost_per_million=0.13,
+        notes="Qwen cheap Flash VLM; extra small China Qwen besides 27B.",
     ),
     ModelConfig(
         openrouter_id="anthropic/claude-sonnet-4.6",
         display_name="Anthropic: Claude Sonnet 4.6",
-        context_window_tokens=200_000,
+        context_window_tokens=1_000_000,
         input_cost_per_million=3.0,
         output_cost_per_million=15.0,
         notes=(
@@ -209,4 +202,3 @@ def get_default_models() -> Sequence[ModelConfig]:
     golds; that model is in MODEL_BY_ID but not in this list.
     """
     return [m for m in MODELS if m.openrouter_id not in GOLD_ONLY_MODEL_IDS]
-

--- a/tests/scripts/test_model_configs.py
+++ b/tests/scripts/test_model_configs.py
@@ -1,0 +1,80 @@
+# WriterAgent tests for scripts/prompt_optimization/model_configs.py
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PO = Path(__file__).resolve().parents[2] / "scripts" / "prompt_optimization"
+if str(_PO) not in sys.path:
+    sys.path.insert(0, str(_PO))
+
+from model_configs import (  # noqa: E402
+    GOLD_ONLY_MODEL_IDS,
+    MODEL_BY_ID,
+    MODELS,
+    get_default_models,
+)
+
+
+# Default sweep + China pack; gold-only stays in MODELS only.
+EXPECTED_DEFAULT_IDS = [
+    "openai/gpt-oss-120b",
+    "openai/gpt-oss-20b",
+    "openai/gpt-5.6-luna",
+    "google/gemini-3.7-flash",
+    "google/gemini-3.5-flash-lite",
+    "nvidia/nemotron-3-nano-30b-a3b",
+    "nvidia/nemotron-3.5-lightning",
+    "inception/mercury-2",
+    "x-ai/grok-4.6",
+    "meta/muse-glimmer-30b",
+    "meta/muse-spark-1.2-contributor",
+    "poolside/laguna-s-2.1",
+    "qwen/qwen3.8-27b",
+    "z-ai/glm-5.3",
+    "minimax/minimax-m3",
+    "deepseek/deepseek-v4-flash-0731",
+    "qwen/qwen3.7-flash",
+]
+
+DROPPED_SLUGS = [
+    "x-ai/grok-4.1-fast",
+    "allenai/olmo-3.1-32b-instruct",
+    "mistralai/devstral-2512",
+    "nvidia/nemotron-3-super-120b-a12b:free",
+    "google/gemini-3-flash-preview",
+    "z-ai/glm-5.1",
+    "minimax/minimax-m2.7",
+    "deepseek/deepseek-v3.2",
+    "qwen/qwen3.5-9b",
+    "qwen/qwen3.5-27b",
+    "qwen/qwen3.5-35b-a3b",
+    "qwen/qwen3.5-122b-a10b",
+]
+
+
+def test_default_models_excludes_gold_only() -> None:
+    default_ids = [m.openrouter_id for m in get_default_models()]
+    assert default_ids == EXPECTED_DEFAULT_IDS
+    assert "anthropic/claude-sonnet-4.6" not in default_ids
+    assert GOLD_ONLY_MODEL_IDS == frozenset({"anthropic/claude-sonnet-4.6"})
+    assert "anthropic/claude-sonnet-4.6" in MODEL_BY_ID
+
+
+def test_models_catalog_matches_defaults_plus_gold() -> None:
+    catalog_ids = [m.openrouter_id for m in MODELS]
+    assert catalog_ids == EXPECTED_DEFAULT_IDS + ["anthropic/claude-sonnet-4.6"]
+    for slug in DROPPED_SLUGS:
+        assert slug not in MODEL_BY_ID
+
+
+def test_model_config_fields_are_populated() -> None:
+    for model in MODELS:
+        assert model.openrouter_id
+        assert model.display_name
+        assert model.context_window_tokens is not None
+        assert model.context_window_tokens > 0
+        assert model.input_cost_per_million >= 0
+        assert model.output_cost_per_million >= 0
+        assert model.notes
+        assert ":" not in model.openrouter_id.split("/", 1)[-1]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update `scripts/prompt_optimization/model_configs.py` to the current OpenRouter catalog (GET `/api/v1/models` on 2026-08-24). Prices are `pricing.prompt` / `pricing.completion` × 1e6. Context windows are `context_length`. Every included slug exists and advertises `tools`.

## Default sweep (`get_default_models()`)

Gold-only `anthropic/claude-sonnet-4.6` stays in `MODELS` / `GOLD_ONLY_MODEL_IDS` and is excluded from the default list (unchanged).

1. `openai/gpt-oss-120b` — keep
2. `openai/gpt-oss-20b` — add
3. `openai/gpt-5.6-luna` — add
4. `google/gemini-3.7-flash` — replaces `google/gemini-3-flash-preview`
5. `google/gemini-3.5-flash-lite` — add
6. `nvidia/nemotron-3-nano-30b-a3b` — keep (paid, not `:free`)
7. `nvidia/nemotron-3.5-lightning` — add (replaces Super `:free` slot)
8. `inception/mercury-2` — keep
9. `x-ai/grok-4.6` — replaces dead `x-ai/grok-4.1-fast` (4.6 only)
10. `meta/muse-glimmer-30b` — add
11. `meta/muse-spark-1.2-contributor` — add
12. `poolside/laguna-s-2.1` — add (paid, not `:free`)
13. `qwen/qwen3.8-27b` — add (the default-set Qwen)
14. `z-ai/glm-5.3` — replaces `z-ai/glm-5.1`
15. `minimax/minimax-m3` — replaces `minimax/minimax-m2.7`
16. `deepseek/deepseek-v4-flash-0731` — replaces `deepseek/deepseek-v3.2`
17. `qwen/qwen3.7-flash` — optional cheap China Qwen; exists and has tools

## Skipped (missing or no tools)

None. Every requested slug was live and advertised `tools`. Optional `qwen/qwen3.7-flash` was included for that reason.

Not added (per spec): Amazon, Grok 4.3 / build, Olmo, Devstral, Kimi K3, Opus 5, Mistral, `:batch`, `openrouter/auto-beta`, Super `:free`.

## Docs / tests

- Apr 2026 ranking tables in `README.md` and `docs/eval-benchmarks.md` are unchanged historical snapshots, plus a one-line “slugs may be stale” note. No new ranking table.
- Judge default stays `x-ai/grok-4.1-fast`.
- Unit tests: `tests/scripts/test_model_configs.py` locks the default id list and dropped slugs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70b1b848-d186-4917-b8ec-a9941e41c95b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70b1b848-d186-4917-b8ec-a9941e41c95b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

