### PR TITLE
fix(chat): stock LO rich-text sidebar stick-to-bottom

### DIFF
--- a/docs/chat-rich-text-control-sidebar.md
+++ b/docs/chat-rich-text-control-sidebar.md
@@ -347,6 +347,35 @@ Add `create_hidden_writer(ctx, *, title="_blank")` to [`plugin/doc/document_help
 
 Run `make test` and the manual QA checklist above after changes. Preserve history batching in `append_rich_messages_via_clipboard`.
 
+### Scroll experiments (2026-08-27)
+
+Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; revert if it fails.
+
+**Keep:** after Send, Ask/instruct keeps focus. If the user clicks into the Writer document during the stream, typing stays there. Stick-to-bottom must not dump keystrokes into the history control.
+
+**Repro:** `make mock-llm` (http://127.0.0.1:18766, model `writeragent-mock`). Chat: any message. Web Research: mock round 0 is `web_search`, then `visit_webpage` / `final_answer`. Success = viewport stays on the newest text.
+
+**What landed:**
+- Stick-to-bottom: after each stream chunk and after HTML copy, `peer.queryDispatch(".uno:SelectAll")` on the **rich control peer** (never the Writer frame).
+- Do not `setFocus` / `reveal_rich_control_caret` / `focus_preserved` on stream append. Those steal the document caret. `control.setSelection` is a no-op on stock.
+- Query after Send: `_do_send` already `query.setFocus()`. SelectAll still focuses the rich peer, so restore Ask/instruct unless the user left.
+- Document during stream: query `focusGained` keeps restoring; Writer `controller.addMouseClickHandler` stops restoring. Toolkit `getFocusWindow` does not exist. Toolkit/window `addFocusListener` only sees top-level windows.
+
+**Did not work (reverted):** idle skip, setFocus/reveal on every chunk, `control.setSelection`, restoring live `getFocusWindow`, toolkit/window focus listeners, `focus_preserved(steal_target=...)`.
+
+**Experiments:**
+
+| # | Change | Result |
+|---|--------|--------|
+| 0-4 | Idle / setFocus / reveal_caret / skip focus_preserved | Fail. Viewport stuck on Line 001. |
+| 5 | `control.setSelection(end, end)` | Fail on stock. Peer is VCLXWindow, not XTextComponent. |
+| 6-7 | `peer.queryDispatch(".uno:SelectAll")` after insert and after HTML copy | Pass. Mid-stream and post-Ready viewport followed the tail (Line 078-080). |
+| 8-9 | Restore live getFocusWindow / steal_target | Fail. getFocusWindow always None. |
+| 10 | No setFocus on stream; keep SelectAll | Partial. Document typing works; query lost after Send (SelectAll steals). |
+| 11-12 | Toolkit / component-window focus listeners | Partial. Query works; document yank — listeners only see top-level windows. |
+| 13 | Query focusGained + Writer `addMouseClickHandler` | Pass. Query after Send (`qqq`). Document click (`xyz`/`zzz`). Stick-to-bottom held. |
+| 14 | Web Research on mock | Scroll passed on content-only mock; hung tool loop round 0 until mock emitted tool_calls. Origin mock already does web_search then final_answer. |
+
 ### Open questions
 
 - Incremental **formatted** HTML during stream (bold/lists live) vs. today’s strip-then-rerender-on-done? (Tag stripping mid-stream is already shipped — do not re-implement that.)

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -953,6 +953,9 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
             # Send button click leaves focus on Send; keep the query field
             # ready for the next question (reveal/scroll must not win later).
             try:
+                from plugin.framework.uno_context import note_user_wants_query
+
+                note_user_wants_query()
                 if hasattr(self.query_control, "setFocus"):
                     self.query_control.setFocus()
             except Exception as e:

--- a/plugin/chatbot/panel_wiring.py
+++ b/plugin/chatbot/panel_wiring.py
@@ -251,9 +251,15 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):  
                 widget = RichTextChatWidget(self.ctx, rich_control, style_window=root_window)
                 self.rich_text_widget = widget
                 try:
-                    from plugin.framework.uno_context import set_default_focus_restore
+                    from plugin.framework.uno_context import (
+                        install_stream_focus_tracker,
+                        set_default_focus_restore,
+                    )
 
                     set_default_focus_restore(controls.get("query"))
+                    install_stream_focus_tracker(
+                        self.ctx, query=controls.get("query"), rich=rich_control
+                    )
                 except Exception as e:
                     log.debug("set_default_focus_restore: %s", e)
                 controls["response_rich"] = rich_control

--- a/plugin/chatbot/rich_text_control.py
+++ b/plugin/chatbot/rich_text_control.py
@@ -972,6 +972,38 @@ def _insert_string_at_rich_cursor(model, cursor, text, char_color=None) -> None:
         pass
 
 
+def _dispatch_rich_select_all(control, ctx=None) -> None:
+    """Stock stick-to-bottom: SelectAll on the rich peer, never the Writer frame.
+
+    Stock 25.2 peer is VCLXWindow, not XTextComponent, so control.setSelection
+    is a no-op (exp 5). Idle/setFocus/reveal_caret also failed (exp 0-4).
+    OSelectAllDispatcher calls EditView.SetSelection(All()); the range is
+    non-collapsed so ShowCursor runs and the viewport follows the tail.
+
+    Do not setFocus here. That steals the Writer document caret (exp 10).
+    SelectAll still focuses the rich peer, so the caller restores Ask/instruct
+    unless the user clicked the document (install_stream_focus_tracker).
+    """
+    try:
+        peer = control.getPeer() if hasattr(control, "getPeer") else None
+        if peer is None or not hasattr(peer, "queryDispatch"):
+            return
+        import uno
+        url = uno.createUnoStruct("com.sun.star.util.URL")
+        setattr(url, "Complete", ".uno:SelectAll")
+        if ctx is not None and hasattr(ctx, "ServiceManager"):
+            transformer = ctx.ServiceManager.createInstanceWithContext(
+                "com.sun.star.util.URLTransformer", ctx
+            )
+            transformer.parseStrict(url)
+        disp = peer.queryDispatch(url, "", 0)
+        if disp is not None:
+            disp.dispatch(url, ())
+            log_rich_scroll("select_all", control=control)
+    except Exception as e:
+        log.debug("_dispatch_rich_select_all: %s", e)
+
+
 def append_text_chunk(control, text, auto_scroll=True, style_window=None, ctx=None):
     """Append plain text during assistant streaming with theme assistant color."""
     if not control or not text:
@@ -983,23 +1015,24 @@ def append_text_chunk(control, text, auto_scroll=True, style_window=None, ctx=No
         model = control.getModel()
         if model is None or not hasattr(model, "createTextCursor"):
             return
-        if auto_scroll and hasattr(control, "setFocus"):
-            control.setFocus()
+        # Do not setFocus on stream. SelectAll already scrolls (exp 6/7).
+        # setFocus + focus_preserved(query) stole document typing (exp 10):
+        # stock Toolkit has no getFocusWindow (PyUNO hasattr lies).
         cursor = model.createTextCursor()
         cursor.gotoEnd(False)
         _apply_sidebar_para_margins(cursor)
         cursor.CharBackColor = theme.bg_color
         _insert_string_at_rich_cursor(model, cursor, text, theme.assistant_color)
         if auto_scroll:
-            # Large UNO inserts leave EditEngine in IsFormatting(); ShowCursor
-            # no-ops until idle. HTML paste already idles around copy; stream
-            # used to skip this and never followed the caret.
+            _dispatch_rich_select_all(control, ctx)
             process_events_to_idle(ctx, force=True)
-            reveal_rich_control_caret(control, ctx=ctx, reason="append_chunk", _already_focus_preserved=True)
+            # SelectAll steals to the rich peer. Put query back unless a
+            # mouse handler saw the user click the document (exp 13).
+            from plugin.framework.uno_context import restore_query_if_user_still_there
+            restore_query_if_user_still_there()
 
     try:
-        with focus_preserved(ctx):
-            _do_append()
+        _do_append()
     except Exception:
         log.exception("append_text_chunk (rich control) failed")
 

--- a/plugin/chatbot/rich_text_paste.py
+++ b/plugin/chatbot/rich_text_paste.py
@@ -44,6 +44,7 @@ from plugin.chatbot.rich_text_control import (
     _insert_string_at_rich_cursor,
     _is_automatic_char_color,
     get_control_text_length,
+    _dispatch_rich_select_all,
     log_rich_scroll,
     reveal_rich_control_caret,
 )
@@ -372,6 +373,7 @@ def _copy_formatted_from_hidden_doc_to_control(
 
             if inserted:
                 if auto_scroll:
+                    _dispatch_rich_select_all(control, ctx)
                     reveal_rich_control_caret(control, ctx=ctx, reason="copy", _already_focus_preserved=True)
                 log_rich_scroll("copy_done", control=control, role=role, auto_scroll=int(auto_scroll))
                 log.info(
@@ -449,6 +451,7 @@ def append_rich_messages_via_clipboard(
                 doc, control, ctx, style_window=style_window, auto_scroll=False, cell_link_targets=batch_links,
             ):
                 any_inserted = True
+                _dispatch_rich_select_all(control, ctx)
                 reveal_rich_control_caret(control, ctx=ctx, reason="history_batch")
             else:
                 log.warning(

--- a/plugin/framework/uno_context.py
+++ b/plugin/framework/uno_context.py
@@ -279,13 +279,119 @@ def get_toolkit(ctx=None):
 
 # Sidebar query field: restore here after RichTextControl setFocus, not
 # getFocusWindow() (often the Send button after a click, or the transcript).
+# Stock Toolkit has no getFocusWindow (PyUNO hasattr lies → always None).
 _default_focus_restore = None
+_restore_query_after_scroll = True
+_stream_focus_trackers = []
+_stream_rich_control = None
 
 
 def set_default_focus_restore(control) -> None:
     """Pin focus restore to the chat query field (or None on panel dispose)."""
     global _default_focus_restore
     _default_focus_restore = control
+
+
+def note_user_wants_query() -> None:
+    """Mark Ask/instruct as the restore target after a stream SelectAll.
+
+    Called from _do_send next to query.setFocus(), and from query focusGained.
+    """
+    global _restore_query_after_scroll
+    _restore_query_after_scroll = True
+
+
+def restore_query_if_user_still_there() -> None:
+    """After a stream SelectAll, put the caret back in Ask/instruct unless the user left."""
+    if not _restore_query_after_scroll:
+        return
+    q = _default_focus_restore
+    if q is None or not hasattr(q, "setFocus"):
+        return
+    try:
+        q.setFocus()
+        log.debug("restore_query_if_user_still_there")
+    except Exception as e:
+        log.debug("restore_query_if_user_still_there: %s", e)
+
+
+def _current_document_controller(ctx):
+    try:
+        smgr = getattr(ctx, "ServiceManager", None)
+        if smgr is None:
+            return None
+        desktop = smgr.createInstanceWithContext("com.sun.star.frame.Desktop", ctx)
+        comp = desktop.getCurrentComponent() if desktop is not None else None
+        if comp is None:
+            return None
+        return comp.getCurrentController()
+    except Exception as e:
+        log.debug("document controller: %s", e)
+        return None
+
+
+def install_stream_focus_tracker(ctx, query=None, rich=None) -> None:
+    """Query focusGained → keep restoring. Document mouse click → stop.
+
+    Window focus listeners miss in-frame query→page clicks (same top-level).
+    Writer's XUserInputInterception mouse handler sees the page click.
+    """
+    global _stream_rich_control, _default_focus_restore
+    if query is not None:
+        _default_focus_restore = query
+    if rich is not None:
+        _stream_rich_control = rich
+    if _stream_focus_trackers:
+        return
+    try:
+        import unohelper
+        from com.sun.star.awt import XFocusListener, XMouseClickHandler
+    except ImportError:
+        return
+
+    class _QueryFocus(unohelper.Base, XFocusListener):
+        def disposing(self, Source):  # noqa: N802, N803 -- UNO signature
+            return
+
+        def focusLost(self, e):  # noqa: N802 -- UNO signature
+            return
+
+        def focusGained(self, e):  # noqa: N802 -- UNO signature
+            global _restore_query_after_scroll
+            _restore_query_after_scroll = True
+            log.debug("stream focus: query")
+
+    class _DocClick(unohelper.Base, XMouseClickHandler):
+        def disposing(self, Source):  # noqa: N802, N803 -- UNO signature
+            return
+
+        def mousePressed(self, e):  # noqa: N802 -- UNO signature
+            global _restore_query_after_scroll
+            _restore_query_after_scroll = False
+            log.debug("stream focus: document click")
+            return False
+
+        def mouseReleased(self, e):  # noqa: N802 -- UNO signature
+            return False
+
+    controller = None
+    try:
+        if query is not None and hasattr(query, "addFocusListener"):
+            q_track = _QueryFocus()
+            query.addFocusListener(q_track)
+            _stream_focus_trackers.append(q_track)
+        controller = _current_document_controller(ctx)
+        if controller is not None and hasattr(controller, "addMouseClickHandler"):
+            d_track = _DocClick()
+            controller.addMouseClickHandler(d_track)
+            _stream_focus_trackers.append(d_track)
+        log.debug(
+            "install_stream_focus_tracker n=%d mouse=%s",
+            len(_stream_focus_trackers),
+            bool(controller is not None and hasattr(controller, "addMouseClickHandler")),
+        )
+    except Exception as e:
+        log.debug("install_stream_focus_tracker: %s", e)
 
 
 def _focus_restore_target(explicit=None):

--- a/tests/chatbot/test_rich_text_control.py
+++ b/tests/chatbot/test_rich_text_control.py
@@ -239,7 +239,7 @@ class TestAppendTextChunk:
         assert mock_prop.call_args_list[0].args[1:] == ("ReadOnly", False)
         assert mock_prop.call_args_list[-1].args[1:] == ("ReadOnly", True)
 
-    def test_append_text_chunk_idles_then_reveals(self):
+    def test_append_text_chunk_select_all_not_reveal(self):
         control = MagicMock()
         model = MagicMock()
         cursor = MagicMock()
@@ -249,13 +249,16 @@ class TestAppendTextChunk:
         with patch("plugin.chatbot.rich_text.get_theme_colors", return_value=(0, 0, 0x1E293B)), \
              patch("plugin.chatbot.rich_text_control._insert_string_at_rich_cursor"), \
              patch("plugin.chatbot.rich_text_control.reveal_rich_control_caret") as mock_reveal, \
+             patch("plugin.chatbot.rich_text_control._dispatch_rich_select_all") as mock_sel, \
              patch("plugin.chatbot.rich_text_control.process_events_to_idle") as mock_idle, \
-             patch("plugin.chatbot.rich_text_control.focus_preserved", _immediate_focus):
+             patch("plugin.framework.uno_context.restore_query_if_user_still_there") as mock_restore:
             append_text_chunk(control, " tail", auto_scroll=True, style_window=MagicMock(), ctx=MagicMock())
 
         mock_idle.assert_called()
-        mock_reveal.assert_called_once()
-        assert mock_reveal.call_args.kwargs.get("reason") == "append_chunk"
+        mock_sel.assert_called_once()
+        mock_restore.assert_called_once()
+        mock_reveal.assert_not_called()
+        control.setFocus.assert_not_called()
 
     def test_sync_bounds_reveals_caret_after_resize_when_transcript_nonempty(self):
         from types import SimpleNamespace

--- a/tests/framework/test_uno_context.py
+++ b/tests/framework/test_uno_context.py
@@ -120,6 +120,24 @@ def test_focus_preserved_prefers_pinned_query_over_toolkit():
     send_btn.setFocus.assert_not_called()
 
 
+def test_restore_query_if_user_still_there():
+    from plugin.framework import uno_context as uc
+
+    query = MagicMock()
+    uc.set_default_focus_restore(query)
+    uc.note_user_wants_query()
+    try:
+        uc.restore_query_if_user_still_there()
+        query.setFocus.assert_called_once()
+        query.reset_mock()
+        uc._restore_query_after_scroll = False
+        uc.restore_query_if_user_still_there()
+        query.setFocus.assert_not_called()
+    finally:
+        uc.set_default_focus_restore(None)
+        uc._restore_query_after_scroll = True
+
+
 def test_process_events_to_idle_calls_toolkit():
     from plugin.framework.uno_context import process_events_to_idle
     from plugin.framework.queue_executor import reset_suppressed_vcl_pump_count


### PR DESCRIPTION
## Summary
- Stock LibreOffice (no C++ peer patch): after each stream chunk, `peer.queryDispatch(".uno:SelectAll")` on the **rich control peer** (never the Writer frame). `OSelectAllDispatcher` calls `EditView.SetSelection(All())`, ShowCursor runs, viewport follows the tail.
- Do **not** `setFocus` / `reveal_rich_control_caret` / `focus_preserved` on stream append. Those steal the Writer document caret. `control.setSelection` is a no-op on stock (`VCLXWindow`, not `XTextComponent`).
- After Send, restore Ask/instruct (`note_user_wants_query` + `query.setFocus()`). SelectAll still focuses the rich peer, so restore query after each chunk unless the user left.
- Document during stream: query `focusGained` keeps restoring; Writer `controller.addMouseClickHandler` stops restoring. Toolkit `getFocusWindow` does not exist (PyUNO `hasattr` lies). Toolkit/window `addFocusListener` only sees top-level windows.

## What did not work (reverted)
- Skipping idle / `setFocus` / `reveal_caret` on every chunk (exps 0–4): viewport stuck on Line 001.
- `control.setSelection(end, end)` (exp 5): no-op on stock.
- Restoring live `getFocusWindow` / `focus_preserved(steal_target=...)` (exps 8–9): always `None`.
- Toolkit or component-window focus listeners (exps 11–12): in-frame query→page clicks are silent, so restore yanked the document caret.

## Test plan
- [ ] `make deploy writer` on stock LO.
- [ ] `make mock-llm` → Settings `http://127.0.0.1:18766`, model `writeragent-mock`.
- [ ] Chat: send anything. Viewport stays on the newest line. After Send, type in Ask/instruct. Click the Writer page mid-stream and type there.
- [ ] Web Research (not Librarian): mock does `web_search` then `final_answer`. Viewport stays on the tail.

Experiments 0–14 are in `docs/chat-rich-text-control-sidebar.md`.