### PR TITLE
Cleanup config getters and ACP registry comments

### DIFF
--- a/plugin/agent_backend/registry.py
+++ b/plugin/agent_backend/registry.py
@@ -25,13 +25,11 @@ from plugin.agent_backend.opencode_simple import OpenCodeBackend
 
 AGENT_BACKEND_REGISTRY = {
     "builtin": ("Built-in", BuiltinBackend),
-    # "aider": ("Aider", AiderBackend),
     "hermes": ("Hermes", HermesBackend),
     "claude": ("Claude Code (ACP)", ClaudeBackend),
     "vibe": ("Mistral Vibe (ACP)", VibeBackend),
     "grok": ("Grok Build (ACP)", GrokBackend),
     "opencode": ("OpenCode (ACP)", OpenCodeBackend),
-    # "openhands": ("OpenHands", OpenHandsBackend),
 }
 
 

--- a/plugin/framework/config.py
+++ b/plugin/framework/config.py
@@ -399,7 +399,7 @@ def get_config(key):
 
 def get_config_int(key) -> int:
     """Get a config value as int. All requested keys MUST be in the schema (WriterAgentConfig or MODULES).
-    Throws ConfigError if the key is missing or invalid."""
+    Throws ConfigError if the key is missing or invalid (use get_config_int_safe to return a default instead)."""
     v = get_config(key)
     # Empty string or None from JSON/UI: use schema default (same as missing key).
     if v == "" or v is None:
@@ -426,13 +426,13 @@ def get_config_str(key) -> str:
 
 def get_config_bool(key) -> bool:
     """Get a config value as bool. ALL requested keys MUST be in the schema.
-    Throws ConfigError if key is not found."""
+    Throws ConfigError if key is not found (use get_config_bool_safe to return a default instead)."""
     v = get_config(key)
     return _config_schema.as_bool(v)
 
 
 def get_config_bool_safe(key: str) -> bool:
-    """Safely read a boolean config value, returning schema default on failure."""
+    """Safely read a boolean config value. Unlike get_config_bool, this returns the schema default (or False) rather than raising an exception if the key is missing or invalid."""
     try:
         return get_config_bool(key)
     except Exception:
@@ -443,7 +443,7 @@ def get_config_bool_safe(key: str) -> bool:
 
 
 def get_config_int_safe(key: str) -> int:
-    """Safely read an integer config value, returning schema default on failure."""
+    """Safely read an integer config value. Unlike get_config_int, this returns the schema default (or 0) rather than raising an exception if the key is missing or the value is invalid."""
     try:
         return get_config_int(key)
     except Exception:
@@ -454,7 +454,7 @@ def get_config_int_safe(key: str) -> int:
 
 
 def get_config_float_safe(key: str) -> float:
-    """Safely read a float config value, returning schema default on failure."""
+    """Safely read a float config value. Unlike get_config_float, this returns the schema default (or 0.0) rather than raising an exception if the key is missing or the value is invalid."""
     try:
         return get_config_float(key)
     except Exception:
@@ -466,7 +466,7 @@ def get_config_float_safe(key: str) -> float:
 
 def get_config_float(key) -> float:
     """Get a config value as float. ALL requested keys MUST be in the schema.
-    Throws ConfigError if key is not found."""
+    Throws ConfigError if key is not found or value is non-float (use get_config_float_safe to return a default instead)."""
     v = get_config(key)
     try:
         return _config_schema.parse_float_robust(v)


### PR DESCRIPTION
This PR applies two small codebase cleanups requested:

1. **Config Typed Getters**: 
The `get_config_int/float` vs `get_config_int/float_safe` pairs are genuinely different in behavior (the former raises an exception on invalid input, the latter returns a default value). The same applies to `get_config_bool` vs `get_config_bool_safe` (one raises for missing keys, the other defaults). Rather than collapsing them, their docstrings have been updated to explicitly document these behavioral differences.

2. **ACP Registry Comments**:
Removed the dead, commented-out entries for `Aider` and `OpenHands` in `plugin/agent_backend/registry.py`.

All changes preserve existing functionality and behavior. Tests and typechecks pass successfully.

---
*PR created automatically by Jules for task [12131993449568218893](https://jules.google.com/task/12131993449568218893) started by @KeithCu*