### PR TITLE
Keep re-run output in-cell, tighten Output spacing, start kernel In count at 1

### DIFF
--- a/docs/calc-notebook-interactive-dev-plan.md
+++ b/docs/calc-notebook-interactive-dev-plan.md
@@ -93,7 +93,7 @@ This plan is **Writer-first**. Calc notebook import is out of scope unless expli
 - **Spellcheck** — set document + paragraph styles to **`zxx`** (no linguistic content) at import start ([`rich_text.py`](../plugin/chatbot/rich_text.py) uses the same locale).
 - **In-flow controls vs `setString`** — `XTextRange.setString` on a paragraph that contains `AS_CHARACTER` ControlShapes deletes those shapes. Rewrite Text portions only (`update_in_prompt` / `_gutter_text_cursor`).
 - **`PARAGRAPH_BREAK` cursor** — After `insertControlCharacter(..., PARAGRAPH_BREAK)`, the cursor stays **before** the break ([`html_export.py`](../plugin/writer/html_export.py)). Move with `goRight(1)` / `gotoNextParagraph` before inserting stdout.
-- **Point bookmarks vs `setString`** — A range that starts at a point bookmark deletes it. Keep `nb_out_*` on the Output heading and clear from the next paragraph.
+- **Point bookmarks vs `setString`** — A range that starts at a point bookmark deletes it. Keep `nb_out_*` *inside* the Output heading (`gotoEndOfParagraph`, not `para.getEnd()` / the paragraph break) and clear from the next paragraph.
 - **Listener de-dupe** — Key ▶ wiring on `RuntimeUID`, not `id(doc)`. Untitled documents get a new PyUNO wrapper from `get_active_document` / import / bootstrap.
 
 ---

--- a/docs/calc-notebook-interactive-dev-plan.md
+++ b/docs/calc-notebook-interactive-dev-plan.md
@@ -76,13 +76,14 @@ This plan is **Writer-first**. Calc notebook import is out of scope unless expli
 
 ### Known gaps / bugs (Phase 1 follow-up)
 
-1. **`clear_cell_output`** — **fixed**: uses `cursor.setString("")` (Writer `XText` has no `deleteContents`). Collapsed `XTextCursor.getString()` is the selection (often `""`); expand to the enclosing paragraph so markdown chrome (`Cell N: Markdown`) is a real boundary. Re-run replaces stdout and does not eat markdown cells between code cells.
-2. **▶ / code field vanished after run** — **fixed**: `update_in_prompt` used to `setString` the whole gutter paragraph, which deleted in-flow `ControlShape`s. It now replaces leading Text portions only. The importer also paragraph-breaks after the gutter so ▶ / the code field are not in that paragraph. `apply_run_result` enters the new paragraph after `PARAGRAPH_BREAK` (Writer leaves the cursor before the break) and inserts a trailing break so stdout cannot mash onto the next heading.
-3. **Re-import** — replaces registry; no merge UX (Phase 3).
-4. **Form URL buttons** — rejected; `TargetURL` / protocol handler does not fire for in-flow form buttons. Use **PUSH** + `XActionListener` only.
-5. **Untitled documents** — `doc.getURL()` empty; listener keeps strong ref to `doc` (PyUNO objects cannot use `weakref`).
-6. **Config keys** — `notebook.enable_interactive` / `notebook.run_on_import` not added yet; Run is always on when registry exists.
-7. **Large imports** — still main-thread synchronous; 100+ cells pause UI (performance backlog unchanged).
+1. **`clear_cell_output`** — **fixed**: uses `cursor.setString("")` (Writer `XText` has no `deleteContents`). Collapsed `XTextCursor.getString()` is the selection (often `""`); expand to the enclosing paragraph so markdown chrome (`Cell N: Markdown`) is a real boundary. Re-run replaces stdout and does not eat markdown cells between code cells. The `nb_out_*` bookmark is re-anchored on the Output heading so `setString` cannot delete it (that used to dump re-click stdout at the document end).
+2. **▶ / code field vanished after run** — **fixed**: `update_in_prompt` used to `setString` the whole gutter paragraph, which deleted in-flow `ControlShape`s. It now replaces leading Text portions only. The importer also paragraph-breaks after the gutter so ▶ / the code field are not in that paragraph. `apply_run_result` fills an existing empty paragraph under Output when present; it only inserts a `PARAGRAPH_BREAK` when the current para has content, and splits afterwards only if stdout would mash onto the next heading.
+3. **Kernel `In [n]`** — **fixed**: a new `notebook:…` session starts at 1 (saved ipynb execution counts are historical). **Reset Python Session** resets the counter to 1. Each run, including failures and re-clicks, increments by 1. ▶ `XActionListener` wiring keys on `RuntimeUID` so untitled documents are not triple-wired (import + dialog + bootstrap).
+4. **Re-import** — replaces registry; no merge UX (Phase 3).
+5. **Form URL buttons** — rejected; `TargetURL` / protocol handler does not fire for in-flow form buttons. Use **PUSH** + `XActionListener` only.
+6. **Untitled documents** — `doc.getURL()` empty; listener keeps strong ref to `doc` (PyUNO objects cannot use `weakref`). Wiring de-dupe uses `RuntimeUID`.
+7. **Config keys** — `notebook.enable_interactive` / `notebook.run_on_import` not added yet; Run is always on when registry exists.
+8. **Large imports** — still main-thread synchronous; 100+ cells pause UI (performance backlog unchanged).
 
 ### Implementation lessons (UNO / PyUNO)
 
@@ -92,6 +93,8 @@ This plan is **Writer-first**. Calc notebook import is out of scope unless expli
 - **Spellcheck** — set document + paragraph styles to **`zxx`** (no linguistic content) at import start ([`rich_text.py`](../plugin/chatbot/rich_text.py) uses the same locale).
 - **In-flow controls vs `setString`** — `XTextRange.setString` on a paragraph that contains `AS_CHARACTER` ControlShapes deletes those shapes. Rewrite Text portions only (`update_in_prompt` / `_gutter_text_cursor`).
 - **`PARAGRAPH_BREAK` cursor** — After `insertControlCharacter(..., PARAGRAPH_BREAK)`, the cursor stays **before** the break ([`html_export.py`](../plugin/writer/html_export.py)). Move with `goRight(1)` / `gotoNextParagraph` before inserting stdout.
+- **Point bookmarks vs `setString`** — A range that starts at a point bookmark deletes it. Keep `nb_out_*` on the Output heading and clear from the next paragraph.
+- **Listener de-dupe** — Key ▶ wiring on `RuntimeUID`, not `id(doc)`. Untitled documents get a new PyUNO wrapper from `get_active_document` / import / bootstrap.
 
 ---
 
@@ -117,7 +120,7 @@ This plan is **Writer-first**. Calc notebook import is out of scope unless expli
 
 3. **Session id** — `notebook:{workbook_key}` from [`notebook_session_id`](../plugin/scripting/session_manager.py). Not gated on `python_session_mode` (Calc-only).
 
-4. **Output refresh** — On run: clear output region (bookmark → next cell boundary), then `apply_run_result`. Stdout is its own paragraph; a trailing `PARAGRAPH_BREAK` keeps the next cell heading from sharing that line.
+4. **Output refresh** — On run: re-anchor `nb_out_*` on the Output heading, clear the following paragraphs to the next cell, then `apply_run_result`. Stdout is its own paragraph under Output (empty paras collapsed). Never append at the document end.
 
 5. **LLM stays out** — Notebook kernel variables are not visible to chat tools.
 

--- a/docs/writer-jupyter-notebook-import.md
+++ b/docs/writer-jupyter-notebook-import.md
@@ -87,7 +87,7 @@ For each cell in order, the importer appends to the **document body**:
 
 **Code fields (in-flow):** `TextField` inside `ControlShape`, **`AS_CHARACTER`**, `insertTextContent` at document end — same pattern as [`FormCreateControl`](../plugin/writer/specialized/forms.py). Models are also registered on the document **draw page** (used to find controls for ▶ wiring and for `read_code_from_field`). A paragraph break after the `[In [n]]` gutter keeps those shapes out of the title paragraph.
 
-**Text outputs:** Stream, error tracebacks (ANSI stripped), and `text/plain` from outputs use **Preformatted Text** (one paragraph per block). Live run writes stdout directly under the Output heading (at most one blank line). Re-run **replaces** that in-cell block; it does not append at the document end. The `nb_out_*` bookmark stays on the Output heading. If stdout would otherwise share a line with the next cell heading, a split restores Heading 3 chrome (PR 461).
+**Text outputs:** Stream, error tracebacks (ANSI stripped), and `text/plain` from outputs use **Preformatted Text** (one paragraph per block). Live run writes stdout directly under the Output heading (at most one blank line). Re-run **replaces** that in-cell block; it does not append at the document end. The `nb_out_*` bookmark stays *inside* the Output heading (before the paragraph break) so `setString` of the following range cannot delete it. If stdout would otherwise share a line with the next cell heading, a split restores Heading 3 chrome (PR 461).
 
 **Spellcheck:** At import start, document and paragraph styles used by the notebook are set to locale **`zxx`** (no linguistic content) so code and markdown are not spell-checked. Form field contents may still show squiggles depending on LO version.
 

--- a/docs/writer-jupyter-notebook-import.md
+++ b/docs/writer-jupyter-notebook-import.md
@@ -62,8 +62,8 @@ After `make deploy`, **restart LibreOffice** so the extension and menu handlers 
 |--------|-----|
 | **Run one cell** | Click the in-flow **▶** push button immediately before the code `TextField`. |
 | **Shared variables** | All code cells in the same Writer document share one `notebook:…` Python namespace (like a Jupyter kernel). Run cell 0 (`x = 1`), then cell 1 (`print(x)`) → `1`. |
-| **Execution count** | After a successful run, the gutter updates to `[In [n]]` (text portions only — in-flow ▶ / code field stay). |
-| **Reset kernel** | **WriterAgent → Reset Python Session** when the document has an imported notebook registry. Clears variables; re-run cells from the top if needed. |
+| **Execution count** | New kernel (import or **Reset Python Session**) starts at 1 — saved ipynb counts are historical until a live run. Each run of any cell, including failures and re-clicks, increments by 1 (Jupyter `In [n]`). Gutter style stays `[In [n]]`. |
+| **Reset kernel** | **WriterAgent → Reset Python Session** when the document has an imported notebook registry. Clears variables and the kernel In count (next run is `[In [1]]`). Re-run cells from the top if needed. |
 | **Errors** | Tracebacks and stdout appear under the cell’s **Output** section (Preformatted Text, own paragraph — not concatenated onto the next cell heading). Empty code shows a msgbox. |
 | **Sandbox** | Code runs in your configured user venv ([`venv_worker.py`](../plugin/scripting/venv_worker.py)), subject to the same AST safety rules as other WriterAgent scripting (e.g. dunder methods may be blocked by design). |
 
@@ -87,7 +87,7 @@ For each cell in order, the importer appends to the **document body**:
 
 **Code fields (in-flow):** `TextField` inside `ControlShape`, **`AS_CHARACTER`**, `insertTextContent` at document end — same pattern as [`FormCreateControl`](../plugin/writer/specialized/forms.py). Models are also registered on the document **draw page** (used to find controls for ▶ wiring and for `read_code_from_field`). A paragraph break after the `[In [n]]` gutter keeps those shapes out of the title paragraph.
 
-**Text outputs:** Stream, error tracebacks (ANSI stripped), and `text/plain` from outputs use **Preformatted Text** (one paragraph per block). Live run inserts a paragraph break *after* stdout as well, so the next cell heading cannot share that line.
+**Text outputs:** Stream, error tracebacks (ANSI stripped), and `text/plain` from outputs use **Preformatted Text** (one paragraph per block). Live run writes stdout directly under the Output heading (at most one blank line). Re-run **replaces** that in-cell block; it does not append at the document end. The `nb_out_*` bookmark stays on the Output heading. If stdout would otherwise share a line with the next cell heading, a split restores Heading 3 chrome (PR 461).
 
 **Spellcheck:** At import start, document and paragraph styles used by the notebook are set to locale **`zxx`** (no linguistic content) so code and markdown are not spell-checked. Form field contents may still show squiggles depending on LO version.
 

--- a/plugin/notebook/notebook_controls.py
+++ b/plugin/notebook/notebook_controls.py
@@ -20,9 +20,9 @@ log = logging.getLogger("writeragent.notebook")
 # com.sun.star.form.FormButtonType.PUSH — URL buttons open TargetURL via desktop, not our handler.
 _FORM_BUTTON_PUSH = 0
 
-# Keep listeners alive (UNO holds weak refs). Key: (doc_id, hex_id).
+# Keep listeners alive (UNO holds weak refs). Key: (doc_key, hex_id).
 _listener_refs: list[Any] = []
-_wired_keys: set[tuple[int, str]] = set()
+_wired_keys: set[tuple[str, str]] = set()
 
 
 def form_button_push_type() -> int:
@@ -44,14 +44,33 @@ def _query_interface(obj: Any, typename: str) -> Any:
     return obj.queryInterface(uno.getTypeByName(typename))
 
 
-def _doc_key(doc: Any) -> int:
+def _doc_key(doc: Any) -> str:
+    """Stable id for listener de-dupe across Python wrappers of the same document.
+
+    Untitled Writer docs have an empty URL, so ``id(doc)`` was used. Import wires
+    once, ``import_dialog`` wires again, and bootstrap
+    ``install_notebook_run_button_wiring`` wires a third time — each with a
+    different PyUNO wrapper — so one ▶ click ran the cell three times
+    (``[In [4]]`` jumped to ``[In [7]]``). ``RuntimeUID`` is the same object
+    for every wrapper of that document.
+    """
+    from plugin.framework.uno_context import get_runtime_uid
+
+    uid = get_runtime_uid(doc)
+    if uid:
+        return f"uid:{uid}"
     try:
         url = doc.getURL()
-        if url:
-            return hash(url)
     except Exception:
-        pass
-    return id(doc)
+        url = None
+    if isinstance(url, str) and url:
+        return f"url:{url}"
+    return f"id:{id(doc)}"
+
+
+def wired_run_listener_count(hex_id: str) -> int:
+    """How many live ▶ listeners are registered for *hex_id* (any document)."""
+    return sum(1 for lis in _listener_refs if getattr(lis, "_hex_id", None) == hex_id)
 
 
 def get_control_view_for_model(doc: Any, model: Any) -> Any | None:

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -236,21 +236,25 @@ def _reanchor_output_bookmark(doc: Any, cell: NotebookCodeCell) -> Any | None:
     vanished; ``apply_run_result`` then got ``cursor is None`` and appended at
     the document end. Re-attach to the Output heading before clear/insert so
     re-runs replace in-cell stdout like Jupyter.
+
+    Find the heading **after** removing the old bookmark. A cursor captured
+    before ``removeTextContent`` is stale and insert then fails, leaving no
+    bookmark for the next run.
     """
     name = cell.output_start_bookmark
     if not name:
         return None
-    heading_end = _find_cell_output_heading_end(doc, cell)
     current = _cursor_after_bookmark(doc, name)
     if current is not None and _paragraph_string(current).strip() == "Output":
-        return current
-    if heading_end is None:
         return current
     try:
         text = doc.getText()
         bookmarks = doc.getBookmarks()
         if bookmarks.hasByName(name):
             text.removeTextContent(bookmarks.getByName(name))
+        heading_end = _find_cell_output_heading_end(doc, cell)
+        if heading_end is None:
+            return _cursor_after_bookmark(doc, name)
         bookmark = doc.createInstance("com.sun.star.text.Bookmark")
         bookmark.Name = name
         text.insertTextContent(heading_end, bookmark, False)

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -211,11 +211,14 @@ def _find_cell_output_heading_end(doc: Any, cell: NotebookCodeCell) -> Any | Non
             continue
         if content.strip() == "Output":
             try:
-                # Stay *inside* the heading. para.getEnd() / gotoEndOfParagraph
-                # is the paragraph break; a bookmark there is the start of the
-                # next para, so setString of the following range deletes nb_out_*.
+                # After the last character of "Output", still in this paragraph.
+                # para.getEnd() / a mid-heading goRight(1) are wrong: the former
+                # is the break (setString of the next range deletes nb_out_*),
+                # the latter splits the heading when we insert PARAGRAPH_BREAK
+                # ("O" / stdout / "utput").
                 cursor = text.createTextCursorByRange(para.getStart())
-                if not cursor.goRight(1, False):
+                n = min(len("Output"), 32767)
+                if not cursor.goRight(n, False):
                     cursor.gotoEndOfParagraph(False)
             except Exception:
                 continue
@@ -564,6 +567,17 @@ def _insert_stdout_paragraph(
     def _finish() -> None:
         _reanchor_output_bookmark(doc, cell)
         _collapse_leading_empty_paragraphs(doc, cell, notebook_in)
+
+    # Bookmark/find cursor may sit inside "Output". A PARAGRAPH_BREAK there
+    # splits the heading into "O" + "utput". Snap to after the last character.
+    if _paragraph_string(cursor).strip() == "Output":
+        try:
+            cursor.gotoStartOfParagraph(False)
+            n = min(len("Output"), 32767)
+            if not cursor.goRight(n, False):
+                cursor.gotoEndOfParagraph(False)
+        except Exception:
+            log.debug("notebook run: snap to end of Output heading failed", exc_info=True)
 
     if _paragraph_is_empty(cursor):
         _fill(cursor)

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -211,11 +211,12 @@ def _find_cell_output_heading_end(doc: Any, cell: NotebookCodeCell) -> Any | Non
             continue
         if content.strip() == "Output":
             try:
-                # Stay *inside* the heading. para.getEnd() is the paragraph
-                # break; a bookmark there is the start of the next para, so
-                # setString of the following range deletes nb_out_*.
+                # Stay *inside* the heading. para.getEnd() / gotoEndOfParagraph
+                # is the paragraph break; a bookmark there is the start of the
+                # next para, so setString of the following range deletes nb_out_*.
                 cursor = text.createTextCursorByRange(para.getStart())
-                cursor.gotoEndOfParagraph(False)
+                if not cursor.goRight(1, False):
+                    cursor.gotoEndOfParagraph(False)
             except Exception:
                 continue
             if first_output_end is None:
@@ -226,9 +227,11 @@ def _find_cell_output_heading_end(doc: Any, cell: NotebookCodeCell) -> Any | Non
         if _is_next_cell_boundary(style, content, notebook_in):
             if seen_code:
                 return matched_output_end
-            # Synthetic docs (Output heading + next-cell chrome, no ``Cell N: Code``).
-            return first_output_end
-    return matched_output_end or first_output_end
+            # Earlier chrome (``Cell 1: Markdown`` before this code cell) is not
+            # this cell's Output. Keep scanning. Synthetic docs with no
+            # ``Cell N: Code`` fall through to first_output_end at EOF.
+            continue
+    return matched_output_end if seen_code else first_output_end
 
 
 def _reanchor_output_bookmark(doc: Any, cell: NotebookCodeCell) -> Any | None:

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -189,6 +189,8 @@ def _find_cell_output_heading_end(doc: Any, cell: NotebookCodeCell) -> Any | Non
     except Exception:
         return None
     seen_code = False
+    first_output_end: Any | None = None
+    matched_output_end: Any | None = None
     steps = 0
     while steps < _ENUM_SAFETY_CAP:
         more = enum.hasMoreElements()
@@ -204,20 +206,26 @@ def _find_cell_output_heading_end(doc: Any, cell: NotebookCodeCell) -> Any | Non
             style = str(para.getPropertyValue("ParaStyleName") or "")
         except Exception:
             continue
-        if not seen_code:
-            if marker in content:
-                seen_code = True
+        if marker in content:
+            seen_code = True
             continue
-        if _is_next_cell_boundary(style, content, notebook_in):
-            return None
         if content.strip() == "Output":
             try:
                 cursor = text.createTextCursorByRange(para.getEnd())
                 cursor.collapseToEnd()
-                return cursor
             except Exception:
-                return None
-    return None
+                continue
+            if first_output_end is None:
+                first_output_end = cursor
+            if seen_code:
+                matched_output_end = cursor
+            continue
+        if _is_next_cell_boundary(style, content, notebook_in):
+            if seen_code:
+                return matched_output_end
+            # Synthetic docs (Output heading + next-cell chrome, no ``Cell N: Code``).
+            return first_output_end
+    return matched_output_end or first_output_end
 
 
 def _reanchor_output_bookmark(doc: Any, cell: NotebookCodeCell) -> Any | None:
@@ -523,9 +531,13 @@ def _insert_stdout_paragraph(
         text.insertString(target, display, False)
         _split_if_stdout_mashed_onto_chrome(doc, text, target, display, output_style, notebook_in)
 
+    def _finish() -> None:
+        _reanchor_output_bookmark(doc, cell)
+        _collapse_leading_empty_paragraphs(doc, cell, notebook_in)
+
     if _paragraph_is_empty(cursor):
         _fill(cursor)
-        _collapse_leading_empty_paragraphs(doc, cell, notebook_in)
+        _finish()
         return
 
     nxt = text.createTextCursorByRange(cursor)
@@ -535,13 +547,13 @@ def _insert_stdout_paragraph(
             _para_style_name(nxt), nxt_text, notebook_in
         ):
             _fill(nxt)
-            _collapse_leading_empty_paragraphs(doc, cell, notebook_in)
+            _finish()
             return
 
     text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
     _enter_paragraph_after_break(cursor)
     _fill(cursor)
-    _collapse_leading_empty_paragraphs(doc, cell, notebook_in)
+    _finish()
 
 
 def _leading_text_cursor(text: Any, para: Any) -> Any | None:

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -194,8 +194,8 @@ def _find_cell_output_heading_end(doc: Any, cell: NotebookCodeCell) -> Any | Non
     steps = 0
     while steps < _ENUM_SAFETY_CAP:
         more = enum.hasMoreElements()
-        # Real UNO returns bool; MagicMock is truthy but is not True — stop.
-        if more is not True:
+        # PyUNO may return 1/0; MagicMock is neither True nor int 1 — stop.
+        if more is not True and more != 1:
             break
         steps += 1
         para = enum.nextElement()

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -308,9 +308,14 @@ _CELL_CHROME_RE = re.compile(r"^Cell \d+: (Markdown|Raw|Code)\b")
 
 
 def _is_next_cell_boundary(para_style: str, content: str, notebook_in_resolved: str | None) -> bool:
-    if notebook_in_resolved and para_style == notebook_in_resolved:
-        return True
     stripped = (content or "").strip()
+    # The importer puts ▶ / the code field in their own paragraph after the
+    # ``[In [n]]`` gutter, still styled WriterAgent Notebook In but empty.
+    # Treating that empty row as a cell boundary made ``_find_cell_output_heading_end``
+    # return None before the Output heading, so re-anchor failed and the bookmark
+    # died on the next clear.
+    if notebook_in_resolved and para_style == notebook_in_resolved and stripped:
+        return True
     if stripped.startswith("[In [") and ": Code" in stripped:
         return True
     # Stopping only at the next code gutter ate markdown cells between code cells
@@ -441,14 +446,6 @@ def _apply_para_style(cursor: Any, style: str | None) -> None:
         log.debug("notebook run: ParaStyleName %r not applied", style)
 
 
-def _stdout_shares_cell_chrome(cursor: Any, notebook_in: str | None) -> bool:
-    following = _paragraph_string(cursor)
-    style = _para_style_name(cursor)
-    return _is_next_cell_boundary(style, following, notebook_in) or bool(
-        _CELL_CHROME_RE.match((following or "").strip())
-    )
-
-
 def _split_if_stdout_mashed_onto_chrome(
     doc: Any,
     text: Any,
@@ -457,21 +454,37 @@ def _split_if_stdout_mashed_onto_chrome(
     output_style: str | None,
     notebook_in: str | None,
 ) -> None:
-    """If insertString landed in the next cell heading, split stdout off (PR 461)."""
-    if not _stdout_shares_cell_chrome(cursor, notebook_in):
-        _apply_para_style(cursor, output_style)
-        return
+    """If insertString prepended onto the next cell heading, split after stdout (PR 461).
+
+    Detect mash by looking at the **rest** of the paragraph after *display*.
+    Checking the whole paragraph fails because mashed text starts with stdout
+    (``WA_NB_SENTINELCell 3: Markdown``) and no longer matches ``^Cell \\d+:``.
+    Do **not** insert a trailing break when the rest is empty — that was the
+    extra blank under Output.
+    """
     try:
         cursor.gotoStartOfParagraph(False)
         n = min(len(display.encode("utf-16-le")) // 2, 32767)
+        rest = text.createTextCursorByRange(cursor)
+        if n:
+            rest.goRight(n, False)
+        rest.gotoEndOfParagraph(True)
+        leftover = _plain_text(rest.getString() or "")
+        if not leftover.strip():
+            _apply_para_style(cursor, output_style)
+            return
         if n:
             cursor.goRight(n, False)
         text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
     except Exception:
         log.debug("notebook run: trailing split after stdout failed", exc_info=True)
+        _apply_para_style(cursor, output_style)
         return
     try:
-        if _stdout_shares_cell_chrome(cursor, notebook_in):
+        following = _paragraph_string(cursor)
+        if _is_next_cell_boundary(_para_style_name(cursor), following, notebook_in) or _CELL_CHROME_RE.match(
+            (following or "").strip()
+        ):
             heading = _resolve_para_style(doc, _STYLE_CELL_HEADING)
             _apply_para_style(cursor, heading)
         if output_style:

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -30,7 +30,6 @@ from plugin.notebook.writer_importer import (
     _STYLE_CELL_HEADING,
     _STYLE_NOTEBOOK_IN,
     _STYLE_OUTPUT,
-    _append_body_text_block,
     _format_in_prompt,
     _insert_image_in_flow,
     _prepare_display_text,
@@ -107,6 +106,11 @@ def execute_code(ctx: Any, doc: Any, code: str) -> dict[str, Any]:
     return run_blocking_in_thread(ctx, _run)
 
 
+def _plain_text(value: Any) -> str:
+    """UNO ``getString()`` is a str; MagicMock probes must not look non-empty."""
+    return value if isinstance(value, str) else ""
+
+
 def _paragraph_string(cursor: Any) -> str:
     """Text of the paragraph containing *cursor*.
 
@@ -120,7 +124,7 @@ def _paragraph_string(cursor: Any) -> str:
     """
     selected = ""
     try:
-        selected = cursor.getString() or ""
+        selected = _plain_text(cursor.getString() or "")
     except Exception:
         selected = ""
     if selected.strip():
@@ -129,9 +133,20 @@ def _paragraph_string(cursor: Any) -> str:
         probe = cursor.getText().createTextCursorByRange(cursor)
         probe.gotoStartOfParagraph(False)
         probe.gotoEndOfParagraph(True)
-        return probe.getString() or ""
+        return _plain_text(probe.getString() or "")
     except Exception:
         return selected
+
+
+def _paragraph_is_empty(cursor: Any) -> bool:
+    return not _paragraph_string(cursor).strip()
+
+
+def _para_style_name(cursor: Any) -> str:
+    try:
+        return str(cursor.ParaStyleName or "")
+    except Exception:
+        return ""
 
 
 def _cursor_after_bookmark(doc: Any, bookmark_name: str) -> Any | None:
@@ -150,6 +165,141 @@ def _cursor_after_bookmark(doc: Any, bookmark_name: str) -> Any | None:
     except Exception:
         log.debug("notebook run: bookmark %r not usable", bookmark_name, exc_info=True)
         return None
+
+
+def _bookmark_exists(doc: Any, bookmark_name: str) -> bool:
+    if not bookmark_name or not hasattr(doc, "getBookmarks"):
+        return False
+    try:
+        return bool(doc.getBookmarks().hasByName(bookmark_name))
+    except Exception:
+        return False
+
+
+_ENUM_SAFETY_CAP = 10000
+
+
+def _find_cell_output_heading_end(doc: Any, cell: NotebookCodeCell) -> Any | None:
+    """Cursor at the end of this cell's Heading 4 ``Output`` paragraph, or None."""
+    marker = f"Cell {cell.index + 1}: Code"
+    notebook_in = _resolve_para_style(doc, _STYLE_NOTEBOOK_IN)
+    try:
+        text = doc.getText()
+        enum = text.createEnumeration()
+    except Exception:
+        return None
+    seen_code = False
+    steps = 0
+    while steps < _ENUM_SAFETY_CAP:
+        more = enum.hasMoreElements()
+        # Real UNO returns bool; MagicMock is truthy but is not True — stop.
+        if more is not True:
+            break
+        steps += 1
+        para = enum.nextElement()
+        try:
+            if hasattr(para, "supportsService") and not para.supportsService("com.sun.star.text.Paragraph"):
+                continue
+            content = _plain_text(para.getString() or "")
+            style = str(para.getPropertyValue("ParaStyleName") or "")
+        except Exception:
+            continue
+        if not seen_code:
+            if marker in content:
+                seen_code = True
+            continue
+        if _is_next_cell_boundary(style, content, notebook_in):
+            return None
+        if content.strip() == "Output":
+            try:
+                cursor = text.createTextCursorByRange(para.getEnd())
+                cursor.collapseToEnd()
+                return cursor
+            except Exception:
+                return None
+    return None
+
+
+def _reanchor_output_bookmark(doc: Any, cell: NotebookCodeCell) -> Any | None:
+    """Keep ``nb_out_*`` at the end of this cell's Output heading.
+
+    ``clear_cell_output`` used ``setString("")`` on a range that started at the
+    point bookmark. Writer treats that bookmark as in-range, so the bookmark
+    vanished; ``apply_run_result`` then got ``cursor is None`` and appended at
+    the document end. Re-attach to the Output heading before clear/insert so
+    re-runs replace in-cell stdout like Jupyter.
+    """
+    name = cell.output_start_bookmark
+    if not name:
+        return None
+    heading_end = _find_cell_output_heading_end(doc, cell)
+    current = _cursor_after_bookmark(doc, name)
+    if current is not None and _paragraph_string(current).strip() == "Output":
+        return current
+    if heading_end is None:
+        return current
+    try:
+        text = doc.getText()
+        bookmarks = doc.getBookmarks()
+        if bookmarks.hasByName(name):
+            text.removeTextContent(bookmarks.getByName(name))
+        bookmark = doc.createInstance("com.sun.star.text.Bookmark")
+        bookmark.Name = name
+        text.insertTextContent(heading_end, bookmark, False)
+        return _cursor_after_bookmark(doc, name)
+    except Exception:
+        log.exception("notebook run: failed to reanchor bookmark %r", name)
+        return _cursor_after_bookmark(doc, name)
+
+
+def _delete_paragraph_at(cursor: Any) -> bool:
+    """Delete the paragraph containing *cursor*, including its trailing break.
+
+    Select from this paragraph start to the next paragraph start so the range
+    is the empty body plus PARAGRAPH_BREAK — not the next paragraph's first
+    character (``goRight(1)`` after ``gotoEndOfParagraph`` is version-fragile).
+    """
+    try:
+        text = cursor.getText()
+        sel = text.createTextCursorByRange(cursor)
+        sel.gotoStartOfParagraph(False)
+        nxt = text.createTextCursorByRange(sel)
+        if nxt.gotoNextParagraph(False):
+            nxt.gotoStartOfParagraph(False)
+            sel.gotoRange(nxt.getStart(), True)
+        else:
+            sel.gotoEndOfParagraph(True)
+        sel.setString("")
+        return True
+    except Exception:
+        log.debug("notebook run: delete empty paragraph failed", exc_info=True)
+        return False
+
+
+def _collapse_leading_empty_paragraphs(
+    doc: Any, cell: NotebookCodeCell, notebook_in: str | None
+) -> None:
+    """Remove blank paragraphs between the Output heading and the first stdout line.
+
+    ``_insert_stdout_paragraph`` used to always insert a PARAGRAPH_BREAK (and a
+    trailing split). When the bookmark paragraph was already empty, that left
+    2–3 blank lines under Output; re-runs accumulated more because
+    ``clear_cell_output`` bailed out on whitespace-only ``getString()``.
+    """
+    for _unused in range(16):
+        start = _cursor_after_bookmark(doc, cell.output_start_bookmark)
+        if start is None:
+            return
+        nxt = doc.getText().createTextCursorByRange(start)
+        if not nxt.gotoNextParagraph(False):
+            return
+        content = _paragraph_string(nxt)
+        if _is_next_cell_boundary(_para_style_name(nxt), content, notebook_in):
+            return
+        if content.strip():
+            return
+        if not _delete_paragraph_at(nxt):
+            return
 
 
 # Markdown/raw chrome is ``Cell N: Markdown`` (Heading 3). Code gutters use
@@ -174,31 +324,46 @@ def clear_cell_output(doc: Any, cell: NotebookCodeCell) -> None:
     Writer ``XText`` has no ``deleteContents`` (PyUNO raises AttributeError, logged as
     ``failed to clear output for cell`` so re-runs appended stdout). House pattern is
     ``cursor.setString("")`` on the selected range (same as ``html_import`` / ``edit_review``).
+
+    The bookmark must not be in that range: a point bookmark at the range start is
+    deleted by ``setString``, and the next insert then falls off the end of the
+    document. Re-anchor to the Output heading first and start the deletion at the
+    *next* paragraph. Still ``setString`` whitespace-only ranges so leftover empty
+    paragraphs do not accumulate under Output.
     """
+    _reanchor_output_bookmark(doc, cell)
     start = _cursor_after_bookmark(doc, cell.output_start_bookmark)
     if start is None:
         return
     text = doc.getText()
     notebook_in = _resolve_para_style(doc, _STYLE_NOTEBOOK_IN)
     end = text.createTextCursorByRange(start)
-    if _is_next_cell_boundary(end.ParaStyleName, _paragraph_string(end), notebook_in):
+    # Live cursor sits at the end of the Output heading after re-anchor. Skip that
+    # paragraph so setString cannot absorb the bookmark. Unit mocks that already
+    # place the cursor on stdout keep the old loop (content is not "Output").
+    if _paragraph_string(start).strip() == "Output":
+        if not end.gotoNextParagraph(False):
+            return
+    if _is_next_cell_boundary(_para_style_name(end), _paragraph_string(end), notebook_in):
         return
+    range_start = text.createTextCursorByRange(end)
     found_boundary = False
     while end.gotoNextParagraph(False):
-        if _is_next_cell_boundary(end.ParaStyleName, _paragraph_string(end), notebook_in):
+        if _is_next_cell_boundary(_para_style_name(end), _paragraph_string(end), notebook_in):
             end.gotoStartOfParagraph(False)
             found_boundary = True
             break
     if not found_boundary:
         end.gotoEnd(False)
-    sel = text.createTextCursorByRange(start)
+    sel = text.createTextCursorByRange(range_start)
+    sel.gotoStartOfParagraph(False)
     sel.gotoRange(end.getStart(), True)
-    if not (sel.getString() or "").strip():
-        return
     try:
         sel.setString("")
     except Exception:
         log.exception("notebook run: failed to clear output for cell %d", cell.index)
+    if not _bookmark_exists(doc, cell.output_start_bookmark):
+        _reanchor_output_bookmark(doc, cell)
 
 
 def _insert_run_image(doc: Any, payload: dict[str, Any], *, ctx: Any, images_before: int) -> bool:
@@ -243,16 +408,23 @@ def apply_run_result(
 ) -> None:
     """Write stdout/errors/result and optional image after the output bookmark."""
     out_text = format_run_output_text(result)
+    _reanchor_output_bookmark(doc, cell)
     cursor = _cursor_after_bookmark(doc, cell.output_start_bookmark)
+    if cursor is None:
+        cursor = _find_cell_output_heading_end(doc, cell)
     output_style = _resolve_para_style(doc, _STYLE_OUTPUT)
     notebook_in = _resolve_para_style(doc, _STYLE_NOTEBOOK_IN)
     if out_text.strip():
         display, _unused = _prepare_display_text(out_text)
         if display.strip():
             if cursor is not None:
-                _insert_stdout_paragraph(doc, cursor, display, output_style, notebook_in)
+                _insert_stdout_paragraph(doc, cell, cursor, display, output_style, notebook_in)
             else:
-                _append_body_text_block(doc, display, _STYLE_OUTPUT, lead_break=True)
+                # Never dump at the document end — that was the re-click bug.
+                log.warning(
+                    "notebook run: output bookmark missing for cell %d; not appending at document end",
+                    cell.index,
+                )
     if result.get("status") == "ok":
         wire = result.get("result")
         images = find_image_payloads(wire)
@@ -260,30 +432,35 @@ def apply_run_result(
             _insert_run_image(doc, img, ctx=ctx, images_before=0)
 
 
-def _insert_stdout_paragraph(
+def _apply_para_style(cursor: Any, style: str | None) -> None:
+    if not style:
+        return
+    try:
+        cursor.setPropertyValue("ParaStyleName", style)
+    except Exception:
+        log.debug("notebook run: ParaStyleName %r not applied", style)
+
+
+def _stdout_shares_cell_chrome(cursor: Any, notebook_in: str | None) -> bool:
+    following = _paragraph_string(cursor)
+    style = _para_style_name(cursor)
+    return _is_next_cell_boundary(style, following, notebook_in) or bool(
+        _CELL_CHROME_RE.match((following or "").strip())
+    )
+
+
+def _split_if_stdout_mashed_onto_chrome(
     doc: Any,
+    text: Any,
     cursor: Any,
     display: str,
     output_style: str | None,
     notebook_in: str | None,
 ) -> None:
-    """Insert *display* as its own paragraph under Output; do not eat the next cell.
-
-    Writer leaves the cursor **before** a just-inserted PARAGRAPH_BREAK
-    (``html_export._range_to_content_via_temp_doc``). After the output bookmark that
-    often means we are at the start of ``Cell N: Markdown``. ``insertString`` then
-    prepends stdout onto that heading. Move to the end of the inserted stdout and
-    split; apply Preformatted Text only to the stdout paragraph so chrome keeps
-    Heading 3.
-    """
-    text = doc.getText()
-    text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
-    _enter_paragraph_after_break(cursor)
-    try:
-        cursor.gotoStartOfParagraph(False)
-    except Exception:
-        log.debug("notebook run: gotoStartOfParagraph after break failed", exc_info=True)
-    text.insertString(cursor, display, False)
+    """If insertString landed in the next cell heading, split stdout off (PR 461)."""
+    if not _stdout_shares_cell_chrome(cursor, notebook_in):
+        _apply_para_style(cursor, output_style)
+        return
     try:
         cursor.gotoStartOfParagraph(False)
         n = min(len(display.encode("utf-16-le")) // 2, 32767)
@@ -292,28 +469,66 @@ def _insert_stdout_paragraph(
         text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
     except Exception:
         log.debug("notebook run: trailing split after stdout failed", exc_info=True)
-    # After the trailing break the cursor is in the following paragraph (cell chrome).
-    # Style that as Heading 3; style the previous paragraph (stdout) as Preformatted Text.
+        return
     try:
-        following = _paragraph_string(cursor)
-        style = ""
-        try:
-            style = str(cursor.ParaStyleName or "")
-        except Exception:
-            style = ""
-        if _is_next_cell_boundary(style, following, notebook_in) or _CELL_CHROME_RE.match(
-            (following or "").strip()
-        ):
+        if _stdout_shares_cell_chrome(cursor, notebook_in):
             heading = _resolve_para_style(doc, _STYLE_CELL_HEADING)
-            if heading:
-                cursor.setPropertyValue("ParaStyleName", heading)
+            _apply_para_style(cursor, heading)
         if output_style:
             prev = text.createTextCursorByRange(cursor)
             if prev.gotoPreviousParagraph(False):
                 prev.gotoStartOfParagraph(False)
-                prev.setPropertyValue("ParaStyleName", output_style)
+                _apply_para_style(prev, output_style)
     except Exception:
         log.debug("notebook run: stdout/chrome style restore failed", exc_info=True)
+
+
+def _insert_stdout_paragraph(
+    doc: Any,
+    cell: NotebookCodeCell,
+    cursor: Any,
+    display: str,
+    output_style: str | None,
+    notebook_in: str | None,
+) -> None:
+    """Insert *display* as its own paragraph under Output; do not eat the next cell.
+
+    Always inserting a PARAGRAPH_BREAK before ``insertString`` (and another
+    trailing split) left a blank paragraph when the bookmark para was already
+    empty. Fill an existing empty paragraph; only split when the current para
+    has content (Output heading or next-cell chrome). Trailing split only if
+    stdout would otherwise share a line with ``Cell N: Markdown`` (PR 461).
+    """
+    text = doc.getText()
+
+    def _fill(target: Any) -> None:
+        try:
+            target.gotoStartOfParagraph(False)
+        except Exception:
+            log.debug("notebook run: gotoStartOfParagraph before stdout failed", exc_info=True)
+        _apply_para_style(target, output_style)
+        text.insertString(target, display, False)
+        _split_if_stdout_mashed_onto_chrome(doc, text, target, display, output_style, notebook_in)
+
+    if _paragraph_is_empty(cursor):
+        _fill(cursor)
+        _collapse_leading_empty_paragraphs(doc, cell, notebook_in)
+        return
+
+    nxt = text.createTextCursorByRange(cursor)
+    if nxt.gotoNextParagraph(False):
+        nxt_text = _paragraph_string(nxt)
+        if not nxt_text.strip() and not _is_next_cell_boundary(
+            _para_style_name(nxt), nxt_text, notebook_in
+        ):
+            _fill(nxt)
+            _collapse_leading_empty_paragraphs(doc, cell, notebook_in)
+            return
+
+    text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
+    _enter_paragraph_after_break(cursor)
+    _fill(cursor)
+    _collapse_leading_empty_paragraphs(doc, cell, notebook_in)
 
 
 def _leading_text_cursor(text: Any, para: Any) -> Any | None:
@@ -481,9 +696,10 @@ def run_cell_target_url(cell_id: str) -> str:
 
 
 def init_registry_execution_counter(state: NotebookDocState) -> None:
-    """After import, set ``next_execution_count`` above any ipynb execution numbers."""
-    max_ec = 0
-    for cell in state.code_cells:
-        if cell.execution_count is not None:
-            max_ec = max(max_ec, int(cell.execution_count))
-    state.next_execution_count = max(max_ec + 1, 1)
+    """New kernel starts at 1. Saved ipynb ``execution_count`` values are historical.
+
+    ``max(saved)+1`` made the first live ▶ show ``[In [4]]`` on the small NumPy
+    fixture (saved 1, 2, 3). Jupyter starts a new kernel at 1; our ``notebook:…``
+    venv session is a new kernel on import. Re-runs still increment by 1.
+    """
+    state.next_execution_count = 1

--- a/plugin/notebook/notebook_runner.py
+++ b/plugin/notebook/notebook_runner.py
@@ -211,8 +211,11 @@ def _find_cell_output_heading_end(doc: Any, cell: NotebookCodeCell) -> Any | Non
             continue
         if content.strip() == "Output":
             try:
-                cursor = text.createTextCursorByRange(para.getEnd())
-                cursor.collapseToEnd()
+                # Stay *inside* the heading. para.getEnd() is the paragraph
+                # break; a bookmark there is the start of the next para, so
+                # setString of the following range deletes nb_out_*.
+                cursor = text.createTextCursorByRange(para.getStart())
+                cursor.gotoEndOfParagraph(False)
             except Exception:
                 continue
             if first_output_end is None:
@@ -239,7 +242,8 @@ def _reanchor_output_bookmark(doc: Any, cell: NotebookCodeCell) -> Any | None:
 
     Find the heading **after** removing the old bookmark. A cursor captured
     before ``removeTextContent`` is stale and insert then fails, leaving no
-    bookmark for the next run.
+    bookmark for the next run. Re-insert with ``gotoEndOfParagraph`` (inside
+    the heading), not ``para.getEnd()`` (the paragraph break).
     """
     name = cell.output_start_bookmark
     if not name:
@@ -302,6 +306,14 @@ def _collapse_leading_empty_paragraphs(
         start = _cursor_after_bookmark(doc, cell.output_start_bookmark)
         if start is None:
             return
+        # Bookmark at the paragraph break reports as the *next* para (often a
+        # leftover blank). Snap to the Output heading so we delete that blank
+        # instead of treating it as the bookmark's home.
+        if _paragraph_string(start).strip() != "Output":
+            heading = _find_cell_output_heading_end(doc, cell)
+            if heading is None:
+                return
+            start = heading
         nxt = doc.getText().createTextCursorByRange(start)
         if not nxt.gotoNextParagraph(False):
             return
@@ -349,18 +361,26 @@ def clear_cell_output(doc: Any, cell: NotebookCodeCell) -> None:
     paragraphs do not accumulate under Output.
     """
     _reanchor_output_bookmark(doc, cell)
-    start = _cursor_after_bookmark(doc, cell.output_start_bookmark)
-    if start is None:
-        return
     text = doc.getText()
     notebook_in = _resolve_para_style(doc, _STYLE_NOTEBOOK_IN)
-    end = text.createTextCursorByRange(start)
-    # Live cursor sits at the end of the Output heading after re-anchor. Skip that
-    # paragraph so setString cannot absorb the bookmark. Unit mocks that already
-    # place the cursor on stdout keep the old loop (content is not "Output").
-    if _paragraph_string(start).strip() == "Output":
+    # Prefer the Output heading over the bookmark cursor. After a first run the
+    # bookmark often sits on the paragraph break, so collapseToEnd is already
+    # in the next para — setString then deletes nb_out_*. Unit mocks have no
+    # heading enumeration, so they still clear from the bookmark cursor.
+    heading = _find_cell_output_heading_end(doc, cell)
+    if heading is not None:
+        start = heading
+        end = text.createTextCursorByRange(start)
         if not end.gotoNextParagraph(False):
             return
+    else:
+        start = _cursor_after_bookmark(doc, cell.output_start_bookmark)
+        if start is None:
+            return
+        end = text.createTextCursorByRange(start)
+        if _paragraph_string(start).strip() == "Output":
+            if not end.gotoNextParagraph(False):
+                return
     if _is_next_cell_boundary(_para_style_name(end), _paragraph_string(end), notebook_in):
         return
     range_start = text.createTextCursorByRange(end)
@@ -426,9 +446,12 @@ def apply_run_result(
     """Write stdout/errors/result and optional image after the output bookmark."""
     out_text = format_run_output_text(result)
     _reanchor_output_bookmark(doc, cell)
-    cursor = _cursor_after_bookmark(doc, cell.output_start_bookmark)
+    # Insert from the Output heading, not the bookmark cursor. After collapseToEnd
+    # a break-anchored bookmark is already in the next paragraph; filling that
+    # range can absorb nb_out_* on the next clear.
+    cursor = _find_cell_output_heading_end(doc, cell)
     if cursor is None:
-        cursor = _find_cell_output_heading_end(doc, cell)
+        cursor = _cursor_after_bookmark(doc, cell.output_start_bookmark)
     output_style = _resolve_para_style(doc, _STYLE_OUTPUT)
     notebook_in = _resolve_para_style(doc, _STYLE_NOTEBOOK_IN)
     if out_text.strip():

--- a/plugin/scripting/session_manager.py
+++ b/plugin/scripting/session_manager.py
@@ -278,17 +278,17 @@ def reset_notebook_python_session(ctx: Any, doc: Any | None = None) -> None:
         return
 
     res = reset_python_session(ctx, session_id)
-    if res.get("status") == "ok":
-        # Jupyter Restart Kernel: the next execution is In [1], not max(saved)+1.
-        try:
-            from plugin.notebook.cell_registry import load_registry, save_registry
+    # Restart Kernel: next In count is 1 even if the worker reset fails (timeout).
+    try:
+        from plugin.notebook.cell_registry import load_registry, save_registry
 
-            state = load_registry(target)
-            if state is not None:
-                state.next_execution_count = 1
-                save_registry(target, state)
-        except Exception:
-            log.debug("notebook reset: could not reset execution counter", exc_info=True)
+        state = load_registry(target)
+        if state is not None:
+            state.next_execution_count = 1
+            save_registry(target, state)
+    except Exception:
+        log.debug("notebook reset: could not reset execution counter", exc_info=True)
+    if res.get("status") == "ok":
         _msgbox(ctx, _("Notebook Python session reset for this document."))
         return
 

--- a/plugin/scripting/session_manager.py
+++ b/plugin/scripting/session_manager.py
@@ -279,6 +279,16 @@ def reset_notebook_python_session(ctx: Any, doc: Any | None = None) -> None:
 
     res = reset_python_session(ctx, session_id)
     if res.get("status") == "ok":
+        # Jupyter Restart Kernel: the next execution is In [1], not max(saved)+1.
+        try:
+            from plugin.notebook.cell_registry import load_registry, save_registry
+
+            state = load_registry(target)
+            if state is not None:
+                state.next_execution_count = 1
+                save_registry(target, state)
+        except Exception:
+            log.debug("notebook reset: could not reset execution counter", exc_info=True)
         _msgbox(ctx, _("Notebook Python session reset for this document."))
         return
 

--- a/tests/notebook/test_notebook_controls.py
+++ b/tests/notebook/test_notebook_controls.py
@@ -53,6 +53,29 @@ def test_wire_run_button_listener_attaches_to_xbutton():
     control.addActionListener.assert_called_once()
 
 
+def test_wire_run_button_listener_idempotent_for_same_runtime_uid():
+    """Untitled docs share RuntimeUID across PyUNO wrappers; one click must be one run."""
+    ctx = MagicMock()
+    doc1 = MagicMock()
+    doc2 = MagicMock()
+    doc1.getURL.return_value = ""
+    doc2.getURL.return_value = ""
+    doc1.getRuntimeUID.return_value = "uid-nb-same"
+    doc2.getRuntimeUID.return_value = "uid-nb-same"
+    model = MagicMock()
+    control = MagicMock()
+    control.queryInterface.return_value = control
+    hex_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    with patch(
+        "plugin.notebook.notebook_controls.get_control_view_for_model",
+        return_value=control,
+    ):
+        assert wire_run_button_listener(ctx, doc1, model, hex_id) is True
+        assert wire_run_button_listener(ctx, doc2, model, hex_id) is True
+    control.addActionListener.assert_called_once()
+
+
 def test_notebook_run_button_listener_calls_runner():
     ctx = MagicMock()
     doc = MagicMock()

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -242,7 +242,7 @@ def test_find_output_heading_skips_earlier_markdown_chrome():
         found = _find_cell_output_heading_end(doc, cell)
     assert found is heading_cursor
     text.createTextCursorByRange.assert_called_with(output_para.getStart())
-    heading_cursor.goRight.assert_called_once_with(1, False)
+    heading_cursor.goRight.assert_called_once_with(6, False)
 
 
 def test_is_next_cell_boundary_markdown_and_code():

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -206,8 +206,43 @@ def test_find_output_heading_stays_inside_paragraph():
     """para.getEnd() is the paragraph break; a bookmark there is deleted by setString."""
     src = inspect.getsource(_find_cell_output_heading_end)
     assert "createTextCursorByRange(para.getEnd())" not in src
-    assert "gotoEndOfParagraph" in src
     assert "para.getStart()" in src
+    assert "goRight" in src
+
+
+def test_find_output_heading_skips_earlier_markdown_chrome():
+    """``Cell 1: Markdown`` is a boundary but must not abort before this cell's Output."""
+
+    def _para(text: str, style: str = "Heading 3") -> MagicMock:
+        para = MagicMock()
+        para.getString.return_value = text
+        para.getPropertyValue.return_value = style
+        para.supportsService.return_value = True
+        para.getStart.return_value = f"start:{text}"
+        return para
+
+    output_para = _para("Output", "Heading 4")
+    paras = [
+        _para("Cell 1: Markdown"),
+        _para("Before code", "Heading 1"),
+        _para("[In [1]]\tCell 2: Code", "WriterAgent Notebook In"),
+        _para("", "WriterAgent Notebook In"),
+        output_para,
+        _para("Cell 3: Markdown"),
+    ]
+    heading_cursor = MagicMock(name="inside-output")
+    heading_cursor.goRight.return_value = True
+    text = MagicMock()
+    text.createEnumeration.return_value = _enum_of(paras)
+    text.createTextCursorByRange.return_value = heading_cursor
+    doc = MagicMock()
+    doc.getText.return_value = text
+    cell = new_code_cell_entry(1, None, "nb_cell_1_code")
+    with patch("plugin.notebook.notebook_runner._resolve_para_style", return_value="WriterAgent Notebook In"):
+        found = _find_cell_output_heading_end(doc, cell)
+    assert found is heading_cursor
+    text.createTextCursorByRange.assert_called_with(output_para.getStart())
+    heading_cursor.goRight.assert_called_once_with(1, False)
 
 
 def test_is_next_cell_boundary_markdown_and_code():

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -9,6 +9,7 @@ import pytest
 
 from plugin.notebook.cell_registry import NotebookDocState, cell_id_to_hex, new_code_cell_entry
 from plugin.notebook.notebook_runner import (
+    _find_cell_output_heading_end,
     _gutter_text_cursor,
     _is_next_cell_boundary,
     _paragraph_string,
@@ -199,6 +200,14 @@ def test_clear_cell_output_source_has_no_delete_contents():
     src = inspect.getsource(clear_cell_output)
     assert ".deleteContents(" not in src
     assert "setString" in src
+
+
+def test_find_output_heading_stays_inside_paragraph():
+    """para.getEnd() is the paragraph break; a bookmark there is deleted by setString."""
+    src = inspect.getsource(_find_cell_output_heading_end)
+    assert "para.getEnd()" not in src
+    assert "gotoEndOfParagraph" in src
+    assert "para.getStart()" in src
 
 
 def test_is_next_cell_boundary_markdown_and_code():

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -205,7 +205,7 @@ def test_clear_cell_output_source_has_no_delete_contents():
 def test_find_output_heading_stays_inside_paragraph():
     """para.getEnd() is the paragraph break; a bookmark there is deleted by setString."""
     src = inspect.getsource(_find_cell_output_heading_end)
-    assert "para.getEnd()" not in src
+    assert "createTextCursorByRange(para.getEnd())" not in src
     assert "gotoEndOfParagraph" in src
     assert "para.getStart()" in src
 

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -84,7 +84,7 @@ def test_init_registry_execution_counter():
     c1 = new_code_cell_entry(1, None, "nb_cell_1_code")
     state = NotebookDocState(code_cells=[c0, c1])
     init_registry_execution_counter(state)
-    assert state.next_execution_count == 4
+    assert state.next_execution_count == 1
 
 
 def test_execute_code_uses_blocking_pump():
@@ -245,11 +245,12 @@ def test_clear_cell_output_uses_set_string_not_delete_contents():
     walker.gotoNextParagraph.side_effect = goto_next
     walker.getStart.return_value = "end-pos"
 
+    range_start = MagicMock(name="range_start")
     sel = MagicMock(name="sel")
     sel.getString.return_value = "old stdout\n"
 
     text = MagicMock()
-    text.createTextCursorByRange.side_effect = [walker, sel]
+    text.createTextCursorByRange.side_effect = [walker, range_start, sel]
     doc = MagicMock()
     doc.getText.return_value = text
 
@@ -282,11 +283,12 @@ def test_clear_cell_output_stops_at_markdown_cell_heading():
     walker.gotoNextParagraph.side_effect = goto_next
     walker.getStart.return_value = "md-start"
 
+    range_start = MagicMock(name="range_start")
     sel = MagicMock(name="sel")
     sel.getString.return_value = "Array: [10 20 30]\n"
 
     text = MagicMock()
-    text.createTextCursorByRange.side_effect = [walker, sel]
+    text.createTextCursorByRange.side_effect = [walker, range_start, sel]
     doc = MagicMock()
     doc.getText.return_value = text
 
@@ -323,11 +325,12 @@ def test_clear_cell_output_collapsed_cursor_stops_at_markdown():
     walker.gotoNextParagraph.side_effect = goto_next
     walker.getStart.return_value = "md-start"
 
+    range_start = MagicMock(name="range_start")
     sel = MagicMock(name="sel")
     sel.getString.return_value = "old stdout\n"
 
     text = MagicMock()
-    text.createTextCursorByRange.side_effect = [walker, sel]
+    text.createTextCursorByRange.side_effect = [walker, range_start, sel]
     doc = MagicMock()
     doc.getText.return_value = text
 
@@ -386,7 +389,7 @@ def test_apply_run_result_replaces_via_clear_then_insert():
 
     with (
         patch("plugin.notebook.notebook_runner._cursor_after_bookmark", return_value=cursor),
-        patch("plugin.notebook.notebook_runner._resolve_para_style", return_value="Preformatted Text"),
+        patch("plugin.notebook.notebook_runner._resolve_para_style", side_effect=lambda _doc, name: name),
     ):
         apply_run_result(doc, cell, {"status": "ok", "stdout": "first\n", "result": None})
         apply_run_result(doc, cell, {"status": "ok", "stdout": "second\n", "result": None})
@@ -394,11 +397,7 @@ def test_apply_run_result_replaces_via_clear_then_insert():
     assert [call.args[1] for call in text.insertString.call_args_list] == ["first", "second"]
     text.deleteContents.assert_not_called()
     cursor.gotoEnd.assert_not_called()
-    from plugin.notebook.writer_importer import _PARAGRAPH_BREAK
-
-    breaks = [call.args[1] for call in text.insertControlCharacter.call_args_list]
-    assert breaks.count(_PARAGRAPH_BREAK) >= 2
-    cursor.goRight.assert_called()
+    text.insertControlCharacter.assert_not_called()
 
 
 def test_insert_stdout_paragraph_splits_before_next_cell_chrome():
@@ -406,15 +405,20 @@ def test_insert_stdout_paragraph_splits_before_next_cell_chrome():
     from plugin.notebook.notebook_runner import _insert_stdout_paragraph
     from plugin.notebook.writer_importer import _PARAGRAPH_BREAK
 
+    cell = new_code_cell_entry(0, None, "nb_cell_0_code")
     cursor = MagicMock()
     cursor.ParaStyleName = "Heading 3"
     cursor.goRight.return_value = True
     cursor.getString.return_value = "Cell 3: Markdown"
     text = MagicMock()
+    nxt = MagicMock()
+    nxt.gotoNextParagraph.return_value = False
+    text.createTextCursorByRange.return_value = nxt
     doc = MagicMock()
     doc.getText.return_value = text
 
-    _insert_stdout_paragraph(doc, cursor, "hello", "Preformatted Text", "WriterAgent Notebook In")
+    with patch("plugin.notebook.notebook_runner._cursor_after_bookmark", return_value=cursor):
+        _insert_stdout_paragraph(doc, cell, cursor, "hello", "Preformatted Text", "WriterAgent Notebook In")
 
     assert [call.args[1] for call in text.insertControlCharacter.call_args_list] == [
         _PARAGRAPH_BREAK,
@@ -485,3 +489,74 @@ def test_update_in_prompt_source_never_setstrings_para_end():
     src = inspect.getsource(update_in_prompt)
     assert "para.getEnd()" not in src
     assert "_gutter_text_cursor" in src
+
+
+def test_run_cell_error_still_increments_execution_count():
+    """Failed runs consume a kernel count, matching Jupyter In [n]."""
+    ctx = MagicMock()
+    cell = new_code_cell_entry(0, None, "nb_cell_0_code")
+    state = NotebookDocState(code_cells=[cell], next_execution_count=1)
+    doc = MagicMock()
+
+    with (
+        patch("plugin.notebook.notebook_runner.load_registry", return_value=state),
+        patch("plugin.notebook.notebook_runner.read_code_from_field", return_value="raise ValueError(1)"),
+        patch(
+            "plugin.notebook.notebook_runner.execute_code",
+            return_value={"status": "error", "message": "ValueError", "stdout": ""},
+        ),
+        patch("plugin.notebook.notebook_runner.clear_cell_output"),
+        patch("plugin.notebook.notebook_runner.apply_run_result"),
+        patch("plugin.notebook.notebook_runner.update_in_prompt"),
+        patch("plugin.notebook.notebook_runner.save_registry"),
+        patch("plugin.notebook.notebook_runner.flush_ui_idle"),
+    ):
+        result = run_cell(ctx, doc, cell.cell_id)
+
+    assert result.status == "error"
+    assert result.execution_count == 1
+    assert cell.execution_count == 1
+    assert state.next_execution_count == 2
+
+
+def test_insert_stdout_paragraph_no_break_when_para_empty():
+    from plugin.notebook.notebook_runner import _insert_stdout_paragraph
+
+    cell = new_code_cell_entry(0, None, "nb_cell_0_code")
+    cursor = MagicMock()
+    cursor.getString.return_value = ""
+    cursor.ParaStyleName = "Preformatted Text"
+    text = MagicMock()
+    nxt = MagicMock()
+    nxt.gotoNextParagraph.return_value = False
+    text.createTextCursorByRange.return_value = nxt
+    doc = MagicMock()
+    doc.getText.return_value = text
+
+    with patch("plugin.notebook.notebook_runner._cursor_after_bookmark", return_value=cursor):
+        _insert_stdout_paragraph(
+            doc, cell, cursor, "NumPy Version: 2.5.2", "Preformatted Text", "WriterAgent Notebook In"
+        )
+
+    text.insertControlCharacter.assert_not_called()
+    text.insertString.assert_called_once_with(cursor, "NumPy Version: 2.5.2", False)
+
+
+def test_apply_run_result_missing_bookmark_does_not_append_at_end():
+    src = inspect.getsource(apply_run_result)
+    assert "_append_body_text_block" not in src
+
+    cell = new_code_cell_entry(0, None, "nb_cell_0_code")
+    doc = MagicMock()
+    text = MagicMock()
+    doc.getText.return_value = text
+    with (
+        patch("plugin.notebook.notebook_runner._reanchor_output_bookmark", return_value=None),
+        patch("plugin.notebook.notebook_runner._cursor_after_bookmark", return_value=None),
+        patch("plugin.notebook.notebook_runner._find_cell_output_heading_end", return_value=None),
+        patch("plugin.notebook.notebook_runner._insert_stdout_paragraph") as insert,
+    ):
+        apply_run_result(doc, cell, {"status": "ok", "stdout": "dumped\n", "result": None})
+    insert.assert_not_called()
+    text.insertString.assert_not_called()
+    text.insertControlCharacter.assert_not_called()

--- a/tests/notebook/test_notebook_runner.py
+++ b/tests/notebook/test_notebook_runner.py
@@ -206,6 +206,7 @@ def test_is_next_cell_boundary_markdown_and_code():
     assert _is_next_cell_boundary("Heading 3", "Cell 5: Raw", None) is True
     assert _is_next_cell_boundary("Preformatted Text", "old stdout", None) is False
     assert _is_next_cell_boundary("WriterAgent Notebook In", "[In [1]]\tCell 2: Code", "WriterAgent Notebook In") is True
+    assert _is_next_cell_boundary("WriterAgent Notebook In", "", "WriterAgent Notebook In") is False
 
 
 def test_paragraph_string_uses_selection_when_nonempty():
@@ -413,6 +414,8 @@ def test_insert_stdout_paragraph_splits_before_next_cell_chrome():
     text = MagicMock()
     nxt = MagicMock()
     nxt.gotoNextParagraph.return_value = False
+    nxt.getString.return_value = "Cell 3: Markdown"
+    nxt.ParaStyleName = "Heading 3"
     text.createTextCursorByRange.return_value = nxt
     doc = MagicMock()
     doc.getText.return_value = text

--- a/tests/notebook/test_notebook_runner_uno.py
+++ b/tests/notebook/test_notebook_runner_uno.py
@@ -117,6 +117,7 @@ def _fire_run_button_via_get_control(_ctx, doc, hex_id: str) -> str:
         _listener_refs,
         _query_interface,
         get_control_view_for_model,
+        wired_run_listener_count,
     )
 
     model = find_form_control_model_by_name(doc, f"nb_run_{hex_id}")
@@ -132,9 +133,13 @@ def _fire_run_button_via_get_control(_ctx, doc, hex_id: str) -> str:
     evt = uno.createUnoStruct("com.sun.star.awt.ActionEvent")
     evt.Source = control
     evt.ActionCommand = str(getattr(model, "Name", "") or "")
+    n = wired_run_listener_count(hex_id)
+    assert n == 1, f"expected 1 XActionListener for ▶, got {n} (triplicate wiring?)"
     matched = [lis for lis in _listener_refs if getattr(lis, "_hex_id", None) == hex_id]
-    assert matched, "no wired XActionListener for this ▶ (getControl view exists)"
-    matched[-1].actionPerformed(evt)
+    assert len(matched) == 1, f"listener list mismatch: {len(matched)}"
+    # Fire every matched listener — a real click would. With n==1 this is one run.
+    for lis in matched:
+        lis.actionPerformed(evt)
     return "action-listener"
 
 
@@ -235,4 +240,179 @@ def test_apply_run_result_stdout_is_own_paragraph(ctx, doc):
     assert sum(1 for _s, t in _paragraphs(doc) if _SENTINEL in t) == 1
     assert _AFTER_HEADING in (doc.getText().getString() or "")
     assert "Cell 3: Markdown" in (doc.getText().getString() or "")
+    assert _empty_paras_between_output_and_content(doc) <= 1
+
+
+_SMALL_IPYNB = Path(__file__).resolve().parents[1] / "fixtures" / "introduction-to-numpy-small.ipynb"
+
+
+def _empty_paras_between_output_and_content(doc) -> int:
+    """Blank paragraphs after the first Output heading before stdout or the next cell."""
+    seen_output = False
+    empties = 0
+    for _style, text in _paragraphs(doc):
+        if not seen_output:
+            if text.strip() == "Output":
+                seen_output = True
+            continue
+        stripped = text.strip()
+        if stripped.startswith("Cell ") or stripped.startswith("[In ["):
+            break
+        if not stripped:
+            empties += 1
+            continue
+        break
+    return empties
+
+
+def _output_text_for_cell(doc, cell) -> str:
+    from plugin.notebook.notebook_runner import (
+        _cursor_after_bookmark,
+        _is_next_cell_boundary,
+        _paragraph_string,
+    )
+    from plugin.notebook.writer_importer import _STYLE_NOTEBOOK_IN, _resolve_para_style
+
+    start = _cursor_after_bookmark(doc, cell.output_start_bookmark)
+    if start is None:
+        return ""
+    text = doc.getText()
+    notebook_in = _resolve_para_style(doc, _STYLE_NOTEBOOK_IN)
+    end = text.createTextCursorByRange(start)
+    while end.gotoNextParagraph(False):
+        if _is_next_cell_boundary(end.ParaStyleName, _paragraph_string(end), notebook_in):
+            end.gotoStartOfParagraph(False)
+            break
+    else:
+        end.gotoEnd(False)
+    sel = text.createTextCursorByRange(start)
+    sel.gotoRange(end.getStart(), True)
+    return str(sel.getString() or "")
+
+
+def _gutter_line_for_cell(doc, cell_index: int) -> str:
+    marker = f"Cell {cell_index + 1}: Code"
+    for _style, text in _paragraphs(doc):
+        if marker in text:
+            return text
+    return ""
+
+
+@native_test
+@with_native_doc("writer", hidden=not show_window)
+def test_small_numpy_button_rerun_stays_in_cell_and_counts_from_one(ctx, doc):
+    """Live ▶ on the small NumPy fixture: in-cell replace, tight Output, In [1] then [2]."""
+    assert _SMALL_IPYNB.is_file(), f"missing fixture {_SMALL_IPYNB}"
+
+    from plugin.notebook.cell_registry import cell_id_to_hex, load_registry
+    from plugin.notebook.notebook_controls import (
+        ensure_form_design_mode_off,
+        wire_all_notebook_run_buttons,
+        wired_run_listener_count,
+    )
+    from plugin.notebook.writer_importer import import_ipynb_to_writer, flush_ui_idle
+
+    boxes: list = []
+
+    def _capture(_c, title, message, *, box_type=1):
+        boxes.append((str(title), str(message), box_type))
+
+    with patch("plugin.notebook.notebook_runner.msgbox", _capture):
+        import_ipynb_to_writer(doc, str(_SMALL_IPYNB), ctx=ctx)
+        flush_ui_idle(ctx)
+
+        state = load_registry(doc)
+        assert state is not None and len(state.code_cells) == 3
+        assert state.next_execution_count == 1, (
+            f"new kernel must start at 1, not max(saved)+1; got {state.next_execution_count}"
+        )
+        cell = state.code_cells[0]
+        hex_id = cell_id_to_hex(cell.cell_id)
+        bm_name = cell.output_start_bookmark
+        assert doc.getBookmarks().hasByName(bm_name), f"missing {bm_name}"
+
+        ensure_form_design_mode_off(doc)
+        wire_all_notebook_run_buttons(ctx, doc)
+        wire_all_notebook_run_buttons(ctx, doc)
+        assert wired_run_listener_count(hex_id) == 1, (
+            f"extra wire_all attached duplicate listeners: {wired_run_listener_count(hex_id)}"
+        )
+        _assert_controls_present(doc, cell)
+
+        _fire_run_button_via_get_control(ctx, doc, hex_id)
+        flush_ui_idle(ctx)
+        state = load_registry(doc)
+        assert state is not None
+        cell = state.code_cells[0]
+        assert cell.execution_count == 1, f"first live run must be In [1], got {cell.execution_count}"
+        assert state.next_execution_count == 2
+        assert "[In [1]]" in _gutter_line_for_cell(doc, cell.index)
+        assert doc.getBookmarks().hasByName(bm_name), "bookmark vanished after first run"
+        out1 = _output_text_for_cell(doc, cell)
+        body = doc.getText().getString() or ""
+        print(
+            f"first ▶ status_out={out1!r} gap={_empty_paras_between_output_and_content(doc)} "
+            f"paras={_paragraphs(doc)!r} boxes={boxes!r}",
+            flush=True,
+        )
+        assert out1.strip(), f"first ▶ produced no in-cell output: {out1!r} boxes={boxes!r}"
+        assert _empty_paras_between_output_and_content(doc) <= 1, (
+            f"extra blank paras under Output: {_paragraphs(doc)!r}"
+        )
+        assert "Cell 3: Markdown" in body
+        assert "1. Creating Arrays" in body
+        _assert_controls_present(doc, cell)
+        tail = body[-400:]
+        needle = "NumPy Version"
+        if needle in out1:
+            assert body.count(needle) == out1.count(needle), (
+                f"stdout also dumped outside the cell: out={out1!r} tail={tail!r}"
+            )
+            assert needle not in tail or "Multiplied" in tail or "Creating Arrays" in tail
+
+        _fire_run_button_via_get_control(ctx, doc, hex_id)
+        flush_ui_idle(ctx)
+        state = load_registry(doc)
+        assert state is not None
+        cell = state.code_cells[0]
+        assert cell.execution_count == 2, f"re-click must increment by 1, got {cell.execution_count}"
+        assert state.next_execution_count == 3
+        assert "[In [2]]" in _gutter_line_for_cell(doc, cell.index)
+        assert doc.getBookmarks().hasByName(bm_name), "bookmark vanished after re-click"
+        out2 = _output_text_for_cell(doc, cell)
+        body2 = doc.getText().getString() or ""
+        print(f"second ▶ out={out2!r} tail={body2[-400:]!r} paras={_paragraphs(doc)!r}", flush=True)
+        assert out2.strip(), f"re-click lost in-cell output (dumped at end?): tail={body2[-400:]!r}"
+        if needle in out1:
+            assert out2.count(needle) == 1, f"re-click duplicated in-cell stdout: {out2!r}"
+            assert body2.count(needle) == 1, f"re-click appended at document end: {body2[-400:]!r}"
+        assert "Cell 3: Markdown" in body2
+        assert "1. Creating Arrays" in body2
+        _assert_controls_present(doc, cell)
+        assert _empty_paras_between_output_and_content(doc) <= 1
+
+        _fire_run_button_via_get_control(ctx, doc, hex_id)
+        flush_ui_idle(ctx)
+        state = load_registry(doc)
+        assert state is not None
+        cell = state.code_cells[0]
+        assert cell.execution_count == 3, f"third click must be 3, got {cell.execution_count}"
+        assert "[In [3]]" in _gutter_line_for_cell(doc, cell.index)
+        assert doc.getBookmarks().hasByName(bm_name)
+        out3 = _output_text_for_cell(doc, cell)
+        body3 = doc.getText().getString() or ""
+        if needle in out1:
+            assert out3.count(needle) == 1
+            assert body3.count(needle) == 1, f"third click dumped extra copies at end: {body3[-400:]!r}"
+        _assert_controls_present(doc, cell)
+
+    import plugin.scripting.session_manager as sm
+
+    with patch.object(sm, "_msgbox", lambda *args, **kwargs: None):
+        sm.reset_workbook_python_session(ctx, doc)
+    state = load_registry(doc)
+    assert state is not None
+    assert state.next_execution_count == 1, (
+        f"Restart Kernel must reset In count to 1, got {state.next_execution_count}"
+    )
 

--- a/tests/notebook/test_notebook_runner_uno.py
+++ b/tests/notebook/test_notebook_runner_uno.py
@@ -98,6 +98,7 @@ def _assert_stdout_not_mashed(doc) -> list[tuple[str, str]]:
     assert chrome, f"Cell 3: Markdown heading missing after run: {paras!r}"
     for text in chrome:
         assert _SENTINEL not in text, f"next-cell chrome contains stdout: {text!r}"
+    assert any(t.strip() == "Output" for _s, t in paras), f"Output heading split or missing: {paras!r}"
     return paras
 
 
@@ -363,6 +364,9 @@ def test_small_numpy_button_rerun_stays_in_cell_and_counts_from_one(ctx, doc):
             )
             assert "Cell 3: Markdown" in body
             assert "1. Creating Arrays" in body
+            assert any(t.strip() == "Output" for _s, t in _paragraphs(doc)), (
+                f"Output heading split or missing: {_paragraphs(doc)!r}"
+            )
             _assert_controls_present(doc, cell)
             needle = "NumPy Version"
             assert needle in out1, f"expected in-cell stdout, got {out1!r}"

--- a/tests/notebook/test_notebook_runner_uno.py
+++ b/tests/notebook/test_notebook_runner_uno.py
@@ -321,12 +321,6 @@ def test_small_numpy_button_rerun_stays_in_cell_and_counts_from_one(ctx, doc):
         import_ipynb_to_writer(doc, str(_SMALL_IPYNB), ctx=ctx)
         flush_ui_idle(ctx)
 
-        from plugin.notebook.notebook_runner import execute_code
-
-        # Cold venv worker can exceed the 32s read timeout on the first real cell.
-        execute_code(ctx, doc, "1")
-        flush_ui_idle(ctx)
-
         state = load_registry(doc)
         assert state is not None and len(state.code_cells) == 3
         assert state.next_execution_count == 1, (
@@ -345,76 +339,74 @@ def test_small_numpy_button_rerun_stays_in_cell_and_counts_from_one(ctx, doc):
         )
         _assert_controls_present(doc, cell)
 
-        _fire_run_button_via_get_control(ctx, doc, hex_id)
-        flush_ui_idle(ctx)
-        state = load_registry(doc)
-        assert state is not None
-        cell = state.code_cells[0]
-        assert cell.execution_count == 1, f"first live run must be In [1], got {cell.execution_count}"
-        assert state.next_execution_count == 2
-        assert "[In [1]]" in _gutter_line_for_cell(doc, cell.index)
-        assert doc.getBookmarks().hasByName(bm_name), "bookmark vanished after first run"
-        out1 = _output_text_for_cell(doc, cell)
-        body = doc.getText().getString() or ""
-        print(
-            f"first ▶ status_out={out1!r} gap={_empty_paras_between_output_and_content(doc)} "
-            f"paras={_paragraphs(doc)!r} boxes={boxes!r}",
-            flush=True,
-        )
-        assert out1.strip(), f"first ▶ produced no in-cell output: {out1!r} boxes={boxes!r}"
-        assert _empty_paras_between_output_and_content(doc) <= 1, (
-            f"extra blank paras under Output: {_paragraphs(doc)!r}"
-        )
-        assert "Cell 3: Markdown" in body
-        assert "1. Creating Arrays" in body
-        _assert_controls_present(doc, cell)
-        tail = body[-400:]
-        needle = "NumPy Version"
-        if needle in out1:
-            assert body.count(needle) == out1.count(needle), (
-                f"stdout also dumped outside the cell: out={out1!r} tail={tail!r}"
+        fake_result = {"status": "ok", "stdout": "NumPy Version: 2.5.2\n", "result": None}
+        with patch("plugin.notebook.notebook_runner.execute_code", return_value=fake_result):
+            _fire_run_button_via_get_control(ctx, doc, hex_id)
+            flush_ui_idle(ctx)
+            state = load_registry(doc)
+            assert state is not None
+            cell = state.code_cells[0]
+            assert cell.execution_count == 1, f"first live run must be In [1], got {cell.execution_count}"
+            assert state.next_execution_count == 2
+            assert "[In [1]]" in _gutter_line_for_cell(doc, cell.index)
+            assert doc.getBookmarks().hasByName(bm_name), "bookmark vanished after first run"
+            out1 = _output_text_for_cell(doc, cell)
+            body = doc.getText().getString() or ""
+            print(
+                f"first ▶ status_out={out1!r} gap={_empty_paras_between_output_and_content(doc)} "
+                f"paras={_paragraphs(doc)!r} boxes={boxes!r}",
+                flush=True,
             )
-            assert needle not in tail or "Multiplied" in tail or "Creating Arrays" in tail
+            assert out1.strip(), f"first ▶ produced no in-cell output: {out1!r} boxes={boxes!r}"
+            assert _empty_paras_between_output_and_content(doc) <= 1, (
+                f"extra blank paras under Output: {_paragraphs(doc)!r}"
+            )
+            assert "Cell 3: Markdown" in body
+            assert "1. Creating Arrays" in body
+            _assert_controls_present(doc, cell)
+            needle = "NumPy Version"
+            assert needle in out1, f"expected in-cell stdout, got {out1!r}"
+            assert body.count(needle) == 1, f"stdout dumped outside the cell: tail={body[-400:]!r}"
 
-        _fire_run_button_via_get_control(ctx, doc, hex_id)
-        flush_ui_idle(ctx)
-        state = load_registry(doc)
-        assert state is not None
-        cell = state.code_cells[0]
-        assert cell.execution_count == 2, f"re-click must increment by 1, got {cell.execution_count}"
-        assert state.next_execution_count == 3
-        assert "[In [2]]" in _gutter_line_for_cell(doc, cell.index)
-        assert doc.getBookmarks().hasByName(bm_name), "bookmark vanished after re-click"
-        out2 = _output_text_for_cell(doc, cell)
-        body2 = doc.getText().getString() or ""
-        print(f"second ▶ out={out2!r} tail={body2[-400:]!r} paras={_paragraphs(doc)!r}", flush=True)
-        assert out2.strip(), f"re-click lost in-cell output (dumped at end?): tail={body2[-400:]!r}"
-        if needle in out1:
+            _fire_run_button_via_get_control(ctx, doc, hex_id)
+            flush_ui_idle(ctx)
+            state = load_registry(doc)
+            assert state is not None
+            cell = state.code_cells[0]
+            assert cell.execution_count == 2, f"re-click must increment by 1, got {cell.execution_count}"
+            assert state.next_execution_count == 3
+            assert "[In [2]]" in _gutter_line_for_cell(doc, cell.index)
+            assert doc.getBookmarks().hasByName(bm_name), "bookmark vanished after re-click"
+            out2 = _output_text_for_cell(doc, cell)
+            body2 = doc.getText().getString() or ""
+            print(f"second ▶ out={out2!r} tail={body2[-400:]!r} paras={_paragraphs(doc)!r}", flush=True)
             assert out2.count(needle) == 1, f"re-click duplicated in-cell stdout: {out2!r}"
             assert body2.count(needle) == 1, f"re-click appended at document end: {body2[-400:]!r}"
-        assert "Cell 3: Markdown" in body2
-        assert "1. Creating Arrays" in body2
-        _assert_controls_present(doc, cell)
-        assert _empty_paras_between_output_and_content(doc) <= 1
+            assert "Cell 3: Markdown" in body2
+            assert "1. Creating Arrays" in body2
+            _assert_controls_present(doc, cell)
+            assert _empty_paras_between_output_and_content(doc) <= 1
 
-        _fire_run_button_via_get_control(ctx, doc, hex_id)
-        flush_ui_idle(ctx)
-        state = load_registry(doc)
-        assert state is not None
-        cell = state.code_cells[0]
-        assert cell.execution_count == 3, f"third click must be 3, got {cell.execution_count}"
-        assert "[In [3]]" in _gutter_line_for_cell(doc, cell.index)
-        assert doc.getBookmarks().hasByName(bm_name)
-        out3 = _output_text_for_cell(doc, cell)
-        body3 = doc.getText().getString() or ""
-        if needle in out1:
+            _fire_run_button_via_get_control(ctx, doc, hex_id)
+            flush_ui_idle(ctx)
+            state = load_registry(doc)
+            assert state is not None
+            cell = state.code_cells[0]
+            assert cell.execution_count == 3, f"third click must be 3, got {cell.execution_count}"
+            assert "[In [3]]" in _gutter_line_for_cell(doc, cell.index)
+            assert doc.getBookmarks().hasByName(bm_name)
+            out3 = _output_text_for_cell(doc, cell)
+            body3 = doc.getText().getString() or ""
             assert out3.count(needle) == 1
             assert body3.count(needle) == 1, f"third click dumped extra copies at end: {body3[-400:]!r}"
-        _assert_controls_present(doc, cell)
+            _assert_controls_present(doc, cell)
 
     import plugin.scripting.session_manager as sm
 
-    with patch.object(sm, "_msgbox", lambda *args, **kwargs: None):
+    with (
+        patch.object(sm, "_msgbox", lambda *args, **kwargs: None),
+        patch.object(sm, "reset_python_session", return_value={"status": "ok"}),
+    ):
         sm.reset_workbook_python_session(ctx, doc)
     state = load_registry(doc)
     assert state is not None

--- a/tests/notebook/test_notebook_runner_uno.py
+++ b/tests/notebook/test_notebook_runner_uno.py
@@ -321,6 +321,12 @@ def test_small_numpy_button_rerun_stays_in_cell_and_counts_from_one(ctx, doc):
         import_ipynb_to_writer(doc, str(_SMALL_IPYNB), ctx=ctx)
         flush_ui_idle(ctx)
 
+        from plugin.notebook.notebook_runner import execute_code
+
+        # Cold venv worker can exceed the 32s read timeout on the first real cell.
+        execute_code(ctx, doc, "1")
+        flush_ui_idle(ctx)
+
         state = load_registry(doc)
         assert state is not None and len(state.code_cells) == 3
         assert state.next_execution_count == 1, (

--- a/tests/notebook/test_session_manager_notebook.py
+++ b/tests/notebook/test_session_manager_notebook.py
@@ -80,6 +80,25 @@ def test_reset_notebook_python_session_resets_execution_counter():
     save.assert_called_once_with(doc, state)
 
 
+def test_reset_notebook_python_session_resets_count_when_worker_fails():
+    ctx = MagicMock()
+    doc = _writer_doc()
+    state = MagicMock()
+    state.next_execution_count = 9
+    with (
+        patch("plugin.scripting.session_manager._writer_document", return_value=doc),
+        patch("plugin.scripting.session_manager._has_notebook_registry", return_value=True),
+        patch("plugin.scripting.session_manager.notebook_session_id", return_value="notebook:file:///tmp/nb.odt"),
+        patch("plugin.scripting.session_manager.reset_python_session", return_value={"status": "error"}),
+        patch("plugin.scripting.session_manager._msgbox"),
+        patch("plugin.notebook.cell_registry.load_registry", return_value=state),
+        patch("plugin.notebook.cell_registry.save_registry") as save,
+    ):
+        reset_notebook_python_session(ctx)
+    assert state.next_execution_count == 1
+    save.assert_called_once_with(doc, state)
+
+
 def test_reset_workbook_python_session_dispatches_to_notebook():
     ctx = MagicMock()
     doc = _writer_doc()

--- a/tests/notebook/test_session_manager_notebook.py
+++ b/tests/notebook/test_session_manager_notebook.py
@@ -60,6 +60,26 @@ def test_reset_notebook_python_session_calls_worker():
     mock_reset.assert_called_once_with(ctx, "notebook:file:///tmp/nb.odt")
 
 
+def test_reset_notebook_python_session_resets_execution_counter():
+    ctx = MagicMock()
+    doc = _writer_doc()
+    state = MagicMock()
+    state.next_execution_count = 9
+    with (
+        patch("plugin.scripting.session_manager._writer_document", return_value=doc),
+        patch("plugin.scripting.session_manager._has_notebook_registry", return_value=True),
+        patch("plugin.scripting.session_manager.notebook_session_id", return_value="notebook:file:///tmp/nb.odt"),
+        patch("plugin.scripting.session_manager.reset_python_session", return_value={"status": "ok"}),
+        patch("plugin.scripting.session_manager._msgbox"),
+        patch("plugin.notebook.cell_registry.load_registry", return_value=state) as load,
+        patch("plugin.notebook.cell_registry.save_registry") as save,
+    ):
+        reset_notebook_python_session(ctx)
+    load.assert_called_once_with(doc)
+    assert state.next_execution_count == 1
+    save.assert_called_once_with(doc, state)
+
+
 def test_reset_workbook_python_session_dispatches_to_notebook():
     ctx = MagicMock()
     doc = _writer_doc()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes live notebook ▶ bugs on the small NumPy fixture (`tests/fixtures/introduction-to-numpy-small.ipynb`).

## What was wrong

1. **Blank gap under Output.** `_insert_stdout_paragraph` always inserted a `PARAGRAPH_BREAK` before stdout (and a trailing split). When the bookmark paragraph was already empty, that left 2–3 blank paras. Re-runs accumulated more because `clear_cell_output` used to skip whitespace-only ranges.
2. **Re-click dumped stdout at the document end.** `setString("")` on a range that started at `nb_out_*` deleted the bookmark (`para.getEnd()` is the paragraph break, so `collapseToEnd` is already in the next para). `apply_run_result` then got `cursor is None` and appended at the body end. Finding the Output heading also aborted at earlier `Cell 1: Markdown` chrome, so the bookmark could not be put back.
3. **In counts started at 4.** `init_registry_execution_counter` used `max(saved)+1`. Jupyter starts a **new kernel** at 1; saved ipynb counts are historical. The `notebook:…` venv session is a new kernel on import and after Restart Kernel.
4. **First re-click jumped +3.** Untitled docs have an empty URL, so wiring keyed on `id(doc)`. Import + dialog + bootstrap each used a different PyUNO wrapper → three `XActionListener`s. One click ran the cell three times.

## Fix

- Re-anchor `nb_out_*` **inside** the Output heading (after the word `Output`, not `para.getEnd()` and not `goRight(1)`). Skip earlier markdown chrome until this cell’s `Cell N: Code`. Clear from the heading’s next paragraph. Never `_append_body_text_block`.
- Fill an existing empty para for stdout; collapse leftover blanks (at most one blank line). Do not split the Output heading with `PARAGRAPH_BREAK`.
- New kernel / Restart Kernel: `next_execution_count = 1`. Re-runs still increment by 1. Failed runs consume a count.
- Listener de-dupe via `RuntimeUID`. One ▶ click → one run.

## Tests

- Unit: empty-para insert, missing-bookmark does not dump at end, counter start/reset, failed-run increment, RuntimeUID de-dupe, heading search skips earlier markdown.
- Native UNO via live `XButton`/`XActionListener` `getControl` (not `run_cell()` alone): two runs stay under the bookmark; In [1] then [2]; exactly one listener; Output heading stays `Output`.

Does not regress PRs 459/461 (▶ / code field stay; following markdown chrome stays). Debug-only import; no Tools → Import; no sandbox widen.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51298f4d-021b-47ca-b2d4-49d7e12bb063?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51298f4d-021b-47ca-b2d4-49d7e12bb063&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

