### PR TITLE
Note unique-origin locate cannot skip queryContentCells

### DIFF
--- a/plugin/calc/python/formula_locator_cache.py
+++ b/plugin/calc/python/formula_locator_cache.py
@@ -350,6 +350,14 @@ def locate_formula_cell_in_doc(
 
     active_cache = cache if cache is not None else FORMULA_LOCATION_CACHE
     doc_url = document_cache_key(doc)
+    # Uniqueness is a negative ("no second origin"). FormulaLocationCache is an
+    # opportunistic MRU, not a complete index, so a cached coord still matching
+    # does not prove there is no duplicate. Do not skip queryContentCells on a
+    # cache hit (that was the first-match bug: spill/image/scalar wrote the wrong
+    # cell). Follow-up: a live complete index (sheet modify listener tracking
+    # every =PY() origin as unique vs ambiguous) could skip the walk when the
+    # formula set is known unchanged. Until then every unique-origin lookup must
+    # scan formula cells.
     collected: list[tuple[Any, Any, tuple[int, int]]] = []
     seen: set[tuple[str, int, int]] = set()
 


### PR DESCRIPTION
Summary

    Comment on locate_formula_cell_in_doc: uniqueness is a negative (no second origin), so FormulaLocationCache must not skip queryContentCells on a hit. That skip was the first-match bug.
    Follow-up called out in-code: a live complete index (sheet modify listener tracking every =PY() origin as unique vs ambiguous) could skip the walk when the formula set is known unchanged. Do not restore the cache fast-path until that exists.

Test plan

    Comment only. Existing test_locate_duplicate_py_formulas_is_ambiguous still covers the unique-origin contract.
