### PR TITLE
Shrink remaining CrossHair domains so deep check can finish

### DIFF
--- a/docs/framework-formal-verification.md
+++ b/docs/framework-formal-verification.md
@@ -667,6 +667,8 @@ Helpers in [`deal_shim.py`](../plugin/framework/deal_shim.py):
 
 `DEAL_MAX_CELL_REF` is **32** because `parse_address` / `parse_range_string` reject sheet prefixes; the longest legal range is well under that. Do **not** put `isascii` on `_()` (msgids include `"✓ Copied!"`, `"Testing…"`), HTML strippers, or formula source.
 
+CrossHair int/path domains are **allowed to be smaller than Calc or POSIX**. `@deal.pre` is stripped at release (`scripts/strip_code.py`); LibreOffice uses the no-op shim. Caps exist so deep check can finish — `DEAL_MAX_ROW_INDEX` is 1000 (not a million rows), `DEAL_MAX_PATH` is 256 (filesystem; `wrap_command` uses `DEAL_MAX_ARGV` for long `-c` probes). Do not grow `DEAL_MAX_COL_INDEX` / `DEAL_MAX_COL_LETTERS` out of sync: `parse_address("ZZZ1")` calls `column_to_index`, and a nested `PreContractError` is a CrossHair error.
+
 Hypothesis `st.text(..., max_codepoint=127)` in `*_verification.py` is a **fuzzer** bound, not a function contract — leave those ASCII alphabets in place. Int domains need the same named caps (`DEAL_MAX_*`) so deep check cannot wander on loops, products, exponents, or f-strings of a giant int.
 
 #### F. Single-pass string stripping vs interleaved control whitespace

--- a/plugin/calc/python/formula_edit.py
+++ b/plugin/calc/python/formula_edit.py
@@ -56,7 +56,12 @@ def _parts_result_ok(result: PythonFormulaParts | None) -> bool:
     )
 
 
-@deal.pre(lambda s, start: str_bounded(s, DEAL_MAX_SOURCE) and isinstance(start, int) and start >= 0)
+# Cap start to len(s): `start >= 0` alone lets CrossHair feed a giant int.
+@deal.pre(
+    lambda s, start: str_bounded(s, DEAL_MAX_SOURCE)
+    and isinstance(start, int)
+    and 0 <= start <= len(s)
+)
 @deal.post(lambda result: result is None or (isinstance(result, tuple) and len(result) == 2))
 @deal.ensure(lambda s, start, result: _quoted_parse_result_ok(s, start, result))
 def _parse_quoted_string(s: str, start: int) -> tuple[str, int] | None:

--- a/plugin/framework/deal_shim.py
+++ b/plugin/framework/deal_shim.py
@@ -14,24 +14,32 @@ from typing import Any
 
 # Domain caps for @deal.pre only. Release OXTs strip @deal.* and LibreOffice
 # uses this shim as a no-op, so these lengths never bind shipped code.
+# CrossHair domains may be smaller than Calc / POSIX; the goal is that deep
+# check finishes. Do not grow these to match production limits.
 DEAL_MAX_COL_LETTERS = 3
 DEAL_MAX_CELL_REF = 32
 DEAL_MAX_TOKEN = 64
 DEAL_MAX_ORIGIN = 256
-DEAL_MAX_URL = 2048
-DEAL_MAX_PATH = 4096
+DEAL_MAX_URL = 256
+DEAL_MAX_PATH = 256  # filesystem paths (is_safe_workspace_path); not PATH_MAX
+# wrap_command argv, including venv ``-c`` probe scripts (~1–2k chars).
+DEAL_MAX_ARGV = 4096
+DEAL_MAX_CMD_ARGS = 32  # wrap_command list length
 DEAL_MAX_SOURCE = 64
 # Int domains need caps too (same reason as §8.1 E): CrossHair otherwise
 # unrolls `while index > 0` forever on a giant int in deep check.
 # Same for products, exponents, and f-strings of a huge int.
+# Keep A–ZZZ so parse_address("ZZZ1") does not nested-PreContractError
+# column_to_index (do not edit address_utils.py). Loop is 3 iterations.
 DEAL_MAX_COL_INDEX = 26 + 26**2 + 26**3 - 1  # 18277, A–ZZZ (not 26**3-1)
 # CrossHair domain only (release strips @deal). 1000 covers 1–4 digit rows;
 # Calc's million-row grid is not worth the extra SMT time.
 DEAL_MAX_ROW_INDEX = 1000
-DEAL_MAX_PLACEHOLDER_INDEX = 1024  # Excel %Pn% deps
+DEAL_MAX_PLACEHOLDER_INDEX = 64  # Excel %Pn% deps; f-string of the int
 DEAL_MAX_SHAPE_RANK = 4  # ndarray rank; grids are 2-D, tests use up to 4
 # cell_count product domain — not Calc's million-row grid. 256^4 still fits in a
 # machine int; CrossHair is testing our multiply loop, not LibreOffice.
+# Also the per-side cap for list grids in @deal.pre (100×100 pack tests fit).
 DEAL_MAX_SHAPE_DIM = 256
 DEAL_MAX_RETRY = 8  # MCP tunnel backoff exponent (production DEFAULT_MAX_RETRIES=5)
 DEAL_MAX_BACKOFF = 300.0  # seconds; Hypothesis uses up to 300

--- a/plugin/scripting/payload_codec.py
+++ b/plugin/scripting/payload_codec.py
@@ -302,9 +302,7 @@ def _deal_grid_ok(grid: object) -> bool:
     ``is_numeric_grid`` / pack. Side length follows ``DEAL_MAX_SHAPE_DIM``
     (100×100 pack-speed tests still fit).
     """
-    if not _is_grid_sequence(grid):
-        return False
-    if not isinstance(grid, (list, tuple)):
+    if not _is_grid_sequence(grid) or not isinstance(grid, (list, tuple)):
         return False
     if len(grid) > DEAL_MAX_SHAPE_DIM:
         return False
@@ -312,7 +310,9 @@ def _deal_grid_ok(grid: object) -> bool:
         return True
     first = grid[0]
     if isinstance(first, (list, tuple)):
-        return all(len(row) <= DEAL_MAX_SHAPE_DIM for row in grid)
+        for row in grid:
+            if not isinstance(row, (list, tuple)) or len(row) > DEAL_MAX_SHAPE_DIM:
+                return False
     return True
 
 

--- a/plugin/scripting/payload_codec.py
+++ b/plugin/scripting/payload_codec.py
@@ -295,6 +295,27 @@ def _is_grid_sequence(grid: object) -> bool:
     return True
 
 
+def _deal_grid_ok(grid: object) -> bool:
+    """CrossHair domain for list grids. Production ``_is_grid_sequence`` stays uncapped.
+
+    Unbounded lists let deep check materialize huge nested grids in
+    ``is_numeric_grid`` / pack. Side length follows ``DEAL_MAX_SHAPE_DIM``
+    (100×100 pack-speed tests still fit).
+    """
+    if not _is_grid_sequence(grid):
+        return False
+    if not isinstance(grid, (list, tuple)):
+        return False
+    if len(grid) > DEAL_MAX_SHAPE_DIM:
+        return False
+    if not grid:
+        return True
+    first = grid[0]
+    if isinstance(first, (list, tuple)):
+        return all(len(row) <= DEAL_MAX_SHAPE_DIM for row in grid)
+    return True
+
+
 @deal.post(lambda result: isinstance(result, bool))
 @deal.ensure(
     lambda envelope, result: not result
@@ -533,7 +554,7 @@ def _is_ndarray(obj: object) -> bool:
     return type(obj).__name__ == "ndarray" and type(obj).__module__ == "numpy"
 
 
-@deal.pre(lambda grid, *_unused, **__: _is_grid_sequence(grid))
+@deal.pre(lambda grid, *_unused, **__: _deal_grid_ok(grid))
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: isinstance(_deal_return(*a, result=result), list))
 @deal.ensure(lambda grid, *a, result=_DEAL_RETURN, **k: all(x in ("int", "float", "bool") for x in _deal_return(*a, result=result)))
 def column_kinds_for_grid(grid: list[Any] | list[list[Any]]) -> list[str]:
@@ -744,7 +765,7 @@ def is_numeric_coercible(value: Any) -> bool:
     return False
 
 
-@deal.pre(lambda grid: isinstance(grid, list))
+@deal.pre(lambda grid: isinstance(grid, list) and _deal_grid_ok(grid))
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: isinstance(_deal_return(*a, result=result), bool))
 @deal.ensure(lambda grid, *a, result=_DEAL_RETURN, **k: bool(grid) or _deal_return(*a, result=result) is True)
 def is_numeric_grid(grid: list[Any] | list[list[Any]]) -> bool:
@@ -786,7 +807,7 @@ def wire_cell_count(data: Any) -> int:
     return len(data)
 
 
-@deal.pre(lambda grid: isinstance(grid, list))
+@deal.pre(lambda grid: isinstance(grid, list) and _deal_grid_ok(grid))
 @deal.post(lambda result: isinstance(result, list))
 def grid_from_nested_list(grid: list[Any] | list[list[Any]]) -> list[Any] | list[list[Any]]:
     """Normalize to flat or 2D Python lists for small grids (below BINARY_MIN_CELLS) or non-split_grid results."""
@@ -938,7 +959,7 @@ def _iter_split_grid_cells(
         yield 0, idx, val
 
 
-@deal.pre(lambda grid: _is_grid_sequence(grid))
+@deal.pre(lambda grid: _deal_grid_ok(grid))
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: (r := _deal_return(*a, result=result)) is not None and isinstance(r, tuple) and len(r) == 4 and isinstance(r[0], array.array) and isinstance(r[1], dict) and isinstance(r[2], list) and isinstance(r[3], list))
 @deal.ensure(lambda grid, *a, result=_DEAL_RETURN, **k: (r := _deal_return(*a, result=result)) is not None and (not grid) == (len(r[0]) == 0 and r[1] == {} and r[2] == [] and r[3] == [0]))
 @deal.ensure(lambda grid, *a, result=_DEAL_RETURN, **k: all(isinstance(key, int) for key in _deal_return(*a, result=result)[1].keys()))
@@ -1074,7 +1095,7 @@ def _flatten_grid_to_components(
     return buf, strings, column_kinds, shape
 
 
-@deal.pre(lambda grid: _is_grid_sequence(grid))
+@deal.pre(lambda grid: _deal_grid_ok(grid))
 @deal.post(lambda *a, result=_DEAL_RETURN, **k: isinstance(_deal_return(*a, result=result), dict))
 @deal.ensure(lambda grid, *a, result=_DEAL_RETURN, **k: _deal_return(*a, result=result).get("__wa_payload__") == PAYLOAD_SPLIT_GRID)
 @deal.ensure(lambda grid, *a, result=_DEAL_RETURN, **k: _deal_return(*a, result=result).get("dtype") == SPLIT_GRID_WIRE_DTYPE)
@@ -1129,7 +1150,7 @@ def host_pack_split_grid(
     return envelope
 
 
-@deal.pre(lambda grid, *_unused, **__: _is_grid_sequence(grid))
+@deal.pre(lambda grid, *_unused, **__: _deal_grid_ok(grid))
 # Same force/min_cells gate as should_use_binary_envelope so CrossHair cannot call pack with invalid policy kwargs.
 @deal.pre(
     lambda grid, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never")
@@ -1172,7 +1193,7 @@ def host_pack_data(
         raise
 
 
-@deal.pre(lambda grids, *_unused, **__: isinstance(grids, list) and all(_is_grid_sequence(g) for g in grids))
+@deal.pre(lambda grids, *_unused, **__: isinstance(grids, list) and len(grids) <= DEAL_MAX_SHAPE_DIM and all(_deal_grid_ok(g) for g in grids))
 @deal.pre(
     lambda grids, *_unused, min_cells=BINARY_MIN_CELLS, force="auto", **__: force in ("auto", "always", "never")
     and isinstance(min_cells, int)

--- a/plugin/scripting/sandbox.py
+++ b/plugin/scripting/sandbox.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     import subprocess
 
-from plugin.framework.deal_shim import DEAL_MAX_PATH, deal, str_bounded
+from plugin.framework.deal_shim import DEAL_MAX_ARGV, DEAL_MAX_CMD_ARGS, DEAL_MAX_PATH, deal, str_bounded
 
 # --- Import whitelist (shared by venv_sandbox and import_policy) ---
 
@@ -268,7 +268,12 @@ def optimize_popen_pipes(proc: subprocess.Popen[Any]) -> None:
 
 
 # Hypothesis and venv-path tests pass Unicode argv/paths; ascii_bounded would reject them.
-@deal.pre(lambda cmd: isinstance(cmd, list) and all(str_bounded(x, DEAL_MAX_PATH) for x in cmd))
+# Argv uses DEAL_MAX_ARGV (venv -c probes are longer than DEAL_MAX_PATH filesystem caps).
+@deal.pre(
+    lambda cmd: isinstance(cmd, list)
+    and len(cmd) <= DEAL_MAX_CMD_ARGS
+    and all(str_bounded(x, DEAL_MAX_ARGV) for x in cmd)
+)
 @deal.post(lambda result: isinstance(result, list) and all(isinstance(x, str) for x in result))
 @deal.ensure(lambda cmd, result: len(result) >= len(cmd) and (result[-len(cmd):] == cmd if cmd else True))
 def wrap_command_for_sandbox(cmd: list[str]) -> list[str]:

--- a/tests/calc/python/test_formula_edit_verification.py
+++ b/tests/calc/python/test_formula_edit_verification.py
@@ -125,6 +125,9 @@ def test_parse_quoted_string_rejects_negative_start() -> None:
     """
     expect_pre_or_body(lambda: _parse_quoted_string('""', -1), body_result=None)
     assert _parse_quoted_string('"x"', 0) == ("x", 3)
+    if deal_pre_present(_parse_quoted_string):
+        with pytest.raises(deal.PreContractError):
+            _parse_quoted_string('"x"', DEAL_MAX_SOURCE + 1)
 
 
 def test_find_matching_paren_rejects_negative_open_idx() -> None:

--- a/tests/framework/test_deal_shim.py
+++ b/tests/framework/test_deal_shim.py
@@ -8,9 +8,11 @@
 from __future__ import annotations
 
 from plugin.framework.deal_shim import (
+    DEAL_MAX_ARGV,
     DEAL_MAX_BACKOFF,
     DEAL_MAX_BACKOFF_FACTOR,
     DEAL_MAX_CELL_REF,
+    DEAL_MAX_CMD_ARGS,
     DEAL_MAX_COL_LETTERS,
     DEAL_MAX_ORIGIN,
     DEAL_MAX_PATH,
@@ -67,11 +69,13 @@ def test_deal_shim_constants() -> None:
     assert DEAL_MAX_CELL_REF == 32
     assert DEAL_MAX_TOKEN == 64
     assert DEAL_MAX_ORIGIN == 256
-    assert DEAL_MAX_URL == 2048
-    assert DEAL_MAX_PATH == 4096
+    assert DEAL_MAX_URL == 256
+    assert DEAL_MAX_PATH == 256
+    assert DEAL_MAX_ARGV == 4096
+    assert DEAL_MAX_CMD_ARGS == 32
     assert DEAL_MAX_SOURCE == 64
     assert DEAL_MAX_ROW_INDEX == 1000
-    assert DEAL_MAX_PLACEHOLDER_INDEX == 1024
+    assert DEAL_MAX_PLACEHOLDER_INDEX == 64
     assert DEAL_MAX_SHAPE_RANK == 4
     assert DEAL_MAX_SHAPE_DIM == 256
     assert DEAL_MAX_RETRY == 8

--- a/tests/scripting/test_payload_codec_policy_verification.py
+++ b/tests/scripting/test_payload_codec_policy_verification.py
@@ -103,6 +103,11 @@ def test_cell_count_overflow_pre_fails_closed() -> None:
         cell_count(tuple([1] * (DEAL_MAX_SHAPE_RANK + 1)))
     with pytest.raises(deal.PreContractError):
         should_use_binary_envelope((1,), min_cells=DEAL_MAX_SHAPE_DIM + 1)
+    with pytest.raises(deal.PreContractError):
+        is_numeric_grid([0] * (DEAL_MAX_SHAPE_DIM + 1))
+    with pytest.raises(deal.PreContractError):
+        is_numeric_grid([[0] * (DEAL_MAX_SHAPE_DIM + 1)])
+    assert is_numeric_grid([0] * DEAL_MAX_SHAPE_DIM) is True
 
 
 def test_host_pack_split_grid_empty() -> None:

--- a/tests/scripting/test_scrub_env_verification.py
+++ b/tests/scripting/test_scrub_env_verification.py
@@ -17,7 +17,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import deal
-from plugin.framework.deal_shim import DEAL_MAX_PATH
+from plugin.framework.deal_shim import DEAL_MAX_ARGV, DEAL_MAX_CMD_ARGS, DEAL_MAX_PATH
 from plugin.scripting.sandbox import scrub_subprocess_env, wrap_command_for_sandbox
 from tests.strip_bundle import deal_pre_present
 from tests.vhs_budget import vhs_max_examples
@@ -65,7 +65,11 @@ def test_wrap_command_overflow_pre_fails_closed() -> None:
     if not deal_pre_present(wrap_command_for_sandbox):
         pytest.skip("@deal.pre stripped in release bundle")
     with pytest.raises(deal.PreContractError):
-        wrap_command_for_sandbox(["python3", "x" * (DEAL_MAX_PATH + 1)])
+        wrap_command_for_sandbox(["python3", "x" * (DEAL_MAX_ARGV + 1)])
+    with pytest.raises(deal.PreContractError):
+        wrap_command_for_sandbox(["x"] * (DEAL_MAX_CMD_ARGS + 1))
+    # Argv may be longer than filesystem DEAL_MAX_PATH (venv -c probes).
+    assert wrap_command_for_sandbox(["python3", "x" * (DEAL_MAX_PATH + 1)])[-1] == "x" * (DEAL_MAX_PATH + 1)
 
 
 @given(cmd=st.lists(st.text(max_size=30), max_size=10))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #438. Deal is stripped at release, so CrossHair `@deal.pre` domains do not have to match Calc or POSIX — they exist so deep check can finish.

## What changed

- **`DEAL_MAX_PATH=256`** for filesystem paths (`is_safe_workspace_path`). POSIX `PATH_MAX` is not worth the SMT time.
- **`DEAL_MAX_ARGV=4096`** + **`DEAL_MAX_CMD_ARGS=32`** for `wrap_command_for_sandbox` (venv `-c` probe scripts are longer than 256).
- **`DEAL_MAX_URL=256`**, **`DEAL_MAX_PLACEHOLDER_INDEX=64`**.
- Cap `_parse_quoted_string` `start` to `0 <= start <= len(s)` (unbounded int was the same hang class as `index_to_column`).
- Cap list-grid sides in `@deal.pre` via `_deal_grid_ok` (`DEAL_MAX_SHAPE_DIM=256`; 100×100 pack tests still fit). Production `_is_grid_sequence` stays uncapped.

Left **`DEAL_MAX_COL_INDEX` / `DEAL_MAX_COL_LETTERS` at A–ZZZ**. Shrinking those without editing `address_utils.py` makes `parse_address("ZZZ1")` raise a nested `PreContractError` from `column_to_index` — a CrossHair error, not a hang.

No skip-list entries, no per-module walls, `address_utils.py` untouched.

## Tests

Overflow `PreContractError` (skip if `@deal.pre` stripped) for path/argv/arity, quoted-string start, and oversized numeric grids. Local: `pytest -m "not slow"` on touched files (174 passed) and `make typecheck` green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40793959-f692-44ed-b9c6-27f3a3a25cb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40793959-f692-44ed-b9c6-27f3a3a25cb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

