### PR TITLE
Refactor endpoint normalizer to use a public hook

### DIFF
--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -64,7 +64,7 @@ def _normalize_configured_endpoint_with_selector(endpoint_str: str, is_openwebui
 
 # Overlay after schema import so WriterAgentConfig.validate() keeps preset labels
 # without config_schema importing chatbot (LibrePy / one-way import).
-_config_schema._endpoint_normalize_impl = _normalize_configured_endpoint_with_selector
+_config_schema.set_endpoint_normalizer(_normalize_configured_endpoint_with_selector)
 
 # Comment header written above the JSON object. Not a config key.
 CONFIG_SCHEMA_DOC_URL = (

--- a/plugin/framework/config_schema.py
+++ b/plugin/framework/config_schema.py
@@ -29,7 +29,7 @@ Manifest tables (``MODULES``, ``CONFIG_DEFAULTS``, ``CONFIG_SCHEMAS``,
 import dataclasses
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from plugin.framework.deal_shim import deal
 from plugin.framework.errors import ConfigError, ConfigValidationError
@@ -279,21 +279,23 @@ _DEFAULT_PYTHON_SCRIPTS = {
 }
 
 
-# Optional overlay from config.py (Settings combobox labels). Typed Any so
-# assigning a different function does not trip the type checker.
-_endpoint_normalize_impl: Any = None
+# Default endpoint normalizer.
+_endpoint_normalizer: Callable[[str, bool], str] = normalize_endpoint_url
+
+
+def set_endpoint_normalizer(fn: Callable[[str, bool], str]) -> None:
+    """Register a custom endpoint normalization function.
+
+    Called by ``config.py`` to parse Settings combobox labels when chatbot is present,
+    since this schema module cannot import chatbot helpers directly.
+    """
+    global _endpoint_normalizer
+    _endpoint_normalizer = fn
 
 
 def _normalize_configured_endpoint(endpoint_str: str, is_openwebui: bool) -> str:
-    """Normalize a stored endpoint URL.
-
-    ``config.py`` sets ``_endpoint_normalize_impl`` to parse Settings combobox
-    labels when chatbot is present. This default path is the LibrePy fallback.
-    """
-    impl = _endpoint_normalize_impl
-    if impl is not None:
-        return impl(endpoint_str, is_openwebui)
-    return normalize_endpoint_url(endpoint_str, is_openwebui=is_openwebui)
+    """Normalize a stored endpoint URL."""
+    return _endpoint_normalizer(endpoint_str, is_openwebui)
 
 
 @dataclasses.dataclass

--- a/tests/framework/test_config_schema.py
+++ b/tests/framework/test_config_schema.py
@@ -24,9 +24,12 @@ from plugin.framework.config_schema import (
     parse_float_robust,
     parse_int_robust,
     prune_default_values,
+    set_endpoint_normalizer,
     set_manifest_modules,
+    _normalize_configured_endpoint,
 )
 from plugin.framework.errors import ConfigValidationError
+from plugin.framework.url_utils import normalize_endpoint_url
 
 _SCHEMA_PATH = Path(__file__).resolve().parents[2] / "plugin" / "framework" / "config_schema.py"
 _FORBIDDEN_IMPORT_ROOTS = frozenset(
@@ -169,3 +172,16 @@ def test_set_and_get_manifest_modules(restore_manifest) -> None:
     assert get_manifest_modules() is restore_manifest.MODULES
     assert restore_manifest.CONFIG_DEFAULTS["only.flag"] is False
     assert coerce_config_value("only.flag", "yes") is True
+
+
+def test_set_endpoint_normalizer() -> None:
+    try:
+        assert _normalize_configured_endpoint("localhost", False) == "localhost"
+
+        def mock_normalizer(endpoint_str: str, is_openwebui: bool) -> str:
+            return f"mock_{endpoint_str}_{is_openwebui}"
+
+        set_endpoint_normalizer(mock_normalizer)
+        assert _normalize_configured_endpoint("localhost", False) == "mock_localhost_False"
+    finally:
+        set_endpoint_normalizer(normalize_endpoint_url)


### PR DESCRIPTION
This change cleans up how `plugin/framework/config.py` injects behavior into `plugin/framework/config_schema.py`. Instead of directly writing to a private variable (`_endpoint_normalize_impl`), `config.py` now calls the public `set_endpoint_normalizer` hook. This preserves the identical fallback logic while ensuring that `config_schema.py` remains unaware of `config.py` or `chatbot` dependencies. Test coverage has been added.

---
*PR created automatically by Jules for task [1311676517030622297](https://jules.google.com/task/1311676517030622297) started by @KeithCu*