### PR TITLE
Small NumPy notebook live run after __version__ allow.

### DIFF
--- a/docs/calc-notebook-interactive-dev-plan.md
+++ b/docs/calc-notebook-interactive-dev-plan.md
@@ -72,7 +72,7 @@ This plan is **Writer-first**. Calc notebook import is out of scope unless expli
 
 ### Tests
 
-[`tests/notebook/`](../tests/notebook/): `test_cell_registry.py`, `test_session_manager_notebook.py`, `test_writer_importer.py`, `test_form_lookup.py`, `test_notebook_controls.py`, `test_notebook_runner.py`. Live Writer (Debug-menu import + run): [`tests/notebook/test_writer_importer_uno.py`](../tests/notebook/test_writer_importer_uno.py) via `python -m plugin.testing_runner tests/notebook/test_writer_importer_uno.py`.
+[`tests/notebook/`](../tests/notebook/): `test_cell_registry.py`, `test_session_manager_notebook.py`, `test_writer_importer.py`, `test_form_lookup.py`, `test_notebook_controls.py`, `test_notebook_runner.py`. Live Writer (Debug-menu import + run): [`tests/notebook/test_writer_importer_uno.py`](../tests/notebook/test_writer_importer_uno.py) via `python -m plugin.testing_runner tests/notebook/test_writer_importer_uno.py`. That smoke **runs** the three code cells; a `__version__` dunder forbid is a hard assert (missing-numpy in the worker venv is still allowed).
 
 ### Known gaps / bugs (Phase 1 follow-up)
 

--- a/docs/writer-jupyter-notebook-import.md
+++ b/docs/writer-jupyter-notebook-import.md
@@ -134,7 +134,7 @@ tail -f ~/.config/libreoffice/4/user/writeragent_debug.log
 | `notebook controls: indexed N form control model(s)` | Draw-page control index built |
 | `notebook controls: wired M/K run button(s)` | ▶ listeners attached (`M` should equal code cell count) |
 | `wired 0/K … missing_model=… no_view=…` | Wiring failed — redeploy extension and re-import |
-| `notebook run cell index=… field=nb_cell_…` | ▶ click ran a cell |
+| `notebook run cell index=… field=nb_cell_… status=…` | ▶ click ran a cell (`ok` / `error`) |
 | `failed to clear output for cell` | `setString("")` on the output range failed (should be rare) |
 | `run_venv_code` / `Task … completed` | Python worker finished |
 
@@ -145,6 +145,8 @@ Live Writer smoke (same Debug-menu action, FilePicker driven to the small fixtur
 ```bash
 python -m plugin.testing_runner tests/notebook/test_writer_importer_uno.py
 ```
+
+The live smoke imports the small NumPy fixture and **runs** the three code cells. A sandbox `Forbidden access to dunder attribute` / `__version__` deny is a **hard failure** (not a “clean error”). A real missing-numpy `ModuleNotFoundError` is allowed when the worker venv has no NumPy.
 
 Optional remaining manual: after `make deploy writer`, **WriterAgent → Debug → Import Jupyter Notebook…**, pick `tests/fixtures/introduction-to-numpy-small.ipynb`, confirm the completion msgbox, click the three ▶ buttons in order.
 

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -288,8 +288,14 @@ def run_cell(ctx: Any, doc: Any, cell_id: str) -> RunResult:
     if not (code or "").strip():
         return RunResult("error", None, "Code cell is empty.")
 
-    log.info("notebook run cell index=%d field=%s", cell.index, cell.code_field_name)
     result = execute_code(ctx, doc, code)
+    # After execute so live smoke can tell ok from a sandbox dunder deny.
+    log.info(
+        "notebook run cell index=%d field=%s status=%s",
+        cell.index,
+        cell.code_field_name,
+        result.get("status"),
+    )
     execution_count: int | None = None
     if result.get("status") == "ok":
         cell.last_run_status = "ok"

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -129,6 +129,12 @@ def test_run_cell_updates_registry_and_execution_count():
     save_reg.assert_called_once_with(doc, state)
 
 
+def test_run_cell_logs_status_after_execute():
+    src = inspect.getsource(run_cell)
+    assert "status=%s" in src
+    assert src.find("execute_code(") < src.find("status=%s")
+
+
 def test_run_cell_empty_code():
     ctx = MagicMock()
     cell = new_code_cell_entry(0, None, "nb_cell_0_code")

--- a/tests/notebook/test_writer_importer_uno.py
+++ b/tests/notebook/test_writer_importer_uno.py
@@ -10,6 +10,10 @@ Entry point is the same action the menubar uses
 click a modal FilePicker, so the test drives that picker to the fixture path
 while still executing ``import_dialog._pick_ipynb_path`` / ``run_import_ipynb_dialog``.
 It does **not** call ``import_ipynb_to_writer`` itself.
+
+A sandbox ``Forbidden access to dunder attribute`` / ``__version__`` deny is a
+hard failure (PR 453 treated that as a clean error). A worker
+``ModuleNotFoundError`` for numpy is allowed when the venv has no NumPy.
 """
 
 from __future__ import annotations
@@ -174,6 +178,31 @@ def _tail_text(doc, n_chars: int = 400) -> str:
     return (doc.getText().getString() or "")[-n_chars:]
 
 
+def _run_blob(result, output: str) -> str:
+    return "\n".join(part for part in (result.status, result.message, output) if part)
+
+
+def _is_dunder_version_forbid(blob: str) -> bool:
+    """True when the sandbox still denies ``np.__version__`` (PR 453 hid this as a clean error)."""
+    text = blob or ""
+    if "Forbidden access to dunder attribute" in text:
+        return True
+    # InterpreterError text is ``Forbidden access to dunder attribute: __version__``.
+    return "Forbidden" in text and "__version__" in text
+
+
+def _is_missing_numpy(blob: str) -> bool:
+    """Worker venv has no NumPy — environment issue, not a dunder-jail regression."""
+    text = blob or ""
+    if "numpy" not in text.lower():
+        return False
+    return (
+        "ModuleNotFoundError" in text
+        or "No module named" in text
+        or "ImportError" in text
+    )
+
+
 @native_test
 def test_debug_menu_import_ipynb_action_registered(ctx):
     from plugin.framework.main_shared import get_action_handler
@@ -314,9 +343,15 @@ def _debug_menu_import_and_run(ctx, doc) -> None:
     for cell in state.code_cells:
         results.append(run_cell(ctx, doc, cell.cell_id))
         out = _output_text_for_cell(doc, cell)
-        assert out.strip() or results[-1].status == "error", (
+        result = results[-1]
+        print(
+            f"notebook run cell index={cell.index} field={cell.code_field_name} "
+            f"status={result.status} message={result.message!r} output={out!r}",
+            flush=True,
+        )
+        assert out.strip() or result.status == "error", (
             f"cell {cell.index} produced no output under its bookmark "
-            f"status={results[-1].status!r} message={results[-1].message!r} "
+            f"status={result.status!r} message={result.message!r} "
             f"bookmarks={list(doc.getBookmarks().getElementNames())}"
         )
 
@@ -325,14 +360,47 @@ def _debug_menu_import_and_run(ctx, doc) -> None:
     out1 = _output_text_for_cell(doc, state.code_cells[0])
     out3 = _output_text_for_cell(doc, state.code_cells[1])
     out5 = _output_text_for_cell(doc, state.code_cells[2])
+    outputs = (out1, out3, out5)
     tail = _tail_text(doc)
 
-    if all(r.status == "ok" for r in results):
+    # PR 453 treated a sandbox dunder deny as a clean error. That must fail this job.
+    numpy_missing = False
+    for cell, result, out in zip(state.code_cells, results, outputs):
+        blob = _run_blob(result, out)
+        assert not _is_dunder_version_forbid(blob), (
+            f"cell {cell.index} still denied __version__ (must not be the outcome): "
+            f"status={result.status!r} message={result.message!r} output={out!r}"
+        )
+        if result.status == "error" and "__version__" in (result.message or ""):
+            raise AssertionError(
+                f"cell {cell.index} error message still mentions __version__: {result.message!r}"
+            )
+        if result.status == "error" and _is_missing_numpy(blob):
+            numpy_missing = True
+            print(
+                f"NOTE: worker venv has no numpy (environment issue, not a dunder deny): "
+                f"cell {cell.index} {result.message}",
+                flush=True,
+            )
+            continue
+        if numpy_missing:
+            print(
+                f"NOTE: notebook run cell {cell.index} skipped strict ok "
+                f"(numpy missing earlier): {result.message}",
+                flush=True,
+            )
+            continue
+        assert result.status == "ok", (
+            f"cell {cell.index} expected ok (numpy is present); "
+            f"status={result.status!r} message={result.message!r} output={out!r}"
+        )
+
+    if not numpy_missing:
         assert "NumPy Version" in out1 or any(ch.isdigit() for ch in out1), (
             f"cell 1 stdout missing version: {out1!r}"
         )
         assert "10" in out3 and "20" in out3 and "30" in out3, f"cell 3 array missing: {out3!r}"
-        assert "20" in out5 or "40" in out5 or "60" in out5, f"cell 5 multiplied values missing: {out5!r}"
+        assert "20" in out5 and "40" in out5 and "60" in out5, f"cell 5 multiplied values missing: {out5!r}"
         later = doc.getText().getString() or ""
         ver_at = later.find("NumPy Version")
         arr_at = later.find("1. Creating Arrays")
@@ -341,12 +409,6 @@ def _debug_menu_import_and_run(ctx, doc) -> None:
         assert "NumPy Version" not in tail or "Multiplied" in tail, (
             f"cell 1 output looks dumped at document end: {tail!r}"
         )
-    else:
-        for idx, result in enumerate(results):
-            assert result.status in ("ok", "error"), f"unexpected status {result.status!r}"
-            if result.status == "error":
-                assert (result.message or "").strip(), f"cell {idx} error with empty message"
-                print(f"NOTE: notebook run cell {state.code_cells[idx].index} error: {result.message}", flush=True)
 
     # Re-run cell 1 via the button/protocol path; output must replace, not append.
     cell0 = state.code_cells[0]
@@ -362,6 +424,12 @@ def _debug_menu_import_and_run(ctx, doc) -> None:
         assert after.count(snippet) <= 1 or after == before or len(after) < len(before) * 2, (
             f"re-run looks like append: before={before!r} after={after!r}"
         )
+
+    # clear_cell_output paragraph-expand: markdown between code cells must survive re-run.
+    body_after = doc.getText().getString() or ""
+    assert "A Small Introduction to NumPy" in body_after
+    assert "1. Creating Arrays" in body_after
+    assert "2. Array Operations" in body_after
 
     import plugin.scripting.session_manager as sm
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR 453’s live Writer smoke treated a sandbox `Forbidden access to dunder attribute: __version__` as a clean cell error. After PR 455 allowed `__version__` reads, the small NumPy notebook should actually **run**.

This pass imports `tests/fixtures/introduction-to-numpy-small.ipynb` via the Debug-menu action (driven FilePicker) and requires the three code cells to behave on the shared `notebook:` kernel.

## Changes

- Live UNO smoke (`tests/notebook/test_writer_importer_uno.py`): a dunder/`__version__` forbid is a **hard assert**. A real worker `ModuleNotFoundError` for numpy is still allowed. When numpy is present, all three cells must be `ok` (version string, `[10 20 30]`, `20/40/60`). Re-run of cell 1 must replace output, and markdown between cells must remain.
- `notebook_runner.run_cell` logs `status=` after execute so the testing_runner excerpt shows ok vs error.
- Docs: live smoke is a run, not an import-only check.

## Live run (this environment)

NumPy **is** present (`python3`: 2.4.4). `python -m plugin.testing_runner tests/notebook/test_writer_importer_uno.py`:

```
notebook import complete stats={'cells': 6, 'markdown': 3, 'code': 3, ...}
notebook controls: wired 3/3 run button(s)
notebook run cell index=1 field=nb_cell_1_code status=ok
  output: NumPy Version: 2.4.4
notebook run cell index=3 field=nb_cell_3_code status=ok
  output: Array: [10 20 30]
notebook run cell index=5 field=nb_cell_5_code status=ok
  output: Multiplied by 2: [20 40 60]
total_passed: 2
```

No `Forbidden access to dunder attribute`. Unit: `tests/notebook/test_notebook_runner.py` + `tests/scripting/test_local_python_executor.py` (30 passed). `make typecheck` clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66d504dd-42de-4510-92fa-f9a2f5738f95?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66d504dd-42de-4510-92fa-f9a2f5738f95&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

