### PR TITLE
fix(chat): SelectAll stick-to-bottom, Hidden so it should not flash (exp 18)

### DIFF
--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -399,3 +399,4 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 - Preserve real `NumberingRules` on paste and drop manual list-prefix reconstruction?
 - Spellcheck/grammar on the transcript?
 - Out-of-process webview still worth it long-term?
+- Create-time whole-control flash (greeting/history SelectAll while viewport is still Std). Pri 7; send/stream paths are Hidden.

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -392,7 +392,7 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 | 17 | Never SelectAll. 1-char at tail then collapse to 0-char via `XAccessibleText.setSelection` (and control.setSelection). Same helper on stream, HTML copy, and history batch. | Fail. Live web research: accessible miss, `via=control` no-op, viewport stuck on greeting at text_len>9000. Reverted to SelectAll. |
 | 18 | Restore query (Hidden mode) before and after SelectAll. Drop reveal_caret after copy/history (GetFocus forces Std and paints All()). | Agent stream: no flash. User message still flashes. |
 | 19 | User trailing-break used reveal_caret after SelectAll (GetFocus + Std + All()). Same Hidden scroll as stream; no reveal. | Pass. Keith click-test: You: insert no longer flashes; stream still Hidden; stick-to-bottom held. |
-| 20 | After resize `setPosSize`, Hidden SelectAll instead of reveal_caret. Stock layoutWindow jumps VisArea to origin; C++ patch not required for stick-to-bottom. | Click-test: drag sidebar width with transcript at bottom — stay on newest text, no flash, typing stays in Ask/instruct. |
+| 20 | After resize `setPosSize`, Hidden SelectAll instead of reveal_caret. Stock layoutWindow jumps VisArea to origin; C++ patch not required for stick-to-bottom. | Nonempty skip removed (was skip_nonempty). Drag restick is Hidden SelectAll with re-entrancy guard, no idle. Click-test: drag width with transcript at bottom; no hang; stay on newest text. |
 
 
 ### Open questions

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -391,7 +391,7 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 | 16 | Always dispatch `.uno:End` / `.uno:GoToEnd` / `.uno:GoRight` after SelectAll (ignore GoToEndOfDoc). Restore query *before* idle. `HideInactiveSelection=True` on the edit model. | Fail. SelectAll paints immediately (active selection) before hide/collapse. Flash on stream, typing, and window create. |
 | 17 | Never SelectAll. 1-char at tail then collapse to 0-char via `XAccessibleText.setSelection` (and control.setSelection). Same helper on stream, HTML copy, and history batch. | Fail. Live web research: accessible miss, `via=control` no-op, viewport stuck on greeting at text_len>9000. Reverted to SelectAll. |
 | 18 | Restore query (Hidden mode) before and after SelectAll. Drop reveal_caret after copy/history (GetFocus forces Std and paints All()). | Agent stream: no flash. User message still flashes. |
-| 19 | User trailing-break used reveal_caret after SelectAll (GetFocus + Std + All()). Same Hidden scroll as stream; no reveal. | Click-test: You: insert must not flash the whole control. |
+| 19 | User trailing-break used reveal_caret after SelectAll (GetFocus + Std + All()). Same Hidden scroll as stream; no reveal. | Pass. Keith click-test: You: insert no longer flashes; stream still Hidden; stick-to-bottom held. |
 
 ### Open questions
 

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -235,7 +235,7 @@ Python cannot scroll this control to “end of document.” UNO `insertString` /
 
 **Contract:** insert at the end, then `reveal_rich_control_caret` (brief ReadOnly lift + focus + idle). Do **not** insert dummy tail text — that is the same UNO path as the real append and does not move the EditView caret. Query focus is restored via `set_default_focus_restore`. Reliable pin-to-end still needs an LO peer API (`setSelection` / `ShowCursor`).
 
-Resize still jumps VisArea to the origin (`layoutWindow()` always `SetVisArea(Point())`). The caret is unchanged; reveal after a real `setPosSize` is the restore. A user who clicked mid-transcript has the caret there — inserts at end will not yank them.
+Resize: stock `layoutWindow()` always `SetVisArea(Point())`, so every `setPosSize` jumps to the top. The C++ patch keeps and clamps the old top-left (like `ImpVclMEdit::Resize`). On stock, after a real bounds change we Hidden-SelectAll (same as stream). That resticks the bottom; a mid-transcript scroll position cannot be restored without the patch.
 
 Width at creation/sync uses `last_response_rect` for height and horizontal position but caps width to the live Clear button row.
 
@@ -305,7 +305,7 @@ DEBUG-level `[RICH-SCROLL]` lines record caret reveal, formatted inserts, layout
 
 **User-send pattern (healthy):** after `phase=copy_done` / `reason=copy`, expect `phase=trailing_break` then another Hidden `_scroll_rich_to_tail` (not `reason=user_trailing_break` / `phase=reveal_caret`) before `phase=user_append_done`. A `phase=reveal_caret` on the user insert is the whole-control flash.
 
-**If scroll jumps after open/resize:** look for `phase=sync_bounds` then `reason=resize`. LibreOffice `layoutWindow()` always resets VisArea to the origin; we reveal the view caret after a real bounds change. A mid-transcript click cannot be restored as “end of document.”
+**If scroll jumps after open/resize:** look for `phase=sync_bounds` then Hidden SelectAll (not `reason=resize` / `phase=reveal_caret`). Stock `layoutWindow()` resets VisArea to the origin; we restick to the tail. Mid-transcript scroll cannot be restored on stock.
 
 ### Formatted insert used a fallback path (diagnostics)
 
@@ -392,6 +392,8 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 | 17 | Never SelectAll. 1-char at tail then collapse to 0-char via `XAccessibleText.setSelection` (and control.setSelection). Same helper on stream, HTML copy, and history batch. | Fail. Live web research: accessible miss, `via=control` no-op, viewport stuck on greeting at text_len>9000. Reverted to SelectAll. |
 | 18 | Restore query (Hidden mode) before and after SelectAll. Drop reveal_caret after copy/history (GetFocus forces Std and paints All()). | Agent stream: no flash. User message still flashes. |
 | 19 | User trailing-break used reveal_caret after SelectAll (GetFocus + Std + All()). Same Hidden scroll as stream; no reveal. | Pass. Keith click-test: You: insert no longer flashes; stream still Hidden; stick-to-bottom held. |
+| 20 | After resize `setPosSize`, Hidden SelectAll instead of reveal_caret. Stock layoutWindow jumps VisArea to origin; C++ patch not required for stick-to-bottom. | Click-test: drag sidebar width with transcript at bottom — stay on newest text, no flash, typing stays in Ask/instruct. |
+
 
 ### Open questions
 

--- a/plugin/chatbot/rich_text_control.py
+++ b/plugin/chatbot/rich_text_control.py
@@ -340,15 +340,15 @@ def sync_rich_control_bounds(rich_control, root_window, placeholder_ctrl, placeh
         bounds_changed = _apply_rich_control_geometry(rich_control, bx, by, bw, bh, update_dialog_model=False)
         if bounds_changed:
             log_rich_scroll("sync_bounds", control=rich_control, rect=f"{bx},{by},{bw},{bh}")
-            # layoutWindow() SetVisArea(Point()) — viewport jumps to top; caret
-            # is unchanged. Reveal the caret so AUTOSCROLL restores the view.
+            # Stock layoutWindow() SetVisArea(Point()) — every setPosSize jumps
+            # to the top. C++ patch keeps old top-left. Stock: Hidden SelectAll, no reveal_caret.
             try:
                 model = rich_control.getModel()
                 text = getattr(model, "Text", "") or "" if model is not None else ""
             except Exception:
                 text = ""
             if text:
-                reveal_rich_control_caret(rich_control, reason="resize")
+                _scroll_rich_to_tail(rich_control)
         if _rich_control_needs_bounds(rich_control, bx, by, bw, bh):
             # Dialog-embedded: model resize after insert fails (-1); reinsert when transcript empty.
             try:

--- a/plugin/chatbot/rich_text_control.py
+++ b/plugin/chatbot/rich_text_control.py
@@ -37,6 +37,7 @@ from plugin.framework.uno_context import focus_preserved, process_events_to_idle
 log = logging.getLogger(__name__)
 
 _CONTROL_INIT_STARTED: set[int] = set()
+_IN_SCROLL_TO_TAIL = False
 _ENV_SNAPSHOT_LOGGED = False
 RICH_CONTROL_NAME = "response_rich"
 # Dialog units (AppFont) — inset RichTextControl inside the response placeholder so glyphs are not clipped.
@@ -348,6 +349,12 @@ def sync_rich_control_bounds(rich_control, root_window, placeholder_ctrl, placeh
             except Exception:
                 text = ""
             if text:
+                try:
+                    peer = rich_control.getPeer() if hasattr(rich_control, "getPeer") else None
+                    if peer is not None and hasattr(peer, "invalidate"):
+                        peer.invalidate(0)
+                except Exception:
+                    pass
                 _scroll_rich_to_tail(rich_control)
         if _rich_control_needs_bounds(rich_control, bx, by, bw, bh):
             # Dialog-embedded: model resize after insert fails (-1); reinsert when transcript empty.
@@ -1008,11 +1015,22 @@ def _scroll_rich_to_tail(control: Any, ctx: Any = None) -> None:
     switches back. SelectAll itself does not GrabFocus. Restore query first so
     the viewport is Hidden, then SelectAll, then restore again. Do not setFocus
     or reveal_caret around this (that is the flash: GetFocus + Std + All()).
+
+    Re-entrant no-op: setPosSize during a sidebar drag can nest through
+    layoutWindow into another restick; that is the hang we must not reintroduce.
+    Do not process_events_to_idle here.
     """
-    from plugin.framework.uno_context import restore_query_if_user_still_there
-    restore_query_if_user_still_there()
-    _dispatch_rich_uno(control, ".uno:SelectAll", ctx)
-    restore_query_if_user_still_there()
+    global _IN_SCROLL_TO_TAIL
+    if _IN_SCROLL_TO_TAIL:
+        return
+    _IN_SCROLL_TO_TAIL = True
+    try:
+        from plugin.framework.uno_context import restore_query_if_user_still_there
+        restore_query_if_user_still_there()
+        _dispatch_rich_uno(control, ".uno:SelectAll", ctx)
+        restore_query_if_user_still_there()
+    finally:
+        _IN_SCROLL_TO_TAIL = False
 
 
 def append_text_chunk(control, text, auto_scroll=True, style_window=None, ctx=None):

--- a/tests/chatbot/test_rich_text_control.py
+++ b/tests/chatbot/test_rich_text_control.py
@@ -273,6 +273,23 @@ class TestAppendTextChunk:
         # SelectAll is between the two restores so Hidden mode stays.
         assert mock_uno.call_count == 1
 
+    def test_scroll_rich_to_tail_is_not_reentrant(self):
+        from plugin.chatbot import rich_text_control as rtc
+
+        control = MagicMock()
+        calls = {"n": 0}
+
+        def nested(_control, _command, _ctx):
+            calls["n"] += 1
+            rtc._scroll_rich_to_tail(control, ctx=None)
+
+        with patch("plugin.chatbot.rich_text_control._dispatch_rich_uno", side_effect=nested), \
+             patch("plugin.framework.uno_context.restore_query_if_user_still_there"):
+            rtc._scroll_rich_to_tail(control, ctx=None)
+
+        assert calls["n"] == 1
+        assert rtc._IN_SCROLL_TO_TAIL is False
+
     def test_sync_bounds_scrolls_tail_after_resize_when_transcript_nonempty(self):
         from types import SimpleNamespace
 

--- a/tests/chatbot/test_rich_text_control.py
+++ b/tests/chatbot/test_rich_text_control.py
@@ -273,7 +273,7 @@ class TestAppendTextChunk:
         # SelectAll is between the two restores so Hidden mode stays.
         assert mock_uno.call_count == 1
 
-    def test_sync_bounds_reveals_caret_after_resize_when_transcript_nonempty(self):
+    def test_sync_bounds_scrolls_tail_after_resize_when_transcript_nonempty(self):
         from types import SimpleNamespace
 
         from plugin.chatbot.rich_text_control import sync_rich_control_bounds
@@ -285,13 +285,13 @@ class TestAppendTextChunk:
         placeholder = MagicMock()
         placeholder.getPosSize.return_value = SimpleNamespace(X=4, Y=16, Width=200, Height=300)
 
-        with patch("plugin.chatbot.rich_text_control.reveal_rich_control_caret") as mock_reveal:
+        with patch("plugin.chatbot.rich_text_control._scroll_rich_to_tail") as mock_scroll:
             sync_rich_control_bounds(rich, None, placeholder)
 
-        mock_reveal.assert_called_once()
-        assert mock_reveal.call_args.kwargs.get("reason") == "resize"
+        mock_scroll.assert_called_once()
+        # reveal_caret is the flash path; resize uses Hidden SelectAll like stream.
 
-    def test_sync_bounds_skips_reveal_when_empty(self):
+    def test_sync_bounds_skips_scroll_when_empty(self):
         from types import SimpleNamespace
 
         from plugin.chatbot.rich_text_control import sync_rich_control_bounds
@@ -303,10 +303,10 @@ class TestAppendTextChunk:
         placeholder = MagicMock()
         placeholder.getPosSize.return_value = SimpleNamespace(X=4, Y=16, Width=200, Height=300)
 
-        with patch("plugin.chatbot.rich_text_control.reveal_rich_control_caret") as mock_reveal:
+        with patch("plugin.chatbot.rich_text_control._scroll_rich_to_tail") as mock_scroll:
             sync_rich_control_bounds(rich, None, placeholder)
 
-        mock_reveal.assert_not_called()
+        mock_scroll.assert_not_called()
 
     def test_clear_control(self):
         control = MagicMock()


### PR DESCRIPTION
## Live result (exp 17)

1-char `XAccessibleText` does **not** stick. Logs: `set_selection via=control` (stock no-op). Viewport stayed on the greeting while `text_len` passed 9000.

## Change

Restore `.uno:SelectAll` on the rich peer (the only path that calls `EditView.SetSelection(All())` / `ShowCursor`).

**Exp 18:** Keep `EESelectionMode::Hidden` around SelectAll. `DrawSelectionXOR` is a no-op while Hidden. `GetFocus` on the viewport forces Std and paints the whole selection. So restore Ask/instruct *before and after* SelectAll, and stop `reveal_caret` after copy/history (that was GetFocus + Std + All()).

## Test plan

- [ ] `make deploy writer` from this branch
- [ ] Web Research long stream: viewport follows the tail
- [ ] No whole-control flash on create, stream, or typing in Ask/instruct
- [ ] After Send, Ask/instruct still takes keys; a click into Writer stays there