### PR TITLE
Split notebook stdout off the next cell heading after ▶ run

### DIFF
--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -27,6 +27,7 @@ from plugin.notebook.cell_registry import (
 )
 from plugin.notebook.writer_importer import (
     _PARAGRAPH_BREAK,
+    _STYLE_CELL_HEADING,
     _STYLE_NOTEBOOK_IN,
     _STYLE_OUTPUT,
     _append_body_text_block,
@@ -266,51 +267,53 @@ def _insert_stdout_paragraph(
     output_style: str | None,
     notebook_in: str | None,
 ) -> None:
-    """Insert *display* as its own paragraph under Output; do not prepend onto the next cell.
+    """Insert *display* as its own paragraph under Output; do not eat the next cell.
 
-    Writer leaves the cursor **before** a just-inserted PARAGRAPH_BREAK. After the
-    output bookmark that often means ``gotoNextParagraph`` lands on ``Cell N: Markdown``.
-    ``insertString`` would then mash stdout onto that heading. Same pattern as
-    ``html_export._range_to_content_via_temp_doc``: enter the next para, and if it is
-    already cell chrome, split a blank paragraph in front and ``setString`` that blank.
+    Writer leaves the cursor **before** a just-inserted PARAGRAPH_BREAK
+    (``html_export._range_to_content_via_temp_doc``). After the output bookmark that
+    often means we are at the start of ``Cell N: Markdown``. ``insertString`` then
+    prepends stdout onto that heading. Move to the end of the inserted stdout and
+    split; apply Preformatted Text only to the stdout paragraph so chrome keeps
+    Heading 3.
     """
     text = doc.getText()
     text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
     _enter_paragraph_after_break(cursor)
     try:
         cursor.gotoStartOfParagraph(False)
-        cursor.gotoEndOfParagraph(True)
     except Exception:
-        log.debug("notebook run: could not select paragraph after break", exc_info=True)
-    existing = _paragraph_string(cursor)
-    style = ""
+        log.debug("notebook run: gotoStartOfParagraph after break failed", exc_info=True)
+    text.insertString(cursor, display, False)
     try:
-        style = str(cursor.ParaStyleName or "")
+        cursor.gotoStartOfParagraph(False)
+        n = min(len(display.encode("utf-16-le")) // 2, 32767)
+        if n:
+            cursor.goRight(n, False)
+        text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
     except Exception:
+        log.debug("notebook run: trailing split after stdout failed", exc_info=True)
+    # After the trailing break the cursor is in the following paragraph (cell chrome).
+    # Style that as Heading 3; style the previous paragraph (stdout) as Preformatted Text.
+    try:
+        following = _paragraph_string(cursor)
         style = ""
-    if existing.strip() and _is_next_cell_boundary(style, existing, notebook_in):
-        # Landed on the following cell. Split an empty paragraph in front of it.
         try:
-            cursor.collapseToStart()
+            style = str(cursor.ParaStyleName or "")
         except Exception:
-            pass
-        text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
-        try:
-            cursor.gotoStartOfParagraph(False)
-            cursor.gotoEndOfParagraph(True)
-        except Exception:
-            pass
-    if output_style:
-        try:
-            cursor.setPropertyValue("ParaStyleName", output_style)
-        except Exception:
-            log.debug("notebook run: ParaStyleName %r not applied", output_style)
-    try:
-        cursor.setString(display)
+            style = ""
+        if _is_next_cell_boundary(style, following, notebook_in) or _CELL_CHROME_RE.match(
+            (following or "").strip()
+        ):
+            heading = _resolve_para_style(doc, _STYLE_CELL_HEADING)
+            if heading:
+                cursor.setPropertyValue("ParaStyleName", heading)
+        if output_style:
+            prev = text.createTextCursorByRange(cursor)
+            if prev.gotoPreviousParagraph(False):
+                prev.gotoStartOfParagraph(False)
+                prev.setPropertyValue("ParaStyleName", output_style)
     except Exception:
-        log.debug("notebook run: setString stdout failed; insertString fallback", exc_info=True)
-        text.insertString(cursor, display, False)
-        text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
+        log.debug("notebook run: stdout/chrome style restore failed", exc_info=True)
 
 
 def _leading_text_cursor(text: Any, para: Any) -> Any | None:

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -391,7 +391,7 @@ def test_apply_run_result_replaces_via_clear_then_insert():
         apply_run_result(doc, cell, {"status": "ok", "stdout": "first\n", "result": None})
         apply_run_result(doc, cell, {"status": "ok", "stdout": "second\n", "result": None})
 
-    assert [call.args[0] for call in cursor.setString.call_args_list] == ["first", "second"]
+    assert [call.args[1] for call in text.insertString.call_args_list] == ["first", "second"]
     text.deleteContents.assert_not_called()
     cursor.gotoEnd.assert_not_called()
     from plugin.notebook.writer_importer import _PARAGRAPH_BREAK
@@ -409,17 +409,20 @@ def test_insert_stdout_paragraph_splits_before_next_cell_chrome():
     cursor = MagicMock()
     cursor.ParaStyleName = "Heading 3"
     cursor.goRight.return_value = True
-    cursor.getString.side_effect = ["Cell 3: Markdown", ""]
+    cursor.getString.return_value = "Cell 3: Markdown"
     text = MagicMock()
     doc = MagicMock()
     doc.getText.return_value = text
 
     _insert_stdout_paragraph(doc, cursor, "hello", "Preformatted Text", "WriterAgent Notebook In")
 
-    assert text.insertControlCharacter.call_count >= 2
-    assert all(call.args[1] == _PARAGRAPH_BREAK for call in text.insertControlCharacter.call_args_list)
-    cursor.collapseToStart.assert_called()
-    cursor.setString.assert_called_once_with("hello")
+    assert [call.args[1] for call in text.insertControlCharacter.call_args_list] == [
+        _PARAGRAPH_BREAK,
+        _PARAGRAPH_BREAK,
+    ]
+    text.insertString.assert_called_once_with(cursor, "hello", False)
+    cursor.setString.assert_not_called()
+    cursor.goRight.assert_called()
 
 
 def test_gutter_text_cursor_stops_before_frame_portion():

--- a/tests/notebook/test_notebook_runner_uno.py
+++ b/tests/notebook/test_notebook_runner_uno.py
@@ -95,7 +95,7 @@ def _assert_stdout_not_mashed(doc) -> list[tuple[str, str]]:
         assert "Cell 3: Markdown" not in text, f"stdout mashed onto next heading: {text!r}"
         assert _AFTER_HEADING not in text, f"stdout mashed onto following markdown: {text!r}"
     chrome = [t for _s, t in paras if "Cell 3: Markdown" in t]
-    assert chrome, "Cell 3: Markdown heading missing after run"
+    assert chrome, f"Cell 3: Markdown heading missing after run: {paras!r}"
     for text in chrome:
         assert _SENTINEL not in text, f"next-cell chrome contains stdout: {text!r}"
     return paras
@@ -177,7 +177,7 @@ def test_run_button_getcontrol_keeps_controls_and_splits_output(ctx, doc):
             patch("plugin.notebook.notebook_runner.execute_code", return_value=fake_result),
         ):
             how = _fire_run_button_via_get_control(ctx, doc, hex_id)
-        print(f"notebook ▶ delivered via {how}; msgboxes={boxes!r}", flush=True)
+        print(f"notebook ▶ delivered via {how}; msgboxes={boxes!r} paras={_paragraphs(doc)!r}", flush=True)
         flush_ui_idle(ctx)
 
         _assert_controls_present(doc, cell)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#459 landed the gutter/`setString` fix so ▶ and the code field survive a run. Live Writer still prepended stdout onto the next cell heading (`WA_NB_SENTINELCell 3: Markdown`). Selecting the landed paragraph and `setString` **replaced** that heading.

## Fix

After `insertString`, move to the start of the paragraph, `goRight` across the stdout UTF-16 length, and `PARAGRAPH_BREAK` so the heading splits onto the next paragraph. Style stdout as Preformatted Text and restore Heading 3 on the following cell chrome.

Verified live with `test_notebook_runner_uno.py` (getControl / XActionListener, not `run_cell()` alone):

```
[In [1]] Cell 2: Code   (gutter updated; ▶ / field still on the draw page)
Output
WA_NB_SENTINEL          (Preformatted Text, own paragraph)
Cell 3: Markdown        (Heading 3)
After code heading
```

Re-click replaces stdout without eating markdown or deleting controls.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cca84db8-8515-458a-adf2-6f6f38d88f3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cca84db8-8515-458a-adf2-6f6f38d88f3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

