### PR TITLE
Restore add_comment spanning absorb=True insert

### DIFF
--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -74,9 +74,9 @@ class AddComment(ToolBase):
     name = "add_comment"
     intent = "review"
     description = (
-        "Add a comment/annotation anchored to text matching search. The comment is inserted "
-        "at the start of the match (visible in Writer's Comments pane). Use occurrence to "
-        "target a later match and author to sign it."
+        "Add a comment/annotation anchored to text matching search. The comment SPANS the "
+        "matched passage (the user sees which text it covers). Use occurrence to target a later "
+        "match and author to sign it."
     )
     parameters = {"type": "object", "properties": {
         "content": {"type": "string", "description": "The comment text."},
@@ -122,16 +122,8 @@ class AddComment(ToolBase):
         annotation.setPropertyValue("Author", author)
         annotation.setPropertyValue("Content", content)
         _set_annotation_date(annotation)
-        # Point insert at the match start (absorb=False), in found.getText() so table
-        # cells / frames work. PR #365 Q15 tried to SPAN the passage with absorb=True
-        # over found so Writer would highlight which text the comment covers. That is
-        # the wrong API: insertTextContent(..., absorb=True) REPLACES the range with
-        # the Annotation field (a point PostIt). Writer then draws no balloon, and
-        # the matched text can disappear, while the tool still returns comment_added.
-        # A real range comment needs a different path — select the match, then
-        # dispatch .uno:InsertAnnotation (what Insert > Comment uses on a selection),
-        # or ODF annotation-start / annotation-end marks. TODO: research that if we
-        # want spanning highlights later. Do not go back to absorb=True.
+        # Span the match with absorb=True (PR #365 Q15). Use found.getText() so table
+        # cells / frames still work.
         anchor_text = ""
         try:
             anchor_text = found.getString()
@@ -140,7 +132,8 @@ class AddComment(ToolBase):
         before = _count_annotations(doc)
         match_text = found.getText()
         cursor = match_text.createTextCursorByRange(found.getStart())
-        match_text.insertTextContent(cursor, annotation, False)
+        cursor.gotoRange(found.getEnd(), True)
+        match_text.insertTextContent(cursor, annotation, True)
         if _count_annotations(doc) <= before:
             return {
                 "status": "error",

--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -122,8 +122,13 @@ class AddComment(ToolBase):
         annotation.setPropertyValue("Author", author)
         annotation.setPropertyValue("Content", content)
         _set_annotation_date(annotation)
-        # Span the match with absorb=True (PR #365 Q15). Use found.getText() so table
-        # cells / frames still work.
+        # Intended spanning-anchor insert (PR #365 Q15): cursor covers the match,
+        # absorb=True. Use found.getText() so table cells / frames still work.
+        # There is no insert/balloon bug. Writer still shows the comment when
+        # View > Comments (ShowAnnotations) is on; a missing balloon is
+        # display-off, not a failed insert. PR #493 switched to a point insert
+        # on that mistaken diagnosis; this restores the original API and keeps
+        # only that PR's field-count check.
         anchor_text = ""
         try:
             anchor_text = found.getString()

--- a/tests/writer/test_add_comment_uno.py
+++ b/tests/writer/test_add_comment_uno.py
@@ -47,6 +47,8 @@ def test_add_comment_reports_anchor_found_uno(ctx, doc):
     assert res.get("comment_added") is True, res
     assert res.get("anchor_text") == "Anchor", res
     assert "a note" in _annotation_contents(doc), _annotation_contents(doc)
+    # absorb=True spans the match; it must not eat the anchored text.
+    assert "Anchor here please" in doc.getText().getString()
 
 
 @native_test

--- a/tests/writer/test_add_comment_uno.py
+++ b/tests/writer/test_add_comment_uno.py
@@ -8,7 +8,8 @@
 #
 # add_comment returns structured fields (matched, comment_added, anchor_text) so the agent
 # can tell whether the anchor was found and the comment actually inserted, instead of having
-# to parse the message string.
+# to parse the message string. Native tests also enumerate TextFields to assert the
+# Annotation registered (and that the spanning insert left the matched passage in the body).
 import uno  # noqa: F401
 
 from plugin.testing_runner import native_test
@@ -47,7 +48,7 @@ def test_add_comment_reports_anchor_found_uno(ctx, doc):
     assert res.get("comment_added") is True, res
     assert res.get("anchor_text") == "Anchor", res
     assert "a note" in _annotation_contents(doc), _annotation_contents(doc)
-    # absorb=True spans the match; it must not eat the anchored text.
+    # Spanning insert: Annotation registered as a TextField; matched passage stays in the body.
     assert "Anchor here please" in doc.getText().getString()
 
 

--- a/tests/writer/test_small_fixes_r5.py
+++ b/tests/writer/test_small_fixes_r5.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 """The 6 smaller R5 fixes: dry_run, apply_style all/occurrence, track_changes_list text/location,
-add_comment point-insert/occurrence/author, insert_page_break anchored, regex/case in apply. No LibreOffice."""
+add_comment span/occurrence/author, insert_page_break anchored, regex/case in apply. No LibreOffice."""
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -159,7 +159,7 @@ def test_apply_style_occurrence_out_of_range():
     assert res["status"] == "error" and "out of range" in res["message"]
 
 
-# ---- D4: add_comment point-insert / occurrence / author ---------------------
+# ---- D4: add_comment span / occurrence / author -----------------------------
 
 class _FiniteEnum:
     def __init__(self, items):
@@ -187,13 +187,15 @@ def _fields_that_grow():
     return fields
 
 
-def test_add_comment_occurrence_author_and_point_insert():
+def test_add_comment_occurrence_author_and_span():
     from plugin.writer.specialized.comments import AddComment
 
     doc = MagicMock()
     first, second = MagicMock(), MagicMock()
     second.getString.return_value = "second hit"
     second.getText.return_value = mtext = MagicMock()
+    cursor = MagicMock()
+    mtext.createTextCursorByRange.return_value = cursor
     doc.findFirst.return_value = first
     doc.findNext.return_value = second
     doc.getTextFields.return_value = _fields_that_grow()
@@ -201,9 +203,10 @@ def test_add_comment_occurrence_author_and_point_insert():
     with patch("plugin.writer.specialized.comments._set_annotation_date"):
         res = AddComment().execute(ctx, content="note", search="hit", occurrence=1, author="Rev")
     assert res["status"] == "ok" and res["author"] == "Rev" and res["anchor_text"] == "second hit"
-    # Point insert: insertTextContent called with absorb=False at the match start.
-    assert mtext.insertTextContent.call_args[0][2] is False
+    # Spans the match: cursor covers found, insertTextContent called with absorb=True.
     mtext.createTextCursorByRange.assert_called_once_with(second.getStart.return_value)
+    cursor.gotoRange.assert_called_once_with(second.getEnd.return_value, True)
+    mtext.insertTextContent.assert_called_once_with(cursor, doc.createInstance.return_value, True)
 
 
 def test_add_comment_errors_when_annotation_does_not_register():

--- a/tests/writer/test_small_fixes_r5.py
+++ b/tests/writer/test_small_fixes_r5.py
@@ -203,7 +203,7 @@ def test_add_comment_occurrence_author_and_span():
     with patch("plugin.writer.specialized.comments._set_annotation_date"):
         res = AddComment().execute(ctx, content="note", search="hit", occurrence=1, author="Rev")
     assert res["status"] == "ok" and res["author"] == "Rev" and res["anchor_text"] == "second hit"
-    # Spans the match: cursor covers found, insertTextContent called with absorb=True.
+    # Assert spanning-anchor insert: cursor covers found, absorb=True.
     mtext.createTextCursorByRange.assert_called_once_with(second.getStart.return_value)
     cursor.gotoRange.assert_called_once_with(second.getEnd.return_value, True)
     mtext.insertTextContent.assert_called_once_with(cursor, doc.createInstance.return_value, True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
There is no balloon/insert bug.

Live Writer QA: spanning `insertTextContent(..., absorb=True)` still shows a comment balloon, keeps the matched text, and lists the comment in Navigator, as long as View > Comments (ShowAnnotations) is on. A missing balloon is display-off, not a failed insert.

This restores the intended spanning-anchor insert from PR #365 Q15 (`found.getText()`, cursor covering the match, `absorb=True`). PR #493 switched to a point insert (`absorb=False`) based on a mistaken diagnosis that absorb=True ate the match and Writer then drew no balloon. That diagnosis was wrong; this PR restores the original API.

Kept from #493 (these do not change insert behavior):
- Annotation field-count check after insert
- UNO/mock tests that the comment exists as a TextField, not only that the tool return dict looks ok

Mock tests that encoded the point insert now assert the spanning `absorb=True` call.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6e6544d-b684-4539-93d8-10d8dfcb6bff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6e6544d-b684-4539-93d8-10d8dfcb6bff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

