### PR TITLE
Notebook import: one form-level ▶ listener instead of N getControl

### DIFF
--- a/docs/calc-notebook-interactive-dev-plan.md
+++ b/docs/calc-notebook-interactive-dev-plan.md
@@ -89,7 +89,7 @@ This plan is **Writer-first**. Calc notebook import is out of scope unless expli
 
 - **`queryInterface`** must use `uno.getTypeByName("com.sun.star.view.XControlAccess")`, not imported IDL classes (same pattern as [`pivot.py`](../plugin/calc/pivot.py)).
 - **Control lookup** — in-flow `ControlShape` models live on **`doc.getDrawPage()`**, not only as `TextPortionType == "Frame"` in body enumeration ([`form_lookup.py`](../plugin/notebook/form_lookup.py); mirrors [`form_list_controls`](../plugin/writer/specialized/forms.py)).
-- **Wire timing** — attach listeners **after** import + `processEventsToIdle()`, not per-cell during insert; batch `wire_all_notebook_run_buttons` once.
+- **Wire timing** — attach **one** form-controller `XActionListener` after import + `processEventsToIdle()`. Do **not** call `controller.getControl(model)` per ▶ (that realized every view; ~2.4s for 144 buttons). `wire_all_notebook_run_buttons` attaches the shared listener to `getFormController(form).getContainer()` (`getControls()` + `XContainerListener`). PUSH clicks are view `XActionListener` / `XApproveActionBroadcaster`; the form model and `runtime.XFormController` are not action broadcasters (live QI).
 - **Spellcheck** — set document + paragraph styles to **`zxx`** (no linguistic content) at import start ([`rich_text.py`](../plugin/chatbot/rich_text.py) uses the same locale).
 - **In-flow controls vs `setString`** — `XTextRange.setString` on a paragraph that contains `AS_CHARACTER` ControlShapes deletes those shapes. Rewrite Text portions only (`update_in_prompt` / `_gutter_text_cursor`).
 - **`PARAGRAPH_BREAK` cursor** — After `insertControlCharacter(..., PARAGRAPH_BREAK)`, the cursor stays **before** the break ([`html_export.py`](../plugin/writer/html_export.py)). Move with `goRight(1)` / `gotoNextParagraph` before inserting stdout.
@@ -184,7 +184,7 @@ flowchart TB
 **Built:**
 
 - **Run control:** In-flow `CommandButton` (`Label` ▶, `ButtonType` PUSH) before each code `TextField`; names `nb_run_{hex}`
-- [`notebook_controls.py`](../plugin/notebook/notebook_controls.py): `wire_all_notebook_run_buttons`, `get_control_view_for_model`, listener → `run_cell_for_doc_hex`
+- [`notebook_controls.py`](../plugin/notebook/notebook_controls.py): `wire_all_notebook_run_buttons` (one form-level listener), `get_control_view_for_model` (tests / single-button), listener → `run_cell_for_doc_hex`
 - [`notebook_runner.py`](../plugin/notebook/notebook_runner.py): `read_code_from_field` (via `form_lookup`), `execute_code` + `run_blocking_in_thread`, `run_cell`, `apply_run_result`, `update_in_prompt`
 - [`main.py`](../plugin/main.py): `_dispatch_command` for `notebook.run_cell.{hex}`; bootstrap wiring hook
 - Import: spellcheck off (`zxx`); wire after import in `import_ipynb_to_writer` and `import_dialog.py`

--- a/docs/writer-jupyter-notebook-import.md
+++ b/docs/writer-jupyter-notebook-import.md
@@ -151,7 +151,7 @@ The live smoke imports the small NumPy fixture and **runs** the three code cells
 
 The same file also covers HTML `<img>` + markdown links (`test_debug_menu_import_html_img_and_markdown_link`): [`tests/fixtures/html-img-and-md-link.ipynb`](../tests/fixtures/html-img-and-md-link.ipynb) uses `../images/numpy-anatomy-of-an-array-updated.png` plus `[NumPy](https://numpy.org/…)`. Assert a graphic object and a Writer hyperlink, not literal `[text](url)` or raw `##`. Do not import the 184-cell Bourke notebook in the live loop.
 
-Live ▶ click (``getControl`` / ``XButton``, not ``run_cell()`` alone):
+Live ▶ click (form-level ``XActionListener`` on the form controller container, not ``run_cell()`` alone; tests still deliver one ``ActionEvent`` through the live view):
 
 ```bash
 python -m plugin.testing_runner tests/notebook/test_notebook_runner_uno.py
@@ -179,7 +179,7 @@ plugin/
 │   ├── cell_registry.py       # WriterAgentNotebookJson, bookmarks, cell_id UUID
 │   ├── form_lookup.py         # Find form models (draw page + text fallback)
 │   ├── import_dialog.py       # File picker, post-import wire + msgbox
-│   ├── notebook_controls.py   # ▶ PUSH buttons, XActionListener wiring
+│   ├── notebook_controls.py   # ▶ PUSH buttons; one form-level XActionListener (not N getControl)
 │   ├── notebook_runner.py     # run_cell, venv execute, output refresh
 │   └── writer_importer.py     # Import loop, zxx locale, flush_ui_idle
 └── contrib/nbformat/          # Vendored .ipynb reader (v4 read only)

--- a/plugin/framework/uno_listeners.py
+++ b/plugin/framework/uno_listeners.py
@@ -40,6 +40,7 @@ _XDocumentEventListener: Any = None
 _XCloseListener: Any = None
 _XTerminateListener: Any = None
 _XActivationEventListener: Any = None
+_XContainerListener: Any = None
 _HAVE_UNO = False
 
 try:
@@ -56,6 +57,7 @@ try:
     from com.sun.star.util import XCloseListener as _XCloseListener_impl
     from com.sun.star.frame import XTerminateListener as _XTerminateListener_impl
     from com.sun.star.sheet import XActivationEventListener as _XActivationEventListener_impl
+    from com.sun.star.container import XContainerListener as _XContainerListener_impl
 
     _unohelper = _unohelper_impl
     _XEventListener = _XEventListener_impl
@@ -68,6 +70,7 @@ try:
     _XCloseListener = _XCloseListener_impl
     _XTerminateListener = _XTerminateListener_impl
     _XActivationEventListener = _XActivationEventListener_impl
+    _XContainerListener = _XContainerListener_impl
     _HAVE_UNO = True
 except ImportError:
     pass
@@ -85,6 +88,7 @@ if TYPE_CHECKING:
     class _XCloseListenerParent: pass
     class _XTerminateListenerParent: pass
     class _XActivationEventListenerParent: pass
+    class _XContainerListenerParent: pass
 else:
     class _DummyBase: pass
     class _DummyEventListener: pass
@@ -97,6 +101,7 @@ else:
     class _DummyCloseListener: pass
     class _DummyTerminateListener: pass
     class _DummyActivationListener: pass
+    class _DummyContainerListener: pass
 
     _BaseParent = _unohelper.Base if _HAVE_UNO else _DummyBase
     _XEventListenerParent = _XEventListener if _HAVE_UNO else _DummyEventListener
@@ -109,6 +114,7 @@ else:
     _XCloseListenerParent = _XCloseListener if _HAVE_UNO else _DummyCloseListener
     _XTerminateListenerParent = _XTerminateListener if _HAVE_UNO else _DummyTerminateListener
     _XActivationEventListenerParent = _XActivationEventListener if _HAVE_UNO else _DummyActivationListener
+    _XContainerListenerParent = _XContainerListener if _HAVE_UNO else _DummyContainerListener
 
 
 def _catch_and_log(func):
@@ -138,6 +144,29 @@ class BaseListener(_BaseParent, _XEventListenerParent):
         self.on_disposing(Source)
 
     def on_disposing(self, Source: Any) -> None:
+        pass
+
+
+class BaseContainerListener(BaseListener, _XContainerListenerParent):
+    @_catch_and_log
+    def elementInserted(self, Event: Any) -> None:  # noqa: N802, N803 -- UNO signature
+        self.on_element_inserted(Event)
+
+    @_catch_and_log
+    def elementRemoved(self, Event: Any) -> None:  # noqa: N802, N803 -- UNO signature
+        self.on_element_removed(Event)
+
+    @_catch_and_log
+    def elementReplaced(self, Event: Any) -> None:  # noqa: N802, N803 -- UNO signature
+        self.on_element_replaced(Event)
+
+    def on_element_inserted(self, Event: Any) -> None:
+        pass
+
+    def on_element_removed(self, Event: Any) -> None:
+        pass
+
+    def on_element_replaced(self, Event: Any) -> None:
         pass
 
 

--- a/plugin/notebook/import_dialog.py
+++ b/plugin/notebook/import_dialog.py
@@ -101,7 +101,12 @@ def run_import_ipynb_dialog(uno_ctx: Any = None) -> None:
         int((time.monotonic() - import_t0) * 1000),
         stats,
     )
-    flush_ui_idle(ctx)
+    to_msg_t0 = time.monotonic()
+    flush_ui_idle(ctx, log_phase="flush_ui_idle before_completion_msgbox")
+    log.info(
+        "notebook import dialog to_completion_msgbox elapsed_ms=%d",
+        int((time.monotonic() - to_msg_t0) * 1000),
+    )
     log.debug("notebook import showing completion message box")
     msgbox(
         ctx,

--- a/plugin/notebook/notebook_controls.py
+++ b/plugin/notebook/notebook_controls.py
@@ -2,27 +2,45 @@
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Wire notebook ▶ buttons to run handlers (form URL buttons do not reach ProtocolHandler)."""
+"""Wire notebook ▶ buttons to run handlers (form URL buttons do not reach ProtocolHandler).
+
+``controller.getControl(model)`` realizes each control view. On a 144-button import
+that was ~2.4s (and ~10s on some machines). PUSH buttons fire ``XActionListener`` on
+the *view*; the form controller's ``XControlContainer`` already holds realized views
+and notifies ``XContainerListener`` when later views appear (scroll / first paint).
+
+Live check (Writer ``XFormLayerAccess.getFormController``):
+``org.openoffice.comp.svx.FormController`` is *not* ``XApproveActionBroadcaster``
+and the form model is not either. ``addMouseClickHandler`` / container mouse /
+``XScriptListener`` did not see PUSH activation. ``doAccessibleAction`` *did*
+notify ``XApproveActionListener`` / ``XActionListener`` on the button view.
+
+So we attach **one** shared ``XActionListener`` to the form controller container
+(existing ``getControls()`` plus ``elementInserted``), not N ``getControl(model)``.
+"""
 
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 import uno
 
-from plugin.framework.uno_listeners import BaseActionListener
-from plugin.notebook.cell_registry import cell_id_to_hex, has_notebook_registry, load_registry
-from plugin.notebook.form_lookup import index_form_control_models
+from plugin.framework.uno_listeners import BaseActionListener, BaseContainerListener
+from plugin.notebook.cell_registry import has_notebook_registry, load_registry
 
 log = logging.getLogger("writeragent.notebook")
 
 # com.sun.star.form.FormButtonType.PUSH — URL buttons open TargetURL via desktop, not our handler.
 _FORM_BUTTON_PUSH = 0
 
-# Keep listeners alive (UNO holds weak refs). Key: (doc_key, hex_id).
+_RUN_PREFIX = "nb_run_"
+
+# Keep listeners alive (UNO holds weak refs). Form-level: one pair per document.
 _listener_refs: list[Any] = []
 _wired_keys: set[tuple[str, str]] = set()
+_wired_form_docs: set[str] = set()
 
 
 def form_button_push_type() -> int:
@@ -68,9 +86,53 @@ def _doc_key(doc: Any) -> str:
     return f"id:{id(doc)}"
 
 
+def _hex_id_from_control_name(name: str) -> str | None:
+    if not isinstance(name, str) or not name.startswith(_RUN_PREFIX):
+        return None
+    hex_id = name[len(_RUN_PREFIX) :]
+    return hex_id or None
+
+
+def _control_name(obj: Any) -> str:
+    if obj is None:
+        return ""
+    model = obj
+    get_model = getattr(obj, "getModel", None)
+    if callable(get_model):
+        try:
+            maybe = get_model()
+            if maybe is not None:
+                model = maybe
+        except Exception:
+            pass
+    try:
+        return str(getattr(model, "Name", "") or "")
+    except Exception:
+        return ""
+
+
+def _hex_id_from_event(rEvent: Any) -> str | None:
+    cmd = str(getattr(rEvent, "ActionCommand", "") or "")
+    hex_id = _hex_id_from_control_name(cmd)
+    if hex_id:
+        return hex_id
+    return _hex_id_from_control_name(_control_name(getattr(rEvent, "Source", None)))
+
+
 def wired_run_listener_count(hex_id: str) -> int:
-    """How many live ▶ listeners are registered for *hex_id* (any document)."""
-    return sum(1 for lis in _listener_refs if getattr(lis, "_hex_id", None) == hex_id)
+    """How many live ▶ handlers would run *hex_id* (form-level counts as one)."""
+    n = 0
+    for lis in _listener_refs:
+        if getattr(lis, "_form_level", False):
+            n += 1
+        elif getattr(lis, "_hex_id", None) == hex_id:
+            n += 1
+    return n
+
+
+def form_run_listeners() -> list[Any]:
+    """Shared form-level ▶ listeners (tests fire these with a real ActionEvent)."""
+    return [lis for lis in _listener_refs if getattr(lis, "_form_level", False)]
 
 
 def get_control_view_for_model(doc: Any, model: Any) -> Any | None:
@@ -99,19 +161,24 @@ def get_control_view_for_model(doc: Any, model: Any) -> Any | None:
 
 def prune_dead_listeners() -> None:
     """Remove listeners whose target document is closed/gone."""
-    global _listener_refs, _wired_keys
+    global _listener_refs, _wired_keys, _wired_form_docs
     survivors: list[Any] = []
     survivor_keys: set[tuple[str, str]] = set()
+    survivor_forms: set[str] = set()
     for lis in _listener_refs:
         try:
             doc = lis._resolve_doc()
             if doc is not None:
                 survivors.append(lis)
-                survivor_keys.add((lis._doc_key_val, lis._hex_id))
+                if getattr(lis, "_form_level", False):
+                    survivor_forms.add(lis._doc_key_val)
+                else:
+                    survivor_keys.add((lis._doc_key_val, lis._hex_id))
         except Exception:
             pass
     _listener_refs = survivors
     _wired_keys = survivor_keys
+    _wired_form_docs = survivor_forms
 
 
 class NotebookRunButtonListener(BaseActionListener):
@@ -120,6 +187,7 @@ class NotebookRunButtonListener(BaseActionListener):
     def __init__(self, ctx: Any, doc: Any, hex_id: str) -> None:
         self._ctx = ctx
         self._hex_id = hex_id
+        self._form_level = False
         self._doc_key_val = _doc_key(doc)
         try:
             self._doc_url = str(doc.getURL() or "")
@@ -174,8 +242,108 @@ class NotebookRunButtonListener(BaseActionListener):
         run_cell_for_doc_hex(self._ctx, doc, self._hex_id)
 
 
+class NotebookFormRunListener(NotebookRunButtonListener):
+    """One listener for every ``nb_run_*`` PUSH button on a document."""
+
+    def __init__(self, ctx: Any, doc: Any) -> None:
+        super().__init__(ctx, doc, hex_id="")
+        self._form_level = True
+        self._attached_names: set[str] = set()
+
+    def on_action_performed(self, rEvent: Any) -> None:
+        hex_id = _hex_id_from_event(rEvent)
+        if not hex_id:
+            return
+        doc = self._resolve_doc()
+        if doc is None:
+            log.warning("notebook run button: document gone")
+            return
+        from plugin.notebook.notebook_runner import run_cell_for_doc_hex
+
+        run_cell_for_doc_hex(self._ctx, doc, hex_id)
+
+
+class NotebookFormContainerListener(BaseContainerListener):
+    """When the form view realizes another control, attach the shared ▶ listener."""
+
+    def __init__(self, form_listener: NotebookFormRunListener) -> None:
+        self._form_listener = form_listener
+        self._doc_key_val = form_listener._doc_key_val
+        self._form_level = False
+
+    def _resolve_doc(self) -> Any | None:
+        return self._form_listener._resolve_doc()
+
+    def on_element_inserted(self, Event: Any) -> None:
+        elem = getattr(Event, "Element", None)
+        _attach_action_listener(elem, self._form_listener)
+
+
+def _attach_action_listener(control: Any, listener: NotebookFormRunListener) -> bool:
+    if control is None:
+        return False
+    name = _control_name(control)
+    hex_id = _hex_id_from_control_name(name)
+    if not hex_id:
+        return False
+    if name in listener._attached_names:
+        return True
+    try:
+        btn = None
+        try:
+            btn = _query_interface(control, "com.sun.star.awt.XButton")
+        except Exception:
+            btn = None
+        if btn is not None:
+            btn.addActionListener(listener)
+        elif hasattr(control, "addActionListener"):
+            control.addActionListener(listener)
+        else:
+            return False
+        listener._attached_names.add(name)
+        return True
+    except Exception:
+        log.debug("notebook controls: form attach failed for %s", name, exc_info=True)
+        return False
+
+
+def _form_and_container(doc: Any) -> tuple[Any | None, Any | None]:
+    """Return ``(form_controller, view_container)`` or ``(None, None)``."""
+    try:
+        controller = doc.getCurrentController()
+        if controller is None:
+            return None, None
+        forms = None
+        if hasattr(doc, "getDrawPage"):
+            try:
+                forms = doc.getDrawPage().getForms()
+            except Exception:
+                forms = None
+        if forms is None or getattr(forms, "getCount", lambda: 0)() < 1:
+            return None, None
+        form = forms.getByIndex(0)
+        fc = None
+        if hasattr(controller, "getFormController"):
+            fc = controller.getFormController(form)
+        if fc is None:
+            access = _query_interface(controller, "com.sun.star.view.XFormLayerAccess")
+            if access is not None:
+                fc = access.getFormController(form)
+        if fc is None:
+            return None, None
+        container = fc.getContainer() if hasattr(fc, "getContainer") else None
+        return fc, container
+    except Exception:
+        log.debug("notebook controls: form controller lookup failed", exc_info=True)
+        return None, None
+
+
 def wire_run_button_listener(ctx: Any, doc: Any, model: Any, hex_id: str) -> bool:
-    """Attach ``XActionListener`` to a ▶ button model's view. Returns True on success."""
+    """Attach ``XActionListener`` to a ▶ button model's view. Returns True on success.
+
+    Import no longer calls this in a loop (``getControl`` per cell). Kept for unit
+    tests and a single-button fallback.
+    """
     prune_dead_listeners()
     key = (_doc_key(doc), hex_id)
     if key in _wired_keys:
@@ -204,7 +372,10 @@ def wire_run_button_listener(ctx: Any, doc: Any, model: Any, hex_id: str) -> boo
 
 
 def wire_all_notebook_run_buttons(ctx: Any, doc: Any) -> int:
-    """Wire every ``nb_run_*`` control listed in the notebook registry. Returns count wired."""
+    """Attach the shared form-level ▶ listener if missing. Returns 1 when wired.
+
+    Does **not** call ``controller.getControl(model)`` per code cell.
+    """
     if not has_notebook_registry(doc):
         return 0
     state = load_registry(doc)
@@ -212,36 +383,52 @@ def wire_all_notebook_run_buttons(ctx: Any, doc: Any) -> int:
         return 0
     from plugin.notebook.writer_importer import flush_ui_idle
 
+    prune_dead_listeners()
+    doc_key = _doc_key(doc)
     ensure_form_design_mode_off(doc)
-    flush_ui_idle(ctx)
-    models_by_name = index_form_control_models(doc)
-    log.debug("notebook controls: indexed %d form control model(s)", len(models_by_name))
-    wired = 0
-    missing_model = 0
-    no_view = 0
-    for cell in state.code_cells:
-        hex_id = cell_id_to_hex(cell.cell_id)
-        name = f"nb_run_{hex_id}"
-        model = models_by_name.get(name)
-        if model is None:
-            missing_model += 1
-            log.debug("notebook controls: model %r not found in document", name)
-            continue
-        if wire_run_button_listener(ctx, doc, model, hex_id):
-            wired += 1
-        else:
-            no_view += 1
-    code_cells = len(state.code_cells)
-    if wired:
-        log.info("notebook controls: wired %d/%d run button(s)", wired, code_cells)
-    elif code_cells:
+    flush_ui_idle(ctx, log_phase="flush_ui_idle before_form_listener")
+    if doc_key in _wired_form_docs:
+        log.debug("notebook controls: form listener already attached doc=%s", doc_key)
+        return 1
+
+    t0 = time.monotonic()
+    _fc, container = _form_and_container(doc)
+    if container is None:
         log.warning(
-            "notebook controls: wired 0/%d run buttons (missing_model=%d no_view=%d); re-import after deploy",
-            code_cells,
-            missing_model,
-            no_view,
+            "notebook controls: no form controller container; ▶ clicks will not run (%d code cells)",
+            len(state.code_cells),
         )
-    return wired
+        return 0
+
+    listener = NotebookFormRunListener(ctx, doc)
+    attached = 0
+    try:
+        controls = container.getControls() if hasattr(container, "getControls") else ()
+        for control in controls or ():
+            if _attach_action_listener(control, listener):
+                attached += 1
+    except Exception:
+        log.debug("notebook controls: getControls attach failed", exc_info=True)
+
+    container_lis: NotebookFormContainerListener | None = NotebookFormContainerListener(listener)
+    try:
+        container.addContainerListener(container_lis)
+    except Exception:
+        log.debug("notebook controls: addContainerListener failed", exc_info=True)
+        container_lis = None
+
+    _listener_refs.append(listener)
+    if container_lis is not None:
+        _listener_refs.append(container_lis)
+    _wired_form_docs.add(doc_key)
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+    log.info(
+        "notebook import attach_form_listener elapsed_ms=%d attached_views=%d code_cells=%d",
+        elapsed_ms,
+        attached,
+        len(state.code_cells),
+    )
+    return 1
 
 
 def install_notebook_run_button_wiring(ctx: Any) -> None:

--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -603,15 +603,19 @@ def _log_shape_add(
         )
 
 
-def flush_ui_idle(ctx: Any | None) -> None:
+def flush_ui_idle(ctx: Any | None, *, log_phase: str | None = None) -> None:
     if ctx is None:
         return
+    t0 = time.monotonic()
     try:
         from plugin.framework.uno_context import process_events_to_idle
 
         process_events_to_idle(ctx)
     except Exception:
         log.debug("processEventsToIdle failed", exc_info=True)
+        return
+    if log_phase:
+        log.info("notebook import %s elapsed_ms=%d", log_phase, _mono_ms(t0))
 
 
 def _resolve_para_style(doc: Any, style_name: str | None) -> str | None:
@@ -1455,6 +1459,7 @@ def import_ipynb_to_writer(doc: Any, path: str, ctx: Any | None = None) -> dict[
     notebook_in = _ensure_notebook_import_styles(doc)
     # Re-import replaces the whole registry (merge UX is Phase 3).
     registry_state = NotebookDocState(source_path=path)
+    cells_t0 = time.monotonic()
     _import_cells(
         doc,
         nb,
@@ -1466,19 +1471,26 @@ def import_ipynb_to_writer(doc: Any, path: str, ctx: Any | None = None) -> dict[
         registry_state=registry_state,
         notebook_dir=os.path.dirname(os.path.abspath(path)) if path else None,
     )
+    log.info("notebook import cells_done elapsed_ms=%d cells=%d", _mono_ms(cells_t0), stats["cells"])
     if registry_state.code_cells:
         from plugin.notebook.notebook_controls import ensure_form_design_mode_off, wire_all_notebook_run_buttons
         from plugin.notebook.notebook_runner import init_registry_execution_counter
 
+        reg_t0 = time.monotonic()
         init_registry_execution_counter(registry_state)
         save_registry(doc, registry_state)
         save_notebook_source_path(doc, path)
         ensure_form_design_mode_off(doc)
-        flush_ui_idle(ctx)
+        log.info(
+            "notebook import registry_and_design_mode elapsed_ms=%d code_cells=%d",
+            _mono_ms(reg_t0),
+            len(registry_state.code_cells),
+        )
+        flush_ui_idle(ctx, log_phase="flush_ui_idle after_registry")
         if ctx is not None:
             wire_all_notebook_run_buttons(ctx, doc)
     else:
-        flush_ui_idle(ctx)
+        flush_ui_idle(ctx, log_phase="flush_ui_idle after_cells")
 
     stats["controls"] = stats["shapes"]
     total_ms = _mono_ms(run_t0)

--- a/tests/notebook/test_notebook_controls.py
+++ b/tests/notebook/test_notebook_controls.py
@@ -6,8 +6,10 @@ from unittest.mock import MagicMock, patch
 
 import plugin.notebook.notebook_controls as notebook_controls
 from plugin.notebook.notebook_controls import (
+    NotebookFormRunListener,
     NotebookRunButtonListener,
     get_control_view_for_model,
+    wire_all_notebook_run_buttons,
     wire_run_button_listener,
 )
 from plugin.tests.testing_utils import setup_uno_mocks
@@ -18,6 +20,7 @@ setup_uno_mocks()
 def setup_function() -> None:
     notebook_controls._listener_refs = []
     notebook_controls._wired_keys = set()
+    notebook_controls._wired_form_docs = set()
 
 
 def test_get_control_view_uses_gettypebyname_for_xcontrolaccess():
@@ -109,3 +112,91 @@ def test_notebook_run_button_listener_untitled_resolves_by_runtime_uid():
         listener.on_action_performed(MagicMock())
     resolve.assert_called_with(ctx, "uid-hidden-nb")
     run.assert_called_once_with(ctx, found, "cafebabecafebabecafebabecafebabe")
+
+
+def test_form_run_listener_dispatches_nb_run_name():
+    ctx = MagicMock()
+    doc = MagicMock()
+    doc.getURL.return_value = ""
+    listener = NotebookFormRunListener(ctx, doc)
+    model = MagicMock()
+    model.Name = "nb_run_deadbeefdeadbeefdeadbeefdeadbeef"
+    control = MagicMock()
+    control.getModel.return_value = model
+    ev = MagicMock()
+    ev.Source = control
+    ev.ActionCommand = ""
+    with patch("plugin.notebook.notebook_runner.run_cell_for_doc_hex") as run:
+        listener.on_action_performed(ev)
+    run.assert_called_once_with(ctx, doc, "deadbeefdeadbeefdeadbeefdeadbeef")
+
+
+def test_form_run_listener_ignores_non_run_controls():
+    ctx = MagicMock()
+    doc = MagicMock()
+    doc.getURL.return_value = ""
+    listener = NotebookFormRunListener(ctx, doc)
+    model = MagicMock()
+    model.Name = "nb_cell_0_code"
+    control = MagicMock()
+    control.getModel.return_value = model
+    ev = MagicMock()
+    ev.Source = control
+    ev.ActionCommand = ""
+    with patch("plugin.notebook.notebook_runner.run_cell_for_doc_hex") as run:
+        listener.on_action_performed(ev)
+    run.assert_not_called()
+
+
+def test_wire_all_attaches_one_form_listener_without_getcontrol():
+    """Import wiring must not call getControl once per ▶ button."""
+    ctx = MagicMock()
+    doc = MagicMock()
+    doc.getURL.return_value = ""
+    doc.getRuntimeUID.return_value = "uid-form-1"
+
+    run_ctrl = MagicMock()
+    run_model = MagicMock()
+    run_model.Name = "nb_run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    run_ctrl.getModel.return_value = run_model
+    run_ctrl.queryInterface.return_value = run_ctrl
+
+    code_ctrl = MagicMock()
+    code_model = MagicMock()
+    code_model.Name = "nb_cell_0_code"
+    code_ctrl.getModel.return_value = code_model
+    code_ctrl.queryInterface.return_value = None
+    code_ctrl.addActionListener.side_effect = RuntimeError("not a button")
+
+    container = MagicMock()
+    container.getControls.return_value = (code_ctrl, run_ctrl)
+    fc = MagicMock()
+    fc.getContainer.return_value = container
+    controller = MagicMock()
+    controller.getFormController.return_value = fc
+    doc.getCurrentController.return_value = controller
+    forms = MagicMock()
+    forms.getCount.return_value = 1
+    forms.getByIndex.return_value = MagicMock()
+    doc.getDrawPage.return_value.getForms.return_value = forms
+
+    cell = MagicMock()
+    cell.cell_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    state = MagicMock()
+    state.code_cells = [cell, cell]
+
+    with (
+        patch("plugin.notebook.notebook_controls.has_notebook_registry", return_value=True),
+        patch("plugin.notebook.notebook_controls.load_registry", return_value=state),
+        patch("plugin.notebook.notebook_controls.get_control_view_for_model") as get_view,
+        patch("plugin.notebook.writer_importer.flush_ui_idle"),
+    ):
+        first = wire_all_notebook_run_buttons(ctx, doc)
+        second = wire_all_notebook_run_buttons(ctx, doc)
+    assert first == 1
+    assert second == 1
+    get_view.assert_not_called()
+    run_ctrl.addActionListener.assert_called_once()
+    container.addContainerListener.assert_called_once()
+    form_lis = [lis for lis in notebook_controls._listener_refs if getattr(lis, "_form_level", False)]
+    assert len(form_lis) == 1

--- a/tests/notebook/test_notebook_runner_uno.py
+++ b/tests/notebook/test_notebook_runner_uno.py
@@ -165,9 +165,11 @@ def _fire_run_button_via_get_control(_ctx, doc, hex_id: str) -> str:
 
     from plugin.notebook.form_lookup import find_form_control_model_by_name
     from plugin.notebook.notebook_controls import (
-        _listener_refs,
+        _doc_key,
         _query_interface,
+        form_run_listeners,
         get_control_view_for_model,
+        prune_dead_listeners,
         wired_run_listener_count,
     )
 
@@ -184,14 +186,69 @@ def _fire_run_button_via_get_control(_ctx, doc, hex_id: str) -> str:
     evt = uno.createUnoStruct("com.sun.star.awt.ActionEvent")
     evt.Source = control
     evt.ActionCommand = str(getattr(model, "Name", "") or "")
+    prune_dead_listeners()
+    key = _doc_key(doc)
     n = wired_run_listener_count(hex_id)
-    assert n == 1, f"expected 1 XActionListener for ▶, got {n} (triplicate wiring?)"
-    matched = [lis for lis in _listener_refs if getattr(lis, "_hex_id", None) == hex_id]
-    assert len(matched) == 1, f"listener list mismatch: {len(matched)}"
-    # Fire every matched listener — a real click would. With n==1 this is one run.
+    matched = [lis for lis in form_run_listeners() if getattr(lis, "_doc_key_val", None) == key]
+    assert len(matched) == 1, f"form listener list mismatch: {len(matched)} (count={n})"
+    # Fire the shared listener — a real click delivers one ActionEvent with Source=button.
     for lis in matched:
         lis.actionPerformed(evt)
     return "action-listener"
+
+
+@native_test
+@with_native_doc("writer", hidden=not show_window)
+def test_import_wires_form_listener_without_getcontrol_loop(ctx, doc):
+    """Import must attach one form-level listener, not N controller.getControl(model)."""
+    from plugin.notebook.cell_registry import cell_id_to_hex, load_registry
+    from plugin.notebook.notebook_controls import form_run_listeners, wired_run_listener_count
+    from plugin.notebook.writer_importer import import_ipynb_to_writer, flush_ui_idle
+
+    ipynb = _tiny_ipynb_path()
+    try:
+        with patch("plugin.notebook.notebook_controls.get_control_view_for_model") as get_view:
+            get_view.side_effect = AssertionError("import must not call getControl per ▶")
+            import_ipynb_to_writer(doc, str(ipynb), ctx=ctx)
+        flush_ui_idle(ctx)
+        state = load_registry(doc)
+        assert state is not None and len(state.code_cells) == 1
+        hex_id = cell_id_to_hex(state.code_cells[0].cell_id)
+        assert len(form_run_listeners()) == 1
+        assert wired_run_listener_count(hex_id) == 1
+
+        fake_result = {"status": "ok", "stdout": f"{_SENTINEL}\n", "result": None}
+        runs: list[str] = []
+
+        def _exec(*_a, **_k):
+            runs.append("run")
+            return fake_result
+
+        with (
+            patch("plugin.notebook.notebook_runner.msgbox", lambda *_a, **_k: None),
+            patch("plugin.notebook.notebook_runner.execute_code", side_effect=_exec),
+        ):
+            _fire_run_button_via_get_control(ctx, doc, hex_id)
+        assert len(runs) == 1, f"first ▶ must run once, got {len(runs)}"
+        # Re-import / bootstrap must not stack listeners (untitled RuntimeUID de-dupe).
+        from plugin.notebook.notebook_controls import wire_all_notebook_run_buttons
+
+        wire_all_notebook_run_buttons(ctx, doc)
+        wire_all_notebook_run_buttons(ctx, doc)
+        assert len(form_run_listeners()) == 1
+        assert wired_run_listener_count(hex_id) == 1
+        runs.clear()
+        with (
+            patch("plugin.notebook.notebook_runner.msgbox", lambda *_a, **_k: None),
+            patch("plugin.notebook.notebook_runner.execute_code", side_effect=_exec),
+        ):
+            _fire_run_button_via_get_control(ctx, doc, hex_id)
+        assert len(runs) == 1, f"re-wire must not triple-fire, got {len(runs)}"
+    finally:
+        try:
+            ipynb.unlink()
+        except OSError:
+            pass
 
 
 @native_test
@@ -219,7 +276,7 @@ def test_run_button_getcontrol_keeps_controls_and_splits_output(ctx, doc):
 
         ensure_form_design_mode_off(doc)
         wired = wire_all_notebook_run_buttons(ctx, doc)
-        assert wired == 1, f"expected wired 1/1 run button, got {wired}"
+        assert wired == 1, f"expected one form-level listener, got {wired}"
 
         boxes: list = []
 
@@ -286,7 +343,7 @@ def test_run_first_of_consecutive_code_cells_keeps_next_controls(ctx, doc):
         _assert_controls_present(doc, second)
 
         ensure_form_design_mode_off(doc)
-        assert wire_all_notebook_run_buttons(ctx, doc) == 2
+        assert wire_all_notebook_run_buttons(ctx, doc) == 1
 
         fake = {"status": "ok", "stdout": "first\nstill first\n", "result": None}
         with (

--- a/tests/notebook/test_writer_importer_uno.py
+++ b/tests/notebook/test_writer_importer_uno.py
@@ -491,7 +491,7 @@ def _debug_menu_import_and_run(ctx, doc) -> None:
 
     ensure_form_design_mode_off(doc)
     wired = wire_all_notebook_run_buttons(ctx, doc)
-    assert wired == 3, f"expected wired 3/3 run buttons, got {wired}"
+    assert wired == 1, f"expected one form-level ▶ listener, got {wired}"
 
     # Shared notebook: kernel — run the three code cells in document order.
     results = []


### PR DESCRIPTION
Import no longer calls `controller.getControl(model)` for every notebook play button. That loop was ~2.4s for 144 buttons on a live 184-cell import (and can be ~10s).

## What changed
Live Writer QI (`XFormLayerAccess.getFormController`): `org.openoffice.comp.svx.FormController` is **not** `XApproveActionBroadcaster`, and the form model is not either. `addMouseClickHandler` / container mouse / `XScriptListener` did not see PUSH activation. `doAccessibleAction` **did** notify `XActionListener` / `XApproveActionListener` on the button view.

`wire_all_notebook_run_buttons` now attaches **one** shared `XActionListener` to the form controller container (`getControls()` for already-realized views + `XContainerListener` for later paint/scroll). On click, it reads `nb_run_*` from the event source and calls `run_cell_for_doc_hex`. RuntimeUID de-dupe is unchanged (one click must not run a cell three times). `ensure_form_design_mode_off` stays. Form URL/ProtocolHandler buttons are not used.

No skip of `processEventsToIdle`, no early completion dialog, no wire-on-first-click that drops the first click.

## Timing logs (`writeragent.notebook` INFO)
`elapsed_ms` via `time.monotonic()`:
- `notebook import cells_done`
- `notebook import registry_and_design_mode`
- `notebook import flush_ui_idle …`
- `notebook import attach_form_listener`
- existing `notebook import complete … total_ms=`
- `notebook import dialog to_completion_msgbox`

## Tests
- Unit: form listener dispatches `nb_run_*`; `wire_all` does not call `getControl` N times; RuntimeUID de-dupe.
- Live UNO (debug menu / `testing_runner`, small notebook only): import wires one form listener, first ▶ runs once, re-wire does not triple-fire. Does not import the 184-cell fixture.