### PR TITLE
test: Fix TOCTOU races and file configuration isolation issues

### DIFF
--- a/tests/chatbot/test_quick_setup.py
+++ b/tests/chatbot/test_quick_setup.py
@@ -48,16 +48,23 @@ def test_local_server_probes_structure():
 
 def test_check_port_open_real_listener():
     """Test _check_port_open with an active socket."""
-    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    srv.bind(("127.0.0.1", 0))
-    srv.listen(1)
-    port = srv.getsockname()[1]
-    try:
-        assert _check_port_open("127.0.0.1", port, timeout_sec=0.5) is True
-    finally:
-        srv.close()
+    for _attempt in range(3):
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        try:
+            assert _check_port_open("127.0.0.1", port, timeout_sec=0.5) is True
+        finally:
+            srv.close()
 
-    assert _check_port_open("127.0.0.1", port, timeout_sec=0.1) is False
+        # If another process bound the port immediately after srv.close(),
+        # _check_port_open might still return True. Retry in that case.
+        if _check_port_open("127.0.0.1", port, timeout_sec=0.1) is False:
+            break
+    else:
+        import pytest
+        pytest.fail("Failed to verify closed port after 3 attempts due to port snatching")
 
 
 @patch("plugin.chatbot.quick_setup._check_port_open")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,12 +252,14 @@ def _setup_grammar_persistence_test_env():
     # MagicMock's default __fspath__ yields a relative "MagicMock/<name>/<id>" path that
     # MemoryStore's makedirs then creates inside the repo. Seeding the module-level cache routes
     # every resolver through this per-test temp dir instead.
+    config_mod.reset_config_for_tests()
     old_resolved = config_mod._resolved_config_path
     config_mod._resolved_config_path = os.path.join(tmp_dir, "writeragent.json")
     try:
         with patch("plugin.framework.config.user_config_dir", return_value=tmp_dir):
             yield
     finally:
+        config_mod.reset_config_for_tests()
         config_mod._resolved_config_path = old_resolved
 
         # Restore logging state

--- a/tests/framework/client/test_model_fetcher.py
+++ b/tests/framework/client/test_model_fetcher.py
@@ -108,10 +108,8 @@ class TestTextModelPlaceholderGuards(unittest.TestCase):
             def mock_config_path():
                 return config_path
             with patch('plugin.framework.config._config_path', side_effect=mock_config_path):
-                import plugin.framework.config as real_config
-                real_config._cached_config_dict = None
-                real_config._cached_config_mtime = 0
-                real_config._cached_config_mtime_last_checked = 0.0
+                from plugin.framework.config import reset_config_for_tests
+                reset_config_for_tests()
                 for k in list(cfg._model_fetch_cache):
                     if ('58904' in k):
                         del cfg._model_fetch_cache[k]
@@ -139,10 +137,8 @@ class TestTextModelPlaceholderGuards(unittest.TestCase):
             def mock_config_path():
                 return config_path
             with patch('plugin.framework.config._config_path', side_effect=mock_config_path):
-                import plugin.framework.config as real_config
-                real_config._cached_config_dict = None
-                real_config._cached_config_mtime = 0
-                real_config._cached_config_mtime_last_checked = 0.0
+                from plugin.framework.config import reset_config_for_tests
+                reset_config_for_tests()
                 for k in list(cfg._model_fetch_cache):
                     if ('58905' in k):
                         del cfg._model_fetch_cache[k]

--- a/tests/framework/test_config.py
+++ b/tests/framework/test_config.py
@@ -157,6 +157,7 @@ class TestConfigSync(unittest.TestCase):
 class TestConfigSyncFileIO(unittest.TestCase):
 
     def setUp(self):
+        reset_config_for_tests()
         self.ctx = MagicMock()
         self.temp_dir = tempfile.TemporaryDirectory()
         self.config_path = os.path.join(self.temp_dir.name, 'writeragent.json')
@@ -167,6 +168,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
         self.path_patcher.start()
 
     def tearDown(self):
+        reset_config_for_tests()
         self.path_patcher.stop()
         self.temp_dir.cleanup()
         backup_path = self.config_path + CONFIG_BACKUP_SUFFIX
@@ -174,13 +176,6 @@ class TestConfigSyncFileIO(unittest.TestCase):
             os.remove(backup_path)
         if os.path.exists(self.config_path):
             os.remove(self.config_path)
-
-    def _reset_config_cache(self):
-        import plugin.framework.config as cfg
-
-        cfg._cache.data = None
-        cfg._cache.mtime = 0
-        cfg._cache.mtime_last_checked = 0.0
 
     def _backup_path(self):
         return self.config_path + CONFIG_BACKUP_SUFFIX
@@ -209,7 +204,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
         corrupt = '{ invalid json '
         with open(self.config_path, 'w', encoding='utf-8') as f:
             f.write(corrupt)
-        self._reset_config_cache()
+        reset_config_for_tests()
         self.assertEqual(get_api_key_for_endpoint('http://api.openai.com'), '')
         with open(self._backup_path(), 'r', encoding='utf-8') as f:
             self.assertEqual(f.read(), corrupt)
@@ -224,7 +219,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
         broken = '{"text_model": "gpt",}'
         with open(self.config_path, 'w', encoding='utf-8') as f:
             f.write(broken)
-        self._reset_config_cache()
+        reset_config_for_tests()
         self.assertEqual(get_config('text_model'), 'gpt')
         with open(self._backup_path(), 'r', encoding='utf-8') as f:
             self.assertEqual(f.read(), broken)
@@ -235,7 +230,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
         corrupt = '{ invalid json '
         with open(self.config_path, 'w', encoding='utf-8') as f:
             f.write(corrupt)
-        self._reset_config_cache()
+        reset_config_for_tests()
         self.assertEqual(get_config('calc_prompt_max_tokens'), 4096)
         self.assertTrue(os.path.exists(self._backup_path()))
         with open(self.config_path, 'r', encoding='utf-8') as f:
@@ -244,7 +239,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
     def test_valid_config_no_backup_on_set(self):
         with open(self.config_path, 'w', encoding='utf-8') as f:
             json.dump({'text_model': 'gpt'}, f)
-        self._reset_config_cache()
+        reset_config_for_tests()
         set_config('text_model', 'other')
         self.assertFalse(os.path.exists(self._backup_path()))
         self.assertEqual(self._load_written()['text_model'], 'other')
@@ -283,7 +278,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
     def test_stale_calc_prompt_max_tokens_upgraded_and_persisted(self):
         with open(self.config_path, 'w', encoding='utf-8') as f:
             json.dump({'text_model': 'gpt', 'calc_prompt_max_tokens': 70}, f)
-        self._reset_config_cache()
+        reset_config_for_tests()
         self.assertEqual(get_config('calc_prompt_max_tokens'), 4096)
         data = self._load_written()
         # Default 4096 is omitted from JSON file on disk
@@ -293,7 +288,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
     def test_calc_prompt_max_tokens_at_or_above_100_preserved(self):
         with open(self.config_path, 'w', encoding='utf-8') as f:
             json.dump({'calc_prompt_max_tokens': 150}, f)
-        self._reset_config_cache()
+        reset_config_for_tests()
         self.assertEqual(get_config('calc_prompt_max_tokens'), 150)
         data = self._load_written()
         self.assertEqual(data['calc_prompt_max_tokens'], 150)
@@ -320,7 +315,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
                 'chat_max_tokens': 16384,
                 'text_model': 'custom-model',
             }, f)
-        self._reset_config_cache()
+        reset_config_for_tests()
         set_config('request_timeout', 60)
         data = self._load_written()
         self.assertEqual(data, {
@@ -334,7 +329,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
                 'endpoint': 'http://localhost:11434',
                 'text_model': 'custom-model',
             }, f)
-        self._reset_config_cache()
+        reset_config_for_tests()
         with patch.object(global_event_bus, 'emit') as mock_emit:
             set_config('text_model', 'custom-model')
             mock_emit.assert_not_called()
@@ -361,7 +356,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
     def test_set_config_invalid_numeric_falls_back_to_current_value(self):
         with open(self.config_path, 'w', encoding='utf-8') as f:
             json.dump({'extend_selection_max_tokens': 1200}, f)
-        self._reset_config_cache()
+        reset_config_for_tests()
 
         set_config('extend_selection_max_tokens', 'not-a-number')
 
@@ -485,7 +480,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
             }
         }]
         with patch("plugin.framework.config_schema.MODULES", mock_modules):
-            self._reset_config_cache()
+            reset_config_for_tests()
             # Because extend_selection_max_tokens was not written to disk, the new default is picked up automatically!
             self.assertEqual(get_config_int('extend_selection_max_tokens'), 2000)
 
@@ -499,7 +494,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
                 'request_timeout': 60,
                 'text_model': 'custom-model'
             }, f)
-        self._reset_config_cache()
+        reset_config_for_tests()
 
         remove_config('request_timeout')
 
@@ -520,7 +515,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
                 'scripting.ppt_master_data_path': '',
                 'scripting.python_convert_datetime': False,
             }, f)
-        self._reset_config_cache()
+        reset_config_for_tests()
         set_config('request_timeout', 60)
         data = self._load_written()
         self.assertEqual(data, {

--- a/tests/framework/test_logging.py
+++ b/tests/framework/test_logging.py
@@ -82,6 +82,8 @@ class TestInitLogging(unittest.TestCase):
 
     def test_init_logging_uses_ctx_config_dir(self):
         # Windows can keep the FileHandler lock briefly after close(); ignore cleanup then.
+        from plugin.framework.config import reset_config_for_tests
+        reset_config_for_tests()
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             config_path = os.path.join(tmp, "writeragent.json")
             with open(config_path, "w", encoding="utf-8") as fh:

--- a/tests/mcp/test_server_bind.py
+++ b/tests/mcp/test_server_bind.py
@@ -28,12 +28,18 @@ class _EmptyRoutes:
 
 
 def test_start_binds_on_free_port():
-    srv = HttpServer(route_registry=_EmptyRoutes(), port=_free_port(), host="127.0.0.1")
-    srv.start()
-    try:
-        assert srv.is_running()
-    finally:
-        srv.stop()
+    for _attempt in range(3):
+        port = _free_port()
+        srv = HttpServer(route_registry=_EmptyRoutes(), port=port, host="127.0.0.1")
+        try:
+            srv.start()
+            assert srv.is_running()
+            srv.stop()
+            break
+        except OSError:
+            pass
+    else:
+        pytest.fail("Failed to start HttpServer after 3 attempts due to port in use")
 
 
 def test_start_raises_immediately_when_port_busy(monkeypatch):


### PR DESCRIPTION
This PR addresses several test isolation issues across the unit test suite, preparing it for multiprocess execution via `pytest-xdist`:

- **TOCTOU in Port Binding**: Fixed `test_start_binds_on_free_port` and `test_check_port_open_real_listener` to use retry logic (up to 3 times) to prevent flakiness if the port returned by the OS is snatched by another process between `close()` and `bind()`.
- **Config file IO caching state**: Removed manual `_cached_config_dict` clears inside `test_model_fetcher.py` and `test_logging.py` in favor of using the robust `reset_config_for_tests()`.
- **ConfigSyncFileIO overrides**: Restored `reset_config_for_tests()` inside the `setUp` and `tearDown` of `TestConfigSyncFileIO` inside `tests/framework/test_config.py` to prevent caching issues. Restored the internal path override.
- **Fixture configuration state safety**: Handled `conftest.py`'s autouse grammar persistence setup fixture to also reset global configs properly, resolving interference.

Remaining list of races to eventually address:
- Tests that run live LO tests must stay serial. Live LibreOffice UNO remains serial.
- Hardcoded string path mutations to actual disk locations when real I/O triggers over UNO mocks.

---
*PR created automatically by Jules for task [13194107597150019337](https://jules.google.com/task/13194107597150019337) started by @KeithCu*