### PR TITLE
fix(chat): no SelectAll flash on rich-text stream

### DIFF
--- a/docs/chat-rich-text-control-sidebar.md
+++ b/docs/chat-rich-text-control-sidebar.md
@@ -375,6 +375,7 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 | 11-12 | Toolkit / component-window focus listeners | Partial. Query works; document yank — listeners only see top-level windows. |
 | 13 | Query focusGained + Writer `addMouseClickHandler` | Pass. Query after Send (`qqq`). Document click (`xyz`/`zzz`). Stick-to-bottom held. |
 | 14 | Web Research on mock | Scroll passed on content-only mock; hung tool loop round 0 until mock emitted tool_calls. Origin mock already does web_search then final_answer. |
+| 15 | After SelectAll, dispatch `.uno:GoToEndOfDoc` (fallback `.uno:End`) on the same peer *before* idle | Un-flash. SelectAll still moves VisArea; collapse so the whole transcript does not paint selected on every chunk. |
 
 ### Open questions
 

--- a/plugin/chatbot/rich_text_control.py
+++ b/plugin/chatbot/rich_text_control.py
@@ -972,36 +972,51 @@ def _insert_string_at_rich_cursor(model, cursor, text, char_color=None) -> None:
         pass
 
 
-def _dispatch_rich_select_all(control, ctx=None) -> None:
-    """Stock stick-to-bottom: SelectAll on the rich peer, never the Writer frame.
-
-    Stock 25.2 peer is VCLXWindow, not XTextComponent, so control.setSelection
-    is a no-op (exp 5). Idle/setFocus/reveal_caret also failed (exp 0-4).
-    OSelectAllDispatcher calls EditView.SetSelection(All()); the range is
-    non-collapsed so ShowCursor runs and the viewport follows the tail.
-
-    Do not setFocus here. That steals the Writer document caret (exp 10).
-    SelectAll still focuses the rich peer, so the caller restores Ask/instruct
-    unless the user clicked the document (install_stream_focus_tracker).
-    """
+def _dispatch_rich_uno(control, command: str, ctx=None) -> bool:
+    """queryDispatch *command* on the rich peer, never the Writer frame."""
     try:
         peer = control.getPeer() if hasattr(control, "getPeer") else None
         if peer is None or not hasattr(peer, "queryDispatch"):
-            return
+            return False
         import uno
         url = uno.createUnoStruct("com.sun.star.util.URL")
-        setattr(url, "Complete", ".uno:SelectAll")
+        setattr(url, "Complete", command)
         if ctx is not None and hasattr(ctx, "ServiceManager"):
             transformer = ctx.ServiceManager.createInstanceWithContext(
                 "com.sun.star.util.URLTransformer", ctx
             )
             transformer.parseStrict(url)
         disp = peer.queryDispatch(url, "", 0)
-        if disp is not None:
-            disp.dispatch(url, ())
-            log_rich_scroll("select_all", control=control)
+        if disp is None:
+            return False
+        disp.dispatch(url, ())
+        log_rich_scroll("dispatch", control=control, command=command)
+        return True
     except Exception as e:
-        log.debug("_dispatch_rich_select_all: %s", e)
+        log.debug("_dispatch_rich_uno %s: %s", command, e)
+        return False
+
+
+def _dispatch_rich_select_all(control, ctx=None) -> None:
+    """Stock stick-to-bottom: SelectAll on the rich peer, then collapse.
+
+    Stock 25.2 peer is VCLXWindow, not XTextComponent, so control.setSelection
+    is a no-op (exp 5). Idle/setFocus/reveal_caret also failed (exp 0-4).
+    OSelectAllDispatcher calls EditView.SetSelection(All()); the range is
+    non-collapsed so ShowCursor runs and the viewport follows the tail.
+
+    SelectAll paints the whole transcript selected (exp 15). Collapse to the
+    end *before* process_events_to_idle so that highlight never paints.
+    Collapsed carets skip ShowCursor, so SelectAll must still run first.
+
+    Do not setFocus here. That steals the Writer document caret (exp 10).
+    SelectAll still focuses the rich peer, so the caller restores Ask/instruct
+    unless the user clicked the document (install_stream_focus_tracker).
+    """
+    _dispatch_rich_uno(control, ".uno:SelectAll", ctx)
+    # Either command is enough if the peer knows it; missing ones no-op.
+    if not _dispatch_rich_uno(control, ".uno:GoToEndOfDoc", ctx):
+        _dispatch_rich_uno(control, ".uno:End", ctx)
 
 
 def append_text_chunk(control, text, auto_scroll=True, style_window=None, ctx=None):

--- a/tests/chatbot/test_rich_text_control.py
+++ b/tests/chatbot/test_rich_text_control.py
@@ -260,6 +260,32 @@ class TestAppendTextChunk:
         mock_reveal.assert_not_called()
         control.setFocus.assert_not_called()
 
+    def test_select_all_collapses_before_return(self):
+        from plugin.chatbot.rich_text_control import _dispatch_rich_select_all
+
+        commands: list[str] = []
+        peer = MagicMock()
+        disp = MagicMock()
+
+        def query_dispatch(url, *_args):
+            commands.append(getattr(url, "Complete", ""))
+            return disp
+
+        peer.queryDispatch.side_effect = query_dispatch
+        control = MagicMock()
+        control.getPeer.return_value = peer
+
+        class Url:
+            Complete = ""
+
+        uno = MagicMock()
+        uno.createUnoStruct.side_effect = lambda *_a, **_k: Url()
+        with patch.dict("sys.modules", {"uno": uno}):
+            _dispatch_rich_select_all(control, ctx=None)
+        assert commands[0] == ".uno:SelectAll"
+        assert ".uno:GoToEndOfDoc" in commands or ".uno:End" in commands
+        assert disp.dispatch.call_count >= 2
+
     def test_sync_bounds_reveals_caret_after_resize_when_transcript_nonempty(self):
         from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary
- Stick-to-bottom still uses `.uno:SelectAll` on the **rich peer** (that is what makes ShowCursor follow the tail on stock LO).
- SelectAll was painting the whole transcript selected on every stream chunk.
- Collapse to the end with `.uno:GoToEndOfDoc` (fallback `.uno:End`) on the same peer **before** `process_events_to_idle`, so the highlight never paints. Collapsed carets skip ShowCursor, so SelectAll still has to run first.

## Test plan
- [ ] `make deploy writer` on the 486 tree.
- [ ] Stream a mock chat. Viewport stays on the tail, transcript does **not** flash selected on each chunk.
- [ ] After Send, typing stays in Ask/instruct. A click into Writer stays there.

If GoToEndOfDoc is a no-op on the rich peer, say so and I will try a different collapse command.