### PR TITLE
Cap remaining unbounded deal.pre ints/strs so CrossHair deep cannot wander

### DIFF
--- a/docs/framework-formal-verification.md
+++ b/docs/framework-formal-verification.md
@@ -667,7 +667,7 @@ Helpers in [`deal_shim.py`](../plugin/framework/deal_shim.py):
 
 `DEAL_MAX_CELL_REF` is **32** because `parse_address` / `parse_range_string` reject sheet prefixes; the longest legal range is well under that. Do **not** put `isascii` on `_()` (msgids include `"✓ Copied!"`, `"Testing…"`), HTML strippers, or formula source.
 
-Hypothesis `st.text(..., max_codepoint=127)` in `*_verification.py` is a **fuzzer** bound, not a function contract — leave those ASCII alphabets in place.
+Hypothesis `st.text(..., max_codepoint=127)` in `*_verification.py` is a **fuzzer** bound, not a function contract — leave those ASCII alphabets in place. Int domains need the same named caps (`DEAL_MAX_*`) so deep check cannot wander on loops, products, exponents, or f-strings of a giant int.
 
 #### F. Single-pass string stripping vs interleaved control whitespace
 

--- a/plugin/calc/excel_py_convert/to_dag.py
+++ b/plugin/calc/excel_py_convert/to_dag.py
@@ -55,7 +55,7 @@ from plugin.calc.excel_py_convert.models import (
     HeaderMode,
 )
 from plugin.calc.excel_py_convert.resolve_refs import ResolvedDep, resolve_deps
-from plugin.framework.deal_shim import DEAL_MAX_SOURCE, str_bounded, deal
+from plugin.framework.deal_shim import DEAL_MAX_PLACEHOLDER_INDEX, DEAL_MAX_SOURCE, DEAL_MAX_TOKEN, str_bounded, deal
 
 _P_TOKEN_RE = re.compile(r"^%P(\d+)%$", re.IGNORECASE)
 # Bare Excel placeholder in source (not anchored); same length as ``_Pn_`` sentinel.
@@ -81,15 +81,26 @@ class _XlCall:
     raw: str = ""
 
 
-@deal.pre(lambda p_num, *_unused, **__: isinstance(p_num, int) and p_num >= 2)
-@deal.post(lambda result: isinstance(result, int) and result >= 0)
+@deal.pre(
+    lambda p_num, *_unused, **__: isinstance(p_num, int)
+    and 2 <= p_num <= 2 + DEAL_MAX_PLACEHOLDER_INDEX
+)
+@deal.post(lambda result: isinstance(result, int) and 0 <= result <= DEAL_MAX_PLACEHOLDER_INDEX)
 def _placeholder_to_data_index(p_num: int) -> int:
     """Map Excel ``%Pk%`` to 0-based original dep index: ``%P2%`` → 0, ``%P3%`` → 1."""
     return p_num - 2
 
 
-@deal.pre(lambda index, *_unused, **__: isinstance(index, int) and index >= 0)
-@deal.post(lambda result: isinstance(result, str) and result.startswith("xl(") and result.endswith(")"))
+@deal.pre(
+    lambda index, *_unused, **__: isinstance(index, int) and 0 <= index <= DEAL_MAX_PLACEHOLDER_INDEX
+)
+@deal.post(
+    lambda result: isinstance(result, str)
+    and result.startswith("xl(")
+    and result.endswith(")")
+    and '"%P' in result
+    and len(result) <= DEAL_MAX_TOKEN
+)
 def _xl_binding_expr(index: int, header_mode: str) -> str:
     """Runnable DAG ``xl("%Pn%", …)`` (quoted token; MS package uses bare ``%Pn%``)."""
     tok = f'"%P{index + 2}%"'

--- a/plugin/calc/python/formula_edit.py
+++ b/plugin/calc/python/formula_edit.py
@@ -123,6 +123,7 @@ def extract_python_code_loose(formula: str) -> str | None:
     return _parse_unquoted_code_arg(body)
 
 
+@deal.pre(lambda formula: str_bounded(formula, DEAL_MAX_SOURCE))
 @deal.post(lambda result: isinstance(result, str))
 @deal.ensure(lambda formula, result: "\u201c" not in result and "\u201d" not in result and "\u2018" not in result and "\u2019" not in result)
 def normalize_formula_string(formula: str) -> str:
@@ -141,6 +142,7 @@ def build_new_python_formula(code: str) -> str:
     return f'={CALC_PYTHON_FN}("{escaped}")'
 
 
+@deal.pre(lambda formula: str_bounded(formula, DEAL_MAX_SOURCE))
 @deal.post(lambda result: result is None or isinstance(result, PythonFormulaParts))
 @deal.ensure(lambda formula, result: _parts_result_ok(result))
 def parse_python_formula(formula: str) -> PythonFormulaParts | None:
@@ -315,6 +317,7 @@ def rebuild_python_formula(parts: PythonFormulaParts, new_code: str) -> str:
     return f'={CALC_PYTHON_FN}("{escaped}"{parts.data_suffix}'
 
 
+@deal.pre(lambda data_suffix: str_bounded(data_suffix, DEAL_MAX_SOURCE))
 @deal.post(lambda result: isinstance(result, str))
 @deal.ensure(lambda data_suffix, result: not result or (not result.startswith(";") and not result.startswith(",") and not result.endswith(")")))
 def format_data_binding_display(data_suffix: str) -> str:
@@ -408,7 +411,12 @@ def build_data_suffix(data_args: list[str], *, separator: str = ";", excel_range
     return f"{sep}{sep.join(args)})"
 
 
-@deal.pre(lambda *args, **kwargs: len(args) >= 2 and isinstance(args[0], str) and isinstance(args[1], list))
+# code is Python source (Unicode-legal); ascii_bounded would reject café comments.
+@deal.pre(
+    lambda *args, **kwargs: len(args) >= 2
+    and str_bounded(args[0], DEAL_MAX_SOURCE)
+    and isinstance(args[1], list)
+)
 @deal.post(lambda result: isinstance(result, str) and result.startswith(f"={CALC_PYTHON_FN}("))
 @deal.ensure(lambda *args, result=None, **kwargs: isinstance(result, str) and result.endswith(")"))
 def rebuild_python_formula_with_data(

--- a/plugin/calc/spreadsheet_import/preprocess.py
+++ b/plugin/calc/spreadsheet_import/preprocess.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from plugin.calc.python.formula_edit import normalize_formula_string
-from plugin.framework.deal_shim import deal
+from plugin.framework.deal_shim import DEAL_MAX_SOURCE, str_bounded, deal
 
 
 def _no_unquoted_semicolon(s: str) -> bool:
@@ -29,6 +29,7 @@ def _no_unquoted_semicolon(s: str) -> bool:
     return True
 
 
+@deal.pre(lambda formula: str_bounded(formula, DEAL_MAX_SOURCE))
 @deal.post(lambda result: isinstance(result, str))
 @deal.ensure(lambda formula, result: "\u201c" not in result and "\u201d" not in result)
 @deal.ensure(lambda formula, result: _no_unquoted_semicolon(result))

--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -41,7 +41,11 @@ def _describe_empty_response_tool_calls(tool_calls: Any) -> str:
     return "present"
 
 
-@deal.pre(lambda round_num, response: isinstance(round_num, int) and isinstance(response, dict))
+@deal.pre(
+    lambda round_num, response: isinstance(round_num, int)
+    and 0 <= round_num <= 10_000
+    and isinstance(response, dict)
+)
 @deal.post(lambda result: isinstance(result, str) and "round=" in result)
 def format_empty_model_response_debug(round_num: int, response: Mapping[str, Any]) -> str:
     """Compact API summary for sidebar when STREAM_DONE has no content and no tools."""

--- a/plugin/framework/deal_shim.py
+++ b/plugin/framework/deal_shim.py
@@ -25,9 +25,12 @@ DEAL_MAX_SOURCE = 64
 # unrolls `while index > 0` forever on a giant int in deep check.
 # Same for products, exponents, and f-strings of a huge int.
 DEAL_MAX_COL_INDEX = 26 + 26**2 + 26**3 - 1  # 18277, A–ZZZ (not 26**3-1)
-DEAL_MAX_ROW_INDEX = 1_048_576 - 1  # Excel/Calc max row, 0-based
+DEAL_MAX_ROW_INDEX = 1_048_576 - 1  # Excel/Calc max row, 0-based (address round-trip)
 DEAL_MAX_PLACEHOLDER_INDEX = 1024  # Excel %Pn% deps
 DEAL_MAX_SHAPE_RANK = 4  # ndarray rank; grids are 2-D, tests use up to 4
+# cell_count product domain — not Calc's million-row grid. 256^4 still fits in a
+# machine int; CrossHair is testing our multiply loop, not LibreOffice.
+DEAL_MAX_SHAPE_DIM = 256
 DEAL_MAX_RETRY = 8  # MCP tunnel backoff exponent (production DEFAULT_MAX_RETRIES=5)
 DEAL_MAX_BACKOFF = 300.0  # seconds; Hypothesis uses up to 300
 DEAL_MAX_BACKOFF_FACTOR = 10.0

--- a/plugin/framework/deal_shim.py
+++ b/plugin/framework/deal_shim.py
@@ -25,7 +25,9 @@ DEAL_MAX_SOURCE = 64
 # unrolls `while index > 0` forever on a giant int in deep check.
 # Same for products, exponents, and f-strings of a huge int.
 DEAL_MAX_COL_INDEX = 26 + 26**2 + 26**3 - 1  # 18277, A–ZZZ (not 26**3-1)
-DEAL_MAX_ROW_INDEX = 1_048_576 - 1  # Excel/Calc max row, 0-based (address round-trip)
+# CrossHair domain only (release strips @deal). 1000 covers 1–4 digit rows;
+# Calc's million-row grid is not worth the extra SMT time.
+DEAL_MAX_ROW_INDEX = 1000
 DEAL_MAX_PLACEHOLDER_INDEX = 1024  # Excel %Pn% deps
 DEAL_MAX_SHAPE_RANK = 4  # ndarray rank; grids are 2-D, tests use up to 4
 # cell_count product domain — not Calc's million-row grid. 256^4 still fits in a

--- a/plugin/framework/deal_shim.py
+++ b/plugin/framework/deal_shim.py
@@ -23,8 +23,14 @@ DEAL_MAX_PATH = 4096
 DEAL_MAX_SOURCE = 64
 # Int domains need caps too (same reason as §8.1 E): CrossHair otherwise
 # unrolls `while index > 0` forever on a giant int in deep check.
+# Same for products, exponents, and f-strings of a huge int.
 DEAL_MAX_COL_INDEX = 26 + 26**2 + 26**3 - 1  # 18277, A–ZZZ (not 26**3-1)
 DEAL_MAX_ROW_INDEX = 1_048_576 - 1  # Excel/Calc max row, 0-based
+DEAL_MAX_PLACEHOLDER_INDEX = 1024  # Excel %Pn% deps
+DEAL_MAX_SHAPE_RANK = 4  # ndarray rank; grids are 2-D, tests use up to 4
+DEAL_MAX_RETRY = 8  # MCP tunnel backoff exponent (production DEFAULT_MAX_RETRIES=5)
+DEAL_MAX_BACKOFF = 300.0  # seconds; Hypothesis uses up to 300
+DEAL_MAX_BACKOFF_FACTOR = 10.0
 
 
 def ascii_bounded(s: object, max_len: int, min_len: int = 0) -> bool:

--- a/plugin/framework/url_utils.py
+++ b/plugin/framework/url_utils.py
@@ -86,6 +86,7 @@ def get_api_version_suffix(url, is_openwebui=False):
     return "/v1"
 
 
+@deal.pre(lambda url, is_openwebui=False: url is None or ascii_bounded(url, DEAL_MAX_URL))
 @deal.post(lambda result: isinstance(result, str))
 @deal.ensure(lambda url, is_openwebui=False, result="": bool(isinstance(url, str) and url.strip()) or result == "")
 def normalize_endpoint_url(url, is_openwebui=False):
@@ -132,6 +133,7 @@ def normalize_endpoint_url(url, is_openwebui=False):
 
     return url
 
+@deal.pre(lambda url: url is None or ascii_bounded(url, DEAL_MAX_URL))
 @deal.post(lambda result: isinstance(result, str))
 def get_url_hostname(url):
     """Return hostname from URL safely."""
@@ -145,6 +147,7 @@ def get_url_hostname(url):
         return ""
 
 
+@deal.pre(lambda url: url is None or ascii_bounded(url, DEAL_MAX_URL))
 @deal.post(lambda result: isinstance(result, str))
 def get_url_domain(url):
     """Return 'example.com' from 'https://api.example.com/v1'."""
@@ -157,6 +160,7 @@ def get_url_domain(url):
     return host
 
 
+@deal.pre(lambda url: url is None or ascii_bounded(url, DEAL_MAX_URL))
 @deal.post(lambda result: isinstance(result, str))
 def get_url_path(url):
     """Return path from URL safely."""
@@ -169,6 +173,7 @@ def get_url_path(url):
         return ""
 
 
+@deal.pre(lambda url: url is None or ascii_bounded(url, DEAL_MAX_URL))
 @deal.post(lambda result: isinstance(result, dict))
 def get_url_query_dict(url):
     """Return query parameters as dict (values are lists)."""
@@ -181,6 +186,7 @@ def get_url_query_dict(url):
         return {}
 
 
+@deal.pre(lambda url: url is None or ascii_bounded(url, DEAL_MAX_URL))
 @deal.post(lambda result: isinstance(result, str))
 def get_url_path_and_query(url):
     """Return path + query string from URL."""
@@ -196,6 +202,7 @@ def get_url_path_and_query(url):
         return "/"
 
 
+@deal.pre(lambda url: url is None or ascii_bounded(url, DEAL_MAX_URL))
 @deal.post(lambda result: isinstance(result, bool))
 def is_pdf_url(url):
     """Check for .pdf in the URL path safely."""

--- a/plugin/mcp/tunnel_state.py
+++ b/plugin/mcp/tunnel_state.py
@@ -18,10 +18,11 @@
 from __future__ import annotations
 
 import dataclasses
+import math
 from enum import Enum, auto
 from typing import Any, List, Optional
 
-from plugin.framework.deal_shim import deal
+from plugin.framework.deal_shim import DEAL_MAX_BACKOFF, DEAL_MAX_BACKOFF_FACTOR, DEAL_MAX_RETRY, deal
 from plugin.framework.service import BaseState, FsmTransition
 
 DEFAULT_INITIAL_BACKOFF: float = 1.0
@@ -113,7 +114,17 @@ class NotifyUrlAcquiredEffect:
 
 @deal.pre(
     lambda retry_count, initial=DEFAULT_INITIAL_BACKOFF, factor=DEFAULT_BACKOFF_FACTOR, max_backoff=DEFAULT_MAX_BACKOFF: (
-        retry_count >= 0 and initial >= 0 and factor >= 1.0 and max_backoff >= initial
+        isinstance(retry_count, int)
+        and 0 <= retry_count <= DEAL_MAX_RETRY
+        and isinstance(initial, (int, float))
+        and math.isfinite(initial)
+        and 0 <= initial <= DEAL_MAX_BACKOFF
+        and isinstance(factor, (int, float))
+        and math.isfinite(factor)
+        and 1.0 <= factor <= DEAL_MAX_BACKOFF_FACTOR
+        and isinstance(max_backoff, (int, float))
+        and math.isfinite(max_backoff)
+        and initial <= max_backoff <= DEAL_MAX_BACKOFF
     )
 )
 @deal.post(lambda result: result >= 0)

--- a/plugin/scripting/payload_codec.py
+++ b/plugin/scripting/payload_codec.py
@@ -26,7 +26,7 @@ import sys
 import tempfile
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from plugin.framework.deal_shim import deal
+from plugin.framework.deal_shim import DEAL_MAX_ROW_INDEX, DEAL_MAX_SHAPE_RANK, deal
 
 # CrossHair may invoke deal post/ensure as ``fn(*call_args, result=return_value, **kwargs)``.
 # Naming a positional parameter ``result`` then raises TypeError (multiple values). Keep ``result`` keyword-only.
@@ -652,7 +652,19 @@ def describe_wire_value(obj: Any, *, sample: int = 3) -> str:
     return f"{type(obj).__name__}={repr(obj)[:120]}"
 
 
-@deal.pre(lambda shape: isinstance(shape, tuple) and all(isinstance(d, int) and d >= 0 for d in shape))
+def _deal_shape_ok(shape: object) -> bool:
+    """True iff *shape* is a rank-bounded tuple of spreadsheet-scale dims.
+
+    Unbounded rank or dims let CrossHair deep multiply forever in ``cell_count``.
+    """
+    return (
+        isinstance(shape, tuple)
+        and len(shape) <= DEAL_MAX_SHAPE_RANK
+        and all(isinstance(d, int) and 0 <= d <= DEAL_MAX_ROW_INDEX for d in shape)
+    )
+
+
+@deal.pre(lambda shape: _deal_shape_ok(shape))
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: isinstance(_deal_return(*a, result=result), int))
 @deal.ensure(lambda shape, *a, result=_DEAL_RETURN, **k: _deal_return(*a, result=result) >= 0)
 @deal.ensure(lambda shape, *a, result=_DEAL_RETURN, **k: len(shape) != 0 or _deal_return(*a, result=result) == 1)
@@ -663,8 +675,12 @@ def cell_count(shape: tuple[int, ...]) -> int:
     return n
 
 
-@deal.pre(lambda shape, *_unused, **__: isinstance(shape, tuple) and all(isinstance(d, int) and d >= 0 for d in shape))
-@deal.pre(lambda shape, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never") and isinstance(min_cells, int) and min_cells >= 0)
+@deal.pre(lambda shape, *_unused, **__: _deal_shape_ok(shape))
+@deal.pre(
+    lambda shape, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never")
+    and isinstance(min_cells, int)
+    and 0 <= min_cells <= DEAL_MAX_ROW_INDEX
+)
 # CrossHair may pass call args + result=; never bind ``result`` as a positional parameter.
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: isinstance(_deal_return(*a, result=result), bool))
 @deal.ensure(lambda *a, result=_DEAL_RETURN, force="auto", **k: force != "always" or _deal_return(*a, result=result) is True)
@@ -1113,7 +1129,11 @@ def host_pack_split_grid(
 
 @deal.pre(lambda grid, *_unused, **__: _is_grid_sequence(grid))
 # Same force/min_cells gate as should_use_binary_envelope so CrossHair cannot call pack with invalid policy kwargs.
-@deal.pre(lambda grid, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never") and isinstance(min_cells, int) and min_cells >= 0)
+@deal.pre(
+    lambda grid, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never")
+    and isinstance(min_cells, int)
+    and 0 <= min_cells <= DEAL_MAX_ROW_INDEX
+)
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: _deal_return(*a, result=result) is not None)
 @deal.raises(ValueError)
 def host_pack_data(
@@ -1151,7 +1171,11 @@ def host_pack_data(
 
 
 @deal.pre(lambda grids, *_unused, **__: isinstance(grids, list) and all(_is_grid_sequence(g) for g in grids))
-@deal.pre(lambda grids, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never") and isinstance(min_cells, int) and min_cells >= 0)
+@deal.pre(
+    lambda grids, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never")
+    and isinstance(min_cells, int)
+    and 0 <= min_cells <= DEAL_MAX_ROW_INDEX
+)
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: _is_multi_data_envelope(_deal_return(*a, result=result)))
 @deal.ensure(
     lambda grids, *a, result=_DEAL_RETURN, **k: len(_deal_return(*a, result=result).get("items", []))

--- a/plugin/scripting/payload_codec.py
+++ b/plugin/scripting/payload_codec.py
@@ -26,7 +26,7 @@ import sys
 import tempfile
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from plugin.framework.deal_shim import DEAL_MAX_ROW_INDEX, DEAL_MAX_SHAPE_RANK, deal
+from plugin.framework.deal_shim import DEAL_MAX_SHAPE_DIM, DEAL_MAX_SHAPE_RANK, deal
 
 # CrossHair may invoke deal post/ensure as ``fn(*call_args, result=return_value, **kwargs)``.
 # Naming a positional parameter ``result`` then raises TypeError (multiple values). Keep ``result`` keyword-only.
@@ -653,14 +653,16 @@ def describe_wire_value(obj: Any, *, sample: int = 3) -> str:
 
 
 def _deal_shape_ok(shape: object) -> bool:
-    """True iff *shape* is a rank-bounded tuple of spreadsheet-scale dims.
+    """True iff *shape* is a rank-bounded tuple of small dims.
 
     Unbounded rank or dims let CrossHair deep multiply forever in ``cell_count``.
+    Dims are capped at ``DEAL_MAX_SHAPE_DIM`` (our product logic), not Calc's
+    million-row grid.
     """
     return (
         isinstance(shape, tuple)
         and len(shape) <= DEAL_MAX_SHAPE_RANK
-        and all(isinstance(d, int) and 0 <= d <= DEAL_MAX_ROW_INDEX for d in shape)
+        and all(isinstance(d, int) and 0 <= d <= DEAL_MAX_SHAPE_DIM for d in shape)
     )
 
 
@@ -679,7 +681,7 @@ def cell_count(shape: tuple[int, ...]) -> int:
 @deal.pre(
     lambda shape, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never")
     and isinstance(min_cells, int)
-    and 0 <= min_cells <= DEAL_MAX_ROW_INDEX
+    and 0 <= min_cells <= DEAL_MAX_SHAPE_DIM
 )
 # CrossHair may pass call args + result=; never bind ``result`` as a positional parameter.
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: isinstance(_deal_return(*a, result=result), bool))
@@ -1132,7 +1134,7 @@ def host_pack_split_grid(
 @deal.pre(
     lambda grid, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never")
     and isinstance(min_cells, int)
-    and 0 <= min_cells <= DEAL_MAX_ROW_INDEX
+    and 0 <= min_cells <= DEAL_MAX_SHAPE_DIM
 )
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: _deal_return(*a, result=result) is not None)
 @deal.raises(ValueError)
@@ -1174,7 +1176,7 @@ def host_pack_data(
 @deal.pre(
     lambda grids, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never")
     and isinstance(min_cells, int)
-    and 0 <= min_cells <= DEAL_MAX_ROW_INDEX
+    and 0 <= min_cells <= DEAL_MAX_SHAPE_DIM
 )
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: _is_multi_data_envelope(_deal_return(*a, result=result)))
 @deal.ensure(

--- a/plugin/scripting/sandbox.py
+++ b/plugin/scripting/sandbox.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     import subprocess
 
-from plugin.framework.deal_shim import deal
+from plugin.framework.deal_shim import DEAL_MAX_PATH, deal, str_bounded
 
 # --- Import whitelist (shared by venv_sandbox and import_policy) ---
 
@@ -267,7 +267,8 @@ def optimize_popen_pipes(proc: subprocess.Popen[Any]) -> None:
             pass
 
 
-@deal.pre(lambda cmd: isinstance(cmd, list) and all(isinstance(x, str) for x in cmd))
+# Hypothesis and venv-path tests pass Unicode argv/paths; ascii_bounded would reject them.
+@deal.pre(lambda cmd: isinstance(cmd, list) and all(str_bounded(x, DEAL_MAX_PATH) for x in cmd))
 @deal.post(lambda result: isinstance(result, list) and all(isinstance(x, str) for x in result))
 @deal.ensure(lambda cmd, result: len(result) >= len(cmd) and (result[-len(cmd):] == cmd if cmd else True))
 def wrap_command_for_sandbox(cmd: list[str]) -> list[str]:
@@ -454,7 +455,7 @@ def resolve_venv_python(venv_dir: str) -> Optional[str]:
     return _first_executable_python(candidates)
 
 
-@deal.pre(lambda target_path, root_dir: isinstance(target_path, str) and isinstance(root_dir, str))
+@deal.pre(lambda target_path, root_dir: str_bounded(target_path, DEAL_MAX_PATH) and str_bounded(root_dir, DEAL_MAX_PATH))
 @deal.post(lambda result: isinstance(result, bool))
 @deal.ensure(
     lambda target_path, root_dir, result: (

--- a/tests/calc/python/test_formula_edit_verification.py
+++ b/tests/calc/python/test_formula_edit_verification.py
@@ -16,6 +16,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+import deal
 from plugin.calc.python.formula_edit import (
     _find_matching_paren,
     _parse_quoted_string,
@@ -27,10 +28,12 @@ from plugin.calc.python.formula_edit import (
     parse_data_binding_text,
     parse_python_formula,
     rebuild_python_formula,
+    rebuild_python_formula_with_data,
     sanitize_inline_py_code,
 )
 from plugin.calc.spreadsheet_import.preprocess import normalize_lo_formula_for_parse
-from tests.strip_bundle import expect_pre_or_body
+from plugin.framework.deal_shim import DEAL_MAX_SOURCE
+from tests.strip_bundle import deal_pre_present, expect_pre_or_body
 from tests.vhs_budget import vhs_max_examples
 
 _CROSSHAIR_ERROR_RE = re.compile(r": error:")
@@ -167,6 +170,22 @@ def test_data_binding_format_and_parse() -> None:
     assert format_data_binding_display(")") == ""
     assert parse_data_binding_text("A1, B1:C5") == ["A1", "B1:C5"]
     assert format_data_binding_text(["A1", "B1:C5"]) == "A1, B1:C5"
+
+
+def test_formula_edit_overflow_pre_fails_closed() -> None:
+    if not deal_pre_present(rebuild_python_formula_with_data):
+        pytest.skip("@deal.pre stripped in release bundle")
+    too_long = "x" * (DEAL_MAX_SOURCE + 1)
+    with pytest.raises(deal.PreContractError):
+        rebuild_python_formula_with_data(too_long, [])
+    with pytest.raises(deal.PreContractError):
+        format_data_binding_display(too_long)
+    with pytest.raises(deal.PreContractError):
+        normalize_formula_string(too_long)
+    with pytest.raises(deal.PreContractError):
+        parse_python_formula(too_long)
+    with pytest.raises(deal.PreContractError):
+        normalize_lo_formula_for_parse(too_long)
 
 
 @given(suffix=st.text(max_size=30))

--- a/tests/calc/test_address_utils_verification.py
+++ b/tests/calc/test_address_utils_verification.py
@@ -26,7 +26,7 @@ from plugin.calc.address_utils import (
     parse_address,
     parse_range_string,
 )
-from plugin.framework.deal_shim import DEAL_MAX_COL_INDEX
+from plugin.framework.deal_shim import DEAL_MAX_COL_INDEX, DEAL_MAX_ROW_INDEX
 from tests.vhs_budget import vhs_max_examples
 
 CROSSHAIR_MODULE = "plugin/calc/address_utils.py"
@@ -35,7 +35,7 @@ _CROSSHAIR_ERROR_RE = re.compile(r": error:")
 # Bound column width so Hypothesis stays fast (Excel max is wider; invariant holds generally).
 _col_letters = st.text(alphabet=st.characters(min_codepoint=ord("A"), max_codepoint=ord("Z")), min_size=1, max_size=3)
 _col_index = st.integers(min_value=0, max_value=DEAL_MAX_COL_INDEX)
-_row_index = st.integers(min_value=0, max_value=10_000)
+_row_index = st.integers(min_value=0, max_value=DEAL_MAX_ROW_INDEX)
 
 
 def _find_crosshair() -> str | None:
@@ -72,6 +72,17 @@ def test_hypothesis_column_index_round_trip(index: int) -> None:
 def test_hypothesis_format_parse_round_trip(col: int, row: int) -> None:
     addr = format_address(col, row)
     assert parse_address(addr) == (col, row)
+
+
+def test_format_address_row_overflow_pre_fails_closed() -> None:
+    import deal
+    from tests.strip_bundle import deal_pre_present
+
+    if not deal_pre_present(format_address):
+        pytest.skip("@deal.pre stripped in release bundle")
+    with pytest.raises(deal.PreContractError):
+        format_address(0, DEAL_MAX_ROW_INDEX + 1)
+    assert format_address(0, DEAL_MAX_ROW_INDEX) == f"A{DEAL_MAX_ROW_INDEX + 1}"
 
 
 def test_parse_address_raises_on_invalid() -> None:

--- a/tests/calc/test_excel_py_dag_verification.py
+++ b/tests/calc/test_excel_py_dag_verification.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 from typing import get_args, get_origin, get_type_hints
 
+import pytest
 from hypothesis import given, strategies as st
 
+import deal
 from plugin.calc.excel_py_convert.to_dag import (
     _normalize_bindings,
     _normalize_excel_placeholders,
@@ -17,6 +19,8 @@ from plugin.calc.excel_py_convert.to_dag import (
     _xl_binding_expr,
 )
 from plugin.calc.spreadsheet_import.preprocess import normalize_lo_formula_for_parse
+from plugin.framework.deal_shim import DEAL_MAX_PLACEHOLDER_INDEX, DEAL_MAX_SOURCE
+from tests.strip_bundle import deal_pre_present
 
 
 def test_xl_binding_expr_header_mode_annotation_is_str() -> None:
@@ -30,14 +34,14 @@ def test_xl_binding_expr_header_mode_annotation_is_str() -> None:
     assert value is str
 
 
-@given(st.integers(min_value=2, max_value=10000))
+@given(st.integers(min_value=2, max_value=2 + DEAL_MAX_PLACEHOLDER_INDEX))
 def test_placeholder_to_data_index_invariant(p_num: int) -> None:
     idx = _placeholder_to_data_index(p_num)
     assert idx >= 0
     assert idx == p_num - 2
 
 
-@given(st.integers(min_value=0, max_value=10000), st.sampled_from(["true", "false", "omit"]))
+@given(st.integers(min_value=0, max_value=DEAL_MAX_PLACEHOLDER_INDEX), st.sampled_from(["true", "false", "omit"]))
 def test_xl_binding_expr_invariants(idx: int, header_mode: str) -> None:
     expr = _xl_binding_expr(idx, header_mode)
     assert expr.startswith("xl(")
@@ -50,7 +54,7 @@ def test_xl_binding_expr_invariants(idx: int, header_mode: str) -> None:
         assert "headers=False" in expr
 
 
-@given(st.text(alphabet=st.characters(blacklist_categories=("Cs",), max_codepoint=127)))
+@given(st.text(alphabet=st.characters(blacklist_categories=("Cs",), max_codepoint=127), max_size=DEAL_MAX_SOURCE))
 def test_normalize_excel_placeholders_length_invariant(src: str) -> None:
     normalized = _normalize_excel_placeholders(src)
     assert len(normalized) == len(src)
@@ -60,10 +64,21 @@ def test_normalize_excel_placeholders_length_invariant(src: str) -> None:
         assert "_P2_" in normalized
 
 
-@given(st.text())
+@given(st.text(max_size=DEAL_MAX_SOURCE))
 def test_normalize_lo_formula_for_parse_invariants(formula: str) -> None:
     result = normalize_lo_formula_for_parse(formula)
     assert isinstance(result, str)
     # Curly quotes should always be normalized away
     assert "\u201c" not in result
     assert "\u201d" not in result
+
+
+def test_placeholder_index_overflow_pre_fails_closed() -> None:
+    if not deal_pre_present(_placeholder_to_data_index):
+        pytest.skip("@deal.pre stripped in release bundle")
+    with pytest.raises(deal.PreContractError):
+        _placeholder_to_data_index(2 + DEAL_MAX_PLACEHOLDER_INDEX + 1)
+    with pytest.raises(deal.PreContractError):
+        _xl_binding_expr(DEAL_MAX_PLACEHOLDER_INDEX + 1, "omit")
+    assert _placeholder_to_data_index(2 + DEAL_MAX_PLACEHOLDER_INDEX) == DEAL_MAX_PLACEHOLDER_INDEX
+    assert '"%P' in _xl_binding_expr(DEAL_MAX_PLACEHOLDER_INDEX, "omit")

--- a/tests/chatbot/test_tool_loop_state.py
+++ b/tests/chatbot/test_tool_loop_state.py
@@ -130,6 +130,19 @@ def test_stream_done_no_text_includes_debug_sidebar():
     assert format_empty_model_response_debug(2, response) in debug_line
 
 
+def test_format_empty_model_response_debug_overflow_pre_fails_closed():
+    import pytest
+
+    import deal
+    from tests.strip_bundle import deal_pre_present
+
+    if not deal_pre_present(format_empty_model_response_debug):
+        pytest.skip("@deal.pre stripped in release bundle")
+    with pytest.raises(deal.PreContractError):
+        format_empty_model_response_debug(10_001, {})
+    assert "round=10000" in format_empty_model_response_debug(10_000, {})
+
+
 def test_format_empty_model_response_debug_content_empty_vs_none():
     none_note = format_empty_model_response_debug(0, {"content": None})
     assert "content=None" in none_note

--- a/tests/framework/test_deal_shim.py
+++ b/tests/framework/test_deal_shim.py
@@ -70,7 +70,7 @@ def test_deal_shim_constants() -> None:
     assert DEAL_MAX_URL == 2048
     assert DEAL_MAX_PATH == 4096
     assert DEAL_MAX_SOURCE == 64
-    assert DEAL_MAX_ROW_INDEX == 1_048_576 - 1
+    assert DEAL_MAX_ROW_INDEX == 1000
     assert DEAL_MAX_PLACEHOLDER_INDEX == 1024
     assert DEAL_MAX_SHAPE_RANK == 4
     assert DEAL_MAX_SHAPE_DIM == 256

--- a/tests/framework/test_deal_shim.py
+++ b/tests/framework/test_deal_shim.py
@@ -17,6 +17,7 @@ from plugin.framework.deal_shim import (
     DEAL_MAX_PLACEHOLDER_INDEX,
     DEAL_MAX_RETRY,
     DEAL_MAX_ROW_INDEX,
+    DEAL_MAX_SHAPE_DIM,
     DEAL_MAX_SHAPE_RANK,
     DEAL_MAX_SOURCE,
     DEAL_MAX_TOKEN,
@@ -72,6 +73,7 @@ def test_deal_shim_constants() -> None:
     assert DEAL_MAX_ROW_INDEX == 1_048_576 - 1
     assert DEAL_MAX_PLACEHOLDER_INDEX == 1024
     assert DEAL_MAX_SHAPE_RANK == 4
+    assert DEAL_MAX_SHAPE_DIM == 256
     assert DEAL_MAX_RETRY == 8
     assert DEAL_MAX_BACKOFF == 300.0
     assert DEAL_MAX_BACKOFF_FACTOR == 10.0

--- a/tests/framework/test_deal_shim.py
+++ b/tests/framework/test_deal_shim.py
@@ -8,10 +8,16 @@
 from __future__ import annotations
 
 from plugin.framework.deal_shim import (
+    DEAL_MAX_BACKOFF,
+    DEAL_MAX_BACKOFF_FACTOR,
     DEAL_MAX_CELL_REF,
     DEAL_MAX_COL_LETTERS,
     DEAL_MAX_ORIGIN,
     DEAL_MAX_PATH,
+    DEAL_MAX_PLACEHOLDER_INDEX,
+    DEAL_MAX_RETRY,
+    DEAL_MAX_ROW_INDEX,
+    DEAL_MAX_SHAPE_RANK,
     DEAL_MAX_SOURCE,
     DEAL_MAX_TOKEN,
     DEAL_MAX_URL,
@@ -63,3 +69,9 @@ def test_deal_shim_constants() -> None:
     assert DEAL_MAX_URL == 2048
     assert DEAL_MAX_PATH == 4096
     assert DEAL_MAX_SOURCE == 64
+    assert DEAL_MAX_ROW_INDEX == 1_048_576 - 1
+    assert DEAL_MAX_PLACEHOLDER_INDEX == 1024
+    assert DEAL_MAX_SHAPE_RANK == 4
+    assert DEAL_MAX_RETRY == 8
+    assert DEAL_MAX_BACKOFF == 300.0
+    assert DEAL_MAX_BACKOFF_FACTOR == 10.0

--- a/tests/framework/test_url_utils_verification.py
+++ b/tests/framework/test_url_utils_verification.py
@@ -32,7 +32,6 @@ _urls = st.one_of(
     st.just(""),
     st.just("   "),
     st.just(None),
-    st.just(123),
     st.from_regex(r"https://[a-z0-9.-]{1,20}\.com(/[a-z0-9]{0,8}){0,3}", fullmatch=True),
     st.sampled_from(
         [
@@ -79,7 +78,26 @@ def test_normalize_empty_and_non_str() -> None:
     assert normalize_endpoint_url("") == ""
     assert normalize_endpoint_url("  ") == ""
     assert normalize_endpoint_url(None) == ""  # type: ignore[arg-type]
-    assert normalize_endpoint_url(1) == ""  # type: ignore[arg-type]
+
+
+def test_url_helpers_overflow_pre_fails_closed() -> None:
+    from plugin.framework.deal_shim import DEAL_MAX_URL
+    from plugin.framework.url_utils import get_url_hostname, is_pdf_url
+    from tests.strip_bundle import deal_pre_present
+
+    import deal
+
+    if not deal_pre_present(normalize_endpoint_url):
+        pytest.skip("@deal.pre stripped in release bundle")
+    too_long = "https://example.com/" + ("a" * DEAL_MAX_URL)
+    with pytest.raises(deal.PreContractError):
+        normalize_endpoint_url(too_long)
+    with pytest.raises(deal.PreContractError):
+        get_url_hostname(too_long)
+    with pytest.raises(deal.PreContractError):
+        is_pdf_url(too_long)
+    with pytest.raises(deal.PreContractError):
+        normalize_endpoint_url(1)  # type: ignore[arg-type]
 
 
 @given(url=_urls)

--- a/tests/mcp/test_tunnel_state.py
+++ b/tests/mcp/test_tunnel_state.py
@@ -1,8 +1,11 @@
 """Unit and contract verification tests for the MCP Tunnel pure FSM (tunnel_state.py)."""
 
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+import deal
+from plugin.framework.deal_shim import DEAL_MAX_RETRY
 from plugin.mcp.tunnel_state import (
     CancelRetryTimerEffect,
     NotifyUrlAcquiredEffect,
@@ -16,6 +19,7 @@ from plugin.mcp.tunnel_state import (
     compute_backoff_delay,
     next_state,
 )
+from tests.strip_bundle import deal_pre_present
 
 
 def test_compute_backoff_delay_exponential_progression():
@@ -25,7 +29,14 @@ def test_compute_backoff_delay_exponential_progression():
     assert compute_backoff_delay(3) == 8.0
     assert compute_backoff_delay(4) == 16.0
     assert compute_backoff_delay(5) == 30.0  # Capped at max_backoff (30.0)
-    assert compute_backoff_delay(10) == 30.0
+    assert compute_backoff_delay(DEAL_MAX_RETRY) == 30.0
+
+
+def test_compute_backoff_delay_overflow_pre_fails_closed():
+    if not deal_pre_present(compute_backoff_delay):
+        pytest.skip("@deal.pre stripped in release bundle")
+    with pytest.raises(deal.PreContractError):
+        compute_backoff_delay(DEAL_MAX_RETRY + 1)
 
 
 def test_compute_backoff_delay_custom_parameters():
@@ -219,7 +230,7 @@ def test_stop_requested_cleans_up_from_any_state():
 
 
 @given(
-    retry_count=st.integers(min_value=0, max_value=100),
+    retry_count=st.integers(min_value=0, max_value=DEAL_MAX_RETRY),
     initial=st.floats(min_value=0.1, max_value=10.0),
     factor=st.floats(min_value=1.0, max_value=5.0),
     max_backoff=st.floats(min_value=10.0, max_value=300.0),

--- a/tests/scripting/test_payload_codec_policy_verification.py
+++ b/tests/scripting/test_payload_codec_policy_verification.py
@@ -17,7 +17,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import deal
-from plugin.framework.deal_shim import DEAL_MAX_ROW_INDEX, DEAL_MAX_SHAPE_RANK
+from plugin.framework.deal_shim import DEAL_MAX_SHAPE_DIM, DEAL_MAX_SHAPE_RANK
 from plugin.scripting.payload_codec import (
     PAYLOAD_CALC_RANGE,
     PAYLOAD_DATAFRAME,
@@ -98,11 +98,11 @@ def test_cell_count_overflow_pre_fails_closed() -> None:
     if not deal_pre_present(cell_count):
         pytest.skip("@deal.pre stripped in release bundle")
     with pytest.raises(deal.PreContractError):
-        cell_count((DEAL_MAX_ROW_INDEX + 1,))
+        cell_count((DEAL_MAX_SHAPE_DIM + 1,))
     with pytest.raises(deal.PreContractError):
         cell_count(tuple([1] * (DEAL_MAX_SHAPE_RANK + 1)))
     with pytest.raises(deal.PreContractError):
-        should_use_binary_envelope((1,), min_cells=DEAL_MAX_ROW_INDEX + 1)
+        should_use_binary_envelope((1,), min_cells=DEAL_MAX_SHAPE_DIM + 1)
 
 
 def test_host_pack_split_grid_empty() -> None:

--- a/tests/scripting/test_payload_codec_policy_verification.py
+++ b/tests/scripting/test_payload_codec_policy_verification.py
@@ -16,6 +16,8 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+import deal
+from plugin.framework.deal_shim import DEAL_MAX_ROW_INDEX, DEAL_MAX_SHAPE_RANK
 from plugin.scripting.payload_codec import (
     PAYLOAD_CALC_RANGE,
     PAYLOAD_DATAFRAME,
@@ -31,8 +33,10 @@ from plugin.scripting.payload_codec import (
     is_numeric_coercible,
     is_numeric_grid,
     is_split_grid,
+    should_use_binary_envelope,
     wire_cell_count,
 )
+from tests.strip_bundle import deal_pre_present
 from tests.vhs_budget import vhs_max_examples
 
 _CROSSHAIR_ERROR_RE = re.compile(r": error:")
@@ -87,6 +91,18 @@ def test_zero_dim_shape_cell_count() -> None:
     assert cell_count((0,)) == 0
     assert cell_count((0, 5)) == 0
     assert cell_count((5, 0)) == 0
+    assert cell_count((1, 1, 1, 1)) == 1
+
+
+def test_cell_count_overflow_pre_fails_closed() -> None:
+    if not deal_pre_present(cell_count):
+        pytest.skip("@deal.pre stripped in release bundle")
+    with pytest.raises(deal.PreContractError):
+        cell_count((DEAL_MAX_ROW_INDEX + 1,))
+    with pytest.raises(deal.PreContractError):
+        cell_count(tuple([1] * (DEAL_MAX_SHAPE_RANK + 1)))
+    with pytest.raises(deal.PreContractError):
+        should_use_binary_envelope((1,), min_cells=DEAL_MAX_ROW_INDEX + 1)
 
 
 def test_host_pack_split_grid_empty() -> None:

--- a/tests/scripting/test_sandbox_path_verification.py
+++ b/tests/scripting/test_sandbox_path_verification.py
@@ -8,10 +8,15 @@
 from __future__ import annotations
 
 import os
+
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+import deal
+from plugin.framework.deal_shim import DEAL_MAX_PATH
 from plugin.scripting.sandbox import is_safe_workspace_path
+from tests.strip_bundle import deal_pre_present
 from tests.vhs_budget import vhs_max_examples
 
 
@@ -48,3 +53,12 @@ def test_hypothesis_path_containment_invariants(rel_path: str, root_dir: str) ->
         abs_root = os.path.abspath(root_dir)
         abs_target = os.path.abspath(os.path.join(abs_root, rel_path))
         assert os.path.commonpath([abs_target, abs_root]) == abs_root
+
+
+def test_safe_workspace_path_overflow_pre_fails_closed() -> None:
+    if not deal_pre_present(is_safe_workspace_path):
+        pytest.skip("@deal.pre stripped in release bundle")
+    too_long = "a" * (DEAL_MAX_PATH + 1)
+    with pytest.raises(deal.PreContractError):
+        is_safe_workspace_path(too_long, "/home/user")
+    assert is_safe_workspace_path("José.txt", "/home/user/workspace") is True

--- a/tests/scripting/test_scrub_env_verification.py
+++ b/tests/scripting/test_scrub_env_verification.py
@@ -16,7 +16,10 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+import deal
+from plugin.framework.deal_shim import DEAL_MAX_PATH
 from plugin.scripting.sandbox import scrub_subprocess_env, wrap_command_for_sandbox
+from tests.strip_bundle import deal_pre_present
 from tests.vhs_budget import vhs_max_examples
 
 _CROSSHAIR_ERROR_RE = re.compile(r": error:")
@@ -56,6 +59,13 @@ def test_wrap_command_for_sandbox_basic() -> None:
     wrapped = wrap_command_for_sandbox(cmd)
     assert isinstance(wrapped, list)
     assert wrapped[-len(cmd):] == cmd
+
+
+def test_wrap_command_overflow_pre_fails_closed() -> None:
+    if not deal_pre_present(wrap_command_for_sandbox):
+        pytest.skip("@deal.pre stripped in release bundle")
+    with pytest.raises(deal.PreContractError):
+        wrap_command_for_sandbox(["python3", "x" * (DEAL_MAX_PATH + 1)])
 
 
 @given(cmd=st.lists(st.text(max_size=30), max_size=10))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto master after #437. Reuses `str_bounded`; does **not** edit `address_utils.py` or add `DEAL_MAX_COL_INDEX`.

Deep CrossHair hung on unbounded `@deal.pre` ints/strs (same class as `index_to_column`: giant int → loop / product / exponent / f-string).

Caps are CrossHair/dev-venv only (release OXTs strip `@deal.*`). They do not have to match Calc’s real limits.

## Caps (named `DEAL_MAX_*` in `plugin/framework/deal_shim.py`)

- **`to_dag`:** `_placeholder_to_data_index` / `_xl_binding_expr` — `DEAL_MAX_PLACEHOLDER_INDEX=1024`; tightened `_xl_binding_expr` post to require `"%P` and `len <= DEAL_MAX_TOKEN`.
- **`payload_codec`:** `cell_count` / `should_use_binary_envelope` (and matching pack `min_cells` pres) — rank ≤ `DEAL_MAX_SHAPE_RANK=4`, each dim and `min_cells` ≤ `DEAL_MAX_SHAPE_DIM=256`.
- **`sandbox`:** `wrap_command_for_sandbox` / `is_safe_workspace_path` use `str_bounded(..., DEAL_MAX_PATH)`.
- **`formula_edit`:** `rebuild_python_formula_with_data`, `format_data_binding_display`, `normalize_formula_string`, `parse_python_formula` use `str_bounded(..., DEAL_MAX_SOURCE)`.
- **`preprocess.normalize_lo_formula_for_parse`:** `str_bounded(formula, DEAL_MAX_SOURCE)`.
- **`url_utils`:** `normalize_endpoint_url` and sibling helpers: `url is None or ascii_bounded(url, DEAL_MAX_URL)`.
- **`tunnel_state.compute_backoff_delay`:** `retry_count <= DEAL_MAX_RETRY=8`; finite backoff floats.
- **`format_empty_model_response_debug`:** `0 <= round_num <= 10_000`. `next_state` untouched.
- **`DEAL_MAX_ROW_INDEX=1000`** (not Calc’s 1 048 575): enough for 1–4 digit row round-trips so CrossHair deep can finish. Hypothesis row strategy matches.

No per-module CrossHair walls, no skip-list entries, no spill/#401.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40793959-f692-44ed-b9c6-27f3a3a25cb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40793959-f692-44ed-b9c6-27f3a3a25cb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

