### PR TITLE
Web research: optional recency filter + today's-date injection

### DIFF
--- a/docs/agent-search.md
+++ b/docs/agent-search.md
@@ -75,6 +75,7 @@ This is the bridge between `smolagents` and WriterAgent's `LlmClient`. It provid
 **What is Done:**
 - **Vendoring core files**: Copied `agents.py`, `models.py`, `tools.py`, `default_tools.py`, etc. to `plugin/contrib/smolagents`.
 - **Tool Adaptation**: Completely rewrote `DuckDuckGoSearchTool` and `VisitWebpageTool` in `default_tools.py` to use `urllib.request` and standard library parsers, with a realistic Firefox user agent to reduce 403s.
+- **Recency filter**: `web_search` now accepts an optional `recency` (`day`/`week`/`month`/`year`/`any`) that maps to DDG Lite's `df` time filter; research prompts inject today's date so fast-changing queries don't go stale.
 - **Model Wrapper**: Built `WriterAgentSmolModel` ([`plugin/chatbot/smol_agent.py`](../plugin/chatbot/smol_agent.py)) to connect the sub-agent directly to WriterAgent's existing `LlmClient`.
 - **Tool Registration**: Registered the `search_web` / web-research path so the ReAct loop runs via the shared smol agent construction.
 - **YAML/Jinja2 removal for ToolCallingAgent**: Replaced `populate_template()` in `ToolCallingAgent.initialize_system_prompt()` with `_render_toolcalling_system_prompt()` and prompts in `toolcalling_agent_prompts.py` using simple placeholders. The search_web path no longer depends on Jinja2.

--- a/plugin/chatbot/web_research.py
+++ b/plugin/chatbot/web_research.py
@@ -25,6 +25,7 @@ import logging
 import os
 import threading
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Callable
 
 from plugin.framework.tool import ToolBase
@@ -291,9 +292,13 @@ def _run_web_agent(
     from plugin.contrib.smolagents.default_tools import DuckDuckGoSearchTool, VisitWebpageTool
 
     max_steps = params.max_steps_override if params.max_steps_override else params.max_steps
+    today = datetime.now().strftime("%Y-%m-%d")
     base_intro = (
-        "You are a research assistant. Use the conversation context provided below to resolve any ambiguity in the user's query. "
-        "Avoid visiting Yelp (yelp.com) links, as Yelp blocks automated requests and returns 403 errors; rely on other sources instead."
+        f"You are a research assistant. Today's date is {today}. "
+        "Use the conversation context provided below to resolve any ambiguity in the user's query. "
+        "Avoid visiting Yelp (yelp.com) links, as Yelp blocks automated requests and returns 403 errors; rely on other sources instead. "
+        "For fast-changing topics (news, prices, model releases), prefer recent sources and pass "
+        "recency='day' or recency='week' to web_search so results are not stale."
     )
     if params.deep_sub_agent and research_goal:
         base_intro += f"\n\nResearch goal for this sub-task: {research_goal.strip()}"

--- a/plugin/chatbot/web_research_deep.py
+++ b/plugin/chatbot/web_research_deep.py
@@ -334,6 +334,7 @@ def _llm_chat(llm_chat: LlmChatFn, messages: list[dict[str, str]], max_tokens: i
 
 
 def generate_search_queries(llm_chat: LlmChatFn, query: str, num_queries: int) -> list[dict[str, str]]:
+    today = datetime.now().strftime("%Y-%m-%d")
     messages = [
         {
             "role": "system",
@@ -349,6 +350,8 @@ def generate_search_queries(llm_chat: LlmChatFn, query: str, num_queries: int) -
                 "For each query, provide a research goal.\n\n"
                 'Return ONLY a JSON array of objects using this exact schema:\n'
                 '[{"query": "<search query>", "researchGoal": "<research goal>"}]\n\n'
+                f"Today's date is {today}. Prefer recent information; where the topic is fast-changing, "
+                "word the queries to surface up-to-date results.\n\n"
                 f"Prompt: {query}"
             ),
         },

--- a/plugin/contrib/smolagents/default_tools.py
+++ b/plugin/contrib/smolagents/default_tools.py
@@ -262,10 +262,34 @@ class UserInputTool(Tool):
         return user_input
 
 
+_RECENCY_TO_DF = {"day": "d", "week": "w", "month": "m", "year": "y"}
+
+
+def _norm_recency(value):
+    """Normalize a recency input to a cache-key token ('any' when unset)."""
+    return (value or "any").strip().lower()
+
+
+def _search_cache_key(query, recency):
+    """Search cache key includes recency so filtered results don't collide with evergreen ones."""
+    return f"{_norm_recency(recency)}|{' '.join(str(query).strip().split())}"
+
+
 class DuckDuckGoSearchTool(Tool):
     name = "web_search"
-    description = "Performs a duckduckgo web search based on your query (think a Google search) then returns the top search results."
-    inputs = {"query": {"type": "string", "description": "The search query to perform."}}
+    description = (
+        "Performs a duckduckgo web search based on your query (think a Google search) then returns the top search results. "
+        "Use the optional recency parameter for fast-changing topics (news, prices, model releases) so results are not stale."
+    )
+    inputs = {
+        "query": {"type": "string", "description": "The search query to perform."},
+        "recency": {
+            "type": "string",
+            "enum": ["any", "day", "week", "month", "year"],
+            "description": "Restrict results to this period: day, week, month, year, or any (no restriction).",
+            "nullable": True,
+        },
+    }
     output_type = "string"
 
     def __init__(self, cache_max_age_days: int, max_results: int = 10, cache_path: str | None = None, cache_max_mb: int = 50, **kwargs):
@@ -275,21 +299,25 @@ class DuckDuckGoSearchTool(Tool):
         self._cache_max_mb = max(cache_max_mb, 0)
         self._cache_max_age_days = max(cache_max_age_days, 1)
 
-    def forward(self, query: str) -> str:
-        key = " ".join(str(query).strip().split())
-        if self._cache_path and self._cache_max_mb > 0 and key:
-            cached = _web_cache_get(self._cache_path, "search", key, max_age_days=self._cache_max_age_days)
+    def forward(self, query: str, recency: str | None = None) -> str:
+        cache_key = _search_cache_key(query, recency)
+        if self._cache_path and self._cache_max_mb > 0 and cache_key:
+            cached = _web_cache_get(self._cache_path, "search", cache_key, max_age_days=self._cache_max_age_days)
             if cached is not None:
-                log.debug("web_cache: search hit: %s" % (key[:60] + "..." if len(key) > 60 else key))
+                log.debug("web_cache: search hit: %s" % (cache_key[:60] + "..." if len(cache_key) > 60 else cache_key))
                 return cached
-            log.debug("web_cache: search miss: %s" % (key[:60] + "..." if len(key) > 60 else key))
+            log.debug("web_cache: search miss: %s" % (cache_key[:60] + "..." if len(cache_key) > 60 else cache_key))
 
         import urllib.request
         import urllib.parse
         from html.parser import HTMLParser
 
         url = "https://lite.duckduckgo.com/lite/"
-        data = urllib.parse.urlencode({"q": query}).encode("utf-8")
+        params = {"q": query}
+        df = _RECENCY_TO_DF.get(_norm_recency(recency))
+        if df:
+            params["df"] = df
+        data = urllib.parse.urlencode(params).encode("utf-8")
         req = urllib.request.Request(url, data=data, headers={"User-Agent": _get_user_agent_for_url(url)})
         try:
             with urllib.request.urlopen(req, timeout=10) as response:
@@ -298,6 +326,14 @@ class DuckDuckGoSearchTool(Tool):
             return f"Error fetching search results: {str(e)}"
 
         class SimpleResultParser(HTMLParser):
+            """Parses DDG Lite result rows.
+
+            Current layout splits one result across multiple <tr> rows: a title row,
+            a snippet row, then a URL/timestamp row. So we accumulate fields across
+            rows and emit a result only when title + description + link are all
+            present (sponsored <tr class="result-sponsored"> rows are skipped).
+            """
+
             def __init__(self):
                 super().__init__()
                 self.results = []
@@ -305,10 +341,26 @@ class DuckDuckGoSearchTool(Tool):
                 self.capture_title = False
                 self.capture_description = False
                 self.capture_link = False
+                self.skip_row = False
+
+            def _flush_current(self):
+                if {"title", "description", "link"} <= set(self.current):
+                    self.current["description"] = "".join(self.current["description"])
+                    self.results.append(self.current)
+                self.current = {}
 
             def handle_starttag(self, tag, attrs):
                 attrs = dict(attrs)
+                if tag == "tr" and attrs.get("class") == "result-sponsored":
+                    self.skip_row = True
+                    self.capture_title = self.capture_description = self.capture_link = False
+                    self.current = {}
+                    return
+                if self.skip_row:
+                    return
                 if tag == "a" and attrs.get("class") == "result-link":
+                    if self.current:
+                        self._flush_current()
                     self.capture_title = True
                 elif tag == "td" and attrs.get("class") == "result-snippet":
                     self.capture_description = True
@@ -316,17 +368,16 @@ class DuckDuckGoSearchTool(Tool):
                     self.capture_link = True
 
             def handle_endtag(self, tag):
-                if tag == "a" and self.capture_title:
+                if tag == "tr":
+                    self.skip_row = False
+                elif self.skip_row:
+                    return
+                elif tag == "a" and self.capture_title:
                     self.capture_title = False
                 elif tag == "td" and self.capture_description:
                     self.capture_description = False
                 elif tag == "span" and self.capture_link:
                     self.capture_link = False
-                elif tag == "tr":
-                    if {"title", "description", "link"} <= self.current.keys():
-                        self.current["description"] = "".join(self.current["description"])
-                        self.results.append(self.current)
-                        self.current = {}
 
             def handle_data(self, data):
                 if self.capture_title:
@@ -337,8 +388,14 @@ class DuckDuckGoSearchTool(Tool):
                 elif self.capture_link:
                     self.current["link"] = "https://" + data.strip()
 
+            def close(self):
+                super().close()
+                if self.current:
+                    self._flush_current()
+
         parser = SimpleResultParser()
         parser.feed(html)
+        parser.close()
         results = parser.results[:self.max_results]
 
         if len(results) == 0:
@@ -351,11 +408,11 @@ class DuckDuckGoSearchTool(Tool):
                 postprocessed_results = [f"<div><h3><a href='{r['link']}'>{r['title']}</a></h3><p>{r['description']}</p></div>" for r in results]
                 result = "<h2>Search Results</h2>\n" + "\n".join(postprocessed_results)
 
-        if self._cache_path and self._cache_max_mb > 0 and key:
+        if self._cache_path and self._cache_max_mb > 0 and cache_key:
             _web_cache_set(
                 self._cache_path,
                 "search",
-                key,
+                cache_key,
                 result,
                 self._cache_max_mb * 1024 * 1024,
             )

--- a/scripts/lo_paths.sh
+++ b/scripts/lo_paths.sh
@@ -133,6 +133,12 @@ find_unopkg() {
 
 find_unopkg_cache_dir() {
     local candidates=()
+    # Prefer the profile unopkg actually pins to (snap), so cache deploys don't
+    # silently sync into a dead ~/.config profile that snap LibreOffice never reads.
+    local snap_conf="$HOME/snap/libreoffice/current/.config/libreoffice/4"
+    if [[ -x "$_LO_SNAP_PROGRAM_DIR/unopkg" && -d "$snap_conf/user" ]]; then
+        candidates+=("$snap_conf/user/uno_packages")
+    fi
     candidates+=("$HOME/.config/libreoffice/4/user/uno_packages")
     candidates+=("$HOME/Library/Application Support/LibreOffice/4/user/uno_packages")
 

--- a/tests/chatbot/test_web_research.py
+++ b/tests/chatbot/test_web_research.py
@@ -959,3 +959,130 @@ def test_web_research_caching_disabled_bypasses_cache(tmp_path):
         mock_exec.return_value.execute_safe.assert_called_once()
 
 
+# =============================================================================
+# DuckDuckGo search tool recency + sponsored-row handling
+# =============================================================================
+
+
+class _FakeUrlopenResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def test_web_search_recency_sets_df_parameter():
+    import urllib.parse
+
+    for recency, expected_df in [("day", "d"), ("week", "w"), ("month", "m"), ("year", "y")]:
+        captured = {}
+        html = b"<html><body>no results</body></html>"
+
+        def _fake_urlopen(req, timeout=None):
+            captured["params"] = dict(urllib.parse.parse_qsl(req.data.decode("utf-8")))
+            return _FakeUrlopenResponse(html)
+
+        from plugin.contrib.smolagents.default_tools import DuckDuckGoSearchTool
+
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            DuckDuckGoSearchTool(cache_max_age_days=30).forward("AI news", recency=recency)
+        assert captured["params"].get("df") == expected_df, f"recency={recency} should map to df={expected_df}"
+
+
+def test_web_search_recency_any_or_none_omits_df():
+    import urllib.parse
+
+    from plugin.contrib.smolagents.default_tools import DuckDuckGoSearchTool
+
+    for recency in [None, "any"]:
+        captured = {}
+
+        def _fake_urlopen(req, timeout=None):
+            captured["params"] = dict(urllib.parse.parse_qsl(req.data.decode("utf-8")))
+            return _FakeUrlopenResponse(b"<html><body>no results</body></html>")
+
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            DuckDuckGoSearchTool(cache_max_age_days=30).forward("AI news", recency=recency)
+        assert "df" not in captured["params"], f"recency={recency} should omit df"
+
+
+def test_web_search_cache_key_includes_recency():
+    from plugin.contrib.smolagents.default_tools import _search_cache_key
+
+    plain = _search_cache_key("AI news", None)
+    assert plain == "any|AI news"
+    assert _search_cache_key("AI news", "day") != plain
+    assert _search_cache_key("AI news", "week") != _search_cache_key("AI news", "day")
+
+
+def test_web_search_skips_sponsored_rows():
+    from plugin.contrib.smolagents.default_tools import DuckDuckGoSearchTool
+
+    html = (
+        "<table>"
+        # Sponsored ad row (single row, has its own result-link anchors incl. 'more info')
+        "<tr class='result-sponsored'>"
+        "<td>&nbsp;</td>"
+        "<td><a href='http://ad.example/' class='result-link'>Sponsored Ad Title</a></td>"
+        "<td>(Sponsored link - <a href='http://help/' rel='nofollow' class='result-link'>more info</a>)</td>"
+        "</tr>"
+        # Real result split across three rows (current DDG Lite layout)
+        "<tr><td valign='top'>1.&nbsp;</td>"
+        "<td><a rel='nofollow' href='http://real.example/story' class='result-link'>Real Result Title</a></td></tr>"
+        "<tr><td>&nbsp;</td><td class='result-snippet'>real result snippet</td></tr>"
+        "<tr><td>&nbsp;</td><td><span class='link-text'>real.example/story</span>"
+        "<span class='timestamp'>2026-08-24</span></td></tr>"
+        "</table>"
+    ).encode("utf-8")
+
+    def _fake_urlopen(req, timeout=None):
+        return _FakeUrlopenResponse(html)
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        tool = DuckDuckGoSearchTool(cache_max_age_days=30)
+        result = tool.forward("AI news")
+
+    assert "Sponsored Ad Title" not in result
+    assert "more info" not in result
+    assert "Real Result Title" in result
+    assert "https://real.example/story" in result
+    assert "real result snippet" in result
+
+
+def test_web_search_parses_split_row_layout():
+    """Current DDG Lite splits each result across title/snippet/link rows."""
+    from plugin.contrib.smolagents.default_tools import DuckDuckGoSearchTool
+
+    html = (
+        "<table>"
+        "<tr><td valign='top'>1.&nbsp;</td>"
+        "<td><a rel='nofollow' href='http://one.example/a' class='result-link'>First Headline</a></td></tr>"
+        "<tr><td>&nbsp;</td><td class='result-snippet'>first snippet</td></tr>"
+        "<tr><td>&nbsp;</td><td><span class='link-text'>one.example/a</span></td></tr>"
+        "<tr><td valign='top'>2.&nbsp;</td>"
+        "<td><a rel='nofollow' href='http://two.example/b' class='result-link'>Second Headline</a></td></tr>"
+        "<tr><td>&nbsp;</td><td class='result-snippet'>second snippet</td></tr>"
+        "<tr><td>&nbsp;</td><td><span class='link-text'>two.example/b</span></td></tr>"
+        "</table>"
+    ).encode("utf-8")
+
+    def _fake_urlopen(req, timeout=None):
+        return _FakeUrlopenResponse(html)
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        tool = DuckDuckGoSearchTool(cache_max_age_days=30)
+        result = tool.forward("AI news")
+
+    assert "First Headline" in result
+    assert "Second Headline" in result
+    assert "one.example/a" in result
+    assert "two.example/b" in result
+
+

--- a/tests/chatbot/test_web_research_deep.py
+++ b/tests/chatbot/test_web_research_deep.py
@@ -239,3 +239,21 @@ def test_assess_research_coverage_parses_score():
     out = assess_research_coverage(llm, "topic", ["finding"], {}, quality_threshold=7)
     assert out["score"] == 8.0
     assert out["stop"] is True
+
+
+def test_generate_search_queries_includes_today():
+    from datetime import datetime
+
+    from plugin.chatbot.web_research_deep import generate_search_queries
+
+    captured: dict[str, str] = {}
+
+    def fake_llm(messages, max_tokens):
+        captured["user"] = messages[-1]["content"]
+        return '[{"query": "q1", "researchGoal": "g1"}, {"query": "q2", "researchGoal": "g2"}]'
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    out = generate_search_queries(fake_llm, "some topic", 2)
+
+    assert len(out) == 2
+    assert today in captured["user"], f"generated query prompt should include today's date ({today})"


### PR DESCRIPTION
Hi Keith,

Small quality-of-life improvement for web/deep research — right now the agents only guess at freshness, since they can't ask the search engine to restrict results.

- `web_search` now accepts an optional `recency` (`day`/`week`/`month`/`year`/`any`), mapped to DDG Lite's `df` time filter. Default behavior is unchanged.
- Research prompts now get today's date deterministically (web agent intro + deep-research query planner), so fast-changing topics surface up-to-date results.
- The DDG Lite parser is more robust against the current split-row layout and skips sponsored rows.

Tests added for the `df` mapping, cache keys, sponsored-row skip, and split-row parsing. (2 pre-existing unrelated failures in `test_web_research.py` remain — a missing `chatbot.prompt_for_web_research` config.)

Also a small dev-tooling fix: `lo_paths.sh` prefers the snap profile for cache deploys so `make deploy` doesn't sync into a dead `~/.config` profile.

Happy to adjust anything.