### PR TITLE
Fix Jupyter Notebook import filter registration and type detection

### DIFF
--- a/extension/registry/org/openoffice/TypeDetection/Filters.xcu
+++ b/extension/registry/org/openoffice/TypeDetection/Filters.xcu
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:package="org.openoffice.TypeDetection" oor:name="Filters">
+<oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:package="org.openoffice.TypeDetection" oor:name="Filter">
   <node oor:name="Filters">
     <node oor:name="writer_WriterAgent_Jupyter_Notebook" oor:op="replace">
       <prop oor:name="UIName" oor:type="xs:string">
@@ -14,7 +14,7 @@
       <prop oor:name="FilterService" oor:type="xs:string">
         <value>org.extension.writeragent.JupyterNotebookImportFilter</value>
       </prop>
-      <prop oor:name="Flags" oor:type="xs:string">
+      <prop oor:name="Flags" oor:type="oor:string-list">
         <value>IMPORT ALIEN 3RDPARTYFILTER</value>
       </prop>
       <prop oor:name="FileFormatVersion" oor:type="xs:int">

--- a/extension/registry/org/openoffice/TypeDetection/Misc.xcu
+++ b/extension/registry/org/openoffice/TypeDetection/Misc.xcu
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:package="org.openoffice.TypeDetection" oor:name="Misc">
+  <node oor:name="DetectServices">
+    <node oor:name="org.extension.writeragent.JupyterNotebookImportFilter" oor:op="replace">
+      <prop oor:name="Types" oor:type="oor:string-list">
+        <value>writer_WriterAgent_Jupyter_Notebook</value>
+      </prop>
+    </node>
+  </node>
+</oor:component-data>

--- a/extension/registry/org/openoffice/TypeDetection/Types.xcu
+++ b/extension/registry/org/openoffice/TypeDetection/Types.xcu
@@ -5,8 +5,11 @@
       <prop oor:name="UIName" oor:type="xs:string">
         <value>Jupyter Notebook</value>
       </prop>
-      <prop oor:name="Extensions" oor:type="xs:string">
+      <prop oor:name="Extensions" oor:type="oor:string-list">
         <value>ipynb</value>
+      </prop>
+      <prop oor:name="DetectService" oor:type="xs:string">
+        <value>org.extension.writeragent.JupyterNotebookImportFilter</value>
       </prop>
       <prop oor:name="MediaType" oor:type="xs:string">
         <value>application/x-ipynb+json</value>

--- a/plugin/notebook/import_filter.py
+++ b/plugin/notebook/import_filter.py
@@ -30,7 +30,7 @@ ensure_plugin_on_path(
 
 import uno  # noqa: E402
 import unohelper  # noqa: E402
-from com.sun.star.document import XFilter, XImporter  # noqa: E402
+from com.sun.star.document import XFilter, XImporter, XExtendedFilterDetection  # noqa: E402
 from com.sun.star.lang import XServiceInfo  # noqa: E402
 
 from plugin.contrib.nbformat import NBFormatError  # noqa: E402
@@ -41,10 +41,22 @@ log = logging.getLogger("writeragent.notebook")
 IMPL_NAME = "org.extension.writeragent.JupyterNotebookImportFilter"
 
 
-class JupyterNotebookImportFilter(unohelper.Base, XFilter, XImporter, XServiceInfo):
+class JupyterNotebookImportFilter(unohelper.Base, XFilter, XImporter, XServiceInfo, XExtendedFilterDetection):
     def __init__(self, ctx: Any) -> None:
         self.ctx = ctx
         self.target_doc = None
+
+    # XExtendedFilterDetection
+    def detect(self, descriptor: Any) -> str:
+        file_url = ""
+        for prop in descriptor:
+            if prop.Name == "URL":
+                file_url = prop.Value
+                break
+
+        if file_url and file_url.lower().endswith(".ipynb"):
+            return "writer_WriterAgent_Jupyter_Notebook"
+        return ""
 
     # XImporter
     def setTargetDocument(self, doc: Any) -> None:
@@ -83,12 +95,18 @@ class JupyterNotebookImportFilter(unohelper.Base, XFilter, XImporter, XServiceIn
         return service_name in self.getSupportedServiceNames()
 
     def getSupportedServiceNames(self) -> tuple[str]:
-        return ("com.sun.star.document.ImportFilter",)
+        return (
+            "com.sun.star.document.ImportFilter",
+            "com.sun.star.document.ExtendedTypeDetection",
+        )
 
 
 g_ImplementationHelper = unohelper.ImplementationHelper()
 g_ImplementationHelper.addImplementation(
     JupyterNotebookImportFilter,
     IMPL_NAME,
-    ("com.sun.star.document.ImportFilter",),
+    (
+        "com.sun.star.document.ImportFilter",
+        "com.sun.star.document.ExtendedTypeDetection",
+    ),
 )

--- a/scripts/manifest_registry.py
+++ b/scripts/manifest_registry.py
@@ -587,6 +587,7 @@ def generate_manifest_xml(modules, output_path):
         ),
         ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/TypeDetection/Types.xcu'),
         ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/TypeDetection/Filters.xcu'),
+        ('application/vnd.sun.star.configuration-data', 'registry/org/openoffice/TypeDetection/Misc.xcu'),
         ('application/vnd.sun.star.configuration-data', 'Addons.xcu'),
         ('application/vnd.sun.star.configuration-data', 'Accelerators.xcu'),
         ('application/vnd.sun.star.configuration-data', 'ProtocolHandler.xcu'),

--- a/tests/notebook/test_import_filter.py
+++ b/tests/notebook/test_import_filter.py
@@ -43,8 +43,12 @@ if "com.sun.star.document" not in sys.modules:
     mock_com.sun = types.ModuleType("com.sun")
     mock_com.sun.star = types.ModuleType("com.sun.star")
     mock_com.sun.star.document = types.ModuleType("com.sun.star.document")
+    class MockXExtendedFilterDetection:
+        pass
+
     mock_com.sun.star.document.XFilter = MockXFilter
     mock_com.sun.star.document.XImporter = MockXImporter
+    mock_com.sun.star.document.XExtendedFilterDetection = MockXExtendedFilterDetection
     mock_com.sun.star.lang = types.ModuleType("com.sun.star.lang")
     mock_com.sun.star.lang.XServiceInfo = MockXServiceInfo
     mock_com.sun.star.lang.XServiceDisplayName = MockXServiceDisplayName
@@ -162,6 +166,7 @@ def test_types_xcu_structural():
     found_ext = False
     for prop in filter_node:
         if prop.get("{http://openoffice.org/2001/registry}name") == "Extensions":
+            assert prop.get("{http://openoffice.org/2001/registry}type") == "oor:string-list"
             val = prop.find("value")
             if val is not None and val.text == "ipynb":
                 found_ext = True
@@ -205,16 +210,82 @@ def test_filters_xcu_structural():
             props[name] = val.text
             
     assert props.get("FilterService") == "org.extension.writeragent.JupyterNotebookImportFilter"
-    assert "IMPORT" in props.get("Flags", "")
-    assert "ALIEN" in props.get("Flags", "")
-    assert "3RDPARTYFILTER" in props.get("Flags", "")
+    assert "IMPORT ALIEN 3RDPARTYFILTER" == props.get("Flags", "")
     assert "EXPORT" not in props.get("Flags", "")
+
+    # Check Flags type is oor:string-list
+    for prop in filter_node:
+        if prop.get("{http://openoffice.org/2001/registry}name") == "Flags":
+            assert prop.get("{http://openoffice.org/2001/registry}type") == "oor:string-list"
+
+
+def test_misc_xcu_structural():
+    path = os.path.join(
+        _repo_root(),
+        "extension",
+        "registry",
+        "org",
+        "openoffice",
+        "TypeDetection",
+        "Misc.xcu",
+    )
+    root = ET.parse(path).getroot()
+    assert root.tag.endswith("component-data")
+    assert root.get("{http://openoffice.org/2001/registry}name") == "Misc"
+
+    detect_services_node = None
+    for child in root:
+        if child.get("{http://openoffice.org/2001/registry}name") == "DetectServices":
+            detect_services_node = child
+            break
+
+    assert detect_services_node is not None
+
+    filter_node = None
+    for child in detect_services_node:
+        if child.get("{http://openoffice.org/2001/registry}name") == "org.extension.writeragent.JupyterNotebookImportFilter":
+            filter_node = child
+            break
+
+    assert filter_node is not None
 
 
 def test_generated_manifest_includes_import_filter():
-    mf = os.path.join(_repo_root(), "extension", "META-INF", "manifest.xml")
-    with open(mf, encoding="utf-8") as f:
-        body = f.read()
-    assert "plugin/notebook/import_filter.py" in body
-    assert "registry/org/openoffice/TypeDetection/Types.xcu" in body
-    assert "registry/org/openoffice/TypeDetection/Filters.xcu" in body
+    import sys
+    import os
+    from unittest.mock import patch
+    # Temporarily append scripts to sys.path to allow imports within the test
+    sys.path.insert(0, _repo_root())
+    sys.path.insert(0, os.path.join(_repo_root(), "scripts"))
+    try:
+        from scripts.manifest_registry import generate_manifest_xml
+
+        with patch("scripts.manifest_registry._write_if_changed") as mock_write:
+            generate_manifest_xml([], "dummy")
+            assert mock_write.called
+            body = mock_write.call_args[0][1]
+
+        assert "plugin/notebook/import_filter.py" in body
+        assert "registry/org/openoffice/TypeDetection/Types.xcu" in body
+        assert "registry/org/openoffice/TypeDetection/Filters.xcu" in body
+        assert "registry/org/openoffice/TypeDetection/Misc.xcu" in body
+    finally:
+        sys.path.pop(0)
+        sys.path.pop(0)
+
+
+def test_detect_method():
+    ctx = Mock()
+    filter_comp = JupyterNotebookImportFilter(ctx)
+
+    media_descriptor = (MockPropertyValue("URL", "file:///fake/path/notebook.ipynb"),)
+    assert filter_comp.detect(media_descriptor) == "writer_WriterAgent_Jupyter_Notebook"
+
+    media_descriptor = (MockPropertyValue("URL", "file:///fake/path/notebook.IPYNB"),)
+    assert filter_comp.detect(media_descriptor) == "writer_WriterAgent_Jupyter_Notebook"
+
+    media_descriptor = (MockPropertyValue("URL", "file:///fake/path/document.txt"),)
+    assert filter_comp.detect(media_descriptor) == ""
+
+    media_descriptor = (MockPropertyValue("ReadOnly", True),)
+    assert filter_comp.detect(media_descriptor) == ""


### PR DESCRIPTION
This commit addresses PR #480 where the LibreOffice Extension File Open operation for `.ipynb` files was attempting to load the notebook as raw text rather than utilizing the Jupyter Notebook import filter. 

It fixes registry configuration (such as XML property types mapping correctly to string arrays, expected schema element names `Filter` instead of `Filters`) and provides `DetectService` settings to tell the Document service which component can sniff a file path properly.

Additionally, `XExtendedFilterDetection` was implemented in `JupyterNotebookImportFilter` to correctly identify the `.ipynb` files.

---
*PR created automatically by Jules for task [12757290294010919846](https://jules.google.com/task/12757290294010919846) started by @KeithCu*