### PR TITLE
fix(chat): 1-char tail selection instead of SelectAll

### DIFF
--- a/docs/chat-rich-text-control-sidebar.md
+++ b/docs/chat-rich-text-control-sidebar.md
@@ -356,9 +356,10 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 **Repro:** `make mock-llm` (http://127.0.0.1:18766, model `writeragent-mock`). Chat: any message. Web Research: mock round 0 is `web_search`, then `visit_webpage` / `final_answer`. Success = viewport stays on the newest text.
 
 **What landed:**
-- Stick-to-bottom: after each stream chunk and after HTML copy, `peer.queryDispatch(".uno:SelectAll")` on the **rich control peer** (never the Writer frame).
-- Do not `setFocus` / `reveal_rich_control_caret` / `focus_preserved` on stream append. Those steal the document caret. `control.setSelection` is a no-op on stock.
-- Query after Send: `_do_send` already `query.setFocus()`. SelectAll still focuses the rich peer, so restore Ask/instruct unless the user left.
+- Stick-to-bottom (exp 6-13): `peer.queryDispatch(".uno:SelectAll")` on the **rich control peer** after each chunk / HTML copy. That stuck the viewport but painted the whole transcript selected (exp 15-16).
+- Exp 17 (in flight): never SelectAll. Select the last character (non-collapsed, so `ShowCursor` can run), then collapse to 0-char at the end. Prefer `XAccessibleText.setSelection`; `control.setSelection` is a no-op on stock.
+- Do not `setFocus` / `reveal_rich_control_caret` / `focus_preserved` on stream append. Those steal the document caret.
+- Query after Send: `_do_send` already `query.setFocus()`. Restore Ask/instruct after scroll unless the user left.
 - Document during stream: query `focusGained` keeps restoring; Writer `controller.addMouseClickHandler` stops restoring. Toolkit `getFocusWindow` does not exist. Toolkit/window `addFocusListener` only sees top-level windows.
 
 **Did not work (reverted):** idle skip, setFocus/reveal on every chunk, `control.setSelection`, restoring live `getFocusWindow`, toolkit/window focus listeners, `focus_preserved(steal_target=...)`.
@@ -376,7 +377,8 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 | 13 | Query focusGained + Writer `addMouseClickHandler` | Pass. Query after Send (`qqq`). Document click (`xyz`/`zzz`). Stick-to-bottom held. |
 | 14 | Web Research on mock | Scroll passed on content-only mock; hung tool loop round 0 until mock emitted tool_calls. Origin mock already does web_search then final_answer. |
 | 15 | After SelectAll, dispatch `.uno:GoToEndOfDoc` (fallback `.uno:End`) on the same peer *before* idle | Fail. queryDispatch returned a dispatcher that no-op'd, so we never tried End. Selection stayed visible after every chunk / while typing in Ask/instruct. |
-| 16 | Always dispatch `.uno:End` / `.uno:GoToEnd` / `.uno:GoRight` after SelectAll (ignore GoToEndOfDoc). Restore query *before* idle. `HideInactiveSelection=True` on the edit model. | Click-test: transcript must not stay selected while typing in Ask/instruct. Stick-to-bottom must still hold. |
+| 16 | Always dispatch `.uno:End` / `.uno:GoToEnd` / `.uno:GoRight` after SelectAll (ignore GoToEndOfDoc). Restore query *before* idle. `HideInactiveSelection=True` on the edit model. | Fail. SelectAll paints immediately (active selection) before hide/collapse. Flash on stream, typing, and window create. |
+| 17 | Never SelectAll. 1-char at tail then collapse to 0-char via `XAccessibleText.setSelection` (and control.setSelection). Same helper on stream, HTML copy, and history batch. | Click-test: no whole-control flash on create/stream/type. Viewport still sticks. 1-char leftover is OK; 0-char is better. |
 
 ### Open questions
 

--- a/docs/chat-rich-text-control-sidebar.md
+++ b/docs/chat-rich-text-control-sidebar.md
@@ -375,7 +375,8 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 | 11-12 | Toolkit / component-window focus listeners | Partial. Query works; document yank — listeners only see top-level windows. |
 | 13 | Query focusGained + Writer `addMouseClickHandler` | Pass. Query after Send (`qqq`). Document click (`xyz`/`zzz`). Stick-to-bottom held. |
 | 14 | Web Research on mock | Scroll passed on content-only mock; hung tool loop round 0 until mock emitted tool_calls. Origin mock already does web_search then final_answer. |
-| 15 | After SelectAll, dispatch `.uno:GoToEndOfDoc` (fallback `.uno:End`) on the same peer *before* idle | Un-flash. SelectAll still moves VisArea; collapse so the whole transcript does not paint selected on every chunk. |
+| 15 | After SelectAll, dispatch `.uno:GoToEndOfDoc` (fallback `.uno:End`) on the same peer *before* idle | Fail. queryDispatch returned a dispatcher that no-op'd, so we never tried End. Selection stayed visible after every chunk / while typing in Ask/instruct. |
+| 16 | Always dispatch `.uno:End` / `.uno:GoToEnd` / `.uno:GoRight` after SelectAll (ignore GoToEndOfDoc). Restore query *before* idle. `HideInactiveSelection=True` on the edit model. | Click-test: transcript must not stay selected while typing in Ask/instruct. Stick-to-bottom must still hold. |
 
 ### Open questions
 

--- a/plugin/chatbot/rich_text_control.py
+++ b/plugin/chatbot/rich_text_control.py
@@ -455,6 +455,10 @@ def _apply_rich_control_style_defaults_on_model(model, style_window=None) -> Non
         ("PaintTransparent", False),
         ("MultiLine", True),
         ("VScroll", True),
+        # SelectAll stick-to-bottom leaves a selection. When Ask/instruct has
+        # focus that selection is inactive; hide it so typing does not show
+        # the whole transcript highlighted (exp 16).
+        ("HideInactiveSelection", True),
     ):
         _set_model_property(model, name, val)
     try:
@@ -1014,9 +1018,11 @@ def _dispatch_rich_select_all(control, ctx=None) -> None:
     unless the user clicked the document (install_stream_focus_tracker).
     """
     _dispatch_rich_uno(control, ".uno:SelectAll", ctx)
-    # Either command is enough if the peer knows it; missing ones no-op.
-    if not _dispatch_rich_uno(control, ".uno:GoToEndOfDoc", ctx):
-        _dispatch_rich_uno(control, ".uno:End", ctx)
+    # queryDispatch can return a dispatcher that no-ops (exp 15 GoToEndOfDoc
+    # "succeeded" and we never tried End). Always fire edit-view collapse
+    # commands. GoRight after SelectAll should land on the tail.
+    for command in (".uno:End", ".uno:GoToEnd", ".uno:GoRight"):
+        _dispatch_rich_uno(control, command, ctx)
 
 
 def append_text_chunk(control, text, auto_scroll=True, style_window=None, ctx=None):
@@ -1040,11 +1046,13 @@ def append_text_chunk(control, text, auto_scroll=True, style_window=None, ctx=No
         _insert_string_at_rich_cursor(model, cursor, text, theme.assistant_color)
         if auto_scroll:
             _dispatch_rich_select_all(control, ctx)
-            process_events_to_idle(ctx, force=True)
-            # SelectAll steals to the rich peer. Put query back unless a
-            # mouse handler saw the user click the document (exp 13).
+            # Restore query BEFORE idle. Idle is what paints. SelectAll
+            # focuses the rich peer; painting then shows an active selection
+            # (exp 15). Query focus first so paint is an inactive selection,
+            # which HideInactiveSelection hides (exp 16).
             from plugin.framework.uno_context import restore_query_if_user_still_there
             restore_query_if_user_still_there()
+            process_events_to_idle(ctx, force=True)
 
     try:
         _do_append()

--- a/plugin/chatbot/rich_text_control.py
+++ b/plugin/chatbot/rich_text_control.py
@@ -455,9 +455,8 @@ def _apply_rich_control_style_defaults_on_model(model, style_window=None) -> Non
         ("PaintTransparent", False),
         ("MultiLine", True),
         ("VScroll", True),
-        # SelectAll stick-to-bottom leaves a selection. When Ask/instruct has
-        # focus that selection is inactive; hide it so typing does not show
-        # the whole transcript highlighted (exp 16).
+        # If a 1-char tail selection is left (collapse missed), hide it when
+        # Ask/instruct has focus (exp 16). Harmless if selection is collapsed.
         ("HideInactiveSelection", True),
     ):
         _set_model_property(model, name, val)
@@ -1001,28 +1000,86 @@ def _dispatch_rich_uno(control, command: str, ctx=None) -> bool:
         return False
 
 
-def _dispatch_rich_select_all(control, ctx=None) -> None:
-    """Stock stick-to-bottom: SelectAll on the rich peer, then collapse.
+def _accessible_set_selection(obj, start: int, end: int) -> bool:
+    """XAccessibleText.setSelection. Skip VCLXWindow's no-op setSelection (exp 5)."""
+    if obj is None:
+        return False
+    acc = obj
+    try:
+        getter = getattr(obj, "getAccessibleContext", None)
+        if callable(getter):
+            ctx = getter()
+            if ctx is not None:
+                acc = ctx
+    except Exception:
+        acc = obj
+    # XAccessibleText has both. Stock peer setSelection is XTextComponent and
+    # a no-op (exp 5) — it has no getCharacterCount, so walk children instead.
+    count_fn = getattr(acc, "getCharacterCount", None)
+    set_fn = getattr(acc, "setSelection", None)
+    if callable(count_fn) and callable(set_fn):
+        try:
+            acc.setSelection(start, end)
+            return True
+        except Exception:
+            pass
+    try:
+        nch = int(acc.getAccessibleChildCount())
+    except Exception:
+        return False
+    for i in range(min(nch, 8)):
+        try:
+            child = acc.getAccessibleChild(i)
+        except Exception:
+            continue
+        if _accessible_set_selection(child, start, end):
+            return True
+    return False
 
-    Stock 25.2 peer is VCLXWindow, not XTextComponent, so control.setSelection
-    is a no-op (exp 5). Idle/setFocus/reveal_caret also failed (exp 0-4).
-    OSelectAllDispatcher calls EditView.SetSelection(All()); the range is
-    non-collapsed so ShowCursor runs and the viewport follows the tail.
 
-    SelectAll paints the whole transcript selected (exp 15). Collapse to the
-    end *before* process_events_to_idle so that highlight never paints.
-    Collapsed carets skip ShowCursor, so SelectAll must still run first.
+def _set_rich_selection_range(control, start: int, end: int) -> bool:
+    """Set [start, end) on the rich control. 1-char is non-collapsed (ShowCursor).
 
-    Do not setFocus here. That steals the Writer document caret (exp 10).
-    SelectAll still focuses the rich peer, so the caller restores Ask/instruct
-    unless the user clicked the document (install_stream_focus_tracker).
+    Always try XAccessibleText. control.setSelection is a no-op on stock
+    (peer is VCLXWindow, not XTextComponent) but would otherwise return first.
     """
-    _dispatch_rich_uno(control, ".uno:SelectAll", ctx)
-    # queryDispatch can return a dispatcher that no-ops (exp 15 GoToEndOfDoc
-    # "succeeded" and we never tried End). Always fire edit-view collapse
-    # commands. GoRight after SelectAll should land on the tail.
-    for command in (".uno:End", ".uno:GoToEnd", ".uno:GoRight"):
-        _dispatch_rich_uno(control, command, ctx)
+    peer = None
+    try:
+        peer = control.getPeer() if hasattr(control, "getPeer") else None
+    except Exception:
+        peer = None
+    if _accessible_set_selection(control, start, end) or _accessible_set_selection(peer, start, end):
+        log_rich_scroll("set_selection", control=control, start=start, end=end, via="accessible")
+        return True
+    try:
+        import uno
+        if hasattr(control, "setSelection"):
+            control.setSelection(uno.createUnoStruct("com.sun.star.awt.Selection", start, end))
+            log_rich_scroll("set_selection", control=control, start=start, end=end, via="control")
+            return True
+    except Exception as e:
+        log.debug("_set_rich_selection_range control: %s", e)
+    return False
+
+
+def _scroll_rich_to_tail(control, ctx=None) -> None:
+    """Stick-to-bottom without SelectAll (whole-control flash).
+
+    Collapsed (0-char) carets skip ShowCursor, so first select the last
+    character (non-collapsed), then collapse to 0-char at the end.
+    Never .uno:SelectAll — that paints the whole transcript (exp 15-16).
+    """
+    del ctx  # same signature as the old dispatcher helper
+    n = get_control_text_length(control)
+    if n <= 0:
+        return
+    _set_rich_selection_range(control, n - 1, n)
+    _set_rich_selection_range(control, n, n)
+
+
+def _dispatch_rich_select_all(control, ctx=None) -> None:
+    """Back-compat alias: one-char tail then collapse, not SelectAll."""
+    _scroll_rich_to_tail(control, ctx)
 
 
 def append_text_chunk(control, text, auto_scroll=True, style_window=None, ctx=None):
@@ -1036,20 +1093,16 @@ def append_text_chunk(control, text, auto_scroll=True, style_window=None, ctx=No
         model = control.getModel()
         if model is None or not hasattr(model, "createTextCursor"):
             return
-        # Do not setFocus on stream. SelectAll already scrolls (exp 6/7).
-        # setFocus + focus_preserved(query) stole document typing (exp 10):
-        # stock Toolkit has no getFocusWindow (PyUNO hasattr lies).
+        # Do not setFocus on stream. setFocus + focus_preserved(query) stole
+        # document typing (exp 10): stock Toolkit has no getFocusWindow
+        # (PyUNO hasattr lies). Scroll with 1-char tail selection, not SelectAll.
         cursor = model.createTextCursor()
         cursor.gotoEnd(False)
         _apply_sidebar_para_margins(cursor)
         cursor.CharBackColor = theme.bg_color
         _insert_string_at_rich_cursor(model, cursor, text, theme.assistant_color)
         if auto_scroll:
-            _dispatch_rich_select_all(control, ctx)
-            # Restore query BEFORE idle. Idle is what paints. SelectAll
-            # focuses the rich peer; painting then shows an active selection
-            # (exp 15). Query focus first so paint is an inactive selection,
-            # which HideInactiveSelection hides (exp 16).
+            _scroll_rich_to_tail(control, ctx)
             from plugin.framework.uno_context import restore_query_if_user_still_there
             restore_query_if_user_still_there()
             process_events_to_idle(ctx, force=True)

--- a/plugin/chatbot/rich_text_paste.py
+++ b/plugin/chatbot/rich_text_paste.py
@@ -44,7 +44,7 @@ from plugin.chatbot.rich_text_control import (
     _insert_string_at_rich_cursor,
     _is_automatic_char_color,
     get_control_text_length,
-    _dispatch_rich_select_all,
+    _scroll_rich_to_tail,
     log_rich_scroll,
     reveal_rich_control_caret,
 )
@@ -373,7 +373,7 @@ def _copy_formatted_from_hidden_doc_to_control(
 
             if inserted:
                 if auto_scroll:
-                    _dispatch_rich_select_all(control, ctx)
+                    _scroll_rich_to_tail(control, ctx)
                     reveal_rich_control_caret(control, ctx=ctx, reason="copy", _already_focus_preserved=True)
                 log_rich_scroll("copy_done", control=control, role=role, auto_scroll=int(auto_scroll))
                 log.info(
@@ -451,7 +451,7 @@ def append_rich_messages_via_clipboard(
                 doc, control, ctx, style_window=style_window, auto_scroll=False, cell_link_targets=batch_links,
             ):
                 any_inserted = True
-                _dispatch_rich_select_all(control, ctx)
+                _scroll_rich_to_tail(control, ctx)
                 reveal_rich_control_caret(control, ctx=ctx, reason="history_batch")
             else:
                 log.warning(

--- a/tests/chatbot/test_rich_text_control.py
+++ b/tests/chatbot/test_rich_text_control.py
@@ -283,8 +283,9 @@ class TestAppendTextChunk:
         with patch.dict("sys.modules", {"uno": uno}):
             _dispatch_rich_select_all(control, ctx=None)
         assert commands[0] == ".uno:SelectAll"
-        assert ".uno:GoToEndOfDoc" in commands or ".uno:End" in commands
-        assert disp.dispatch.call_count >= 2
+        assert ".uno:End" in commands
+        assert ".uno:GoRight" in commands
+        assert disp.dispatch.call_count >= 3
 
     def test_sync_bounds_reveals_caret_after_resize_when_transcript_nonempty(self):
         from types import SimpleNamespace

--- a/tests/chatbot/test_rich_text_control.py
+++ b/tests/chatbot/test_rich_text_control.py
@@ -9,7 +9,7 @@
 
 from contextlib import contextmanager
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from plugin.tests.testing_utils import setup_uno_mocks
 
@@ -239,7 +239,7 @@ class TestAppendTextChunk:
         assert mock_prop.call_args_list[0].args[1:] == ("ReadOnly", False)
         assert mock_prop.call_args_list[-1].args[1:] == ("ReadOnly", True)
 
-    def test_append_text_chunk_select_all_not_reveal(self):
+    def test_append_text_chunk_scrolls_tail_not_reveal(self):
         control = MagicMock()
         model = MagicMock()
         cursor = MagicMock()
@@ -249,43 +249,73 @@ class TestAppendTextChunk:
         with patch("plugin.chatbot.rich_text.get_theme_colors", return_value=(0, 0, 0x1E293B)), \
              patch("plugin.chatbot.rich_text_control._insert_string_at_rich_cursor"), \
              patch("plugin.chatbot.rich_text_control.reveal_rich_control_caret") as mock_reveal, \
-             patch("plugin.chatbot.rich_text_control._dispatch_rich_select_all") as mock_sel, \
+             patch("plugin.chatbot.rich_text_control._scroll_rich_to_tail") as mock_scroll, \
              patch("plugin.chatbot.rich_text_control.process_events_to_idle") as mock_idle, \
              patch("plugin.framework.uno_context.restore_query_if_user_still_there") as mock_restore:
             append_text_chunk(control, " tail", auto_scroll=True, style_window=MagicMock(), ctx=MagicMock())
 
         mock_idle.assert_called()
-        mock_sel.assert_called_once()
+        mock_scroll.assert_called_once()
         mock_restore.assert_called_once()
         mock_reveal.assert_not_called()
         control.setFocus.assert_not_called()
 
-    def test_select_all_collapses_before_return(self):
-        from plugin.chatbot.rich_text_control import _dispatch_rich_select_all
+    def test_scroll_rich_to_tail_one_char_then_collapse(self):
+        from plugin.chatbot.rich_text_control import _scroll_rich_to_tail
 
-        commands: list[str] = []
-        peer = MagicMock()
-        disp = MagicMock()
-
-        def query_dispatch(url, *_args):
-            commands.append(getattr(url, "Complete", ""))
-            return disp
-
-        peer.queryDispatch.side_effect = query_dispatch
         control = MagicMock()
-        control.getPeer.return_value = peer
+        with patch("plugin.chatbot.rich_text_control.get_control_text_length", return_value=80), \
+             patch("plugin.chatbot.rich_text_control._set_rich_selection_range") as mock_set, \
+             patch("plugin.chatbot.rich_text_control._dispatch_rich_uno") as mock_uno:
+            _scroll_rich_to_tail(control, ctx=None)
+        assert mock_set.call_args_list == [
+            call(control, 79, 80),
+            call(control, 80, 80),
+        ]
+        mock_uno.assert_not_called()
 
-        class Url:
-            Complete = ""
+    def test_scroll_rich_to_tail_skips_empty(self):
+        from plugin.chatbot.rich_text_control import _scroll_rich_to_tail
 
-        uno = MagicMock()
-        uno.createUnoStruct.side_effect = lambda *_a, **_k: Url()
-        with patch.dict("sys.modules", {"uno": uno}):
-            _dispatch_rich_select_all(control, ctx=None)
-        assert commands[0] == ".uno:SelectAll"
-        assert ".uno:End" in commands
-        assert ".uno:GoRight" in commands
-        assert disp.dispatch.call_count >= 3
+        control = MagicMock()
+        with patch("plugin.chatbot.rich_text_control.get_control_text_length", return_value=0), \
+             patch("plugin.chatbot.rich_text_control._set_rich_selection_range") as mock_set:
+            _scroll_rich_to_tail(control, ctx=None)
+        mock_set.assert_not_called()
+
+    def test_accessible_set_selection_skips_noop_peer(self):
+        """VCLXWindow has setSelection without getCharacterCount. Walk to XAccessibleText."""
+        from plugin.chatbot.rich_text_control import _accessible_set_selection
+
+        class Text:
+            def __init__(self):
+                self.range = None
+
+            def getCharacterCount(self):
+                return 10
+
+            def setSelection(self, start, end):
+                self.range = (start, end)
+
+        class Peer:
+            def __init__(self):
+                self.child = Text()
+
+            def setSelection(self, *args):
+                raise AssertionError("must not use VCLXWindow setSelection")
+
+            def getAccessibleContext(self):
+                return self
+
+            def getAccessibleChildCount(self):
+                return 1
+
+            def getAccessibleChild(self, _i):
+                return self.child
+
+        peer = Peer()
+        assert _accessible_set_selection(peer, 9, 10) is True
+        assert peer.child.range == (9, 10)
 
     def test_sync_bounds_reveals_caret_after_resize_when_transcript_nonempty(self):
         from types import SimpleNamespace


### PR DESCRIPTION
## Why 487/488 still flash

SelectAll paints the whole transcript immediately (active selection) before any collapse, hide, or query restore. That is why End/GoRight and `HideInactiveSelection` still flash on stream, typing, and window create.

## Change (exp 17)

Never `.uno:SelectAll`. After each stream chunk, HTML copy, and history batch:

1. Select the last character (non-collapsed so `ShowCursor` can run).
2. Collapse to 0-char at the end.

Prefer `XAccessibleText.setSelection` (walk past the stock VCLXWindow no-op). `control.setSelection` is still tried and still a no-op on stock.

Risk: if accessible selection does not hit EditView, stick-to-bottom regresses. Do not bring SelectAll back without asking.

## Test plan

- [ ] `make deploy writer` from this branch.
- [ ] Open the sidebar: greeting/history must **not** flash the whole control selected.
- [ ] Stream a mock chat. Viewport stays on the tail. No whole-control flash on chunks or while typing in Ask/instruct.
- [ ] Click into Writer mid-stream: typing still goes to the document.
- [ ] A 1-char leftover at the tail is OK. Whole-control highlight is not.