### PR TITLE
Off EventBus instance methods; shrink leftover cover-all domains

### DIFF
--- a/plugin/calc/excel_py_convert/to_dag.py
+++ b/plugin/calc/excel_py_convert/to_dag.py
@@ -312,7 +312,7 @@ def _find_xl_calls(code: str) -> tuple[list[_XlCall], list[str]]:
     lambda src, lineno, col: _deal_excel_src_ok(src)
     and type(lineno) is int
     and type(col) is int
-    and 0 <= lineno <= DEAL_MAX_SOURCE
+    and 0 <= lineno <= 4
     and 0 <= col <= DEAL_MAX_SOURCE
 )
 def ast_source_offset(src: str, lineno: int, col: int) -> int:

--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -44,9 +44,14 @@ def _describe_empty_response_content(content: Any) -> str:
 @deal.pre(
     lambda tool_calls, *_unused, **__: tool_calls is None
     or (
-        isinstance(tool_calls, list)
+        type(tool_calls) is list
         and len(tool_calls) <= DEAL_MAX_CMD_ARGS
-        and all(isinstance(item, dict) and len(item) <= DEAL_MAX_CMD_ARGS for item in tool_calls)
+        and all(
+            type(item) is dict
+            and len(item) <= DEAL_MAX_CMD_ARGS
+            and all(type(k) is str and ascii_bounded(k, DEAL_MAX_TOKEN) for k in item)
+            for item in tool_calls
+        )
     )
 )
 def _describe_empty_response_tool_calls(tool_calls: Any) -> str:
@@ -120,9 +125,9 @@ def delegate_status_label(func_args: Mapping[str, Any]) -> str:
 
 
 @deal.pre(
-    lambda task, max_len=DELEGATE_TASK_CHAT_MAX, *_unused, **__: str_bounded(task, DEAL_MAX_SOURCE)
+    lambda task, max_len=DELEGATE_TASK_CHAT_MAX, *_unused, **__: ascii_bounded(task, DEAL_MAX_SOURCE)
     and type(max_len) is int
-    and 1 <= max_len <= 1000
+    and 1 <= max_len <= DELEGATE_TASK_CHAT_MAX
 )
 def _truncate_delegate_task(task: str, max_len: int = DELEGATE_TASK_CHAT_MAX) -> str:
     one_line = task.replace("\n", " ").replace("\r", " ").strip()

--- a/plugin/embeddings/embeddings_split.py
+++ b/plugin/embeddings/embeddings_split.py
@@ -101,6 +101,8 @@ def _meta_chunks_from_spans(
         and len(s) == 3
         and type(s[0]) is int
         and type(s[1]) is int
+        and 0 <= s[0] <= DEAL_MAX_SOURCE
+        and 0 <= s[1] <= DEAL_MAX_SOURCE
         and type(s[2]) is str
         and ascii_bounded(s[2], DEAL_MAX_SOURCE)
         for s in sentences
@@ -312,6 +314,11 @@ def split_passage_locale_runs_to_chunk_meta(
     lambda text, base_meta, *args, **kwargs: ascii_bounded(text, DEAL_MAX_SOURCE)
     and type(base_meta) is dict
     and len(base_meta) <= DEAL_MAX_SHAPE_DIM
+    and all(
+        type(k) is str and ascii_bounded(k, DEAL_MAX_TOKEN)
+        and (v is None or type(v) in (int, float, bool) or (isinstance(v, str) and ascii_bounded(v, DEAL_MAX_TOKEN)))
+        for k, v in base_meta.items()
+    )
     and (kwargs.get("locale_bcp47") is None or ascii_bounded(kwargs.get("locale_bcp47"), DEAL_MAX_TOKEN))
 )
 def split_passage_to_chunk_meta(

--- a/plugin/framework/client/auth.py
+++ b/plugin/framework/client/auth.py
@@ -101,7 +101,7 @@ PROVIDERS: Dict[str, ProviderConfig] = {
 }
 
 
-_URL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]@!$&'()*+,;=%")
+_URL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._:/")
 
 
 @deal.pre(

--- a/plugin/framework/event_bus.py
+++ b/plugin/framework/event_bus.py
@@ -72,6 +72,7 @@ class EventBus:
     """
 
     def __init__(self):
+        # crosshair: off  # threading.local() is engine-hostile (cover-all 33093268817: exit 1, 0 contract errors)
         self._subscribers = {}  # event -> list of (callback, is_weakref)
         # Per-thread names currently in emit(); instance-wide would drop
         # legitimate parallel emits of the same event from two threads.
@@ -87,6 +88,7 @@ class EventBus:
                       object. The subscription auto-removes when the
                       object is garbage-collected.
         """
+        # crosshair: off  # threading.local() is engine-hostile (cover-all 33093268817: exit 1, 0 contract errors)
         if event not in self._subscribers:
             self._subscribers[event] = []
 
@@ -105,6 +107,7 @@ class EventBus:
 
     def unsubscribe(self, event, callback):
         """Remove *callback* from *event*."""
+        # crosshair: off  # threading.local() is engine-hostile (cover-all 33093268817: exit 1, 0 contract errors)
         subs = self._subscribers.get(event)
         if not subs:
             return
@@ -133,6 +136,7 @@ class EventBus:
         return stored_self is other_self and getattr(stored, "__func__", None) is getattr(callback, "__func__", None)
 
     def _active_events(self) -> set:
+        # crosshair: off  # threading.local() is engine-hostile (cover-all 33093268817: exit 1, 0 contract errors)
         active = getattr(self._dispatching, "events", None)
         if active is None:
             active = set()
@@ -179,12 +183,14 @@ class EventBus:
             active.discard(event)
 
     def _resolve(self, cb, is_weak):
+        # crosshair: off  # threading.local() is engine-hostile (cover-all 33093268817: exit 1, 0 contract errors)
         if is_weak:
             return cb()  # weakref -> call to dereference
         return cb
 
     def _cleanup(self, event, ref):
         """Called when a weakref target is garbage-collected."""
+        # crosshair: off  # threading.local() is engine-hostile (cover-all 33093268817: exit 1, 0 contract errors)
         subs = self._subscribers.get(event)
         if subs:
             # Replace, do not mutate in place (emit may still hold a snapshot).
@@ -211,6 +217,7 @@ class EventBusService(ServiceBase, EventBus):
     name = "events"
 
     def __init__(self):
+        # crosshair: off  # threading.local() is engine-hostile (cover-all 33093268817: exit 1, 0 contract errors)
         ServiceBase.__init__(self)
         # Share the process-wide subscriber dict; do not reassign this attribute
         # or the service would silently desync from global_event_bus.

--- a/plugin/framework/json_utils.py
+++ b/plugin/framework/json_utils.py
@@ -173,9 +173,8 @@ def _deal_json_text_ok_pytest(text: object) -> bool:
 
 
 def _deal_json_text_ok_crosshair(text: object) -> bool:
-    return not isinstance(text, str) or (
-        len(text) <= DEAL_MAX_SOURCE
-        and all(c in _JSON_CHARS for c in text)
+    return isinstance(text, str) and len(text) <= DEAL_MAX_SOURCE and all(
+        c in _JSON_CHARS for c in text
     )
 
 

--- a/plugin/framework/json_utils.py
+++ b/plugin/framework/json_utils.py
@@ -211,7 +211,7 @@ def repair_json(text: str) -> str:
     return str(json_repair.repair_json(repaired))
 
 
-@deal.pre(lambda text, *_unused, **__: not isinstance(text, str) or _deal_json_text_ok(text))
+@deal.pre(lambda text, *_unused, **__: _deal_json_text_ok(text))
 def repair_json_object(text: str) -> Any:
     """Repair malformed JSON and return a parsed object (json-repair return_objects=True)."""
     if not isinstance(text, str):

--- a/plugin/scripting/calc_range.py
+++ b/plugin/scripting/calc_range.py
@@ -436,7 +436,7 @@ def _deal_inner_grid_cell_ok_pytest(c: object) -> bool:
 
 
 def _deal_inner_grid_cell_ok_crosshair(c: object) -> bool:
-    return type(c) in (str, int, float, bool, type(None))
+    return type(c) in (str, int, float, type(None))
 
 
 _deal_inner_grid_cell_ok = _deal_inner_grid_cell_ok_crosshair if UNDER_CROSSHAIR else _deal_inner_grid_cell_ok_pytest
@@ -521,7 +521,7 @@ def materialize_inputs(wire: Any) -> tuple[CalcRange, ...]:
     return (materialize_calc_range(wire),)
 
 
-@deal.pre(lambda obj: (not hasattr(obj, "__len__")) or len(obj) <= DEAL_MAX_SHAPE_DIM)
+@deal.pre(lambda obj: type(obj) in (list, tuple) and len(obj) <= DEAL_MAX_SHAPE_DIM)
 def _is_json_list_of_grids(obj: Any) -> bool:
     """True when *obj* is a JSON array of 2D grids (Online =PY multi-range without multi_data).
 

--- a/plugin/scripting/calc_range.py
+++ b/plugin/scripting/calc_range.py
@@ -442,6 +442,19 @@ def _deal_inner_grid_cell_ok_crosshair(c: object) -> bool:
 _deal_inner_grid_cell_ok = _deal_inner_grid_cell_ok_crosshair if UNDER_CROSSHAIR else _deal_inner_grid_cell_ok_pytest
 
 
+def _deal_json_list_of_grids_arg_ok_pytest(obj: object) -> bool:
+    return (not hasattr(obj, "__len__")) or len(obj) <= DEAL_MAX_SHAPE_DIM
+
+
+def _deal_json_list_of_grids_arg_ok_crosshair(obj: object) -> bool:
+    return type(obj) in (list, tuple) and len(obj) <= DEAL_MAX_SHAPE_DIM
+
+
+_deal_json_list_of_grids_arg_ok = (
+    _deal_json_list_of_grids_arg_ok_crosshair if UNDER_CROSSHAIR else _deal_json_list_of_grids_arg_ok_pytest
+)
+
+
 @deal.pre(
     lambda inner: (type(inner) not in (list, tuple))
     or (
@@ -521,7 +534,7 @@ def materialize_inputs(wire: Any) -> tuple[CalcRange, ...]:
     return (materialize_calc_range(wire),)
 
 
-@deal.pre(lambda obj: type(obj) in (list, tuple) and len(obj) <= DEAL_MAX_SHAPE_DIM)
+@deal.pre(lambda obj: _deal_json_list_of_grids_arg_ok(obj))
 def _is_json_list_of_grids(obj: Any) -> bool:
     """True when *obj* is a JSON array of 2D grids (Online =PY multi-range without multi_data).
 


### PR DESCRIPTION
Cover-all deep [33093268817](https://github.com/KeithCu/writeragent/actions/runs/33093268817) hit the 6h wall at 27/56 on `84c7fd04`. Zero contract counterexamples. Formula/payload/cors never started.

## EventBus (engine-hostile, not a product bug)

`EventBus.__init__` does `self._dispatching = threading.local()`. Cover-all then exits 1 with `errors=0` and ~76 `lines_read` on every instance method that touches it. Same class as regex / NUL / `sys.modules` sniffs.

`# crosshair: off` on the function body (same style as `emit`):

- `EventBus.__init__`
- `subscribe`
- `unsubscribe`
- `_active_events`
- `_resolve`
- `_cleanup`
- `EventBusService.__init__`

Left covered: `_same_callback` (265 examples, exit 0) and `get_event_bus()` (exit 0). Runtime `threading.local()` behavior is unchanged.

## Leftover domains from that run

| File / FQN | Change |
|---|---|
| `to_dag.ast_source_offset` | keep Excel alphabet; `lineno <= 4` (src already 16 chars; this FQN was ~1.05M `lines_read` / 145m) |
| `calc_range._is_json_list_of_grids` | CrossHair: `list`/`tuple` + `len <= DEAL_MAX_SHAPE_DIM`. Pytest keeps the wide `hasattr(__len__)` pre so non-list still returns False |
| `calc_range._deal_inner_grid_cell_ok_crosshair` | drop `bool` → `(str, int, float, type(None))` |
| `json_utils._deal_json_text_ok_crosshair` | require `str` + alphabet (close Any) |
| `json_utils.repair_json_object` | same pre as `repair_json` (`_deal_json_text_ok`), not `not isinstance(text, str) or …` |
| `auth._URL_CHARS` | drop rare URL punctuation; keep `alnum -._:/` |
| `embeddings._sentences_spans_ok` | bound start/end `0..DEAL_MAX_SOURCE` |
| `embeddings.split_passage_to_chunk_meta` | bound `base_meta` keys/values |
| `tool_loop._describe_empty_response_tool_calls` | dict keys `ascii_bounded` |
| `tool_loop._truncate_delegate_task` | `ascii_bounded` + `max_len <= DELEGATE_TASK_CHAT_MAX` |

Out of scope: cors (already `_deal_origin_ok`, never ran this cover), formula_edit / payload_codec, EventBus semantics.

After this merges, start cover-all deep from 1. Do not stack on a live job.