### PR TITLE
fix(notebook): File Open wiring is not main-thread-only

### DIFF
--- a/plugin/notebook/notebook_controls.py
+++ b/plugin/notebook/notebook_controls.py
@@ -40,11 +40,18 @@ _FORM_BUTTON_PUSH = 0
 _RUN_PREFIX = "nb_run_"
 
 # Keep listeners alive (UNO holds weak refs). Form-level: one pair per document.
-# Main-thread only (Red): File Open, protocol dispatch, GlobalEventBroadcaster.
-# Public UNO entry points use @main_thread_only (Layer A assert; release OXT
-# strips it). Do not decorate listener methods — LO already invokes those on
-# the UI thread (docs/framework-uno-thread-safety.md §A4). _lock only serializes
-# the one-shot global _doc_listener install.
+# File Open XFilter.filter() runs on Dummy-2 while main waits (Yellow; same as
+# issue #402). GlobalEventBroadcaster OnViewCreated during load is Dummy-3.
+# ensure_form_design_mode_off, prune_dead_listeners, and
+# wire_all_notebook_run_buttons must run there; decorating them breaks
+# WRITERAGENT_UNO_THREAD_GUARD=1 File Open (filter returns False → General I/O
+# error). Do not marshal with execute_on_main_thread from the filter (host
+# waiting = deadlock #402). ApplyFormDesignMode=False must happen before the
+# filter returns. Listener methods stay undecorated (LO already invokes those
+# on the UI thread; docs/framework-uno-thread-safety.md §A4). Release OXT still
+# strips remaining decorators. Keep @main_thread_only on getControl /
+# per-button wire / bootstrap install. _lock only serializes the one-shot
+# global _doc_listener install.
 _listener_refs: list[Any] = []
 _wired_keys: set[tuple[str, str]] = set()
 _wired_form_docs: set[str] = set()
@@ -57,7 +64,6 @@ def form_button_push_type() -> int:
     return _FORM_BUTTON_PUSH
 
 
-@main_thread_only
 def ensure_form_design_mode_off(doc: Any) -> None:
     """Form controls only fire when design mode is off (user mode).
 
@@ -181,7 +187,6 @@ def get_control_view_for_model(doc: Any, model: Any) -> Any | None:
         return None
 
 
-@main_thread_only
 def prune_dead_listeners() -> None:
     """Remove listeners whose target document is closed/gone."""
     global _listener_refs, _wired_keys, _wired_form_docs
@@ -395,7 +400,6 @@ def wire_run_button_listener(ctx: Any, doc: Any, model: Any, hex_id: str) -> boo
         return False
 
 
-@main_thread_only
 def wire_all_notebook_run_buttons(ctx: Any, doc: Any) -> int:
     """Attach the shared form-level ▶ listener if missing. Returns 1 when wired.
 

--- a/tests/notebook/test_notebook_controls.py
+++ b/tests/notebook/test_notebook_controls.py
@@ -27,15 +27,22 @@ def setup_function() -> None:
     notebook_controls._doc_listener = None
 
 
-def test_wire_all_raises_off_main_thread(monkeypatch):
-    """@main_thread_only on wire_all: Layer A tripwire, not the Python lock."""
+def test_wire_all_ok_off_main_thread(monkeypatch):
+    """File Open XFilter is Dummy-2, not threading.main_thread()."""
     monkeypatch.setattr(tg, "on_main_thread", lambda: False)
     monkeypatch.setenv("WRITERAGENT_TESTING", "1")
     was = tg.GUARD_ON
     tg.GUARD_ON = True
     try:
-        with pytest.raises(RuntimeError, match="UNO thread violation"):
-            wire_all_notebook_run_buttons(MagicMock(), MagicMock())
+        with patch("plugin.notebook.notebook_controls.has_notebook_registry", return_value=False):
+            result = wire_all_notebook_run_buttons(MagicMock(), MagicMock())
+        assert result == 0
+
+        from plugin.notebook.notebook_controls import ensure_form_design_mode_off
+        doc = MagicMock()
+        doc.getCurrentController.return_value = None
+        ensure_form_design_mode_off(doc)
+        assert doc.ApplyFormDesignMode is False
     finally:
         tg.GUARD_ON = was
 


### PR DESCRIPTION
## Summary

`d429cea` put `@main_thread_only` on `ensure_form_design_mode_off` / `wire_all_notebook_run_buttons` / `prune_dead_listeners`. `XFilter.filter()` runs on Dummy-2 while the LibreOffice main thread waits (Yellow, issue #402). With `WRITERAGENT_UNO_THREAD_GUARD=1` the decorator raised, `filter()` returned False, and File Open of an `.ipynb` showed **General input/output error**.

Do **not** marshal this path with `execute_on_main_thread` — that is the same host-waiting deadlock as #402. The import already does PyUNO on Dummy-2. Drop the decorator on the File Open / OnViewCreated bulk-wiring path; keep it on `get_control_view_for_model`, `wire_run_button_listener`, and bootstrap `install_notebook_run_button_wiring`.

## Test plan

- [x] Unit: `test_notebook_controls.py` + `test_writer_importer.py` (74 passed)
- [x] Live File Open of `introduction-to-numpy-small.ipynb` with `WRITERAGENT_UNO_THREAD_GUARD=1`
  - no General I/O error; opens as notebook (`In [1]`/`[2]`/`[3]`, not JSON)
  - extra blank above `In [2]` still gone (`empty_text_body_between=0`)
  - Design Mode off; first ▶ prints `NumPy Version: 2.2.4`; no move/resize handles