### PR TITLE
fix(sidebar): clamp HiDPI kids at create so the default H-bar is not seeded

### DIFF
--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -402,9 +402,9 @@ An 800px "frame hint" cap treated HiDPI columns (900-1200 device px) as the docu
 
 Do not raise `getMinimalWidth` to the HiDPI child extent. DeckLayouter sets max to min+100 when min exceeds the configured MaximumWidth (500 * DPI). A 600-900px min leaves ~100px of splitter travel, i.e. "cannot resize". Keep 320. Narrow H-bar is overflow: clamp width and X so children stay in the column.
 
-Native weld panels (`SidebarPanelBase::getHeightForWidth`) return height only. GTK `ChildFrame` hexpands; `Layout()` sizes the AWT child to the allocation. AWT HiDPI is different: `GtkSalFrame::SetPosSize` on a SYSTEMCHILD calls `gtk_widget_set_size_request`, and that request sticks. Keith 2026-08-27: `parent_after=992` the whole shrink while `deck_hint` 899→806; H-bar vanished only when the column ≥ 992. Sync ChildFrame *width only* to `deck_hint` every layout so the request cannot stay at 992. Do not set HEIGHT (that sticks the 2488 content request).
+Native weld panels (`SidebarPanelBase::getHeightForWidth`) return height only. GTK `ChildFrame` hexpands; `Layout()` sizes the AWT child to the allocation. AWT HiDPI is different: `GtkSalFrame::SetPosSize` on a SYSTEMCHILD calls `gtk_widget_set_size_request`, and that request sticks. Keith 2026-08-27: `parent_after=992` the whole shrink while `deck_hint` 899→806; H-bar vanished only when the column ≥ 992. Do not `setPosSize` the ChildFrame. That is `gtk_widget_set_size_request` (a minimum). Keith 2026-08-28: typing after a good drag did `windowResized` 995→1019 with no `getHeightForWidth`, and we filled 1019. Last month only sized the AWT dialog. Size the dialog only; keep child clamp.
 
-Create-time (Keith 2026-08-27): `[FIRST LAYOUT] root_w=320 max_child_right=1087 overflow=YES` then `parent=1115`. Relayout used to defer until deck negotiation, so HiDPI XDL kids seeded the H-bar. Clamp children first (even at 320), then set the ChildFrame. Narrow leftover (~2 inches) is that same 1087 − column.
+Create-time (Keith 2026-08-27): `[FIRST LAYOUT] root_w=320 max_child_right=1087 overflow=YES` then `parent=1115`. Relayout used to defer until deck negotiation, so HiDPI XDL kids seeded the H-bar. Clamp children first (even at 320). Do not set the ChildFrame. Narrow leftover (~2 inches) is that same 1087 − column.
 
 ### Open questions
 

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -404,6 +404,8 @@ Do not raise `getMinimalWidth` to the HiDPI child extent. DeckLayouter sets max 
 
 Native weld panels (`SidebarPanelBase::getHeightForWidth`) return height only. GTK `ChildFrame` hexpands; `Layout()` sizes the AWT child to the allocation. AWT HiDPI is different: `GtkSalFrame::SetPosSize` on a SYSTEMCHILD calls `gtk_widget_set_size_request`, and that request sticks. Keith 2026-08-27: `parent_after=992` the whole shrink while `deck_hint` 899→806; H-bar vanished only when the column ≥ 992. Sync ChildFrame *width only* to `deck_hint` every layout so the request cannot stay at 992. Do not set HEIGHT (that sticks the 2488 content request).
 
+Create-time (Keith 2026-08-27): `[FIRST LAYOUT] root_w=320 max_child_right=1087 overflow=YES` then `parent=1115`. Relayout used to defer until deck negotiation, so HiDPI XDL kids seeded the H-bar. Clamp children first (even at 320), then set the ChildFrame. Narrow leftover (~2 inches) is that same 1087 − column.
+
 ### Open questions
 
 - Incremental **formatted** HTML during stream (bold/lists live) vs. today’s strip-then-rerender-on-done? (Tag stripping mid-stream is already shipped — do not re-implement that.)

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -396,13 +396,18 @@ Live loop on stock LibreOffice (no C++ peer patch). One experiment at a time; re
 
 ### Sidebar column / H-scroll (2026-08-27)
 
+Experiment log (theories, logs, what not to restack): [sidebar-hscroll-experiments.md](sidebar-hscroll-experiments.md).
+
+
 Deck ScrolledWindow H-policy is AUTOMATIC. Fill `min(nWidth, parent)`; XDL 180 is AppFont, not pixels.
 
 An 800px "frame hint" cap treated HiDPI columns (900-1200 device px) as the document frame and pinned the panel at `getMinimalWidth` 320. That is the gutter plus deck H-bar on Keith's screen. Cap dropped; if both values agree they are the column.
 
 Do not raise `getMinimalWidth` to the HiDPI child extent. DeckLayouter sets max to min+100 when min exceeds the configured MaximumWidth (500 * DPI). A 600-900px min leaves ~100px of splitter travel, i.e. "cannot resize". Keep 320. Narrow H-bar is overflow: clamp width and X so children stay in the column.
 
-Native weld panels (`SidebarPanelBase::getHeightForWidth`) return height only. GTK `ChildFrame` hexpands; `Layout()` sizes the AWT child to the allocation. AWT HiDPI is different: `GtkSalFrame::SetPosSize` on a SYSTEMCHILD calls `gtk_widget_set_size_request`, and that request sticks. Keith 2026-08-27: `parent_after=992` the whole shrink while `deck_hint` 899→806; H-bar vanished only when the column ≥ 992. Do not `setPosSize` the ChildFrame. That is `gtk_widget_set_size_request` (a minimum). Keith 2026-08-28: typing after a good drag did `windowResized` 995→1019 with no `getHeightForWidth`, and we filled 1019. Last month only sized the AWT dialog. Size the dialog only; keep child clamp.
+Native weld panels (`SidebarPanelBase::getHeightForWidth`) return height only. GTK `ChildFrame` hexpands; `Layout()` sizes the AWT child to the allocation. AWT HiDPI is different: `GtkSalFrame::SetPosSize` on a SYSTEMCHILD calls `gtk_widget_set_size_request`, and that request sticks. Keith 2026-08-27: `parent_after=992` the whole shrink while `deck_hint` 899→806; H-bar vanished only when the column ≥ 992. Do not `setPosSize` the ChildFrame. That is `gtk_widget_set_size_request` (a minimum).
+
+Keith 2026-08-28: dropping ChildFrame sync did not stop the type-widen. `query_text` then `windowResized` 995→1019 with no `getHeightForWidth` (28+963+24+4). Query is XDL multiline+vscroll; HiDPI adds a ~24px V-scrollbar outside the size-request, we filled it, controls went past the viewport. 1x does not grow (scrollbar already in the empty Ask box). Do not `setPosSize` the dialog from `windowResized` (that can beat `getHeightForWidth` on a widen drag). H8: lay children out to min(window, last deck_hint); seed that from the first layout (320) until hfw. Splitter still fills after getHeightForWidth.
 
 Create-time (Keith 2026-08-27): `[FIRST LAYOUT] root_w=320 max_child_right=1087 overflow=YES` then `parent=1115`. Relayout used to defer until deck negotiation, so HiDPI XDL kids seeded the H-bar. Clamp children first (even at 320). Do not set the ChildFrame. Narrow leftover (~2 inches) is that same 1087 − column.
 

--- a/docs/chat/sidebar-hscroll-experiments.md
+++ b/docs/chat/sidebar-hscroll-experiments.md
@@ -1,0 +1,143 @@
+# Chat sidebar H-scroll and type-widen
+
+Deck `ScrolledWindow` H-policy is **AUTOMATIC**. The column width is `getHeightForWidth(nWidth)` (`rContentBox.GetWidth()`). Native weld panels return height only. Our panel is an AWT XDL dialog inside a GTK `ChildFrame`.
+
+**Rule (H8, this branch):** children lay out to `min(window, last deck_hint)`. Before the first `getHeightForWidth`, the first layout width (usually 320) is that column. Never `setPosSize` the ChildFrame. Never `setPosSize` the dialog from `windowResized` (that event can beat `getHeightForWidth` on a widen drag).
+
+Grep:
+
+```
+rg "getHeightForWidth|LAYOUT|layout_sanity|cap_width" ~/.config/libreoffice/4/user/config/writeragent_debug.log | tail -50
+```
+
+Box is 1x 1280×800. Keith is HiDPI. Do not trust screenshot captions for H-bars. `GDK_SCALE=2` does **not** map XDL AppFont (query stays 49px, not 206).
+
+## What is not the bug
+
+Stick-to-bottom (SelectAll / Hidden) is merged (`4187416d` / PR 490). This file is only: deck H-bar, fill on drag, type-widen after a good drag.
+
+## Native facts
+
+- `Deck.cxx`: H and V policy AUTOMATIC. `tdf#142458` extra width for the **deck** V-scrollbar.
+- `DeckLayouter.cxx`: `getHeightForWidth(rContentBox.GetWidth())`. If `getMinimalWidth() > getMaximumWidth()`, max becomes min+100 (splitter freeze).
+- GTK `ChildFrame`: hexpand+fill. `Layout()` sizes the AWT child to the allocation.
+- `GtkSalFrame::SetPosSize` on SYSTEMCHILD: `gtk_widget_set_size_request` — a **minimum**, not a max. Widgets can still grow the request.
+- XDL `ChatPanelDialog.xdl`: `query` and `response` are `multiline` + `vscroll`. `query` height 30 AppFont (Keith HiDPI ≈ 206px; 1x ≈ 49px). `dlg:width="180"` is AppFont, not pixels.
+
+## Experiments
+
+| # | Change | Result |
+|---|--------|--------|
+| H1 | Cap fill at 800px "frame hint" | Fail. HiDPI column 900–1200 treated as the document frame. Panel stuck at `getMinimalWidth` 320. Gutter + H-bar. |
+| H2 | Raise `getMinimalWidth` to HiDPI child extent (~600–1087) | Fail. DeckLayouter sets max to min+100. Splitter barely moves. |
+| H3 | Fill `min(nWidth, parent)`; 180 is AppFont; drop 800 cap | Partial. Drag fill looks right when parent tracks. Shrink: ChildFrame request sticks, H-bar until column ≥ stuck width. |
+| H4 | `setPosSize` ChildFrame **width only** to `deck_hint` every layout | Partial. Keith 2026-08-27: `parent_after` tracked 641→557 (was stuck at 992). Typing still grew: GTK min, not max. |
+| H5 | Clamp HiDPI kids at create (even at 320), before any ChildFrame sync | Partial. Stops `[FIRST LAYOUT] max_child_right=1087` seeding the H-bar. Typing still grew. PR 492 / `685e76c8`. |
+| H6 | Drop ChildFrame `setPosSize`. Keep dialog fill + child clamp. `a1dab202` | Fail for type-widen. Log A: 995→1019 still. Shrink H-bar came back (`parent_after` stuck at 1067). |
+| H7 | On `windowResized` grow, `setPosSize` dialog back to last `deck_hint` | **Not shipped.** 1x: `windowResized` 465 **before** `getHeightForWidth` 465. Snapping back would fight a widen drag. |
+| H8 | Layout children to `min(window, last deck_hint)`. Seed `_viewport_w` from first layout. No dialog `setPosSize` from `windowResized`. | **This branch.** 1x: `cap_width` stops the +4 ratchet; drag still fills after hfw (logs D–E). HiDPI type-widen not reproduced here (query stays 49px). |
+
+## Log A — Keith HiDPI 2026-08-28 11:06 (`a1dab202`)
+
+Drag: `parent_after` stuck at **1067** while `deck_hint`/`root` 1016→995. H-bar vanishes only when the column is wide enough to cover 1067.
+
+```
+getHeightForWidth deck_hint=995 parent=1067x2488 current_root=998x2488 eff_W=995
+source=windowResized root=995x2488
+response_rect ... w=963 ... root=995x2488 max_child_right=991 overflow=no
+getHeightForWidth root_after=995x2488 parent_after=1067x2488
+```
+
+Type (no `getHeightForWidth`):
+
+```
+source=query_text query=963x206@28 has_text=True
+source=windowResized root=1019x2488
+response_rect ... w=987 ... root=1019x2488 max_child_right=1015 overflow=no
+```
+
+Then clear:
+
+```
+source=query_text query=987x206@28 has_text=False
+source=windowResized root=1043x2488
+```
+
+1019 = query X 28 + width 963 + **24** + right margin 4. Query is multiline+vscroll. +24 is a HiDPI V-scrollbar outside the size-request. Filling 1019 put controls past the ~995 viewport.
+
+## Log B — Scrolly 1x 2026-08-28 15:15 (`a1dab202`)
+
+Create: `root=320 max_child_right=316 overflow=no`, then `windowResized` 324, `parent_after` 324 then 328.
+
+Widen: `windowResized` **465 first**, then `getHeightForWidth deck_hint=465`. Parent tracked 465.
+
+Type `hello` / clear: `query=453x49@8`, **no** `windowResized`. Ask box already shows a V-scrollbar when empty at 1x. Type-widen is HiDPI-only on current code.
+
+## Log C — Scrolly `GDK_SCALE=2` 2026-08-28 16:39 (`a1dab202` cache)
+
+`GDK_SCALE=2` was set. AppFont did **not** scale: `query=431x49@8`. Create ratchet without H8:
+
+```
+windowResized root=357x485
+getHeightForWidth deck_hint=357 parent_after=357
+windowResized root=361x577
+windowResized root=365x577
+windowResized root=369x577
+```
+
+No `getHeightForWidth` on those +4 steps. Same "fill GTK's grow" as log A, +4 not +24.
+
+## Log D — Scrolly 1x H8 2026-08-28 16:45 (cap, no first-width seed)
+
+```
+FIRST LAYOUT root=320 max_child_right=316
+windowResized root=383          # before hfw; filled 383 (viewport still 0)
+getHeightForWidth deck_hint=383 parent_after=383
+windowResized root=387
+cap_width window=387 viewport=383
+response_rect root=383 max_child_right=379
+```
+
+Widen drag still filled after hfw:
+
+```
+windowResized root=460
+cap_width window=460 viewport=383
+getHeightForWidth deck_hint=460 parent_after=460
+response_rect root=460 max_child_right=456
+```
+
+## Log E — Scrolly 1x H8 + first-width seed 2026-08-28 16:52
+
+Sidebar restored wide. First layout 320 is the column until hfw:
+
+```
+FIRST LAYOUT root=320 max_child_right=316
+windowResized root=460
+cap_width window=460 viewport=320
+response_rect root=320 max_child_right=316
+getHeightForWidth deck_hint=460 parent_after=460
+response_rect root=460 max_child_right=456
+windowResized root=464
+cap_width window=464 viewport=460
+response_rect root=460 max_child_right=456
+```
+
+Kids never followed the +4 GTK bump. Restore-to-wide still filled once the deck spoke.
+
+## What we learned
+
+1. **Column is `getHeightForWidth`, not `windowResized`.** The AWT dialog also resizes when GTK inflates a child (query `vscroll`). Treating that width as the column is how 995 became 1019 became 1043, and how 357 became 361 became 369.
+2. **`setPosSize` on GTK is a minimum.** ChildFrame sync (H4) made `parent_after` track on shrink, then typing grew past the min. Snapping the dialog back from `windowResized` (H7) would fight a widen drag, because that event can beat `getHeightForWidth`.
+3. **Type-widen is HiDPI.** 1x query is ~49px and already shows a V-scrollbar when empty, so typing does not fire `windowResized`. Keith's query is ~206px; first keystroke adds ~24px chrome outside the size-request.
+4. **`GDK_SCALE=2` is not a HiDPI stand-in** for this bug. AppFont stays 1x.
+5. **H8 does not shrink a stuck ChildFrame.** Log A `parent=1067` while `deck_hint` 995 is still open. Restacking H4 without a max re-opens type-grow.
+
+## Next
+
+1. **HiDPI click-test of H8** (the only machine that shows log A). After a good drag, type in Ask/instruct. Expect `cap_width window=1019 viewport=995` and kids staying in the column. Same grep as above. 1x cannot prove this.
+2. **Stuck ChildFrame on shrink** (`parent_after` 1067). Needs a max, not another size-request min. Do not `setPosSize` the ChildFrame until that exists (native hexpand, or a real max).
+3. **Default H-bar leftover** of a few px when parent is 464 and viewport is 460. Kids are in the column; the bar is the GTK request, not child overflow. Same problem as (2) at small delta.
+4. **Do not** raise `getMinimalWidth`, treat XDL 180 as pixels, restore the 800px cap, or add a magic 24px scrollbar gutter unless a HiDPI log after H8 still shows controls offscreen.
+
+Code: `plugin/chatbot/panel_resize.py` (`_relayout` cap + first-width seed). Tests in `tests/chatbot/test_panel_resize.py`.

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -201,6 +201,16 @@ class QueryTextListener(BaseTextListener):
         if not model:
             model = rEvent.Source.getModel()
         text = model.Text.strip()
+        try:
+            src = rEvent.Source
+            ps = src.getPosSize() if hasattr(src, "getPosSize") else None
+            log.info(
+                "[LAYOUT] source=query_text query=%s has_text=%s",
+                ("%sx%s@%s" % (ps.Width, ps.Height, ps.X)) if ps else "?",
+                bool(text),
+            )
+        except Exception:
+            log.info("[LAYOUT] source=query_text has_text=%s", bool(text))
 
         # Dispatch event to the state machine
         self.send_listener.dispatch(SendEvent(SendEventKind.TEXT_UPDATED, {"has_text": bool(text)}))

--- a/plugin/chatbot/panel_factory.py
+++ b/plugin/chatbot/panel_factory.py
@@ -74,7 +74,7 @@ try:
 except ImportError:
     TOOLPANEL = 3  # Fallback
 
-from plugin.framework.sidebar_column import sidebar_column_width, sync_childframe_width
+from plugin.framework.sidebar_column import sidebar_column_width
 from plugin.framework.uno_listeners import BaseItemListener, BaseTextListener
 from plugin.framework.config import get_config, get_current_endpoint
 from plugin.framework.client.model_fetcher import get_text_model, get_image_model, set_image_model, set_text_model
@@ -209,22 +209,10 @@ class ChatToolPanel(unohelper.Base, XToolPanel, XSidebarPanel):
             with suppress_disposed("getHeightForWidth note_width_negotiated", logger=log):
                 rl.note_width_negotiated(eff_w)
         with suppress_disposed("getHeightForWidth setPosSize", logger=log):
-            # Dialog first, then clamp children, then ChildFrame. Setting the
-            # ChildFrame while kids still request 1087 lets GTK keep max(875, 1087).
+            # Size the AWT dialog only, like last month. ChildFrame setPosSize is
+            # gtk_widget_set_size_request (a minimum); typing grew past it and we
+            # filled the new width (Keith: 995 → 1019).
             self.PanelWindow.setPosSize(0, 0, eff_w, current_h, 15)
-
-        if rl is not None:
-            with suppress_disposed("getHeightForWidth relayout_now", logger=log):
-                from plugin.chatbot.rich_text_control import log_rich_scroll
-
-                rich = rl._c.get("response_rich") if hasattr(rl, "_c") else None
-                log_rich_scroll("getHeightForWidth_before", control=rich, eff_w=eff_w)
-                rl.relayout_now(self.PanelWindow)
-                log_rich_scroll("getHeightForWidth_after", control=rich, eff_w=eff_w)
-
-        with suppress_disposed("getHeightForWidth childframe", logger=log):
-            log.info("childframe_sync %s -> %s", parent_w, eff_w)
-            sync_childframe_width(self.parent_window, eff_w)
             after = self.PanelWindow.getPosSize()
             parent_after = self.parent_window.getPosSize()
             log.info(
@@ -234,6 +222,15 @@ class ChatToolPanel(unohelper.Base, XToolPanel, XSidebarPanel):
                 parent_after.Width,
                 parent_after.Height,
             )
+
+        if rl is not None:
+            with suppress_disposed("getHeightForWidth relayout_now", logger=log):
+                from plugin.chatbot.rich_text_control import log_rich_scroll
+
+                rich = rl._c.get("response_rich") if hasattr(rl, "_c") else None
+                log_rich_scroll("getHeightForWidth_before", control=rich, eff_w=eff_w)
+                rl.relayout_now(self.PanelWindow)
+                log_rich_scroll("getHeightForWidth_after", control=rich, eff_w=eff_w)
 
         return uno.createUnoStruct("com.sun.star.ui.LayoutSize", 100, -1, 400)
 
@@ -340,7 +337,6 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                 parent_rect.Height if parent_rect.Height > 0 else 400
             )
             if target_w > 0 and target_h > 0:
-                sync_childframe_width(self.xParentWindow, target_w)
                 self.m_panelRootWindow.setPosSize(0, 0, target_w, target_h, 15)
                 log.debug("panel pre-negotiation constrained to W=%s H=%s" % (target_w, target_h))
         return self.m_panelRootWindow

--- a/plugin/chatbot/panel_factory.py
+++ b/plugin/chatbot/panel_factory.py
@@ -207,23 +207,11 @@ class ChatToolPanel(unohelper.Base, XToolPanel, XSidebarPanel):
         rl = getattr(self, "resize_listener", None)
         if rl is not None and hasattr(rl, "note_width_negotiated"):
             with suppress_disposed("getHeightForWidth note_width_negotiated", logger=log):
-                rl.note_width_negotiated()
+                rl.note_width_negotiated(eff_w)
         with suppress_disposed("getHeightForWidth setPosSize", logger=log):
-            # Width only on the ChildFrame. HEIGHT would stick Keith's 2488 request.
-            # Native weld never needs this; AWT preferred size on HiDPI does.
-            if parent_w != eff_w:
-                log.info("childframe_sync %s -> %s", parent_w, eff_w)
-                sync_childframe_width(self.parent_window, eff_w)
+            # Dialog first, then clamp children, then ChildFrame. Setting the
+            # ChildFrame while kids still request 1087 lets GTK keep max(875, 1087).
             self.PanelWindow.setPosSize(0, 0, eff_w, current_h, 15)
-            after = self.PanelWindow.getPosSize()
-            parent_after = self.parent_window.getPosSize()
-            log.info(
-                "getHeightForWidth root_after=%sx%s parent_after=%sx%s",
-                after.Width,
-                after.Height,
-                parent_after.Width,
-                parent_after.Height,
-            )
 
         if rl is not None:
             with suppress_disposed("getHeightForWidth relayout_now", logger=log):
@@ -233,6 +221,19 @@ class ChatToolPanel(unohelper.Base, XToolPanel, XSidebarPanel):
                 log_rich_scroll("getHeightForWidth_before", control=rich, eff_w=eff_w)
                 rl.relayout_now(self.PanelWindow)
                 log_rich_scroll("getHeightForWidth_after", control=rich, eff_w=eff_w)
+
+        with suppress_disposed("getHeightForWidth childframe", logger=log):
+            log.info("childframe_sync %s -> %s", parent_w, eff_w)
+            sync_childframe_width(self.parent_window, eff_w)
+            after = self.PanelWindow.getPosSize()
+            parent_after = self.parent_window.getPosSize()
+            log.info(
+                "getHeightForWidth root_after=%sx%s parent_after=%sx%s",
+                after.Width,
+                after.Height,
+                parent_after.Width,
+                parent_after.Height,
+            )
 
         return uno.createUnoStruct("com.sun.star.ui.LayoutSize", 100, -1, 400)
 
@@ -332,16 +333,14 @@ class ChatPanelElement(unohelper.Base, XUIElement):
         with suppress_disposed("constrain panel window", logger=log):
             parent_rect = self.xParentWindow.getPosSize()
             current_rect = self.m_panelRootWindow.getPosSize()
-            parent_w = parent_rect.Width if parent_rect else 0
-            current_w = current_rect.Width if current_rect else 0
-            # 180 here used to be XDL AppFont treated as pixels; children are
-            # already ~304px (Clear), so a 180px root overflowed and seeded H-scroll.
-            min_w = self.toolpanel.getMinimalWidth() if self.toolpanel else _PRE_NEGOTIATION_PANEL_WIDTH
-            target_w = sidebar_column_width(0, parent_w, current_w, min_w=min_w)
+            # Cap to 320, not parent. sidebar_column_width(0, 1115) would fill
+            # the HiDPI ChildFrame request and seed the default H-bar.
+            target_w = _PRE_NEGOTIATION_PANEL_WIDTH
             target_h = current_rect.Height if current_rect.Height > 0 else (
                 parent_rect.Height if parent_rect.Height > 0 else 400
             )
             if target_w > 0 and target_h > 0:
+                sync_childframe_width(self.xParentWindow, target_w)
                 self.m_panelRootWindow.setPosSize(0, 0, target_w, target_h, 15)
                 log.debug("panel pre-negotiation constrained to W=%s H=%s" % (target_w, target_h))
         return self.m_panelRootWindow

--- a/plugin/chatbot/panel_resize.py
+++ b/plugin/chatbot/panel_resize.py
@@ -141,6 +141,7 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
         self._root_window = None
         self._parent_window = None
         self._width_negotiated = False
+        self._viewport_w = 0
         self._last_response_rect = None
 
     @property
@@ -158,9 +159,8 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
     def relayout_now(self, win):
         if not win:
             return
-        if not self._width_negotiated and self._snapshot is None:
-            _resize_debug("relayout_now: deferred until deck width negotiated")
-            return
+        # Do not wait for deck negotiation. Keith create-time: root=320 with
+        # max_child_right=1087 seeded the H-bar until the first widen.
         if self._in_relayout:
             _resize_debug("relayout_now: skipped (in_relayout)")
             return
@@ -176,8 +176,10 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
         _resize_debug("windowResized: W=%d H=%d" % (rEvent.Source.getPosSize().Width, rEvent.Source.getPosSize().Height))
         self.relayout_now(rEvent.Source)
 
-    def note_width_negotiated(self):
+    def note_width_negotiated(self, viewport_w: int = 0):
         self._width_negotiated = True
+        if viewport_w > 0:
+            self._viewport_w = int(viewport_w)
 
     def _capture_snapshot(self, win):
         r = win.getPosSize()
@@ -219,17 +221,6 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
         if w <= 0 or h <= 0:
             return
 
-        # Shrink can skip getHeightForWidth. Keep the ChildFrame request = dialog.
-        parent = getattr(self, "_parent_window", None)
-        if parent is not None:
-            try:
-                pr = parent.getPosSize()
-                if pr.Width != w:
-                    log.info("childframe_sync relayout %s -> %s", pr.Width, w)
-                    sync_childframe_width(parent, w)
-            except Exception:
-                pass
-
         if self._snapshot is None:
             self._capture_snapshot(win)
         snapshot = self._snapshot
@@ -241,10 +232,22 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
         if not layouts:
             return
 
+        # Clamp children first so GTK preferred width drops, then the ChildFrame.
         for name, rect in layouts.items():
             ctrl = self._c.get(name)
             if ctrl is not None:
                 self._apply_rect(ctrl, rect)
+
+        viewport = self._viewport_w if self._viewport_w > 0 else w
+        parent = getattr(self, "_parent_window", None)
+        if parent is not None:
+            try:
+                pr = parent.getPosSize()
+                if pr.Width != viewport:
+                    log.info("childframe_sync relayout %s -> %s", pr.Width, viewport)
+                    sync_childframe_width(parent, viewport)
+            except Exception:
+                pass
 
         response = layouts.get("response")
         if response is not None:

--- a/plugin/chatbot/panel_resize.py
+++ b/plugin/chatbot/panel_resize.py
@@ -2,7 +2,6 @@ import logging
 
 from dataclasses import dataclass
 
-from plugin.framework.sidebar_column import sync_childframe_width
 from plugin.framework.uno_listeners import BaseWindowListener
 
 log = logging.getLogger(__name__)
@@ -233,22 +232,10 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
         if not layouts:
             return
 
-        # Clamp children first so GTK preferred width drops, then the ChildFrame.
         for name, rect in layouts.items():
             ctrl = self._c.get(name)
             if ctrl is not None:
                 self._apply_rect(ctrl, rect)
-
-        viewport = self._viewport_w if self._viewport_w > 0 else w
-        parent = getattr(self, "_parent_window", None)
-        if parent is not None:
-            try:
-                pr = parent.getPosSize()
-                if pr.Width != viewport:
-                    log.info("childframe_sync relayout %s -> %s", pr.Width, viewport)
-                    sync_childframe_width(parent, viewport)
-            except Exception:
-                pass
 
         response = layouts.get("response")
         if response is not None:

--- a/plugin/chatbot/panel_resize.py
+++ b/plugin/chatbot/panel_resize.py
@@ -174,6 +174,9 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
     def on_window_resized(self, rEvent):
         r = rEvent.Source.getPosSize()
         log.info("[LAYOUT] source=windowResized root=%dx%d", r.Width, r.Height)
+        # Do not setPosSize the dialog here. windowResized can beat
+        # getHeightForWidth on a widen drag (1x: 465 then hfw 465); snapping
+        # back to last deck_hint would fight the splitter.
         self.relayout_now(rEvent.Source)
 
     def note_width_negotiated(self, viewport_w: int = 0):
@@ -220,6 +223,15 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
         w, h = int(r.Width), int(r.Height)
         if w <= 0 or h <= 0:
             return
+        # Column is last getHeightForWidth. Before the first hfw, the first
+        # layout width (320) is the column so a GTK jump (320→383) is not filled.
+        # A windowResized grow without a new deck_hint is GTK, not a drag.
+        # Do not setPosSize the dialog here; that can beat hfw on a widen.
+        if self._viewport_w <= 0:
+            self._viewport_w = w
+        elif w > self._viewport_w:
+            log.info("[LAYOUT] cap_width window=%s viewport=%s", w, self._viewport_w)
+            w = self._viewport_w
 
         if self._snapshot is None:
             self._capture_snapshot(win)

--- a/plugin/chatbot/panel_resize.py
+++ b/plugin/chatbot/panel_resize.py
@@ -173,7 +173,8 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
             self._in_relayout = False
 
     def on_window_resized(self, rEvent):
-        _resize_debug("windowResized: W=%d H=%d" % (rEvent.Source.getPosSize().Width, rEvent.Source.getPosSize().Height))
+        r = rEvent.Source.getPosSize()
+        log.info("[LAYOUT] source=windowResized root=%dx%d", r.Width, r.Height)
         self.relayout_now(rEvent.Source)
 
     def note_width_negotiated(self, viewport_w: int = 0):
@@ -252,14 +253,19 @@ class _PanelResizeListener(BaseWindowListener):  # pyright: ignore[reportUnusedC
         response = layouts.get("response")
         if response is not None:
             self._last_response_rect = (response.x, response.y, response.width, response.height)
+            max_right = 0
+            for rect in layouts.values():
+                max_right = max(max_right, rect.x + rect.width)
             log.info(
-                "[LAYOUT] response_rect x=%d y=%d w=%d h=%d root=%dx%d",
+                "[LAYOUT] response_rect x=%d y=%d w=%d h=%d root=%dx%d max_child_right=%d overflow=%s",
                 response.x,
                 response.y,
                 response.width,
                 response.height,
                 w,
                 h,
+                max_right,
+                "YES" if max_right > w - 2 else "no",
             )
             rich = self._c.get("response_rich")
             if rich is not None:

--- a/plugin/chatbot/panel_wiring.py
+++ b/plugin/chatbot/panel_wiring.py
@@ -209,7 +209,7 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):  
                         max_right = max(max_right, pr.X + pr.Width)
                     except Exception:
                         pass
-            log.debug("layout_sanity: root_w=%d max_child_right=%d overflow=%s" % (rw, max_right, "YES" if max_right > rw - 2 else "no"))
+            log.info("[LAYOUT] layout_sanity root_w=%d max_child_right=%d overflow=%s" % (rw, max_right, "YES" if max_right > rw - 2 else "no"))
         except Exception:
             pass
     except Exception:

--- a/plugin/framework/sidebar_column.py
+++ b/plugin/framework/sidebar_column.py
@@ -2,23 +2,19 @@
 # Copyright (c) 2026 KeithCu
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Sidebar column width: fill the deck viewport, keep the ChildFrame request in sync.
+"""Sidebar column width: fill the deck viewport.
 
 Deck.cxx ScrolledWindow H-policy is AUTOMATIC. getHeightForWidth is called
 with rContentBox.GetWidth() (the viewport). The AWT parent is CreateChildFrame
 inside that box.
 
-GtkSalFrame::SetPosSize on a SYSTEMCHILD calls gtk_widget_set_size_request.
-That request sticks. Keith's HiDPI log: parent_after stayed 992 while
-deck_hint/root shrank 899 → 806. Extra space = 992 − viewport. Wide enough
-that the column >= 992 and the H-bar vanished.
-
 Trust nWidth (the viewport) except:
   - 180: XDL AppFont leak, use parent
   - nWidth > 1.5× parent: document-frame leak, use parent
 
-Then setPosSize the ChildFrame WIDTH only to that value, every layout,
-so the request cannot stay at 992.
+Do not setPosSize the ChildFrame. GtkSalFrame::SetPosSize on a SYSTEMCHILD
+is gtk_widget_set_size_request (a minimum). Kids can grow past it.
+Experiments: docs/chat/sidebar-hscroll-experiments.md
 """
 
 from __future__ import annotations

--- a/plugin/librepy/panel_factory.py
+++ b/plugin/librepy/panel_factory.py
@@ -119,13 +119,13 @@ class PythonToolPanel(unohelper.Base, XToolPanel, XSidebarPanel):
             eff_w,
         )
         with suppress_disposed("getHeightForWidth setPosSize", logger=log):
-            if parent_w != eff_w:
-                sync_childframe_width(self.parent_window, eff_w)
             self.PanelWindow.setPosSize(0, 0, eff_w, current_h, 15)
         rl = getattr(self, "resize_listener", None)
         if rl is not None:
             with suppress_disposed("getHeightForWidth relayout_now", logger=log):
                 rl.relayout_now(self.PanelWindow)
+        with suppress_disposed("getHeightForWidth childframe", logger=log):
+            sync_childframe_width(self.parent_window, eff_w)
         return uno.createUnoStruct("com.sun.star.ui.LayoutSize", 100, -1, 400)
 
     def getMinimalWidth(self):

--- a/plugin/librepy/panel_factory.py
+++ b/plugin/librepy/panel_factory.py
@@ -35,7 +35,7 @@ from plugin.framework.uno_bootstrap import ensure_plugin_on_path
 ensure_plugin_on_path(__file__, levels_up=3, also_add_contrib=True)
 
 from plugin.framework.errors import UnoObjectError, suppress_disposed
-from plugin.framework.sidebar_column import sidebar_column_width, sync_childframe_width
+from plugin.framework.sidebar_column import sidebar_column_width
 from plugin.framework.uno_context import get_extension_url, get_ctx
 
 if TYPE_CHECKING:
@@ -124,8 +124,6 @@ class PythonToolPanel(unohelper.Base, XToolPanel, XSidebarPanel):
         if rl is not None:
             with suppress_disposed("getHeightForWidth relayout_now", logger=log):
                 rl.relayout_now(self.PanelWindow)
-        with suppress_disposed("getHeightForWidth childframe", logger=log):
-            sync_childframe_width(self.parent_window, eff_w)
         return uno.createUnoStruct("com.sun.star.ui.LayoutSize", 100, -1, 400)
 
     def getMinimalWidth(self):

--- a/tests/chatbot/test_panel_resize.py
+++ b/tests/chatbot/test_panel_resize.py
@@ -195,6 +195,58 @@ class TestPanelResizeListenerIntegration:
             assert ps.X + ps.Width <= right, name
         parent.setPosSize.assert_not_called()
 
+    def test_create_gtk_jump_before_hfw_does_not_become_the_column(self):
+        # 1x H8 log: FIRST LAYOUT 320 then windowResized 383 before hfw.
+        # Filling 383 is how the default H-bar gets its extra width.
+        snapshot = _xdl_snapshot()
+        controls = {
+            name: _mock_control(x, y, w, h) for name, (x, y, w, h) in snapshot.items()
+        }
+        root = MagicMock()
+        root.getPosSize.return_value = SimpleNamespace(Width=320, Height=400)
+        listener = _PanelResizeListener(controls)
+        listener.relayout_now(root)
+        root.getPosSize.return_value = SimpleNamespace(Width=383, Height=485)
+        listener.on_window_resized(SimpleNamespace(Source=root))
+        root.setPosSize.assert_not_called()
+        right = 320 - 4
+        for name, ctrl in controls.items():
+            ps = ctrl.getPosSize()
+            assert ps.X + ps.Width <= right, name
+
+    def test_window_resized_grow_layouts_to_viewport_not_gtk_inflation(self):
+        # Keith 2026-08-28: query_text then windowResized 995→1019, no hfw.
+        # Do not setPosSize the dialog (that fights a widen drag). Layout to 995.
+        snapshot = _xdl_snapshot()
+        controls = {
+            name: _mock_control(x, y, w, h) for name, (x, y, w, h) in snapshot.items()
+        }
+        root = MagicMock()
+        root.getPosSize.return_value = SimpleNamespace(Width=1019, Height=2488)
+        listener = _PanelResizeListener(controls)
+        listener.note_width_negotiated(995)
+        listener.on_window_resized(SimpleNamespace(Source=root))
+        root.setPosSize.assert_not_called()
+        right = 995 - 4
+        for name, ctrl in controls.items():
+            ps = ctrl.getPosSize()
+            assert ps.X + ps.Width <= right, name
+
+    def test_window_resized_shrink_trusts_the_window(self):
+        snapshot = _xdl_snapshot()
+        controls = {
+            name: _mock_control(x, y, w, h) for name, (x, y, w, h) in snapshot.items()
+        }
+        root = MagicMock()
+        root.getPosSize.return_value = SimpleNamespace(Width=800, Height=500)
+        listener = _PanelResizeListener(controls)
+        listener.note_width_negotiated(995)
+        listener.on_window_resized(SimpleNamespace(Source=root))
+        root.setPosSize.assert_not_called()
+        q = controls["query"].getPosSize()
+        assert q.X + q.Width <= 800 - 4
+        assert q.Width > 700
+
 
 class TestSidebarHeaderButtonListeners:
     def test_settings_button_listener(self):

--- a/tests/chatbot/test_panel_resize.py
+++ b/tests/chatbot/test_panel_resize.py
@@ -193,7 +193,7 @@ class TestPanelResizeListenerIntegration:
         for name, ctrl in controls.items():
             ps = ctrl.getPosSize()
             assert ps.X + ps.Width <= right, name
-        parent.setPosSize.assert_called_with(0, 0, 320, 0, 4)
+        parent.setPosSize.assert_not_called()
 
 
 class TestSidebarHeaderButtonListeners:

--- a/tests/chatbot/test_panel_resize.py
+++ b/tests/chatbot/test_panel_resize.py
@@ -174,6 +174,27 @@ class TestPanelResizeListenerIntegration:
         response = layouts["response"]
         assert response.x + response.width <= 180 - 4
 
+    def test_create_time_overflow_is_clamped_before_negotiation(self):
+        # Keith: FIRST LAYOUT root=320 max_child_right=1087 overflow=YES
+        snapshot = {
+            name: (x * 3, y * 3, w * 3, h * 3) for name, (x, y, w, h) in _xdl_snapshot().items()
+        }
+        controls = {
+            name: _mock_control(x, y, w, h) for name, (x, y, w, h) in snapshot.items()
+        }
+        parent = MagicMock()
+        parent.getPosSize.return_value = SimpleNamespace(Width=1115, Height=1684)
+        root = MagicMock()
+        root.getPosSize.return_value = SimpleNamespace(Width=320, Height=400)
+        listener = _PanelResizeListener(controls)
+        listener._parent_window = parent
+        listener.relayout_now(root)
+        right = 320 - 4
+        for name, ctrl in controls.items():
+            ps = ctrl.getPosSize()
+            assert ps.X + ps.Width <= right, name
+        parent.setPosSize.assert_called_with(0, 0, 320, 0, 4)
+
 
 class TestSidebarHeaderButtonListeners:
     def test_settings_button_listener(self):

--- a/tests/librepy/test_python_sidebar.py
+++ b/tests/librepy/test_python_sidebar.py
@@ -305,7 +305,7 @@ def test_python_tool_panel_get_height_for_width_handles_all_sizes():
     # deck_hint is the viewport; ChildFrame request is synced to it (width only)
     panel.getHeightForWidth(350)
     panel_win.setPosSize.assert_called_with(0, 0, 350, 400, 15)
-    parent_win.setPosSize.assert_called_with(0, 0, 350, 0, 4)
+    parent_win.setPosSize.assert_not_called()
     listener.relayout_now.assert_called_with(panel_win)
 
     # Wide column width (> 500)


### PR DESCRIPTION
## Summary
- Create-time log: `root_w=320 max_child_right=1087 overflow=YES`, then ChildFrame 1115. That seeds the default H-bar; widen overwrites it, restart brings it back. Narrow leftover (~2 inches) is 1087 minus the column.
- Stop deferring first relayout. Clamp children first, then set ChildFrame width to the viewport. Pre-neg stays at 320 (do not fill a 1115 parent request).

## Test plan
- [ ] Restart Writer, open Chat, do not drag: no deck H-bar at default.
- [ ] Narrow: no extra pan-able space.
- [ ] Widen then shrink: still no H-bar (baseline from master).