### PR TITLE
Finish chatbot ownership cut (no new files)

### DIFF
--- a/docs/chat-sidebar-implementation.md
+++ b/docs/chat-sidebar-implementation.md
@@ -485,7 +485,9 @@ Simpler approach:
 |------|--------|
 | `registry/org/openoffice/Office/UI/Sidebar.xcu` | Deck + panel; include `WantsAWT` true |
 | `registry/org/openoffice/Office/UI/Factories.xcu` | ChatPanelFactory registration |
-| `panel_factory.py` / `panel.py` | ChatPanelFactory, ChatPanelElement, ChatToolPanel; ContainerWindowProvider + setVisible(True) |
+| `panel_factory.py` | ChatPanelFactory, ChatPanelElement, ChatToolPanel; ContainerWindowProvider + setVisible(True). Wires controls only — does not build `[DOCUMENT CONTENT]`. |
+| `panel.py` | `ChatSession` + Send/Stop/Clear listeners. Mode-switch context refresh is `ChatSession.refresh_document_context`. |
+| `send_handlers.py` / `tool_loop.py` | Mixins on Send; refresh document context on each send / mutating tool. |
 | `WriterAgentDialogs/ChatPanelDialog.xdl` | Panel UI; `dlg:withtitlebar="false"` |
 | `META-INF/manifest.xml` | Register panel factory, Sidebar.xcu, Factories.xcu |
 | `Makefile` / OXT bundle | Include `plugin/chatbot/panel*.py` and registry in the extension zip |

--- a/plugin/chatbot/AGENTS.md
+++ b/plugin/chatbot/AGENTS.md
@@ -13,6 +13,21 @@ the area gotchas.
 - Memory (experimental): `memory.py` — `MEMORY_GUIDANCE` is in `plugin/framework/prompts.py`
 - Librarian is a **sidebar mode** (last in the dropdown). Do **not** gate `_do_send` on missing `USER.md`. Default selection uses `chatbot.librarian_invoked` (first open only), not `USER.md`. History is a global `ChatSession` (`LIBRARIAN_HISTORY_SESSION_ID`), not per document.
 
+## File ownership (existing modules; no new panel/dialog/session files)
+
+- `panel_factory.py` — UNO `XUIElementFactory` / XDL load / control wiring / listener attach. Resolves the document from the frame (`get_document_from_frame`). Does **not** import or call `get_document_context_for_chat`.
+- `panel.py` — `ChatSession` + button listeners. `ChatSession.refresh_document_context` rebuilds system prompt + `[DOCUMENT CONTENT]` when the sidebar switches to Chat (dropdown / `switch_to_document_mode`).
+- `send_handlers.py` / `tool_loop.py` — mixins on `SendButtonListener`. Build document context on send / mid-loop refresh. Stay mixins (no `session.py` / `send.py`).
+- `dialogs.py` — shared XDL / msgbox / checkbox / translate kit. LibrePy Settings and Run Python Script import this.
+- `dialog_views.py` — WriterAgent Settings pages, provider buttons, venv probe UI. `input_box` (Edit/Extend selection) stays here; it is not a generic XDL helper.
+
+## Legal imports
+
+- factory → `panel` (session + listeners), `dialogs` (control helpers), `get_document_from_frame`
+- factory must **not** import `get_document_context_for_chat`
+- views → `dialogs` helpers; views must **not** import `tool_loop`
+- send / tool loop → `get_document_context_for_chat` (still in `document_helpers` unless that builder has moved); must **not** import `panel_factory`
+
 Topic docs: [docs/chat-sidebar-implementation.md](../../docs/chat-sidebar-implementation.md),
 [docs/chat-smol-tool-architecture.md](../../docs/chat-smol-tool-architecture.md),
 [docs/chat-llm-hacks.md](../../docs/chat-llm-hacks.md),

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -16,10 +16,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Chat sidebar panel logic: session, send/tool loop, and button listeners.
 
-ChatSession holds conversation history. SendButtonListener drives the
-streaming tool-calling loop. StopButtonListener and ClearButtonListener
-are wired by panel_factory. UNO UI element factory and XDL wiring
-remain in panel_factory.py.
+ChatSession holds conversation history and refreshes ``[DOCUMENT CONTENT]``
+on Chat-mode switch. SendButtonListener drives the streaming tool-calling
+loop (via SendHandlersMixin / ToolCallingMixin). StopButtonListener and
+ClearButtonListener are wired by panel_factory. UNO UI element factory
+and XDL wiring remain in panel_factory.py.
 """
 
 from __future__ import annotations
@@ -105,6 +106,27 @@ class ChatSession:
             self.messages.insert(0, {"role": "system", "content": content})
         else:
             self.messages[0]["content"] = content
+
+    def refresh_document_context(self, model, ctx):
+        """Reload the Chat system prompt and ``[DOCUMENT CONTENT]`` from the live document.
+
+        Why this lives on ChatSession, not panel_factory: the factory only wires
+        XDL/controls. Mode switch (Chat dropdown / switch_to_document_mode) still
+        needs a fresh snapshot so the session does not keep an earlier send's
+        excerpt. Send/tool_loop also refresh on each send — this is the other
+        owner of that same builder, not a second factory import of it.
+        """
+        from plugin.doc.document_helpers import get_document_context_for_chat
+        from plugin.framework.config import get_config
+        from plugin.framework.constants import CHAT_DOCUMENT_CONTEXT_MAX_CHARS
+        from plugin.framework.prompts import get_chat_system_prompt_for_document
+
+        extra_instructions = str(get_config("additional_instructions") or "")
+        base_prompt = get_chat_system_prompt_for_document(model, extra_instructions, ctx=ctx)
+        doc_text = get_document_context_for_chat(
+            model, CHAT_DOCUMENT_CONTEXT_MAX_CHARS, include_end=True, include_selection=True, ctx=ctx
+        )
+        self.set_system_context(base_prompt, doc_text)
 
     def add_user_message(self, content):
         self.messages.append({"role": "user", "content": content})

--- a/plugin/chatbot/panel_factory.py
+++ b/plugin/chatbot/panel_factory.py
@@ -17,6 +17,8 @@
 # Chat with Document - Sidebar Panel implementation
 # Follows the working pattern from LibreOffice's Python ToolPanel example:
 # XUIElement wrapper creates panel in getRealInterface() via ContainerWindowProvider + XDL.
+# This module owns UNO/XDL wiring only. Chat document context is built on ChatSession
+# (mode switch) and send_handlers / tool_loop (each send) — not here.
 
 from __future__ import annotations
 
@@ -701,7 +703,13 @@ class ChatPanelElement(unohelper.Base, XUIElement):
         else:
             self.session = self.doc_session
         if mode == CHAT_MODE_CHAT:
-            self._refresh_doc_session_context(model)
+            # Session owns the builder; factory only asks for a fresh snapshot.
+            session = getattr(self, "doc_session", None)
+            if session is not None and model is not None:
+                try:
+                    session.refresh_document_context(model, self.ctx)
+                except Exception:
+                    log.debug("refresh_document_context failed", exc_info=True)
         toggle_image_ui(is_image_mode(mode))
         greeting = self._greeting_for_sidebar_mode(mode, model)
         if send_listener:
@@ -711,30 +719,6 @@ class ChatPanelElement(unohelper.Base, XUIElement):
         if response_ctrl:
             self._render_session_history(self.session, response_ctrl, model, greeting)
         return greeting
-
-    def _refresh_doc_session_context(self, model) -> None:
-        """Reload Chat system prompt + [DOCUMENT CONTENT] for the document session.
-
-        Why: switch_to_document_mode (and picking Chat) must not keep a stale snapshot
-        from an earlier send. Visible pane still shows Chat history; the model sees
-        the current document on the next turn because tool_loop also refreshes — this
-        keeps the session consistent immediately after the dropdown flips.
-        """
-        session = getattr(self, "doc_session", None)
-        if session is None or model is None:
-            return
-        try:
-            from plugin.doc.document_helpers import get_document_context_for_chat
-            from plugin.framework.constants import CHAT_DOCUMENT_CONTEXT_MAX_CHARS
-
-            extra_instructions = str(get_config("additional_instructions") or "")
-            base_prompt = get_chat_system_prompt_for_document(model, extra_instructions, ctx=self.ctx)
-            doc_text = get_document_context_for_chat(
-                model, CHAT_DOCUMENT_CONTEXT_MAX_CHARS, include_end=True, include_selection=True, ctx=self.ctx
-            )
-            session.set_system_context(base_prompt, doc_text)
-        except Exception:
-            log.debug("_refresh_doc_session_context failed", exc_info=True)
 
     def _wire_chat_mode_listener(self, chat_mode_selector, model, response_ctrl, send_listener, clear_listener, toggle_image_ui, mode_flags):
         from plugin.chatbot.chat_sidebar_mode import mode_from_selector_with_flags

--- a/tests/chatbot/test_chat_session.py
+++ b/tests/chatbot/test_chat_session.py
@@ -129,6 +129,32 @@ def test_history_load_uses_persisted_messages():
     mock_db.add_message.assert_not_called()
 
 
+def test_refresh_document_context_sets_prompt_and_excerpt():
+    session = ChatSession(system_prompt="stale")
+    session.add_user_message("prior")
+    model = MagicMock()
+    ctx = MagicMock()
+
+    with (
+        patch("plugin.doc.document_helpers.get_document_context_for_chat", return_value="DOC BODY") as mock_doc,
+        patch("plugin.framework.prompts.get_chat_system_prompt_for_document", return_value="FRESH PROMPT") as mock_prompt,
+        patch("plugin.framework.config.get_config", return_value="extra notes"),
+    ):
+        session.refresh_document_context(model, ctx)
+
+    mock_doc.assert_called_once()
+    assert mock_doc.call_args.args[0] is model
+    assert mock_doc.call_args.kwargs["include_end"] is True
+    assert mock_doc.call_args.kwargs["include_selection"] is True
+    assert mock_doc.call_args.kwargs["ctx"] is ctx
+    mock_prompt.assert_called_once_with(model, "extra notes", ctx=ctx)
+    assert session.base_system_prompt == "FRESH PROMPT"
+    assert session.document_context == "DOC BODY"
+    assert session.messages[0]["content"].startswith("FRESH PROMPT")
+    assert "[DOCUMENT CONTENT]\nDOC BODY\n[END DOCUMENT]" in session.messages[0]["content"]
+    assert session.messages[1]["role"] == "user"
+
+
 def test_history_load_failure_still_applies_system_prompt():
     with patch(
         "plugin.chatbot.panel.get_chat_history",

--- a/tests/chatbot/test_panel_factory.py
+++ b/tests/chatbot/test_panel_factory.py
@@ -1,0 +1,69 @@
+"""Import-graph ownership tests for the sidebar factory (no UNO import)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FACTORY = _REPO_ROOT / "plugin" / "chatbot" / "panel_factory.py"
+_DIALOG_VIEWS = _REPO_ROOT / "plugin" / "chatbot" / "dialog_views.py"
+_SEND_HANDLERS = _REPO_ROOT / "plugin" / "chatbot" / "send_handlers.py"
+_TOOL_LOOP = _REPO_ROOT / "plugin" / "chatbot" / "tool_loop.py"
+
+
+def _imported_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            names.add(module)
+            for alias in node.names:
+                names.add(alias.name)
+                if module:
+                    names.add("%s.%s" % (module, alias.name))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+    return names
+
+
+def _calls_name(path: Path, func_name: str) -> bool:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == func_name:
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == func_name:
+            return True
+    return False
+
+
+def test_panel_factory_does_not_import_or_call_chat_context_builder():
+    """Factory wires XDL/controls. Document context is ChatSession / send / tool_loop."""
+    imported = _imported_names(_FACTORY)
+    assert "get_document_context_for_chat" not in imported
+    assert "plugin.doc.document_helpers.get_document_context_for_chat" not in imported
+    assert not _calls_name(_FACTORY, "get_document_context_for_chat")
+
+
+def test_panel_factory_mode_switch_delegates_context_refresh_to_session():
+    src = _FACTORY.read_text(encoding="utf-8")
+    assert "session.refresh_document_context(model, self.ctx)" in src
+    assert "_refresh_doc_session_context" not in src
+
+
+def test_dialog_views_does_not_import_tool_loop():
+    imported = _imported_names(_DIALOG_VIEWS)
+    assert "plugin.chatbot.tool_loop" not in imported
+    assert "tool_loop" not in imported
+
+
+def test_send_and_tool_loop_do_not_import_panel_factory():
+    for path in (_SEND_HANDLERS, _TOOL_LOOP):
+        imported = _imported_names(path)
+        assert "plugin.chatbot.panel_factory" not in imported
+        assert "panel_factory" not in imported


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finish the existing chatbot split by clarifying ownership among files that already exist. Behavior-preserving. No new production modules.

## Ownership after this change

- **`panel_factory.py`** — UNO factory / XDL load / control wiring / listener attach. Resolves the document from the frame (`get_document_from_frame`). Does **not** build `[DOCUMENT CONTENT]`.
- **`panel.py`** — `ChatSession` + button listeners. `ChatSession.refresh_document_context` reloads system prompt + document excerpt when the sidebar switches to Chat (dropdown / `switch_to_document_mode`).
- **`send_handlers.py` / `tool_loop.py`** — mixins on `SendButtonListener`. Still build document context on send / mid-loop refresh. Left as mixins (un-mixin would need a new file).
- **`dialogs.py`** — shared XDL / msgbox / checkbox / translate kit. LibrePy Settings and Run Python Script keep importing this.
- **`dialog_views.py`** — WriterAgent Settings pages, provider buttons, venv probe UI. `input_box` (Edit/Extend selection) stays here; it is not a generic XDL helper.

## What crossed the line before

`panel_factory._refresh_doc_session_context` imported and called `get_document_context_for_chat` when applying Chat mode. That is a real second site (initial populate + dropdown / `switch_to_document_mode`), but the factory should not own chat-context builders.

## What moved

The builder call moved onto `ChatSession.refresh_document_context`. Factory still *asks* for a refresh on Chat-mode switch; it no longer imports the builder.

## What was left (moving it needed a new file)

- Send / tool-loop stay mixins on `SendButtonListener` (`send_handlers.py` / `tool_loop.py`). No `session.py` or `send.py`.
- `_apply_sidebar_mode` stays in the factory (session swap + greeting + history render + listener rebind). Extracting it would be a new module or would grow `panel.py` with UNO layout/wiring.
- `dialogs.py` / `dialog_views.py` already match the kit-vs-settings split. Generic load/translate/checkbox helpers are already in `dialogs`. No settings pages remain in `dialogs`. `input_box` is Edit/Extend selection UI, not a generic XDL helper.

## Legal imports (remaining)

- factory → `panel` (session + listeners), `dialogs` (control helpers), `get_document_from_frame`
- factory must **not** import `get_document_context_for_chat`
- views → `dialogs` helpers; views must **not** import `tool_loop`
- send / tool loop → `get_document_context_for_chat` (still in `plugin/doc/document_helpers.py`); must **not** import `panel_factory`

## Left alone

- **`plugin/agent_backend/`** — ACP PR in flight / merged; not touched.
- **`get_document_context_for_chat`** — still lives in `document_helpers`. Did not redo the Calc/chat-context split. Callers still import it from there.

## Tests

- Extended `tests/chatbot/test_chat_session.py` for the moved refresh.
- Added `tests/chatbot/test_panel_factory.py` (import-graph: factory does not import/call the builder; views/send/tool-loop forbidden edges).
- Existing hamburger / send / dialog UNO tests are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18db5bfe-2274-4cb2-bccb-2146e9eb0ff9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18db5bfe-2274-4cb2-bccb-2146e9eb0ff9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

