### PR TITLE
Document scripting design so reviewers stop re-proposing the same fixes

### DIFF
--- a/plugin/scripting/venv/duckdb_sql.py
+++ b/plugin/scripting/venv/duckdb_sql.py
@@ -40,6 +40,12 @@ def _scoped_cwd(path: str):
 
 
 def _looks_like_write_or_escape(sql: str) -> bool:
+    # Crude substring scan (tokens in strings/CTEs/comments can false-positive).
+    # Real threats it covers are path escape (``..``, absolute paths, COPY TO),
+    # which tests/scripting/test_duckdb_sql.py already pins. Writes to registered
+    # tables never hit disk. Do not replace this with ``duckdb.connect(read_only=True)``
+    # — see the connect site. Engine-side alternative: ``allowed_directories=[scoped_dir]``
+    # plus ``lock_configuration`` at connect, then re-prove those folder tests.
     s = " " + sql.upper() + " "
     write_tokens = (
         " COPY ",
@@ -129,6 +135,12 @@ def query_folder_sql(
         else:
             validated = _validate_files(scoped_dir, files) if files and scoped_dir else []
 
+        # In-memory catalog (``duckdb.connect()`` with no file). DuckDB refuses
+        # ``read_only=True`` on ``:memory:`` ("Cannot launch in-memory database in
+        # read-only mode"); ``read_only`` is for a database file shared across
+        # processes. This helper must read folder files: tests use ``FROM 'sales.csv'``
+        # after chdir; the modern path calls ``con.read_csv`` / ``read_parquet``.
+        # ``enable_external_access=false`` would break those reads.
         con = duckdb.connect()
         try:
             # Register any preloaded tables (e.g. from sibling .xlsx/.ods or live ranges)

--- a/plugin/scripting/venv/trusted_dispatch.py
+++ b/plugin/scripting/venv/trusted_dispatch.py
@@ -128,6 +128,7 @@ def dispatch_sql(data: dict[str, Any], *, heartbeat_fn: Callable[[dict[str, Any]
         data.get("flat_files"),
     )
 
+
 def dispatch_languagetool(data: dict[str, Any], *, heartbeat_fn: Callable[[dict[str, Any]], None] | None = None) -> Any:
     _ = heartbeat_fn
     from plugin.writer.locale.languagetool import run_languagetool_check

--- a/plugin/scripting/venv/venv_sandbox.py
+++ b/plugin/scripting/venv/venv_sandbox.py
@@ -614,6 +614,11 @@ def _inject_bindings(executor: LocalPythonExecutor, bindings: dict[str, Any] | N
 
 
 _RESULT_MISSING = object()
+# Intentional check-then-set with no lock: LibrePy/WriterAgent venv workers are
+# one thread per process (execution is serialized; ``_SESSION_LOCK`` is for
+# session state, not this). ``matplotlib.use("Agg")`` twice is harmless. Do not
+# add a threading.Lock here unless the worker becomes multi-threaded; then this
+# flag needs a lock (or to move under ``_SESSION_LOCK``).
 _MPL_AGG_SET = False
 
 

--- a/plugin/scripting/venv/worker_harness.py
+++ b/plugin/scripting/venv/worker_harness.py
@@ -30,6 +30,8 @@ from plugin.scripting.ipc import read_pickle_frame, write_pickle_frame
 from plugin.scripting.venv.venv_sandbox import reset_sandbox_session, run_sandboxed_code, serialize_result
 
 
+# Test-facing alias of ``run_sandboxed_code``; do not inline it away without
+# retargeting tests that import this name.
 def _execute_request(
     code: str,
     data: Any | None,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Keith reviewed a list of proposed `plugin/scripting` “fixes” and rejected them. This PR only documents the first three in place (plus one PEP8 blank-line fix) so the next reviewer/model does not reopen them.

## What changed

Comments only, plus a missing blank line. No query/worker behavior change.

1. **`venv_sandbox.py` `_MPL_AGG_SET` / `_ensure_mpl_agg`** — venv workers are one thread per process; `matplotlib.use("Agg")` twice is harmless. Do not add a lock unless the worker becomes multi-threaded.

2. **`duckdb_sql.py` `_looks_like_write_or_escape` and `duckdb.connect()`** — this is an in-memory catalog. `read_only=True` is refused on `:memory:` and would be the wrong knob anyway (folder reads via `FROM 'sales.csv'` / `read_csv` / `read_parquet` must keep external access). The substring scan is crude; the real threats are path escape / `COPY TO`, already pinned in `tests/scripting/test_duckdb_sql.py`. Replacement would be `allowed_directories` + `lock_configuration`, not `read_only=True`.

3. **`worker_harness.py` `_execute_request`** — test-facing alias of `run_sandboxed_code`. Do not inline it away without retargeting those tests.

4. **`trusted_dispatch.py`** — two blank lines before `dispatch_languagetool` to match the other `dispatch_*` functions (PEP8).

## Out of scope (still rejected)

Do not split `analysis.py`. Do not cache numpy in `coerce.py` `is_missing_value`. Do not change DuckDB connect kwargs. Do not add locks. Do not delete `_execute_request`.

## Testing

- `make typecheck` passed (ruff, ty, mypy, basedpyright, pyspector).
- `tests/scripting/test_venv_worker.py` plus the DuckDB happy-path / COPY TO / missing-package cases: 58 passed, 1 skipped.
- Direct smoke: `SELECT * FROM '../evil.csv'` still returns `READONLY_VIOLATION`; `_execute_request("result = 1 + 1")` still returns ok/2.

Two assertions in `test_duckdb_sql.py` (`test_query_folder_sql_rejects_escape` files= basename case, and `test_query_folder_sql_requires_scoped_and_files`) already fail on `origin/master` the same way. Left untouched per “no query/test changes.”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04299f26-6629-4875-81c3-a049d5f7bcc6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04299f26-6629-4875-81c3-a049d5f7bcc6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

