### PR TITLE
Fix trailing empty paragraph left after markdown HTML insert

### DIFF
--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -1323,6 +1323,52 @@ def _append_body_text_block(
     _append_body_paragraph(doc, display, para_style, lead_break=lead_break)
 
 
+def _trim_trailing_empty_paragraph(doc: Any) -> None:
+    try:
+        text = doc.getText()
+        cursor = text.createTextCursor()
+        cursor.gotoEnd(False)
+
+        para_rng = text.createTextCursorByRange(cursor)
+        para_rng.gotoStartOfParagraph(False)
+        para_rng.gotoEndOfParagraph(True)
+        if (para_rng.getString() or "").strip() != "":
+            return
+
+        try:
+            style = str(cursor.getPropertyValue("ParaStyleName") or "")
+        except Exception:
+            style = str(getattr(cursor, "ParaStyleName", "") or "")
+        if "Heading" in style:
+            return
+        try:
+            portions = para_rng.createEnumeration()
+        except Exception:
+            portions = None
+        if portions:
+            psteps = 0
+            while psteps < 64:
+                pmore = portions.hasMoreElements()
+                if pmore is not True and pmore != 1:
+                    break
+                psteps += 1
+                portion = portions.nextElement()
+                try:
+                    ptype = str(portion.getPropertyValue("TextPortionType") or "")
+                except Exception:
+                    ptype = str(getattr(portion, "TextPortionType", "") or "")
+                if ptype == "Frame":
+                    return
+
+        prev = text.createTextCursorByRange(cursor)
+        if prev.gotoPreviousParagraph(False):
+            prev.gotoEndOfParagraph(False)
+            cursor.gotoRange(prev.getEnd(), True)
+            cursor.setString("")
+    except Exception:
+        log.debug("notebook import: trim trailing empty paragraph failed", exc_info=True)
+
+
 def _insert_html_at_body_end(doc: Any, html: str, *, lead_break: bool) -> bool:
     """Insert an HTML fragment at the document end. Returns False on failure."""
     text = doc.getText()
@@ -1335,6 +1381,7 @@ def _insert_html_at_body_end(doc: Any, html: str, *, lead_break: bool) -> bool:
 
     try:
         insert_html_fragment_at_cursor(cursor, _wrap_html_fragment(html), wrap=False)
+        _trim_trailing_empty_paragraph(doc)
         return True
     except Exception:
         log.exception("notebook import HTML insert failed; falling back to plain text")

--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -26,6 +26,7 @@ from plugin.notebook.writer_importer import (
     _coerce_notebook_text,
     _create_import_para_style,
     _decode_notebook_image,
+    _trim_trailing_empty_paragraph,
     _DEFAULT_WIDTH,
     _ensure_notebook_import_styles,
     _FIELD_HEIGHT_PAD,
@@ -145,6 +146,99 @@ class _FakePoint:
     def __init__(self, x, y):
         self.X = x
         self.Y = y
+
+
+def test_trim_trailing_empty_paragraph_deletes_when_empty():
+    doc, body_text, body_cursor = _writer_doc_mock()
+    body_cursor.getString.return_value = "   "
+    body_cursor.getPropertyValue.return_value = "Text Body"
+
+    enum = MagicMock()
+    enum.hasMoreElements.return_value = False
+
+    para_rng = MagicMock()
+    para_rng.getString.return_value = ""
+    para_rng.createEnumeration.return_value = enum
+
+    sel = MagicMock()
+    sel.gotoPreviousParagraph.return_value = True
+
+    body_text.createTextCursorByRange.side_effect = [para_rng, sel]
+
+    _trim_trailing_empty_paragraph(doc)
+
+    body_cursor.setString.assert_called_once_with("")
+
+
+def test_trim_trailing_empty_paragraph_keeps_in_prompt():
+    doc, body_text, body_cursor = _writer_doc_mock()
+    body_cursor.getString.return_value = ""
+
+    para_rng = MagicMock()
+    para_rng.getString.return_value = "In [2]:"
+    body_text.createTextCursorByRange.return_value = para_rng
+
+    _trim_trailing_empty_paragraph(doc)
+
+    body_cursor.setString.assert_not_called()
+
+
+def test_trim_trailing_empty_paragraph_keeps_heading():
+    doc, body_text, body_cursor = _writer_doc_mock()
+    body_cursor.getString.return_value = ""
+    body_cursor.getPropertyValue.return_value = "Heading 2"
+
+    para_rng = MagicMock()
+    para_rng.getString.return_value = ""
+    body_text.createTextCursorByRange.return_value = para_rng
+
+    _trim_trailing_empty_paragraph(doc)
+
+    # Text cursor by range is only called once
+    assert body_text.createTextCursorByRange.call_count == 1
+
+
+def test_trim_trailing_empty_paragraph_keeps_frame():
+    doc, body_text, body_cursor = _writer_doc_mock()
+    body_cursor.getString.return_value = ""
+    body_cursor.getPropertyValue.return_value = "Text Body"
+
+    enum = MagicMock()
+    portion = MagicMock()
+    portion.getPropertyValue.return_value = "Frame"
+    enum.hasMoreElements.side_effect = [True, False]
+    enum.nextElement.return_value = portion
+
+    para_rng = MagicMock()
+    para_rng.createEnumeration.return_value = enum
+    body_text.createTextCursorByRange.return_value = para_rng
+
+    _trim_trailing_empty_paragraph(doc)
+
+    # prev text.createTextCursorByRange shouldn't be called because it returns early
+    assert body_text.createTextCursorByRange.call_count == 1
+
+
+def test_insert_html_at_body_end_calls_trim(monkeypatch):
+    doc, body_text, body_cursor = _writer_doc_mock()
+    body_cursor.getString.return_value = ""
+
+    def fake_insert_html(cursor, html, **kwargs):
+        return True
+
+    monkeypatch.setattr("plugin.writer.html_import.insert_html_fragment_at_cursor", fake_insert_html)
+
+    trim_called = False
+    def fake_trim(doc):
+        nonlocal trim_called
+        trim_called = True
+
+    monkeypatch.setattr("plugin.notebook.writer_importer._trim_trailing_empty_paragraph", fake_trim)
+
+    import plugin.notebook.writer_importer as wi
+    wi._insert_html_at_body_end(doc, "<p>html</p>", lead_break=False)
+
+    assert trim_called is True
 
 
 def test_import_stack_cursor_place_advances(monkeypatch):


### PR DESCRIPTION
Fixes an issue where LibreOffice StarWriter's HTML filter leaves a trailing empty Text-body paragraph after inserting a markdown HTML fragment. This caused an extra blank line to appear before the `In [n]:` block when opening certain notebooks (e.g., `introduction-to-numpy-small.ipynb`).

Changes made:
- Added `_trim_trailing_empty_paragraph(doc)` to `plugin/notebook/writer_importer.py` which safely checks the last paragraph and removes it along with the paragraph break if it's completely empty, doesn't contain a Frame, and isn't a heading.
- Called the helper inside `_insert_html_at_body_end` after `insert_html_fragment_at_cursor` succeeds.
- Added comprehensive unit tests in `tests/notebook/test_writer_importer.py` covering deletion, retention of headings, and retention of frames.

---
*PR created automatically by Jules for task [8525170552523917518](https://jules.google.com/task/8525170552523917518) started by @KeithCu*