### PR TITLE
test(notebook): fix false-green Frame trim test

### DIFF
--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -210,11 +210,13 @@ def test_trim_trailing_empty_paragraph_keeps_frame():
     enum.nextElement.return_value = portion
 
     para_rng = MagicMock()
+    para_rng.getString.return_value = ""
     para_rng.createEnumeration.return_value = enum
     body_text.createTextCursorByRange.return_value = para_rng
 
     _trim_trailing_empty_paragraph(doc)
 
+    body_cursor.setString.assert_not_called()
     # prev text.createTextCursorByRange shouldn't be called because it returns early
     assert body_text.createTextCursorByRange.call_count == 1
 


### PR DESCRIPTION
Fixed false-green `test_trim_trailing_empty_paragraph_keeps_frame` by making it correctly exercise the path.

---
*PR created automatically by Jules for task [1377278853976935316](https://jules.google.com/task/1377278853976935316) started by @KeithCu*