### PR TITLE
Make Writer Jupyter import work for the small NumPy notebook

### DIFF
--- a/docs/archive/sagemath-integration-dev-plan.md
+++ b/docs/archive/sagemath-integration-dev-plan.md
@@ -4,7 +4,7 @@
 > **Product note (2026-06):** SymPy trusted helpers (`symbolic_math`, Run Python Script **[Math]**) ship first; Sage integration below remains optional future work.  
 > **Last updated:** 2026-06-07  
 > **Owner:** WriterAgent core  
-> **Related:** [Scientific Python bridge](enabling_numpy_in_libreoffice.md) · [Symbolic Math roadmap](scripting-numpy-domains.md#symbolic-math) · [Analysis sub-agent](calc-analysis-sub-agent.md) · [Jupyter notebook import](calc-jupyter-notebook-import.md) · [Math / TeX design](writer-math-tex.md) · [Community integration strategy](../community_integration_strategy.md)
+> **Related:** [Scientific Python bridge](enabling_numpy_in_libreoffice.md) · [Symbolic Math roadmap](scripting-numpy-domains.md#symbolic-math) · [Analysis sub-agent](calc-analysis-sub-agent.md) · [Jupyter notebook import](writer-jupyter-notebook-import.md) · [Math / TeX design](writer-math-tex.md) · [Community integration strategy](../community_integration_strategy.md)
 
 ---
 
@@ -310,7 +310,7 @@ Aligns with [scripting-numpy-domains.md §3 Symbolic Math](scripting-numpy-domai
 
 | Step           | Scope                                                                                                                                     |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **4a (docs)**  | Import `.ipynb` via [jupyter-notebook-import](calc-jupyter-notebook-import.md); cells use WriterAgent venv — document Sage syntax requirements |
+| **4a (docs)**  | Import `.ipynb` via [jupyter-notebook-import](writer-jupyter-notebook-import.md); cells use WriterAgent venv — document Sage syntax requirements |
 | **4b**         | Detect `kernelspec.name == "sage"` → actionable Settings message                                                                          |
 | **4c (defer)** | External Sage Jupyter kernel subprocess — only if 4a–4b insufficient                                                                      |
 

--- a/docs/calc-notebook-interactive-dev-plan.md
+++ b/docs/calc-notebook-interactive-dev-plan.md
@@ -6,7 +6,7 @@ todos:
     content: "Phase 0: Document notebook model -- cell registry, UserDefinedProperties, session_id notebook:…"
     status: completed
   - id: nb-phase1-run-cell
-    content: "Phase 1: Run single code cell -- ▶ button, shared kernel, output refresh (clear-output API fix pending)"
+    content: "Phase 1: Run single code cell -- ▶ button, shared kernel, output refresh"
     status: completed
   - id: nb-phase2-run-all-stop
     content: "Phase 2: Run All / Run from here, Stop, execution state on gutter [In [n]]"
@@ -30,7 +30,7 @@ isProject: false
 
 ## Purpose
 
-WriterAgent **imports** `.ipynb` files into Writer ([`calc-jupyter-notebook-import.md`](calc-jupyter-notebook-import.md)): markdown, editable code **TextFields** (`nb_cell_{i}_code`), frozen outputs, and (since Phase 1) **▶ Run** per code cell against a **shared `notebook:…` venv kernel**.
+WriterAgent **imports** `.ipynb` files into Writer ([`writer-jupyter-notebook-import.md`](writer-jupyter-notebook-import.md)): markdown, editable code **TextFields** (`nb_cell_{i}_code`), frozen outputs, and (since Phase 1) **▶ Run** per code cell against a **shared `notebook:…` venv kernel**.
 
 Still to build: Run All / Stop, cell CRUD, sidebar, `.ipynb` export, and (later) in-kernel UNO via host proxy.
 
@@ -47,12 +47,12 @@ This plan is **Writer-first**. Calc notebook import is out of scope unless expli
 
 ---
 
-## Current status (2026-05-28)
+## Current status (2026-08)
 
 | Phase | State | Summary |
 |-------|--------|---------|
 | **0** | **Shipped** | Registry JSON on document, stable `cell_id` (UUID), output bookmarks, `notebook:…` session id, reset via **WriterAgent → Reset Python Session** |
-| **1** | **Shipped (core)** | In-flow ▶ push buttons, `notebook_runner`, shared kernel, gutter `[In [n]]` updates, venv execution + UI drain |
+| **1** | **Shipped** | In-flow ▶ push buttons, `notebook_runner`, shared kernel, gutter `[In [n]]` updates, venv execution + UI drain, **output replace** (`setString("")`), ATX markdown headings + inline ``code`` |
 | **2–6** | **Not started** | Run All / Stop, CRUD, sidebar, export, UNO proxy |
 
 **Manual smoke (verified on small notebook):** Import → `wired 3/3 run button(s)` in log → click ▶ → `notebook run cell index=…` → venv worker runs → second cell sees variables from first after cell 0 run.
@@ -76,7 +76,7 @@ This plan is **Writer-first**. Calc notebook import is out of scope unless expli
 
 ### Known gaps / bugs (Phase 1 follow-up)
 
-1. **`clear_cell_output`** — uses `text.deleteContents(...)`, which is not valid on Writer `XText` in PyUNO (`AttributeError: deleteContents`). Re-runs log `failed to clear output for cell N`; new stdout may **append** beside old output until fixed (use cursor `setString("")` or `removeContents` on the selection range).
+1. **`clear_cell_output`** — **fixed**: uses `cursor.setString("")` (Writer `XText` has no `deleteContents`). Re-run replaces stdout; boundary includes markdown/raw cell chrome so the small NumPy fixture does not lose cells between code runs.
 2. **Re-import** — replaces registry; no merge UX (Phase 3).
 3. **Form URL buttons** — rejected; `TargetURL` / protocol handler does not fire for in-flow form buttons. Use **PUSH** + `XActionListener` only.
 4. **Untitled documents** — `doc.getURL()` empty; listener keeps strong ref to `doc` (PyUNO objects cannot use `weakref`).
@@ -171,7 +171,7 @@ flowchart TB
 
 ---
 
-## Phase 1: Run single code cell — **done (core); polish pending**
+## Phase 1: Run single code cell — **done**
 
 **Goal:** User clicks **▶**; code runs in shared kernel; output area updates; gutter shows `[In [n]]`.
 
@@ -187,7 +187,6 @@ flowchart TB
 
 **Remaining Phase 1 work:**
 
-- Fix `clear_cell_output` UNO API so re-run replaces output cleanly
 - Optional UNO test: `tests/notebook/test_notebook_run_uno.py` (tiny ipynb, run cell, assert body text)
 - Session persistence test through `notebook_runner` API (mirror `test_session_persistence.py`)
 
@@ -283,31 +282,30 @@ Add keys in [`plugin/notebook/module.yaml`](../plugin/notebook/module.yaml) when
 
 ## Performance backlog (parallel / lower priority)
 
-From [`calc-jupyter-notebook-import.md`](calc-jupyter-notebook-import.md):
+From [`writer-jupyter-notebook-import.md`](writer-jupyter-notebook-import.md):
 
 - Background import: decode images off-thread, UNO insert on main thread every *k* images
 - nbformat **v3** upgrade path
-- Full CommonMark markdown (today: HTML-tagged cells only)
+- Full CommonMark markdown (ATX headings + inline ``code`` shipped; lists/tables/images later)
 
 ---
 
 ## Suggested implementation order for a fresh agent
 
-1. Read [`calc-jupyter-notebook-import.md`](calc-jupyter-notebook-import.md) and this file’s **Current status** section.
-2. **Fix Phase 1 polish** — `clear_cell_output` API; confirm output replace in Writer.
-3. **Phase 2** — Run All + Stop + menubar entries.
-4. **Phase 3** — cell CRUD + re-import merge dialog.
-5. Update shipped/deferred tables in `calc-jupyter-notebook-import.md` after each phase.
-6. `make test` + manual Writer smoke.
+1. Read [`writer-jupyter-notebook-import.md`](writer-jupyter-notebook-import.md) and this file’s **Current status** section.
+2. **Phase 2** — Run All + Stop + menubar entries.
+3. **Phase 3** — cell CRUD + re-import merge dialog.
+4. Update shipped/deferred tables in `writer-jupyter-notebook-import.md` after each phase.
+5. `make test` + manual Writer smoke.
 
 **Manual smoke (Phase 1 — current):**
 
 1. `make deploy writer` (or restart LO after OXT update).
-2. Import small two-cell notebook (`x = 1` / `print(x)`).
-3. Log: `notebook controls: wired 2/2 run button(s)`.
-4. Run cell 0, then cell 1 → `print` shows `1`.
-5. **Reset Python Session** → cell 1 fails until cell 0 re-run.
-6. Re-run cell 0 → verify output region (after clear-output fix, no duplicate paragraphs).
+2. **Debug → Import Jupyter Notebook…** and pick `tests/fixtures/introduction-to-numpy-small.ipynb`.
+3. Log: `notebook controls: wired 3/3 run button(s)`.
+4. Run code cells in order (▶ cell 2, then 4, then 6) → NumPy version / array / `a2` (cell 6 sees `a1` from cell 4).
+5. **Reset Python Session** → cell 6 fails until cell 4 re-run.
+6. Re-run a code cell → output region is replaced (no duplicate paragraphs).
 
 **Debug log keywords:** `notebook controls`, `wired`, `notebook run cell`, `failed to clear output`, `venv_worker`.
 
@@ -330,7 +328,7 @@ From [`calc-jupyter-notebook-import.md`](calc-jupyter-notebook-import.md):
 
 ## References
 
-- [Jupyter notebook import (user-facing)](calc-jupyter-notebook-import.md)
+- [Jupyter notebook import (user-facing)](writer-jupyter-notebook-import.md)
 - [Shared kernel semantics (§6)](enabling_numpy_in_libreoffice.md#session-modes-and-recalc-semantics) · [Calc UX backlog](enabling_numpy_in_libreoffice.md#calc-ux-backlog)
 - [NumPy / venv bridge](enabling_numpy_in_libreoffice.md)
 - [Writer forms / in-flow controls](../plugin/writer/specialized/forms.py)

--- a/docs/calc-spreadsheet-to-python-import.md
+++ b/docs/calc-spreadsheet-to-python-import.md
@@ -43,7 +43,7 @@ Back to [Enabling NumPy & Python in LibreOffice](enabling_numpy_in_libreoffice.m
 
 This plan is **in-workbook** conversion (formulas stay in Calc as `=PY()`). It does **not** replace the two-phase chat workflow ([compute in venv → write back with tools](enabling_numpy_in_libreoffice.md#two-phase-llm-workflow)); it automates that rewrite for existing sheets.
 
-**Related:** [Jupyter notebook import](calc-jupyter-notebook-import.md) (external `.ipynb` → Writer) · [Enabling NumPy in LibreOffice](enabling_numpy_in_libreoffice.md) (shipped `=PY()` infrastructure) · [Calc UX backlog](enabling_numpy_in_libreoffice.md#calc-ux-backlog) · [Analysis sub-agent](calc-analysis-sub-agent.md) (xlcalculator / excel_in_python references) · [Microsoft `xl()` vs WriterAgent `calc.*`](#microsoft-xl-vs-writeragent-calc) (formula-parity helpers vs Excel data bridge)
+**Related:** [Jupyter notebook import](writer-jupyter-notebook-import.md) (external `.ipynb` → Writer) · [Enabling NumPy in LibreOffice](enabling_numpy_in_libreoffice.md) (shipped `=PY()` infrastructure) · [Calc UX backlog](enabling_numpy_in_libreoffice.md#calc-ux-backlog) · [Analysis sub-agent](calc-analysis-sub-agent.md) (xlcalculator / excel_in_python references) · [Microsoft `xl()` vs WriterAgent `calc.*`](#microsoft-xl-vs-writeragent-calc) (formula-parity helpers vs Excel data bridge)
 
 ---
 

--- a/docs/enabling_numpy_in_libreoffice.md
+++ b/docs/enabling_numpy_in_libreoffice.md
@@ -36,7 +36,7 @@ These Python / NumPy features also now ship in **LibrePy.oxt**. The WriterAgent 
 | [Monaco editor dev plan](scripting-monaco-editor-dev-plan.md) | IPC, phases 2B–2F |
 | [Collabora Online / jail-safe](scripting-numpy-jailsafe.md) | Thin C++ Add-In + compute service |
 | [Calc spreadsheet → Python import](calc-spreadsheet-to-python-import.md) | Convert formulas to `=PY()` |
-| [Jupyter notebook import](calc-jupyter-notebook-import.md) | Writer `.ipynb` import (not venv compute) |
+| [Jupyter notebook import](writer-jupyter-notebook-import.md) | Writer `.ipynb` import + ▶ run (shared `notebook:…` kernel; not Calc `=PY()`) |
 
 ---
 
@@ -848,7 +848,7 @@ Complex returns (DataFrame, dict, class) should show a compact cell label (e.g. 
 ### Other deferred pointers
 
 - Serialization performance: [scripting-numpy-serialization.md — Future work](scripting-numpy-serialization.md#future-work--serialization-performance)
-- Jupyter `.ipynb` import (Writer only, not venv compute): [calc-jupyter-notebook-import.md](calc-jupyter-notebook-import.md)
+- Jupyter Writer `.ipynb` import + ▶ run: [writer-jupyter-notebook-import.md](writer-jupyter-notebook-import.md)
 - Monaco remaining phases: [scripting-monaco-editor-dev-plan.md](scripting-monaco-editor-dev-plan.md)
 - Domain roadmaps: [scripting-numpy-domains.md](scripting-numpy-domains.md)
 
@@ -874,5 +874,5 @@ Remaining work lives in the child doc (or [§7 backlog](#calc-ux-backlog)). Do *
 | Venv ↔ LO tool RPC | [§7](#venv--libreoffice-tool-rpc) |
 | Collabora Online (Steps A–C landed; plot / Monaco remain) | [scripting-numpy-jailsafe.md](scripting-numpy-jailsafe.md), [online#16010](https://github.com/CollaboraOnline/online/issues/16010) |
 | Monaco editor remaining phases | [scripting-monaco-editor-dev-plan.md](scripting-monaco-editor-dev-plan.md) |
-| Jupyter Writer import (execution loop deferred) | [calc-jupyter-notebook-import.md](calc-jupyter-notebook-import.md) |
+| Jupyter Writer import (Phase 1: import + ▶ run, ATX markdown, output replace) | [writer-jupyter-notebook-import.md](writer-jupyter-notebook-import.md) |
 

--- a/docs/scripting-librepy-split.md
+++ b/docs/scripting-librepy-split.md
@@ -888,7 +888,7 @@ See [scripting-numpy-domains.md](scripting-numpy-domains.md) and [image-recognit
 - [Math / TeX import](writer-math-tex.md) — LaTeX, MathML, StarMath pipeline
 - [Calc integration](calc-integration.md) — broader Calc chat/tools (WriterAgent scope)
 
-**Out of scope for core** (separate PM/dev docs): [embeddings.md](embeddings.md), [calc-duckdb-dev-plan.md](calc-duckdb-dev-plan.md), [calc-jupyter-notebook-import.md](calc-jupyter-notebook-import.md), [calc-spreadsheet-to-python-import.md](calc-spreadsheet-to-python-import.md)
+**Out of scope for core** (separate PM/dev docs): [embeddings.md](embeddings.md), [calc-duckdb-dev-plan.md](calc-duckdb-dev-plan.md), [writer-jupyter-notebook-import.md](writer-jupyter-notebook-import.md), [calc-spreadsheet-to-python-import.md](calc-spreadsheet-to-python-import.md)
 
 ---
 

--- a/docs/writer-jupyter-notebook-import.md
+++ b/docs/writer-jupyter-notebook-import.md
@@ -26,13 +26,13 @@ For the full interactive roadmap (Run All, Stop, export, …), see [calc-noteboo
 
 ### Shipped vs deferred
 
-| Shipped (2026-05) | Deferred |
+| Shipped (2026-08) | Deferred |
 |-------------------|----------|
 | Vendored **nbformat v4** read — [`plugin/contrib/nbformat/`](../plugin/contrib/nbformat/): `read_ipynb(path)`, `reads(json_string)` → `NotebookNode` with `rejoin_lines` | **nbformat v3** upgrade |
-| Menu: **Tools → Import Jupyter Notebook…** — [`import_dialog.py`](../plugin/notebook/import_dialog.py) | Full CommonMark/HTML for all markdown (HTML-tagged cells only today) |
-| Import engine — [`writer_importer.py`](../plugin/notebook/writer_importer.py): headings, body text, in-flow code fields, images; **`zxx` locale** at import start (spellcheck off for imported body) | Run All / Stop ([dev plan](calc-notebook-interactive-dev-plan.md) Phase 2) |
+| Menu: **WriterAgent → Debug → Import Jupyter Notebook…** — [`import_dialog.py`](../plugin/notebook/import_dialog.py) | Full CommonMark/GFM (lists, tables, images-in-markdown) |
+| Import engine — [`writer_importer.py`](../plugin/notebook/writer_importer.py): **ATX `#`/`##` headings** (Heading 1/2), inline `` `code` ``, HTML-tagged cells, in-flow code fields, images; **`zxx` locale** at import start | Run All / Stop ([dev plan](calc-notebook-interactive-dev-plan.md) Phase 2) |
 | **Notebook registry (Phase 0)** — [`cell_registry.py`](../plugin/notebook/cell_registry.py): `WriterAgentNotebookJson`, stable `cell_id`, output bookmarks `nb_out_*`, `WriterAgentNotebookSourcePath` | Export back to `.ipynb` (Phase 5) |
-| **Run code cell (Phase 1)** — in-flow ▶ **push** button + [`notebook_controls.py`](../plugin/notebook/notebook_controls.py) + [`notebook_runner.py`](../plugin/notebook/notebook_runner.py); shared `notebook:…` kernel; UI drain on every run | Cell CRUD, sidebar (Phases 3–4) |
+| **Run code cell (Phase 1)** — in-flow ▶ **push** button + [`notebook_controls.py`](../plugin/notebook/notebook_controls.py) + [`notebook_runner.py`](../plugin/notebook/notebook_runner.py); shared `notebook:…` kernel; re-run **replaces** output (`setString("")`); UI drain on every run | Cell CRUD, sidebar (Phases 3–4) |
 | Control lookup — [`form_lookup.py`](../plugin/notebook/form_lookup.py) indexes `ControlShape` models on the document draw page (required for wiring ▶ buttons) | Batched background image decode |
 | **Reset Python Session** — clears `notebook:…` kernel for Writer docs with a registry ([`session_manager.py`](../plugin/scripting/session_manager.py)) | `notebook.enable_interactive` / Settings UI keys |
 | Output images: `image/png`, `image/jpeg` in `display_data` / `execute_result` | JSON schema validation (`fastjsonschema`), `traitlets`, `jupyter_core` |
@@ -47,7 +47,7 @@ For the full interactive roadmap (Run All, Stop, export, …), see [calc-noteboo
 ### How to use
 
 1. Open a **Writer** document (empty or existing — import appends at the end).
-2. **Tools → Import Jupyter Notebook…**
+2. **WriterAgent → Debug → Import Jupyter Notebook…** (dev / `make deploy` builds; **release OXTs strip the Debug menu**, so there is no import UI in `make release`).
 3. Pick a `.ipynb` file.
 4. Wait for the completion dialog (cells / code fields / image counts). Large notebooks run on the **main thread**; the UI may pause — see [Debugging](#debugging-import-and-run).
 5. Click **▶** beside a code cell to run it (see [Run a code cell](#run-a-code-cell)).
@@ -69,8 +69,6 @@ After `make deploy`, **restart LibreOffice** so the extension and menu handlers 
 
 **Not supported yet:** Run All, Stop mid-batch, export to `.ipynb`, add/delete cells in the UI.
 
-**Known limitation:** Re-running a cell may **not fully clear** the previous output paragraph until `clear_cell_output` is fixed in [`notebook_runner.py`](../plugin/notebook/notebook_runner.py) (`deleteContents` is not a valid Writer API — see [dev plan](calc-notebook-interactive-dev-plan.md)).
-
 **How ▶ wiring works (developers):** Form **URL** buttons do **not** reach the extension protocol handler. The importer creates **PUSH** `CommandButton` controls; after import, [`notebook_controls.py`](../plugin/notebook/notebook_controls.py) attaches `XActionListener` on the control **view** via `XControlAccess` (PyUNO must use `uno.getTypeByName`). Protocol dispatch `notebook.run_cell.{hex}` in [`main.py`](../plugin/main.py) remains available for future menu/URL entry points.
 
 ---
@@ -81,9 +79,9 @@ For each cell in order, the importer appends to the **document body**:
 
 | Cell type | Structure in Writer |
 |-----------|-------------------|
-| **All cells** | **Heading 2** — `Cell N: Markdown` / `Cell N: Code` / `Cell N: Raw` |
+| **All cells** | Cell chrome: markdown/raw **Heading 3** (`Cell N: Markdown`); code **`WriterAgent Notebook In`** (`[In [n]]` + `Cell N: Code`) |
 | **code (gutter)** | **`WriterAgent Notebook In`** — `[In [k]]` or `[In [ ]]` (updates after ▶ run) |
-| **markdown** | HTML-tagged source → [`insert_html_fragment_at_cursor`](../plugin/writer/format.py); else **Text Body** plain text |
+| **markdown** | HTML-tagged source → [`insert_html_fragment_at_cursor`](../plugin/writer/html_import.py); CommonMark **ATX `#` → Heading 1**, **`##+` → Heading 2** (not cell chrome Heading 3); inline `` `code` `` → `<code>` via HTML; other lines **Text Body** |
 | **code (body)** | Gutter line + title → in-flow **▶** (`nb_run_{cell_id hex}`) → **TextField** (`nb_cell_{index}_code`) → **Heading 4** “Output” (bookmark `nb_out_{hex}`) → **Preformatted Text** / images |
 | **raw** | **Text Body** — raw cell source |
 
@@ -137,7 +135,7 @@ tail -f ~/.config/libreoffice/4/user/writeragent_debug.log
 | `notebook controls: wired M/K run button(s)` | ▶ listeners attached (`M` should equal code cell count) |
 | `wired 0/K … missing_model=… no_view=…` | Wiring failed — redeploy extension and re-import |
 | `notebook run cell index=… field=nb_cell_…` | ▶ click ran a cell |
-| `failed to clear output for cell` | Output replace bug (run still executes) |
+| `failed to clear output for cell` | `setString("")` on the output range failed (should be rare) |
 | `run_venv_code` / `Task … completed` | Python worker finished |
 
 [`flush_ui_idle`](../plugin/notebook/writer_importer.py) calls `processEventsToIdle()` after import, after wiring, and after each run.
@@ -180,13 +178,12 @@ Vendored nbformat: [`plugin/contrib/nbformat/README.md`](../plugin/contrib/nbfor
 
 | Item | Phase |
 |------|--------|
-| Fix output clear on re-run | Phase 1 polish |
 | Run All / Run from here / Stop | 2 |
 | Add / delete / reorder cells; re-import merge | 3 |
 | Notebook sidebar (cell list, clear outputs) | 4 |
 | Export `.ipynb` | 5 |
 | In-kernel UNO via host tool proxy | 6 (deferred) |
-| nbformat v3, full markdown, background import | Backlog |
+| nbformat v3, lists/tables/images-in-markdown, background import | Backlog |
 
 ---
 
@@ -204,4 +201,4 @@ Vendored nbformat: [`plugin/contrib/nbformat/README.md`](../plugin/contrib/nbfor
 
 ### Not shipped
 
-Run All, Stop, cell CRUD, sidebar, export `.ipynb`, nbformat v3, full CommonMark markdown, background image import, optional `notebook.*` config keys.
+Run All, Stop, cell CRUD, sidebar, export `.ipynb`, nbformat v3, full CommonMark (lists/tables/images), background image import, optional `notebook.*` config keys.

--- a/locales/writeragent.pot
+++ b/locales/writeragent.pot
@@ -51,8 +51,8 @@ msgstr ""
 
 #: plugin/notebook/notebook_runner.py
 msgid ""
-"This document has no imported notebook. Use Tools → Import Jupyter Notebook…"
-" first."
+"This document has no imported notebook. Use WriterAgent → Debug → Import "
+"Jupyter Notebook… first."
 msgstr ""
 
 #: plugin/notebook/notebook_runner.py
@@ -2035,8 +2035,8 @@ msgstr ""
 
 #: plugin/scripting/session_manager.py
 msgid ""
-"This Writer document has no imported notebook registry. Use Tools → Import "
-"Jupyter Notebook… first."
+"This Writer document has no imported notebook registry. Use WriterAgent → "
+"Debug → Import Jupyter Notebook… first."
 msgstr ""
 
 #: plugin/scripting/session_manager.py
@@ -2076,8 +2076,8 @@ msgstr ""
 
 #: plugin/scripting/session_manager.py
 msgid ""
-"This Writer document has no imported notebook registry. Use Tools → Import "
-"Jupyter Notebook… to enable notebook Python session reset."
+"This Writer document has no imported notebook registry. Use WriterAgent → "
+"Debug → Import Jupyter Notebook… to enable notebook Python session reset."
 msgstr ""
 
 #: plugin/scripting/units.py

--- a/plugin/contrib/nbformat/README.md
+++ b/plugin/contrib/nbformat/README.md
@@ -10,7 +10,7 @@ Subset of [jupyter/nbformat](https://github.com/jupyter/nbformat) (BSD-3-Clause)
 
 **Not shipped:** v1/v2/v3 packages, JSON schema validation (`fastjsonschema`), `traitlets`, `jupyter_core`, top-level `nbformat/__init__.py` (`validate`, `convert`, `as_version`).
 
-**Deferred:** nbformat v3 upgrade (`v4/convert.py` in upstream). Revisit when users need legacy `.ipynb` files; see [calc-jupyter-notebook-import.md](../../docs/calc-jupyter-notebook-import.md#jupyter-notebook-import-ipynb).
+**Deferred:** nbformat v3 upgrade (`v4/convert.py` in upstream). Revisit when users need legacy `.ipynb` files; see [writer-jupyter-notebook-import.md](../../docs/writer-jupyter-notebook-import.md#jupyter-notebook-import-ipynb).
 
 **Vendored files (synced from upstream):**
 

--- a/plugin/contrib/nbformat/reader.py
+++ b/plugin/contrib/nbformat/reader.py
@@ -97,7 +97,7 @@ def reads(s, **kwargs):
             raise NBFormatError(msg) from None
     raise NBFormatError(
         f"Unsupported nbformat version {major}; WriterAgent only supports v4 "
-        "(v3 and older upgrade deferred — see docs/calc-jupyter-notebook-import.md)."
+        "(v3 and older upgrade deferred — see docs/writer-jupyter-notebook-import.md)."
     )
 
 

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,6 +26,7 @@ from plugin.notebook.cell_registry import (
     save_registry,
 )
 from plugin.notebook.writer_importer import (
+    _PARAGRAPH_BREAK,
     _STYLE_NOTEBOOK_IN,
     _STYLE_OUTPUT,
     _append_body_text_block,
@@ -122,38 +124,51 @@ def _cursor_after_bookmark(doc: Any, bookmark_name: str) -> Any | None:
         return None
 
 
+# Markdown/raw chrome is ``Cell N: Markdown`` (Heading 3). Code gutters use
+# ``WriterAgent Notebook In`` and/or ``[In [n]]\tCell N: Code``.
+_CELL_CHROME_RE = re.compile(r"^Cell \d+: (Markdown|Raw|Code)\b")
+
+
 def _is_next_cell_boundary(para_style: str, content: str, notebook_in_resolved: str | None) -> bool:
     if notebook_in_resolved and para_style == notebook_in_resolved:
         return True
     stripped = (content or "").strip()
-    return stripped.startswith("[In [") and ": Code" in stripped
+    if stripped.startswith("[In [") and ": Code" in stripped:
+        return True
+    # Stopping only at the next code gutter ate markdown cells between code cells
+    # (the small NumPy fixture is markdown/code/markdown/…).
+    return bool(_CELL_CHROME_RE.match(stripped))
 
 
 def clear_cell_output(doc: Any, cell: NotebookCodeCell) -> None:
-    """Remove body content after the output bookmark through the next cell boundary."""
+    """Remove body content after the output bookmark through the next cell boundary.
+
+    Writer ``XText`` has no ``deleteContents`` (PyUNO raises AttributeError, logged as
+    ``failed to clear output for cell`` so re-runs appended stdout). House pattern is
+    ``cursor.setString("")`` on the selected range (same as ``html_import`` / ``edit_review``).
+    """
     start = _cursor_after_bookmark(doc, cell.output_start_bookmark)
     if start is None:
         return
     text = doc.getText()
-    if not start.gotoNextParagraph(False):
-        return
-    start.gotoStartOfParagraph(False)
     notebook_in = _resolve_para_style(doc, _STYLE_NOTEBOOK_IN)
-    end = text.createTextCursorByRange(start.getStart())
-    end.gotoStartOfParagraph(False)
+    end = text.createTextCursorByRange(start)
+    if _is_next_cell_boundary(end.ParaStyleName, end.getString(), notebook_in):
+        return
+    found_boundary = False
     while end.gotoNextParagraph(False):
         if _is_next_cell_boundary(end.ParaStyleName, end.getString(), notebook_in):
             end.gotoStartOfParagraph(False)
+            found_boundary = True
             break
-    else:
+    if not found_boundary:
         end.gotoEnd(False)
-    sel = text.createTextCursor()
-    sel.gotoRange(start.getStart(), False)
+    sel = text.createTextCursorByRange(start)
     sel.gotoRange(end.getStart(), True)
     if not (sel.getString() or "").strip():
         return
     try:
-        text.deleteContents(sel, False)
+        sel.setString("")
     except Exception:
         log.exception("notebook run: failed to clear output for cell %d", cell.index)
 
@@ -188,13 +203,15 @@ def apply_run_result(
         if display.strip():
             if cursor is not None:
                 text = doc.getText()
+                # New paragraph under the Output heading. Do not gotoEnd() — that is
+                # the document end and would drop later cells' output at the bottom.
+                text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
                 if output_style:
                     try:
                         cursor.setPropertyValue("ParaStyleName", output_style)
                     except Exception:
                         log.debug("notebook run: ParaStyleName %r not applied", output_style)
                 text.insertString(cursor, display, False)
-                cursor.gotoEnd(False)
             else:
                 _append_body_text_block(doc, display, _STYLE_OUTPUT, lead_break=True)
     if result.get("status") == "ok":
@@ -278,7 +295,7 @@ def run_cell_for_doc_hex(ctx: Any, doc: Any, hex_id: str) -> None:
         msgbox(
             ctx,
             "WriterAgent",
-            _("This document has no imported notebook. Use Tools → Import Jupyter Notebook… first."),
+            _("This document has no imported notebook. Use WriterAgent → Debug → Import Jupyter Notebook… first."),
         )
         return
     cell = find_cell_by_hex(state, hex_id)

--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import base64
+import html as html_lib
 import logging
 import os
 import re
@@ -62,6 +63,10 @@ _DEFAULT_IMAGE_HEIGHT_MM = 80
 _IMAGE_MIME_SUFFIX = {"image/png": ".png", "image/jpeg": ".jpg", "image/jpg": ".jpg", "image/svg+xml": ".svg"}
 
 # Writer paragraph styles (document locale usually provides these English names).
+# Markdown ATX uses Heading 1/2 so it does not collide with cell chrome (Heading 3)
+# or the Output label (Heading 4).
+_STYLE_MD_H1 = "Heading 1"
+_STYLE_MD_H2 = "Heading 2"
 _STYLE_CELL_HEADING = "Heading 3"
 _STYLE_SECTION_HEADING = "Heading 4"
 _STYLE_OUTPUT = "Preformatted Text"
@@ -75,6 +80,9 @@ _NOTEBOOK_IN_MARGIN_BOTTOM = 40
 
 _PARAGRAPH_BREAK = 0  # com.sun.star.text.ControlCharacter.PARAGRAPH_BREAK
 _HTML_TAG_RE = re.compile(r"<\s*[a-zA-Z]", re.DOTALL)
+# CommonMark ATX: 1–6 hashes, space, title, optional closing hashes.
+_ATX_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.*?)[ \t]*#*[ \t]*$")
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 
 
 def _mono_ms(t0: float) -> int:
@@ -477,6 +485,8 @@ def _apply_no_spellcheck_for_import(doc: Any) -> None:
     for style_name in (
         "Standard",
         _STYLE_BODY,
+        _STYLE_MD_H1,
+        _STYLE_MD_H2,
         _STYLE_CELL_HEADING,
         _STYLE_SECTION_HEADING,
         _STYLE_OUTPUT,
@@ -581,6 +591,51 @@ def _looks_like_html(text: str) -> bool:
     return bool(_HTML_TAG_RE.search((text or "").strip()))
 
 
+def _inline_backticks_to_html(text: str) -> str:
+    """Escape *text* and wrap `` `code` `` spans in ``<code>``."""
+    parts: list[str] = []
+    last = 0
+    for match in _INLINE_CODE_RE.finditer(text):
+        parts.append(html_lib.escape(text[last : match.start()]))
+        parts.append(f"<code>{html_lib.escape(match.group(1))}</code>")
+        last = match.end()
+    parts.append(html_lib.escape(text[last:]))
+    return "".join(parts)
+
+
+def _iter_markdown_blocks(source: str) -> list[tuple[str, str]]:
+    """Split CommonMark source into ATX headings and paragraphs.
+
+    Not a full CommonMark parser: lists, tables, and images stay as body text.
+    ``#`` → h1, ``##`` and deeper → h2 so markdown does not reuse Heading 3/4
+    (cell titles / Output).
+    """
+    blocks: list[tuple[str, str]] = []
+    para: list[str] = []
+
+    def flush_para() -> None:
+        if para:
+            blocks.append(("p", "\n".join(para)))
+            para.clear()
+
+    for raw_line in (source or "").splitlines():
+        line = raw_line.rstrip()
+        match = _ATX_HEADING_RE.match(line)
+        if match:
+            flush_para()
+            title = (match.group(2) or "").strip()
+            if title:
+                kind = "h1" if len(match.group(1)) <= 1 else "h2"
+                blocks.append((kind, title))
+            continue
+        if not line.strip():
+            flush_para()
+            continue
+        para.append(line)
+    flush_para()
+    return blocks
+
+
 def _wrap_html_fragment(html: str) -> str:
     body = (html or "").strip()
     if re.search(r"(?is)<\s*html\b", body):
@@ -632,27 +687,51 @@ def _append_body_text_block(
     _append_body_paragraph(doc, display, para_style, lead_break=lead_break)
 
 
+def _insert_html_at_body_end(doc: Any, html: str, *, lead_break: bool) -> bool:
+    """Insert an HTML fragment at the document end. Returns False on failure."""
+    text = doc.getText()
+    cursor = text.createTextCursor()
+    cursor.gotoEnd(False)
+    if lead_break and _doc_body_nonempty(doc):
+        text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
+        cursor.gotoEnd(False)
+    from plugin.writer.html_import import insert_html_fragment_at_cursor
+
+    try:
+        insert_html_fragment_at_cursor(cursor, _wrap_html_fragment(html), wrap=False)
+        return True
+    except Exception:
+        log.exception("notebook import HTML insert failed; falling back to plain text")
+        return False
+
+
 def _append_markdown_cell(doc: Any, source: str, *, lead_break: bool) -> None:
-    """Markdown cell: HTML fragments via StarWriter filter; else plain text body."""
+    """Markdown cell: HTML as-is; CommonMark ATX headings + inline ``code``; else body text.
+
+    Jupyter cells are CommonMark, not HTML. The old path only ran the StarWriter HTML
+    filter when ``_looks_like_html`` matched, so ``# Heading`` stayed literal Text Body.
+    """
     display, _unused = _prepare_display_text(source)
     if not display:
         return
     if _looks_like_html(display):
-        text = doc.getText()
-        cursor = text.createTextCursor()
-        cursor.gotoEnd(False)
-        if lead_break and _doc_body_nonempty(doc):
-            text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
-            cursor.gotoEnd(False)
-        from plugin.writer.html_import import insert_html_fragment_at_cursor
-
-        try:
-            insert_html_fragment_at_cursor(cursor, _wrap_html_fragment(display), wrap=False)
-        except Exception:
-            log.exception("notebook import HTML insert failed; falling back to plain text")
+        if not _insert_html_at_body_end(doc, display, lead_break=lead_break):
             _append_body_paragraph(doc, display, _STYLE_BODY, lead_break=False)
-    else:
-        _append_body_text_block(doc, display, _STYLE_BODY, lead_break=lead_break)
+        return
+    first = True
+    for kind, text in _iter_markdown_blocks(display):
+        block_lead = lead_break if first else True
+        first = False
+        if kind == "h1":
+            _append_body_paragraph(doc, text, _STYLE_MD_H1, lead_break=block_lead)
+        elif kind == "h2":
+            _append_body_paragraph(doc, text, _STYLE_MD_H2, lead_break=block_lead)
+        elif "`" in text:
+            html = f"<p>{_inline_backticks_to_html(text)}</p>"
+            if not _insert_html_at_body_end(doc, html, lead_break=block_lead):
+                _append_body_paragraph(doc, text, _STYLE_BODY, lead_break=False)
+        else:
+            _append_body_paragraph(doc, text, _STYLE_BODY, lead_break=block_lead)
 
 
 def _append_cell_heading(doc: Any, title: str, *, lead_break: bool) -> None:

--- a/plugin/scripting/session_manager.py
+++ b/plugin/scripting/session_manager.py
@@ -267,7 +267,7 @@ def reset_notebook_python_session(ctx: Any, doc: Any | None = None) -> None:
             ctx,
             _(
                 "This Writer document has no imported notebook registry. "
-                "Use Tools → Import Jupyter Notebook… first."
+                "Use WriterAgent → Debug → Import Jupyter Notebook… first."
             ),
         )
         return
@@ -361,7 +361,7 @@ def reset_workbook_python_session(ctx: Any, doc: Any | None = None) -> None:
                     ctx,
                     _(
                         "This Writer document has no imported notebook registry. "
-                        "Use Tools → Import Jupyter Notebook… to enable notebook Python session reset."
+                        "Use WriterAgent → Debug → Import Jupyter Notebook… to enable notebook Python session reset."
                     ),
                 )
             return
@@ -383,7 +383,7 @@ def reset_workbook_python_session(ctx: Any, doc: Any | None = None) -> None:
                 ctx,
                 _(
                     "This Writer document has no imported notebook registry. "
-                    "Use Tools → Import Jupyter Notebook… to enable notebook Python session reset."
+                    "Use WriterAgent → Debug → Import Jupyter Notebook… to enable notebook Python session reset."
                 ),
             )
         return

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import inspect
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from plugin.notebook.cell_registry import NotebookDocState, cell_id_to_hex, new_code_cell_entry
 from plugin.notebook.notebook_runner import (
+    _is_next_cell_boundary,
+    apply_run_result,
+    clear_cell_output,
     execute_code,
     format_run_output_text,
     init_registry_execution_counter,
@@ -180,3 +184,142 @@ def test_cell_id_hex_round_trip(hex_id, expected_ok):
         return
     assert restored is not None
     assert cell_id_to_hex(restored) == hex_id
+
+
+def test_clear_cell_output_source_has_no_delete_contents():
+    src = inspect.getsource(clear_cell_output)
+    assert ".deleteContents(" not in src
+    assert "setString" in src
+
+
+def test_is_next_cell_boundary_markdown_and_code():
+    assert _is_next_cell_boundary("Heading 3", "Cell 3: Markdown", None) is True
+    assert _is_next_cell_boundary("Heading 3", "Cell 5: Raw", None) is True
+    assert _is_next_cell_boundary("Preformatted Text", "old stdout", None) is False
+    assert _is_next_cell_boundary("WriterAgent Notebook In", "[In [1]]\tCell 2: Code", "WriterAgent Notebook In") is True
+
+
+def test_clear_cell_output_uses_set_string_not_delete_contents():
+    cell = new_code_cell_entry(0, None, "nb_cell_0_code")
+    start = MagicMock(name="start")
+    start.ParaStyleName = "Preformatted Text"
+    start.getString.return_value = "old stdout"
+
+    walker = MagicMock(name="walker")
+    walker.ParaStyleName = "Preformatted Text"
+    walker.getString.return_value = "old stdout"
+
+    def goto_next(_expand):
+        walker.ParaStyleName = "WriterAgent Notebook In"
+        walker.getString.return_value = "[In [ ]]\tCell 2: Code"
+        return True
+
+    walker.gotoNextParagraph.side_effect = goto_next
+    walker.getStart.return_value = "end-pos"
+
+    sel = MagicMock(name="sel")
+    sel.getString.return_value = "old stdout\n"
+
+    text = MagicMock()
+    text.createTextCursorByRange.side_effect = [walker, sel]
+    doc = MagicMock()
+    doc.getText.return_value = text
+
+    with (
+        patch("plugin.notebook.notebook_runner._cursor_after_bookmark", return_value=start),
+        patch("plugin.notebook.notebook_runner._resolve_para_style", return_value="WriterAgent Notebook In"),
+    ):
+        clear_cell_output(doc, cell)
+
+    text.deleteContents.assert_not_called()
+    sel.gotoRange.assert_called_once_with("end-pos", True)
+    sel.setString.assert_called_once_with("")
+
+
+def test_clear_cell_output_stops_at_markdown_cell_heading():
+    cell = new_code_cell_entry(1, None, "nb_cell_1_code")
+    start = MagicMock(name="start")
+    start.ParaStyleName = "Preformatted Text"
+    start.getString.return_value = "Array: [10 20 30]"
+
+    walker = MagicMock(name="walker")
+    walker.ParaStyleName = "Preformatted Text"
+    walker.getString.return_value = "Array: [10 20 30]"
+
+    def goto_next(_expand):
+        walker.ParaStyleName = "Heading 3"
+        walker.getString.return_value = "Cell 3: Markdown"
+        return True
+
+    walker.gotoNextParagraph.side_effect = goto_next
+    walker.getStart.return_value = "md-start"
+
+    sel = MagicMock(name="sel")
+    sel.getString.return_value = "Array: [10 20 30]\n"
+
+    text = MagicMock()
+    text.createTextCursorByRange.side_effect = [walker, sel]
+    doc = MagicMock()
+    doc.getText.return_value = text
+
+    with (
+        patch("plugin.notebook.notebook_runner._cursor_after_bookmark", return_value=start),
+        patch("plugin.notebook.notebook_runner._resolve_para_style", return_value="WriterAgent Notebook In"),
+    ):
+        clear_cell_output(doc, cell)
+
+    sel.setString.assert_called_once_with("")
+    walker.gotoStartOfParagraph.assert_called_once()
+
+
+def test_run_cell_rerun_clears_then_applies():
+    ctx = MagicMock()
+    cell = new_code_cell_entry(0, None, "nb_cell_0_code")
+    state = NotebookDocState(code_cells=[cell], next_execution_count=1)
+    doc = MagicMock()
+    order: list[str] = []
+
+    def rec_clear(*_a, **_k):
+        order.append("clear")
+
+    def rec_apply(*_a, **_k):
+        order.append("apply")
+
+    with (
+        patch("plugin.notebook.notebook_runner.load_registry", return_value=state),
+        patch("plugin.notebook.notebook_runner.read_code_from_field", return_value="print(1)"),
+        patch(
+            "plugin.notebook.notebook_runner.execute_code",
+            return_value={"status": "ok", "result": None, "stdout": "1\n"},
+        ),
+        patch("plugin.notebook.notebook_runner.clear_cell_output", side_effect=rec_clear),
+        patch("plugin.notebook.notebook_runner.apply_run_result", side_effect=rec_apply),
+        patch("plugin.notebook.notebook_runner.update_in_prompt"),
+        patch("plugin.notebook.notebook_runner.save_registry"),
+        patch("plugin.notebook.notebook_runner.flush_ui_idle"),
+    ):
+        assert run_cell(ctx, doc, cell.cell_id).status == "ok"
+        assert run_cell(ctx, doc, cell.cell_id).status == "ok"
+
+    assert order == ["clear", "apply", "clear", "apply"]
+
+
+def test_apply_run_result_replaces_via_clear_then_insert():
+    """Re-run path: clear empties the range; apply writes the new stdout under Output."""
+    cell = new_code_cell_entry(0, None, "nb_cell_0_code")
+    cursor = MagicMock()
+    text = MagicMock()
+    doc = MagicMock()
+    doc.getText.return_value = text
+
+    with (
+        patch("plugin.notebook.notebook_runner._cursor_after_bookmark", return_value=cursor),
+        patch("plugin.notebook.notebook_runner._resolve_para_style", return_value="Preformatted Text"),
+    ):
+        apply_run_result(doc, cell, {"status": "ok", "stdout": "first\n", "result": None})
+        apply_run_result(doc, cell, {"status": "ok", "stdout": "second\n", "result": None})
+
+    inserted = [call.args[1] for call in text.insertString.call_args_list]
+    assert inserted == ["first", "second"]
+    text.deleteContents.assert_not_called()
+    cursor.gotoEnd.assert_not_called()

--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -13,6 +13,8 @@ from plugin.notebook.writer_importer import (
     _ImportStackCursor,
     _MAX_IMAGE_DECODE_BYTES,
     _MAX_IMPORT_TEXT_CHARS,
+    _STYLE_MD_H1,
+    _STYLE_MD_H2,
     _STYLE_NOTEBOOK_IN,
     _append_body_text_block,
     _append_body_paragraph,
@@ -23,6 +25,8 @@ from plugin.notebook.writer_importer import (
     _decode_notebook_image,
     _ensure_notebook_import_styles,
     _format_in_prompt,
+    _inline_backticks_to_html,
+    _iter_markdown_blocks,
     _looks_like_html,
     _notebook_image_payload,
     _png_pixel_size,
@@ -491,3 +495,102 @@ def test_import_ipynb_saves_registry_with_two_code_cells(tmp_path, monkeypatch):
     assert state.code_cells[0].execution_count == 1
     assert state.code_cells[1].execution_count == 2
     assert state.code_cells[0].output_start_bookmark.startswith("nb_out_")
+
+
+def test_iter_markdown_blocks_atx_and_paragraphs():
+    blocks = _iter_markdown_blocks(
+        "# A Small Introduction to NumPy\n\n"
+        "This is a compact version.\n\n"
+        "## 1. Creating Arrays\n\n"
+        "The primary data structure is the `ndarray`.\n"
+    )
+    assert blocks[0] == ("h1", "A Small Introduction to NumPy")
+    assert blocks[1] == ("p", "This is a compact version.")
+    assert blocks[2] == ("h2", "1. Creating Arrays")
+    assert blocks[3] == ("p", "The primary data structure is the `ndarray`.")
+    assert not any(kind.startswith("#") or text.lstrip().startswith("#") for kind, text in blocks)
+
+
+def test_iter_markdown_blocks_deeper_atx_maps_to_h2():
+    blocks = _iter_markdown_blocks("### Deep\n\nbody")
+    assert blocks[0] == ("h2", "Deep")
+
+
+def test_inline_backticks_to_html_wraps_code():
+    html = _inline_backticks_to_html("The primary data structure in NumPy is the `ndarray`.")
+    assert "<code>ndarray</code>" in html
+    assert "`ndarray`" not in html
+    assert "NumPy" in html
+
+
+class FakeSize:
+    def __init__(self, w, h):
+        self.Width = w
+        self.Height = h
+
+
+def test_import_small_numpy_notebook_fixture(monkeypatch):
+    ipynb = Path(__file__).resolve().parents[1] / "fixtures" / "introduction-to-numpy-small.ipynb"
+    assert ipynb.is_file()
+
+    doc, body_text, body_cursor = _writer_doc_mock(with_bookmarks=True)
+    para_styles = MagicMock()
+    para_styles.hasByName.return_value = False
+    para_styles.getElementNames.return_value = [
+        "Text Body",
+        "Heading 1",
+        "Heading 2",
+        "Heading 3",
+        "Heading 4",
+        "Preformatted Text",
+        _STYLE_NOTEBOOK_IN,
+    ]
+    families = MagicMock()
+    families.getByName.return_value = para_styles
+    doc.getStyleFamilies.return_value = families
+
+    text_fields: list[Any] = []
+    style_instance = MagicMock()
+
+    def create_instance(service):
+        if service == "com.sun.star.style.ParagraphStyle":
+            return style_instance
+        model = MagicMock()
+        if service == "com.sun.star.form.component.TextField":
+            text_fields.append(model)
+        return model
+
+    doc.createInstance.side_effect = create_instance
+    monkeypatch.setattr("plugin.notebook.writer_importer.Size", FakeSize)
+    monkeypatch.setattr("plugin.notebook.cell_registry.insert_output_start_bookmark", lambda _d, _n: True)
+
+    html_calls: list[str] = []
+
+    def fake_insert_html(cursor, html, **kwargs):
+        html_calls.append(html)
+        return True
+
+    monkeypatch.setattr("plugin.writer.html_import.insert_html_fragment_at_cursor", fake_insert_html)
+
+    stats = import_ipynb_to_writer(doc, str(ipynb))
+
+    assert stats["cells"] == 6
+    assert stats["markdown"] == 3
+    assert stats["code"] == 3
+    assert stats["shapes"] == 6
+    assert [f.Name for f in text_fields] == ["nb_cell_1_code", "nb_cell_3_code", "nb_cell_5_code"]
+
+    inserted = [call.args[1] for call in body_text.insertString.call_args_list]
+    assert "A Small Introduction to NumPy" in inserted
+    assert "1. Creating Arrays" in inserted
+    assert "2. Array Operations" in inserted
+    assert not any(str(t).lstrip().startswith("#") for t in inserted)
+
+    style_names = [
+        call.args[1] for call in body_cursor.setPropertyValue.call_args_list if call.args[0] == "ParaStyleName"
+    ]
+    assert _STYLE_MD_H1 in style_names
+    assert _STYLE_MD_H2 in style_names
+
+    assert any("<code>ndarray</code>" in h for h in html_calls)
+    assert not any("# A Small" in h or "## 1." in h for h in html_calls)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Writer Jupyter import already succeeded; using the notebook did not. CommonMark cells were dumped as Text Body with literal `#`, and re-running a cell appended stdout because `clear_cell_output` called `XText.deleteContents` (not a Writer API).

## What changed

- Markdown cells now parse ATX `#` / `##+` onto Heading 1 / Heading 2 (cell chrome stays Heading 3 / `WriterAgent Notebook In`) and wrap inline `` `code` `` in `<code>` via `plugin.writer.html_import.insert_html_fragment_at_cursor`.
- `clear_cell_output` uses `cursor.setString("")` and stops at markdown/raw cell chrome, so re-run replaces output instead of duplicating or eating the next markdown cell.
- `▶` run path is unchanged: in-flow PUSH + `XActionListener`, shared `notebook:…` kernel, `run_blocking_in_thread`. NumPy is not a whitelist change.
- Renamed `docs/calc-jupyter-notebook-import.md` → `docs/writer-jupyter-notebook-import.md` and updated in-repo links / Phase 1 status. User-facing copy now says **WriterAgent → Debug → Import Jupyter Notebook…** (not Tools).

## Menu / release note

Import lives under **WriterAgent → Debug** (last child of Debug). `tests/scripts/test_writeragent_addons_xcu.py::test_writeragent_jupyter_is_under_debug_not_top_level` covers that. **Release OXTs strip the entire Debug node** (`scripts/build_oxt.py`, `DEBUG_MENU_NODE_MARKER` `oor:name="M16"` when not `with_tests`), so `make release` has **no import UI**. This PR does not add a Tools menubar item. LibrePy `extension-core/Addons.xcu` is unchanged.

## Tests

- Import of `tests/fixtures/introduction-to-numpy-small.ipynb`: 6 cells, 3 code, 3 markdown, 6 shapes, headings without leading `#`, fields `nb_cell_{1,3,5}_code`.
- `clear_cell_output` no longer calls `.deleteContents(`; re-run path clears then applies.
- Shared-session test stays green.

`pytest tests/notebook/ tests/scripts/test_writeragent_addons_xcu.py tests/scripting/test_session_manager.py` — 93 passed. `make typecheck` clean.

## Manual smoke

1. `make deploy writer` (or equivalent) and restart LibreOffice. Dev/deploy builds keep the Debug menu; a release OXT will not.
2. **WriterAgent → Debug → Import Jupyter Notebook…** (hamburger Debug is the same command).
3. Pick `tests/fixtures/introduction-to-numpy-small.ipynb`.
4. Check log: `wired 3/3 run button(s)`.
5. Confirm markdown headings (not raw `#` / `##`) and inline `ndarray`.
6. ▶ cell 2, then 4, then 6 → NumPy version / array / `a2` (cell 6 sees `a1`).
7. Re-run a code cell: output is replaced, not duplicated.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f4f7a98-63a9-42ff-b8a9-dffb87583bab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f4f7a98-63a9-42ff-b8a9-dffb87583bab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

