### PR TITLE
Add medium NumPy notebook fixture for Writer import.

### DIFF
--- a/tests/fixtures/introduction-to-numpy-medium.ipynb
+++ b/tests/fixtures/introduction-to-numpy-medium.ipynb
@@ -1,0 +1,292 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A Medium Introduction to NumPy\n",
+    "\n",
+    "This notebook sits between `introduction-to-numpy-small.ipynb` (6 cells) and Daniel Bourke's full intro (`introduction-to-numpy.ipynb`, ~184 cells). It is an intermediate Writer import/run smoke target: more of the curriculum than the tiny file, still short enough not to hang the UI thread."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "print(f\"NumPy Version: {np.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What is NumPy?\n",
+    "\n",
+    "NumPy stands for numerical Python. It is the backbone of scientific and numerical computing in Python."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why NumPy?\n",
+    "\n",
+    "Pure Python loops get slow on large numerical data. NumPy is fast because the heavy work runs in C, using vectorization so you operate on whole `ndarray`s without writing those loops."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. DataTypes and attributes\n",
+    "\n",
+    "The main type in NumPy is `ndarray`. A vector, a matrix, and a 3D array are all still `ndarray`s, so the same operations work on each."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1-dimensional array (vector)\n",
+    "a1 = np.array([1, 2, 3])\n",
+    "# 2-dimensional array (matrix)\n",
+    "a2 = np.array([[1, 2.0, 3.3],\n",
+    "               [4, 5, 6.5]])\n",
+    "# 3-dimensional array\n",
+    "a3 = np.array([[[1, 2, 3],\n",
+    "                [4, 5, 6],\n",
+    "                [7, 8, 9]],\n",
+    "               [[10, 11, 12],\n",
+    "                [13, 14, 15],\n",
+    "                [16, 17, 18]]])\n",
+    "print(\"a1:\", a1)\n",
+    "print(\"a2:\\n\", a2)\n",
+    "print(\"a3 shape:\", a3.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"a1 shape/ndim/dtype/size/type:\", a1.shape, a1.ndim, a1.dtype, a1.size, type(a1))\n",
+    "print(\"a2 shape/ndim/dtype/size/type:\", a2.shape, a2.ndim, a2.dtype, a2.size, type(a2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Anatomy of an array\n",
+    "\n",
+    "Key terms:\n",
+    "* **Array** - A list of numbers, can be multi-dimensional.\n",
+    "* **Scalar** - A single number (e.g. `7`).\n",
+    "* **Vector** - A list of numbers with 1-dimension (e.g. `np.array([1, 2, 3])`).\n",
+    "* **Matrix** - A (usually) multi-dimensional list of numbers (e.g. `np.array([[1, 2, 3], [4, 5, 6]])`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Creating arrays\n",
+    "\n",
+    "* `np.array()`\n",
+    "* `np.ones()`\n",
+    "* `np.zeros()`\n",
+    "* `np.arange()`\n",
+    "* `np.random.randint()`\n",
+    "* `np.random.seed()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ones = np.ones((2, 3))\n",
+    "zeros = np.zeros((2, 3))\n",
+    "range_array = np.arange(0, 10, 2)\n",
+    "random_array = np.random.randint(10, size=(3, 3))\n",
+    "print(\"ones:\\n\", ones)\n",
+    "print(\"zeros:\\n\", zeros)\n",
+    "print(\"range:\", range_array)\n",
+    "print(\"random:\\n\", random_array)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NumPy uses pseudo-random numbers: they look random but are predetermined. Call `np.random.seed()` so the same random values appear each run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(0)\n",
+    "print(np.random.randint(10, size=(3, 3)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Viewing arrays (indexing)\n",
+    "\n",
+    "Array shapes are listed as `(row, column, ...)`. Extra dimensions are optional."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"a1[0]:\", a1[0])\n",
+    "print(\"a2[1]:\", a2[1])\n",
+    "print(\"a3[:2, :2, :2]:\\n\", a3[:2, :2, :2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Manipulating arrays\n",
+    "\n",
+    "Arithmetic, broadcasting, aggregation, reshape/transpose, and comparison all operate on `ndarray`s.\n",
+    "\n",
+    "### Arithmetic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ones1d = np.ones(3)\n",
+    "print(\"a1 + ones:\", a1 + ones1d)\n",
+    "print(\"a1 * ones:\", a1 * ones1d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Broadcasting\n",
+    "\n",
+    "Broadcasting performs an operation across dimensions without copying data. For example, adding a 1x3 array to a 3x3 array adds that row to every row.\n",
+    "\n",
+    "Rules: pad the shorter shape with 1s on the left; stretch size-1 axes to match; if sizes disagree and neither is 1, raise an error. Trailing axes must be equal or one of them must be 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"a1 + a2:\\n\", a1 + a2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Aggregation\n",
+    "\n",
+    "Aggregation brings values together (sum, mean, min, max). Use NumPy's `np.sum()` on ndarrays and Python's `sum()` on lists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"sum a1:\", np.sum(a1))\n",
+    "print(\"mean a2:\", np.mean(a2))\n",
+    "print(\"max a2:\", np.max(a2))\n",
+    "print(\"min a2:\", np.min(a2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reshape and transpose\n",
+    "\n",
+    "A transpose swaps axes (for example shape `(2, 3)` becomes `(3, 2)`). Reshape must keep the same number of elements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"a2.T:\\n\", a2.T)\n",
+    "print(\"reshape a2 -> (2, 3, 1) shape:\", a2.reshape(2, 3, 1).shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparison\n",
+    "\n",
+    "Comparison operators test whether one array is larger, smaller, or equal to another."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(a1 > 2)\n",
+    "print(a1 == a1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The full curriculum is `introduction-to-numpy.ipynb` (too large for Writer import today). The tiny smoke target is `introduction-to-numpy-small.ipynb`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add an intermediate NumPy curriculum notebook for Writer Jupyter import/run smoke, without touching the importer.

## Why

Writer import hangs on Daniel Bourke's full intro because every code cell becomes an in-flow form TextField plus a ▶ button on the UI thread. The existing small fixture is only a first smoke target. This medium notebook is for the **next** import/run pass **after** the small notebook works. It does not conflict with the in-flight importer fix for the small file.

## Cell counts

| Fixture | Cells | Code | Markdown | Size |
|---------|------:|-----:|---------:|-----:|
| `tests/fixtures/introduction-to-numpy-small.ipynb` | 6 | 3 | 3 | ~1.8 KB |
| `tests/fixtures/introduction-to-numpy-medium.ipynb` (**this PR**) | 25 | 11 | 14 | ~7.6 KB |
| `tests/fixtures/introduction-to-numpy.ipynb` (full Bourke) | 184 | 144 | 40 | ~122 KB |

Medium is ~4× the small notebook (22–26 cells, 10–12 code), compact like the small file (several related lines per code cell, not 144 one-liners). Pulled from the full curriculum: datatypes, creating arrays, seed, indexing, arithmetic, broadcasting, aggregation, reshape/transpose, comparison.

## What's in the fixture

- nbformat 4 / minor 4, kernelspec copied from the small fixture
- All code cells have empty `outputs` (no html, png, `%timeit`, pandas, matplotlib, `imread`, error cells, or 100_000-element arrays)
- CommonMark markdown only (no Colab HTML, no `<img src="../images/...">`)
- Shared kernel: later cells reuse `a1` / `a2` / `a3` from the first array cell; numpy is imported once

## Out of scope

No importer, Makefile, or plugin changes. Small and full notebooks are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03dd1637-960c-45e9-9651-5335c9e807ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03dd1637-960c-45e9-9651-5335c9e807ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

