### PR TITLE
Fix Jupyter Notebook import filter detect method to return tuple for PyUNO

### DIFF
--- a/plugin/notebook/import_filter.py
+++ b/plugin/notebook/import_filter.py
@@ -47,16 +47,18 @@ class JupyterNotebookImportFilter(unohelper.Base, XFilter, XImporter, XServiceIn
         self.target_doc = None
 
     # XExtendedFilterDetection
-    def detect(self, descriptor: Any) -> str:
+    def detect(self, Descriptor: Any) -> Any:  # type: ignore
         file_url = ""
-        for prop in descriptor:
-            if prop.Name == "URL":
-                file_url = prop.Value
+        props = list(Descriptor or ())
+        for prop in props:
+            if getattr(prop, "Name", "") == "URL":
+                file_url = str(prop.Value or "")
                 break
 
-        if file_url and file_url.lower().endswith(".ipynb"):
-            return "writer_WriterAgent_Jupyter_Notebook"
-        return ""
+        type_name = ""
+        if file_url.lower().endswith(".ipynb"):
+            type_name = "writer_WriterAgent_Jupyter_Notebook"
+        return type_name, tuple(props)
 
     # XImporter
     def setTargetDocument(self, doc: Any) -> None:

--- a/tests/notebook/test_import_filter.py
+++ b/tests/notebook/test_import_filter.py
@@ -279,13 +279,25 @@ def test_detect_method():
     filter_comp = JupyterNotebookImportFilter(ctx)
 
     media_descriptor = (MockPropertyValue("URL", "file:///fake/path/notebook.ipynb"),)
-    assert filter_comp.detect(media_descriptor) == "writer_WriterAgent_Jupyter_Notebook"
+    type_name, out_desc = filter_comp.detect(media_descriptor)
+    assert type_name == "writer_WriterAgent_Jupyter_Notebook"
+    assert isinstance(out_desc, tuple)
+    assert len(out_desc) == 1
 
     media_descriptor = (MockPropertyValue("URL", "file:///fake/path/notebook.IPYNB"),)
-    assert filter_comp.detect(media_descriptor) == "writer_WriterAgent_Jupyter_Notebook"
+    type_name, out_desc = filter_comp.detect(media_descriptor)
+    assert type_name == "writer_WriterAgent_Jupyter_Notebook"
+    assert isinstance(out_desc, tuple)
+    assert len(out_desc) == 1
 
     media_descriptor = (MockPropertyValue("URL", "file:///fake/path/document.txt"),)
-    assert filter_comp.detect(media_descriptor) == ""
+    type_name, out_desc = filter_comp.detect(media_descriptor)
+    assert type_name == ""
+    assert isinstance(out_desc, tuple)
+    assert len(out_desc) == 1
 
     media_descriptor = (MockPropertyValue("ReadOnly", True),)
-    assert filter_comp.detect(media_descriptor) == ""
+    type_name, out_desc = filter_comp.detect(media_descriptor)
+    assert type_name == ""
+    assert isinstance(out_desc, tuple)
+    assert len(out_desc) == 1

--- a/tests/notebook/test_import_filter_uno.py
+++ b/tests/notebook/test_import_filter_uno.py
@@ -51,3 +51,39 @@ def test_import_filter_uno_load_component(ctx):
     finally:
         if doc is not None:
             doc.close(True)
+
+
+@native_test
+def test_import_filter_uno_detect_without_filtername(ctx):
+    """Load an .ipynb via desktop.loadComponentFromURL without explicit FilterName to test detect()."""
+    desktop = get_desktop(ctx)
+    assert desktop is not None
+
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    fixture_path = os.path.join(
+        repo_root, "tests", "fixtures", "introduction-to-numpy-small.ipynb"
+    )
+    assert os.path.exists(fixture_path), f"Fixture not found: {fixture_path}"
+
+    file_url = uno.systemPathToFileUrl(fixture_path)
+
+    from com.sun.star.beans import PropertyValue
+
+    prop_hidden = PropertyValue()
+    prop_hidden.Name = "Hidden"
+    prop_hidden.Value = True
+
+    doc = desktop.loadComponentFromURL(file_url, "_blank", 0, (prop_hidden,))
+    try:
+        assert doc is not None
+        assert is_writer(doc)
+        state = load_registry(doc)
+        assert state is not None
+        assert len(state.code_cells) > 0
+
+        doc_text = doc.getText().getString()
+        assert "In [" in doc_text
+        assert '"cell_type"' not in doc_text
+    finally:
+        if doc is not None:
+            doc.close(True)


### PR DESCRIPTION
Fix Jupyter Notebook import filter detect method to return tuple for PyUNO

The `detect` method for `XExtendedFilterDetection` was updated to return a 2-tuple `(type_name, tuple(props))` and use the `Descriptor` parameter name to align with the `[inout]` PyUNO binding requirements.

Unit tests in `tests/notebook/test_import_filter.py` were adjusted to check the new return format.
Added a new live UNO test `test_import_filter_uno_detect_without_filtername` in `tests/notebook/test_import_filter_uno.py` to confirm correct extension detection without `FilterName`.

---
*PR created automatically by Jules for task [6086834686293097778](https://jules.google.com/task/6086834686293097778) started by @KeithCu*