### PR TITLE
fix(notebook): disable form design mode correctly during file open

### DIFF
--- a/plugin/notebook/notebook_controls.py
+++ b/plugin/notebook/notebook_controls.py
@@ -22,12 +22,13 @@ So we attach **one** shared ``XActionListener`` to the form controller container
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from typing import Any
 
 import uno
 
-from plugin.framework.uno_listeners import BaseActionListener, BaseContainerListener
+from plugin.framework.uno_listeners import BaseActionListener, BaseContainerListener, BaseDocumentEventListener
 from plugin.notebook.cell_registry import has_notebook_registry, load_registry
 
 log = logging.getLogger("writeragent.notebook")
@@ -41,6 +42,9 @@ _RUN_PREFIX = "nb_run_"
 _listener_refs: list[Any] = []
 _wired_keys: set[tuple[str, str]] = set()
 _wired_form_docs: set[str] = set()
+
+_doc_listener: Any | None = None
+_lock = threading.Lock()
 
 
 def form_button_push_type() -> int:
@@ -439,6 +443,46 @@ def wire_all_notebook_run_buttons(ctx: Any, doc: Any) -> int:
     return 1
 
 
+def _install_doc_event_listener(ctx: Any) -> None:
+    """Attach a global listener so documents/views opened AFTER bootstrap get the menu too."""
+    global _doc_listener
+    with _lock:
+        if _doc_listener is not None:
+            return
+    try:
+        class NotebookDocumentEventListener(BaseDocumentEventListener):  # type: ignore[misc, valid-type]
+            def __init__(self, ctx: Any) -> None:
+                self._ctx = ctx
+
+            def on_document_event(self, Event: Any) -> None:  # noqa: N803 -- UNO signature
+                try:
+                    name = getattr(Event, "EventName", "") or ""
+                    if name not in ("OnViewCreated", "OnLoadFinished", "OnLoad", "OnNew"):
+                        return
+
+                    controller = getattr(Event, "ViewController", None)
+                    doc = controller.getModel() if controller else getattr(Event, "Source", None)
+
+                    if doc is not None and has_notebook_registry(doc):
+                        # File Open wire_all runs inside XFilter.filter() before XFormLayerAccess.getFormController exists (_form_and_container returns None,None).
+                        # Menu import has a live controller so the same call works.
+                        # This listener is the retry once the view exists. wire_all is idempotent (_wired_form_docs).
+                        ensure_form_design_mode_off(doc)
+                        wire_all_notebook_run_buttons(self._ctx, doc)
+                except Exception:
+                    log.warning("notebook controls: doc-event handling failed", exc_info=True)
+
+        smgr = ctx.getServiceManager()
+        broadcaster = smgr.createInstanceWithContext("com.sun.star.frame.GlobalEventBroadcaster", ctx)
+        listener = NotebookDocumentEventListener(ctx)
+        broadcaster.addDocumentEventListener(listener)
+        with _lock:
+            _doc_listener = listener
+        log.debug("notebook controls: global doc-event listener attached")
+    except Exception:
+        log.warning("notebook controls: doc-event listener install failed", exc_info=True)
+
+
 def install_notebook_run_button_wiring(ctx: Any) -> None:
     """Bootstrap: wire ▶ buttons on the active Writer document (if any)."""
     try:
@@ -446,8 +490,9 @@ def install_notebook_run_button_wiring(ctx: Any) -> None:
         from plugin.framework.uno_context import get_active_document
 
         doc = get_active_document(ctx)
-        if doc is None or not is_writer(doc):
-            return
-        wire_all_notebook_run_buttons(ctx, doc)
+        if doc is not None and is_writer(doc):
+            wire_all_notebook_run_buttons(ctx, doc)
+
+        _install_doc_event_listener(ctx)
     except Exception:
         log.debug("notebook controls: install wiring failed", exc_info=True)

--- a/plugin/notebook/notebook_controls.py
+++ b/plugin/notebook/notebook_controls.py
@@ -48,8 +48,19 @@ def form_button_push_type() -> int:
 
 
 def ensure_form_design_mode_off(doc: Any) -> None:
-    """Form controls only fire when design mode is off (user mode)."""
+    """Form controls only fire when design mode is off (user mode).
+
+    ▶ are UNO form CommandButtons.
+    Design Mode on = click shows move/resize handles; off = click runs the cell.
+    File Open import filter runs ensure_form_design_mode_off before the window/controller exists, so setFormDesignMode no-ops.
+    ApplyFormDesignMode=False is the load-time switch so the view that attaches after the filter returns is in user mode.
+    setFormDesignMode(False) still needed when a controller already exists (Import into an open doc).
+    """
     try:
+        # Load-time switch for File Open (runs before view/controller exists)
+        doc.ApplyFormDesignMode = False
+
+        # Runtime switch for Menu Import (runs when controller already exists)
         controller = doc.getCurrentController()
         if controller is not None and hasattr(controller, "setFormDesignMode"):
             controller.setFormDesignMode(False)

--- a/tests/notebook/test_import_filter_uno.py
+++ b/tests/notebook/test_import_filter_uno.py
@@ -84,6 +84,8 @@ def test_import_filter_uno_detect_without_filtername(ctx):
         doc_text = doc.getText().getString()
         assert "In [" in doc_text
         assert '"cell_type"' not in doc_text
+
+        assert doc.ApplyFormDesignMode is False
     finally:
         if doc is not None:
             doc.close(True)

--- a/tests/notebook/test_notebook_controls.py
+++ b/tests/notebook/test_notebook_controls.py
@@ -23,6 +23,22 @@ def setup_function() -> None:
     notebook_controls._wired_form_docs = set()
 
 
+def test_ensure_form_design_mode_off_no_controller():
+    from plugin.notebook.notebook_controls import ensure_form_design_mode_off
+    doc = MagicMock()
+    doc.getCurrentController.return_value = None
+    ensure_form_design_mode_off(doc)
+    assert doc.ApplyFormDesignMode is False
+
+def test_ensure_form_design_mode_off_with_controller():
+    from plugin.notebook.notebook_controls import ensure_form_design_mode_off
+    doc = MagicMock()
+    controller = MagicMock()
+    doc.getCurrentController.return_value = controller
+    ensure_form_design_mode_off(doc)
+    assert doc.ApplyFormDesignMode is False
+    controller.setFormDesignMode.assert_called_once_with(False)
+
 def test_get_control_view_uses_gettypebyname_for_xcontrolaccess():
     doc = MagicMock()
     controller = MagicMock()

--- a/tests/notebook/test_notebook_controls.py
+++ b/tests/notebook/test_notebook_controls.py
@@ -21,6 +21,77 @@ def setup_function() -> None:
     notebook_controls._listener_refs = []
     notebook_controls._wired_keys = set()
     notebook_controls._wired_form_docs = set()
+    notebook_controls._doc_listener = None
+
+
+def test_wire_all_returns_0_no_container():
+    ctx = MagicMock()
+    doc = MagicMock()
+    doc.getURL.return_value = ""
+    doc.getRuntimeUID.return_value = "uid-form-no-container"
+
+    state = MagicMock()
+    state.code_cells = [MagicMock()]
+
+    with (
+        patch("plugin.notebook.notebook_controls.has_notebook_registry", return_value=True),
+        patch("plugin.notebook.notebook_controls.load_registry", return_value=state),
+        patch("plugin.notebook.notebook_controls._form_and_container", return_value=(None, None))
+    ):
+        result = wire_all_notebook_run_buttons(ctx, doc)
+
+    assert result == 0
+    assert notebook_controls._doc_key(doc) not in notebook_controls._wired_form_docs
+
+
+def test_install_notebook_run_button_wiring_global_listener():
+    ctx = MagicMock()
+    smgr = MagicMock()
+    ctx.getServiceManager.return_value = smgr
+    broadcaster = MagicMock()
+    smgr.createInstanceWithContext.return_value = broadcaster
+
+    with (
+        patch("plugin.framework.uno_context.get_active_document", return_value=None),
+        patch("plugin.framework.uno_context.get_active_document", return_value=None),
+    ):
+        notebook_controls.install_notebook_run_button_wiring(ctx)
+
+    smgr.createInstanceWithContext.assert_called_with("com.sun.star.frame.GlobalEventBroadcaster", ctx)
+    broadcaster.addDocumentEventListener.assert_called_once()
+    assert notebook_controls._doc_listener is not None
+
+
+def test_doc_event_listener_wires_buttons():
+    ctx = MagicMock()
+    smgr = MagicMock()
+    ctx.getServiceManager.return_value = smgr
+    broadcaster = MagicMock()
+    smgr.createInstanceWithContext.return_value = broadcaster
+
+    with (
+        patch("plugin.framework.uno_context.get_active_document", return_value=None),
+    ):
+        notebook_controls.install_notebook_run_button_wiring(ctx)
+
+    listener = notebook_controls._doc_listener
+    assert listener is not None
+
+    doc = MagicMock()
+    doc_event = MagicMock()
+    doc_event.EventName = "OnViewCreated"
+    doc_event.Source = doc
+    doc_event.ViewController = None
+
+    with (
+        patch("plugin.notebook.notebook_controls.has_notebook_registry", return_value=True),
+        patch("plugin.notebook.notebook_controls.wire_all_notebook_run_buttons") as wire_all,
+        patch("plugin.notebook.notebook_controls.ensure_form_design_mode_off") as ensure_off
+    ):
+        listener.on_document_event(doc_event)
+
+    ensure_off.assert_called_once_with(doc)
+    wire_all.assert_called_once_with(ctx, doc)
 
 
 def test_ensure_form_design_mode_off_no_controller():


### PR DESCRIPTION
File Open left Design Mode on; this is the load-time off switch so ▶ clicks run cells instead of showing handles.

---
*PR created automatically by Jules for task [14600144785386709295](https://jules.google.com/task/14600144785386709295) started by @KeithCu*