### PR TITLE
Register .ipynb as a Writer import filter

### DIFF
--- a/docs/writer-jupyter-notebook-import.md
+++ b/docs/writer-jupyter-notebook-import.md
@@ -47,17 +47,17 @@ WriterAgent can **read** Jupyter notebooks (nbformat v4) and **import** them int
 | **Control lookup** — [`form_lookup.py`](../plugin/notebook/form_lookup.py) indexes `ControlShape` models on the document draw page (required for wiring ▶ buttons) | Batched background image decode |
 | **Reset Python Session** — clears `notebook:…` kernel for Writer docs with a registry ([`session_manager.py`](../plugin/scripting/session_manager.py)) | `notebook.enable_interactive` / Settings UI keys |
 | **Output images** — `image/png`, `image/jpeg` in `display_data` / `execute_result` | JSON schema validation (`fastjsonschema`), `traitlets`, `jupyter_core` |
-| **Tests** — [`tests/contrib/test_nbformat_read.py`](../tests/contrib/test_nbformat_read.py), [`tests/notebook/`](../tests/notebook/) (pytest) plus live Writer smoke [`tests/notebook/test_writer_importer_uno.py`](../tests/notebook/test_writer_importer_uno.py) and [`tests/notebook/test_notebook_runner_uno.py`](../tests/notebook/test_notebook_runner_uno.py) | Pixel-click FilePicker (optional manual) |
+| **Tests** — [`tests/contrib/test_nbformat_read.py`](../tests/contrib/test_nbformat_read.py), [`tests/notebook/`](../tests/notebook/) (pytest) including [`tests/notebook/test_import_filter.py`](../tests/notebook/test_import_filter.py), plus live Writer smoke [`tests/notebook/test_writer_importer_uno.py`](../tests/notebook/test_writer_importer_uno.py), [`tests/notebook/test_notebook_runner_uno.py`](../tests/notebook/test_notebook_runner_uno.py), and [`tests/notebook/test_import_filter_uno.py`](../tests/notebook/test_import_filter_uno.py) | Pixel-click FilePicker (optional manual) |
 
 ---
 
 ## How to Use
 
-1. Open a **Writer** document (empty or existing — import appends at the end).
-2. Click **WriterAgent → Import Jupyter Notebook…** (below Text Analytics...).
-3. Pick a `.ipynb` file.
-4. Wait for the completion dialog (summarizing cells, code fields, images). Cell insertion runs on the main thread using `lockControllers` to prevent layout thrashing.
-5. Click **▶** beside any code cell to execute it.
+**File Open (no UI)** — the primary path. **File → Open…**, desktop double-click, Open Recent, or `soffice notebook.ipynb` creates a new Writer document and imports the notebook with no FilePicker and no completion dialog.
+
+**Menu (append into an open document)** — **WriterAgent → Import Jupyter Notebook…** (below Text Analytics...) still appends into the already-open Writer document. Pick a `.ipynb`; a completion dialog summarizes cells, code fields, and images. Insertion runs on the main thread using `lockControllers` to prevent layout thrashing.
+
+Click **▶** beside any code cell to execute it.
 
 ---
 
@@ -198,19 +198,24 @@ Native test suite execution:
 
 ## Native File Import Filter Registration (`.ipynb` via UNO)
 
-Rather than manually opening an empty Writer document and clicking **WriterAgent → Import Jupyter Notebook…**, `.ipynb` can be registered as a native LibreOffice file import filter. This enables opening `.ipynb` files directly via **File → Open...**, desktop double-click, recent document lists, or CLI (`soffice notebook.ipynb`).
+Rather than manually opening an empty Writer document and clicking **WriterAgent → Import Jupyter Notebook…**, `.ipynb` is registered as a native LibreOffice file import filter. 
+
+**How to Use:**
+- **No-UI Path**: Open `.ipynb` files directly via **File → Open...**, desktop double-click, Open Recent, or CLI (`soffice notebook.ipynb`). This creates a new Writer document and imports the notebook contents directly without showing a FilePicker or a completion message box. 
+- Open Recent works seamlessly because LibreOffice records the `.ipynb` URL and detects the file type by extension upon reopening, allowing re-importing directly from the source. (Note: Saving modifications as `.odt` will create a separate recent item).
+- **Append Path**: The **WriterAgent → Import Jupyter Notebook…** menu entry remains available to *append* a notebook into an already-open Writer document with the completion UI.
 
 ### 1. PyUNO Import Filter Component (`plugin/notebook/import_filter.py`)
 
-A lightweight UNO component implementing `XImporter` and `XImportFilter`:
+A lightweight UNO component implementing `XImporter` and `XFilter`:
 
 ```python
 import uno
 import unohelper
-from com.sun.star.document import XImporter, XImportFilter
+from com.sun.star.document import XImporter, XFilter
 from com.sun.star.lang import XServiceInfo
 
-class JupyterNotebookImportFilter(unohelper.Base, XImporter, XImportFilter, XServiceInfo):
+class JupyterNotebookImportFilter(unohelper.Base, XImporter, XFilter, XServiceInfo):
     def __init__(self, ctx):
         self.ctx = ctx
         self.target_doc = None
@@ -219,7 +224,7 @@ class JupyterNotebookImportFilter(unohelper.Base, XImporter, XImportFilter, XSer
     def setTargetDocument(self, doc):
         self.target_doc = doc
 
-    # XImportFilter: Triggered on File -> Open / double-click
+    # XFilter: Triggered on File -> Open / double-click
     def filter(self, media_descriptor):
         file_url = ""
         for prop in media_descriptor:
@@ -230,9 +235,9 @@ class JupyterNotebookImportFilter(unohelper.Base, XImporter, XImportFilter, XSer
         if not file_url or not self.target_doc:
             return False
             
-        file_path = uno.fileUrlToAbsolutePath(file_url)
-        from plugin.notebook.writer_importer import import_notebook_to_writer
-        import_notebook_to_writer(self.target_doc, file_path)
+        file_path = uno.fileUrlToSystemPath(file_url)
+        from plugin.notebook.writer_importer import import_ipynb_to_writer
+        import_ipynb_to_writer(self.target_doc, file_path, ctx=self.ctx)
         return True
 
     # XServiceInfo
@@ -255,8 +260,8 @@ g_ImplementationHelper.addImplementation(
 ### 2. Registry Configurations (`.xcu`)
 
 - **`TypeDetection/Types.xcu`**: Registers file extension `ipynb` and MIME type `application/x-ipynb+json`.
-- **`TypeDetection/Filters.xcu`**: Maps `ipynb_Jupyter_Notebook` to `com.sun.star.text.TextDocument` and FilterService `org.extension.writeragent.JupyterNotebookImportFilter` with flags `IMPORT ALIEN 3RDPARTY`.
-- **`META-INF/manifest.xml`**: Registers `plugin/notebook/import_filter.py` as an active Python UNO component entry.
+- **`TypeDetection/Filters.xcu`**: Maps `writer_WriterAgent_Jupyter_Notebook` to `com.sun.star.text.TextDocument` and FilterService `org.extension.writeragent.JupyterNotebookImportFilter` with flags `IMPORT ALIEN 3RDPARTYFILTER`.
+- **`META-INF/manifest.xml`**: Registers `plugin/notebook/import_filter.py` and the two `.xcu` files as active extension entries. (Note: Updated statically in `scripts/manifest_registry.py` and regenerated via `python3 scripts/generate_manifest.py`).
 
 ---
 
@@ -267,6 +272,7 @@ g_ImplementationHelper.addImplementation(
 | `cell_registry.py` | [`plugin/notebook/cell_registry.py`](../plugin/notebook/cell_registry.py) | Document registry serialization, cell UUIDs, bookmarks |
 | `import_dialog.py` | [`plugin/notebook/import_dialog.py`](../plugin/notebook/import_dialog.py) | File picker, import dialog, post-import status |
 | `writer_importer.py` | [`plugin/notebook/writer_importer.py`](../plugin/notebook/writer_importer.py) | Core import loop, nbformat processing, Writer DOM insertion |
+| `import_filter.py` | [`plugin/notebook/import_filter.py`](../plugin/notebook/import_filter.py) | Native File Open XFilter+XImporter (no FilePicker / no completion msgbox) |
 | `notebook_controls.py` | [`plugin/notebook/notebook_controls.py`](../plugin/notebook/notebook_controls.py) | ▶ button wiring and PyUNO form listener management |
 | `notebook_runner.py` | [`plugin/notebook/notebook_runner.py`](../plugin/notebook/notebook_runner.py) | Field reading, execution, output replacement |
 | `form_lookup.py` | [`plugin/notebook/form_lookup.py`](../plugin/notebook/form_lookup.py) | Draw page indexer for form controls |

--- a/extension/registry/org/openoffice/TypeDetection/Filters.xcu
+++ b/extension/registry/org/openoffice/TypeDetection/Filters.xcu
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:package="org.openoffice.TypeDetection" oor:name="Filters">
+  <node oor:name="Filters">
+    <node oor:name="writer_WriterAgent_Jupyter_Notebook" oor:op="replace">
+      <prop oor:name="UIName" oor:type="xs:string">
+        <value>Jupyter Notebook</value>
+      </prop>
+      <prop oor:name="Type" oor:type="xs:string">
+        <value>writer_WriterAgent_Jupyter_Notebook</value>
+      </prop>
+      <prop oor:name="DocumentService" oor:type="xs:string">
+        <value>com.sun.star.text.TextDocument</value>
+      </prop>
+      <prop oor:name="FilterService" oor:type="xs:string">
+        <value>org.extension.writeragent.JupyterNotebookImportFilter</value>
+      </prop>
+      <prop oor:name="Flags" oor:type="xs:string">
+        <value>IMPORT ALIEN 3RDPARTYFILTER</value>
+      </prop>
+      <prop oor:name="FileFormatVersion" oor:type="xs:int">
+        <value>0</value>
+      </prop>
+    </node>
+  </node>
+</oor:component-data>

--- a/extension/registry/org/openoffice/TypeDetection/Types.xcu
+++ b/extension/registry/org/openoffice/TypeDetection/Types.xcu
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:package="org.openoffice.TypeDetection" oor:name="Types">
+  <node oor:name="Types">
+    <node oor:name="writer_WriterAgent_Jupyter_Notebook" oor:op="replace">
+      <prop oor:name="UIName" oor:type="xs:string">
+        <value>Jupyter Notebook</value>
+      </prop>
+      <prop oor:name="Extensions" oor:type="xs:string">
+        <value>ipynb</value>
+      </prop>
+      <prop oor:name="MediaType" oor:type="xs:string">
+        <value>application/x-ipynb+json</value>
+      </prop>
+      <prop oor:name="Preferred" oor:type="xs:boolean">
+        <value>true</value>
+      </prop>
+      <prop oor:name="PreferredFilter" oor:type="xs:string">
+        <value>writer_WriterAgent_Jupyter_Notebook</value>
+      </prop>
+    </node>
+  </node>
+</oor:component-data>

--- a/plugin/notebook/import_filter.py
+++ b/plugin/notebook/import_filter.py
@@ -1,0 +1,94 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Native file import filter for Jupyter Notebooks (.ipynb) in Writer."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+# --- Minimal stdlib-only bootstrap ---
+_this = os.path.abspath(__file__)
+for __ in range(3):  # plugin/notebook/import_filter.py → plugin/notebook/ → plugin/ → extension root
+    _this = os.path.dirname(_this)
+if _this not in sys.path:
+    sys.path.insert(0, _this)
+
+from plugin.framework.uno_bootstrap import ensure_plugin_on_path
+
+ensure_plugin_on_path(
+    __file__,
+    levels_up=3,
+    also_add_plugin_dir=True,
+    also_add_lib=True,
+    also_add_vendor=True,
+)
+
+import uno  # noqa: E402
+import unohelper  # noqa: E402
+from com.sun.star.document import XFilter, XImporter  # noqa: E402
+from com.sun.star.lang import XServiceInfo  # noqa: E402
+
+from plugin.contrib.nbformat import NBFormatError  # noqa: E402
+from plugin.notebook.writer_importer import import_ipynb_to_writer  # noqa: E402
+
+log = logging.getLogger("writeragent.notebook")
+
+IMPL_NAME = "org.extension.writeragent.JupyterNotebookImportFilter"
+
+
+class JupyterNotebookImportFilter(unohelper.Base, XFilter, XImporter, XServiceInfo):
+    def __init__(self, ctx: Any) -> None:
+        self.ctx = ctx
+        self.target_doc = None
+
+    # XImporter
+    def setTargetDocument(self, doc: Any) -> None:
+        self.target_doc = doc
+
+    # XFilter
+    def filter(self, media_descriptor: Any) -> bool:
+        file_url = ""
+        for prop in media_descriptor:
+            if prop.Name == "URL":
+                file_url = prop.Value
+                break
+
+        if not file_url or not self.target_doc:
+            return False
+
+        try:
+            file_path = uno.fileUrlToSystemPath(file_url)
+            import_ipynb_to_writer(self.target_doc, file_path, ctx=self.ctx)
+            return True
+        except NBFormatError:
+            log.exception("Notebook format error")
+            return False
+        except Exception:
+            log.exception("Failed to import notebook")
+            return False
+
+    def cancel(self) -> None:
+        pass
+
+    # XServiceInfo
+    def getImplementationName(self) -> str:
+        return IMPL_NAME
+
+    def supportsService(self, service_name: str) -> bool:
+        return service_name in self.getSupportedServiceNames()
+
+    def getSupportedServiceNames(self) -> tuple[str]:
+        return ("com.sun.star.document.ImportFilter",)
+
+
+g_ImplementationHelper = unohelper.ImplementationHelper()
+g_ImplementationHelper.addImplementation(
+    JupyterNotebookImportFilter,
+    IMPL_NAME,
+    ("com.sun.star.document.ImportFilter",),
+)

--- a/scripts/manifest_registry.py
+++ b/scripts/manifest_registry.py
@@ -580,10 +580,13 @@ def generate_manifest_xml(modules, output_path):
         ('application/vnd.sun.star.uno-component;type=Python', 'plugin/chatbot/panel_factory.py'),
         ('application/vnd.sun.star.uno-component;type=Python', 'plugin/librepy/panel_factory.py'),
         ('application/vnd.sun.star.uno-component;type=Python', 'plugin/writer/locale/ai_grammar_proofreader.py'),
+        ('application/vnd.sun.star.uno-component;type=Python', 'plugin/notebook/import_filter.py'),
         (
             'application/vnd.sun.star.configuration-data',
             'registry/org/openoffice/Office/LinguisticWriterAgentGrammar.xcu',
         ),
+        ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/TypeDetection/Types.xcu'),
+        ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/TypeDetection/Filters.xcu'),
         ('application/vnd.sun.star.configuration-data', 'Addons.xcu'),
         ('application/vnd.sun.star.configuration-data', 'Accelerators.xcu'),
         ('application/vnd.sun.star.configuration-data', 'ProtocolHandler.xcu'),

--- a/tests/notebook/test_import_filter.py
+++ b/tests/notebook/test_import_filter.py
@@ -1,0 +1,220 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for the Jupyter Notebook native import filter component."""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+from typing import Any
+from unittest.mock import Mock, patch
+
+
+# We mock these before importing JupyterNotebookImportFilter so it works without real UNO.
+import sys
+import types
+if "com.sun.star.document" not in sys.modules:
+    class MockUnoBase:
+        pass
+    class MockXFilter:
+        pass
+    class MockXImporter:
+        pass
+    class MockXServiceInfo:
+        pass
+    class MockXServiceDisplayName:
+        pass
+    class MockXServiceName:
+        pass
+
+    mock_uno = types.ModuleType("uno")
+    mock_uno.fileUrlToSystemPath = lambda x: x
+    class MockImplementationHelper:
+        def addImplementation(self, *args, **kwargs):
+            pass
+
+    mock_unohelper = types.ModuleType("unohelper")
+    mock_unohelper.Base = MockUnoBase
+    mock_unohelper.ImplementationHelper = MockImplementationHelper
+    
+    mock_com = types.ModuleType("com")
+    mock_com.sun = types.ModuleType("com.sun")
+    mock_com.sun.star = types.ModuleType("com.sun.star")
+    mock_com.sun.star.document = types.ModuleType("com.sun.star.document")
+    mock_com.sun.star.document.XFilter = MockXFilter
+    mock_com.sun.star.document.XImporter = MockXImporter
+    mock_com.sun.star.lang = types.ModuleType("com.sun.star.lang")
+    mock_com.sun.star.lang.XServiceInfo = MockXServiceInfo
+    mock_com.sun.star.lang.XServiceDisplayName = MockXServiceDisplayName
+    mock_com.sun.star.lang.XServiceName = MockXServiceName
+
+    sys.modules["uno"] = mock_uno
+    sys.modules["unohelper"] = mock_unohelper
+    sys.modules["com.sun.star.document"] = mock_com.sun.star.document
+    sys.modules["com.sun.star.lang"] = mock_com.sun.star.lang
+
+from plugin.notebook.import_filter import JupyterNotebookImportFilter
+
+
+class MockPropertyValue:
+    def __init__(self, name: str, value: Any):
+        self.Name = name
+        self.Value = value
+
+
+def test_import_filter_success():
+    ctx = Mock()
+    target_doc = Mock()
+    filter_comp = JupyterNotebookImportFilter(ctx)
+    filter_comp.setTargetDocument(target_doc)
+
+    media_descriptor = (MockPropertyValue("URL", "file:///fake/path/notebook.ipynb"),)
+
+    with patch("plugin.notebook.import_filter.import_ipynb_to_writer") as mock_import, \
+         patch("uno.fileUrlToSystemPath", return_value="/fake/path/notebook.ipynb"):
+        mock_import.return_value = {"cells": 1}
+        
+        result = filter_comp.filter(media_descriptor)
+        
+        assert result is True
+        mock_import.assert_called_once_with(target_doc, "/fake/path/notebook.ipynb", ctx=ctx)
+
+
+def test_import_filter_missing_url():
+    ctx = Mock()
+    target_doc = Mock()
+    filter_comp = JupyterNotebookImportFilter(ctx)
+    filter_comp.setTargetDocument(target_doc)
+
+    media_descriptor = (MockPropertyValue("ReadOnly", True),)
+
+    result = filter_comp.filter(media_descriptor)
+    assert result is False
+
+
+def test_import_filter_missing_target_doc():
+    ctx = Mock()
+    filter_comp = JupyterNotebookImportFilter(ctx)
+
+    media_descriptor = (MockPropertyValue("URL", "file:///fake/path/notebook.ipynb"),)
+
+    result = filter_comp.filter(media_descriptor)
+    assert result is False
+
+
+def test_import_filter_exception():
+    ctx = Mock()
+    target_doc = Mock()
+    filter_comp = JupyterNotebookImportFilter(ctx)
+    filter_comp.setTargetDocument(target_doc)
+
+    media_descriptor = (MockPropertyValue("URL", "file:///fake/path/notebook.ipynb"),)
+
+    with patch("plugin.notebook.import_filter.import_ipynb_to_writer") as mock_import, \
+         patch("uno.fileUrlToSystemPath", return_value="/fake/path/notebook.ipynb"):
+        mock_import.side_effect = Exception("Test Exception")
+        
+        result = filter_comp.filter(media_descriptor)
+        
+        assert result is False
+        mock_import.assert_called_once()
+
+
+def _repo_root() -> str:
+    _resolved = os.path.abspath(os.path.dirname(__file__))
+    if "tests" in _resolved.split(os.sep):
+        return os.path.abspath(os.path.join(_resolved, "..", ".."))
+    return os.path.abspath(os.path.join(_resolved, "..", "..", ".."))
+
+
+def test_types_xcu_structural():
+    path = os.path.join(
+        _repo_root(),
+        "extension",
+        "registry",
+        "org",
+        "openoffice",
+        "TypeDetection",
+        "Types.xcu",
+    )
+    root = ET.parse(path).getroot()
+    assert root.tag.endswith("component-data")
+    assert root.get("{http://openoffice.org/2001/registry}name") == "Types"
+    
+    types_node = None
+    for child in root:
+        if child.get("{http://openoffice.org/2001/registry}name") == "Types":
+            types_node = child
+            break
+            
+    assert types_node is not None
+    
+    filter_node = None
+    for child in types_node:
+        if child.get("{http://openoffice.org/2001/registry}name") == "writer_WriterAgent_Jupyter_Notebook":
+            filter_node = child
+            break
+            
+    assert filter_node is not None
+    
+    found_ext = False
+    for prop in filter_node:
+        if prop.get("{http://openoffice.org/2001/registry}name") == "Extensions":
+            val = prop.find("value")
+            if val is not None and val.text == "ipynb":
+                found_ext = True
+    assert found_ext
+
+
+def test_filters_xcu_structural():
+    path = os.path.join(
+        _repo_root(),
+        "extension",
+        "registry",
+        "org",
+        "openoffice",
+        "TypeDetection",
+        "Filters.xcu",
+    )
+    root = ET.parse(path).getroot()
+    assert root.tag.endswith("component-data")
+    
+    filters_node = None
+    for child in root:
+        if child.get("{http://openoffice.org/2001/registry}name") == "Filters":
+            filters_node = child
+            break
+            
+    assert filters_node is not None
+    
+    filter_node = None
+    for child in filters_node:
+        if child.get("{http://openoffice.org/2001/registry}name") == "writer_WriterAgent_Jupyter_Notebook":
+            filter_node = child
+            break
+            
+    assert filter_node is not None
+    
+    props = {}
+    for prop in filter_node:
+        name = prop.get("{http://openoffice.org/2001/registry}name")
+        val = prop.find("value")
+        if val is not None:
+            props[name] = val.text
+            
+    assert props.get("FilterService") == "org.extension.writeragent.JupyterNotebookImportFilter"
+    assert "IMPORT" in props.get("Flags", "")
+    assert "ALIEN" in props.get("Flags", "")
+    assert "3RDPARTYFILTER" in props.get("Flags", "")
+    assert "EXPORT" not in props.get("Flags", "")
+
+
+def test_generated_manifest_includes_import_filter():
+    mf = os.path.join(_repo_root(), "extension", "META-INF", "manifest.xml")
+    with open(mf, encoding="utf-8") as f:
+        body = f.read()
+    assert "plugin/notebook/import_filter.py" in body
+    assert "registry/org/openoffice/TypeDetection/Types.xcu" in body
+    assert "registry/org/openoffice/TypeDetection/Filters.xcu" in body

--- a/tests/notebook/test_import_filter_uno.py
+++ b/tests/notebook/test_import_filter_uno.py
@@ -1,0 +1,53 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Live UNO tests for the Jupyter Notebook native import filter."""
+
+from __future__ import annotations
+
+import os
+
+import uno
+
+from plugin.doc.doc_type import is_writer
+from plugin.framework.uno_context import get_desktop
+from plugin.notebook.cell_registry import load_registry
+from plugin.testing_runner import native_test
+
+
+@native_test
+def test_import_filter_uno_load_component(ctx):
+    """Load an .ipynb via desktop.loadComponentFromURL using the native filter."""
+    desktop = get_desktop(ctx)
+    assert desktop is not None
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    fixture_path = os.path.join(
+        repo_root, "tests", "fixtures", "introduction-to-numpy-small.ipynb"
+    )
+    assert os.path.exists(fixture_path), f"Fixture not found: {fixture_path}"
+
+    file_url = uno.systemPathToFileUrl(fixture_path)
+
+    from com.sun.star.beans import PropertyValue
+
+    prop = PropertyValue()
+    prop.Name = "FilterName"
+    prop.Value = "writer_WriterAgent_Jupyter_Notebook"
+
+    prop_hidden = PropertyValue()
+    prop_hidden.Name = "Hidden"
+    prop_hidden.Value = True
+
+    doc = desktop.loadComponentFromURL(file_url, "_blank", 0, (prop, prop_hidden))
+    try:
+        assert doc is not None
+        assert is_writer(doc)
+        state = load_registry(doc)
+        assert state is not None
+        assert len(state.code_cells) > 0
+        assert "In [" in doc.getText().getString()
+    finally:
+        if doc is not None:
+            doc.close(True)


### PR DESCRIPTION
## Summary
- Native import: **File → Open**, Open Recent, double-click, and `soffice notebook.ipynb` import a notebook into a new Writer document with no FilePicker and no completion dialog.
- **WriterAgent → Import Jupyter Notebook…** still appends into an already-open Writer doc (completion dialog stays on that path).
- UNO component is `XFilter` + `XImporter` + `XServiceInfo` (`org.extension.writeragent.JupyterNotebookImportFilter`). Type/filter name `writer_WriterAgent_Jupyter_Notebook`. Flags `IMPORT ALIEN 3RDPARTYFILTER`. No `EXPORT`, so Save cannot write JSON.

## Test plan
- [ ] Unit: `python3 -m pytest tests/notebook/test_import_filter.py -q`
- [ ] `soffice notebook.ipynb` (or File → Open a small `.ipynb`) opens a Writer doc with `In [` prompts
- [ ] Open Recent on that `.ipynb` re-imports from source
- [ ] Menu Import still appends into an already-open doc
- [ ] Save does not offer `.ipynb` / does not write JSON
- [ ] Live UNO: `tests/notebook/test_import_filter_uno.py` loads `tests/fixtures/introduction-to-numpy-small.ipynb` via `FilterName=writer_WriterAgent_Jupyter_Notebook`