### PR TITLE
fix add_comment so the annotation actually shows

### DIFF
--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -122,9 +122,16 @@ class AddComment(ToolBase):
         annotation.setPropertyValue("Author", author)
         annotation.setPropertyValue("Content", content)
         _set_annotation_date(annotation)
-        # Point insert at the start of the match with absorb=False. Spanning via absorb=True
-        # (PR #365) replaced the passage with the field and LibreOffice did not show a balloon.
-        # Anchor in the match's own text object (cell/frame safe).
+        # Point insert at the match start (absorb=False), in found.getText() so table
+        # cells / frames work. PR #365 Q15 tried to SPAN the passage with absorb=True
+        # over found so Writer would highlight which text the comment covers. That is
+        # the wrong API: insertTextContent(..., absorb=True) REPLACES the range with
+        # the Annotation field (a point PostIt). Writer then draws no balloon, and
+        # the matched text can disappear, while the tool still returns comment_added.
+        # A real range comment needs a different path — select the match, then
+        # dispatch .uno:InsertAnnotation (what Insert > Comment uses on a selection),
+        # or ODF annotation-start / annotation-end marks. TODO: research that if we
+        # want spanning highlights later. Do not go back to absorb=True.
         anchor_text = ""
         try:
             anchor_text = found.getString()

--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -74,9 +74,9 @@ class AddComment(ToolBase):
     name = "add_comment"
     intent = "review"
     description = (
-        "Add a comment/annotation anchored to text matching search. The comment SPANS the "
-        "matched passage (the user sees which text it covers). Use occurrence to target a later "
-        "match and author to sign it."
+        "Add a comment/annotation anchored to text matching search. The comment is inserted "
+        "at the start of the match (visible in Writer's Comments pane). Use occurrence to "
+        "target a later match and author to sign it."
     )
     parameters = {"type": "object", "properties": {
         "content": {"type": "string", "description": "The comment text."},
@@ -122,18 +122,26 @@ class AddComment(ToolBase):
         annotation.setPropertyValue("Author", author)
         annotation.setPropertyValue("Content", content)
         _set_annotation_date(annotation)
-        # Insert SPANNING the match (absorb=True over a cursor covering found), so the annotation
-        # highlights the passage instead of a zero-width point. Anchor in the match's own text
-        # object (cell/frame safe).
+        # Point insert at the start of the match with absorb=False. Spanning via absorb=True
+        # (PR #365) replaced the passage with the field and LibreOffice did not show a balloon.
+        # Anchor in the match's own text object (cell/frame safe).
         anchor_text = ""
         try:
             anchor_text = found.getString()
         except Exception:
             pass
+        before = _count_annotations(doc)
         match_text = found.getText()
         cursor = match_text.createTextCursorByRange(found.getStart())
-        cursor.gotoRange(found.getEnd(), True)
-        match_text.insertTextContent(cursor, annotation, True)
+        match_text.insertTextContent(cursor, annotation, False)
+        if _count_annotations(doc) <= before:
+            return {
+                "status": "error",
+                "message": "Comment insert did not register an annotation.",
+                "matched": True,
+                "comment_added": False,
+                "anchor_text": anchor_text or search_text,
+            }
 
         return {"status": "ok", "message": "Comment added.", "author": author, "matched": True, "comment_added": True, "anchor_text": anchor_text or search_text}
 
@@ -450,6 +458,28 @@ class CommentCheckStop(ToolWriterCommentBase):
 # ------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------
+
+
+def _count_annotations(doc):
+    """How many Annotation text fields are on *doc* (0 if the enumeration is unusable)."""
+    n = 0
+    try:
+        enum = doc.getTextFields().createEnumeration()
+    except Exception:
+        return 0
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            field = enum.nextElement()
+        except Exception:
+            break
+        try:
+            if field.supportsService("com.sun.star.text.textfield.Annotation"):
+                n += 1
+        except Exception:
+            continue
+    return n
 
 
 def _set_annotation_date(annotation):

--- a/tests/writer/test_add_comment_uno.py
+++ b/tests/writer/test_add_comment_uno.py
@@ -26,6 +26,16 @@ def _set_body(doc, text_value):
     text.insertString(cur, text_value, False)
 
 
+def _annotation_contents(doc):
+    out = []
+    enum = doc.getTextFields().createEnumeration()
+    while enum.hasMoreElements():
+        field = enum.nextElement()
+        if field.supportsService("com.sun.star.text.textfield.Annotation"):
+            out.append(field.getPropertyValue("Content"))
+    return out
+
+
 @native_test
 @with_native_doc("writer")
 def test_add_comment_reports_anchor_found_uno(ctx, doc):
@@ -36,6 +46,7 @@ def test_add_comment_reports_anchor_found_uno(ctx, doc):
     assert res.get("matched") is True, res
     assert res.get("comment_added") is True, res
     assert res.get("anchor_text") == "Anchor", res
+    assert "a note" in _annotation_contents(doc), _annotation_contents(doc)
 
 
 @native_test

--- a/tests/writer/test_small_fixes_r5.py
+++ b/tests/writer/test_small_fixes_r5.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 """The 6 smaller R5 fixes: dry_run, apply_style all/occurrence, track_changes_list text/location,
-add_comment span/occurrence/author, insert_page_break anchored, regex/case in apply. No LibreOffice."""
+add_comment point-insert/occurrence/author, insert_page_break anchored, regex/case in apply. No LibreOffice."""
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -159,9 +159,35 @@ def test_apply_style_occurrence_out_of_range():
     assert res["status"] == "error" and "out of range" in res["message"]
 
 
-# ---- D4: add_comment span / occurrence / author -----------------------------
+# ---- D4: add_comment point-insert / occurrence / author ---------------------
 
-def test_add_comment_occurrence_author_and_span():
+class _FiniteEnum:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def hasMoreElements(self):
+        return bool(self._items)
+
+    def nextElement(self):
+        return self._items.pop(0)
+
+
+def _fields_that_grow():
+    """getTextFields mock: empty on first enumeration, one Annotation after insert."""
+    calls = {"n": 0}
+    field = MagicMock()
+    field.supportsService.return_value = True
+    fields = MagicMock()
+
+    def _enum():
+        calls["n"] += 1
+        return _FiniteEnum([] if calls["n"] == 1 else [field])
+
+    fields.createEnumeration.side_effect = _enum
+    return fields
+
+
+def test_add_comment_occurrence_author_and_point_insert():
     from plugin.writer.specialized.comments import AddComment
 
     doc = MagicMock()
@@ -170,12 +196,29 @@ def test_add_comment_occurrence_author_and_span():
     second.getText.return_value = mtext = MagicMock()
     doc.findFirst.return_value = first
     doc.findNext.return_value = second
+    doc.getTextFields.return_value = _fields_that_grow()
     ctx = SimpleNamespace(doc=doc)
     with patch("plugin.writer.specialized.comments._set_annotation_date"):
         res = AddComment().execute(ctx, content="note", search="hit", occurrence=1, author="Rev")
     assert res["status"] == "ok" and res["author"] == "Rev" and res["anchor_text"] == "second hit"
-    # Spans the match: insertTextContent called with absorb=True.
-    assert mtext.insertTextContent.call_args[0][2] is True
+    # Point insert: insertTextContent called with absorb=False at the match start.
+    assert mtext.insertTextContent.call_args[0][2] is False
+    mtext.createTextCursorByRange.assert_called_once_with(second.getStart.return_value)
+
+
+def test_add_comment_errors_when_annotation_does_not_register():
+    from plugin.writer.specialized.comments import AddComment
+
+    doc = MagicMock()
+    found = MagicMock()
+    found.getString.return_value = "hit"
+    found.getText.return_value = MagicMock()
+    doc.findFirst.return_value = found
+    empty = MagicMock()
+    empty.createEnumeration.side_effect = lambda: _FiniteEnum([])
+    doc.getTextFields.return_value = empty
+    res = AddComment().execute(SimpleNamespace(doc=doc), content="note", search="hit")
+    assert res["status"] == "error" and res["comment_added"] is False and res["matched"] is True
 
 
 def test_add_comment_not_found_at_occurrence():


### PR DESCRIPTION
## Summary
- `add_comment` was returning `status=ok` / `comment_added=true` while Writer showed no balloon. The spanning `insertTextContent(..., absorb=True)` from #365 replaced the matched text with the field; LibreOffice does not draw a comment for that.
- Restore a point insert at the start of the match with `absorb=False`, still using `found.getText()` so cell/frame anchors stay valid.
- After insert, count Annotation text fields and return an error if the field did not register (no more fake success).
- UNO test now enumerates `doc.getTextFields()` and asserts the note content is actually there. Mock tests cover absorb=False and the missing-field error.

## Test plan
- [x] `pytest tests/writer/specialized/test_comments.py tests/writer/test_small_fixes_r5.py`
- [x] `plugin.testing_runner test_add_comment_uno` (2 passed, including the new field-exists assertion)
- [ ] Live: `make mock-llm`, empty Writer doc, say `comment` — mock inserts Hello world then `add_comment`; comment should appear in the Comments pane.