### PR TITLE
test(llm): pytest streaming parse, retry, and malformed chunks

### DIFF
--- a/docs/chat/connection-management.md
+++ b/docs/chat/connection-management.md
@@ -48,6 +48,8 @@ LocalHttpsCertificateFallback     # local HTTPS verified-to-unverified retry pol
 6. **SSL Handling**: Public HTTPS is always verified. Local HTTPS starts verified and retries unverified only after a certificate verification failure (self-signed Ollama/LM Studio).
 7. **Transient Retry**: Retries one connection failure on a fresh connection if no stream tokens have been delivered yet. After the first content/thinking token, a reset is surfaced as connection-lost (retrying would duplicate text). User stop still exits without retry. HTTP 429/5xx are not retried.
 
+Pytest (no UNO): [`tests/framework/test_client_llm.py`](../../tests/framework/test_client_llm.py) drives this with [`create_mock_http_response`](../../tests/testing_utils.py) — 503/429 do not retry, one timeout/reset retry before tokens, `CONNECTION_LOST` after the first token, and malformed / truncated SSE chunks are skipped. Parser unit tests: [`tests/framework/test_stream_normalizer.py`](../../tests/framework/test_stream_normalizer.py) (`iterate_sse`).
+
 ### Current Limitations
 
 The existing system works well for sequential requests but has some limitations:

--- a/plugin/framework/client/base_provider_shim.py
+++ b/plugin/framework/client/base_provider_shim.py
@@ -67,8 +67,12 @@ class BaseProviderShim:
         from .stream_normalizer import _extract_thinking_from_delta
 
         choices = chunk.get("choices", [])
-        choice = choices[0] if choices else {}
-        delta = choice.get("delta", {})
+        # Unexpected schema (string "choices", non-dict first element) used to
+        # AttributeError on .get and abort the whole stream. Treat as no choice
+        # so later valid chunks can still apply.
+        choice = choices[0] if isinstance(choices, list) and choices and isinstance(choices[0], dict) else {}
+        delta_raw = choice.get("delta", {})
+        delta = delta_raw if isinstance(delta_raw, dict) else {}
 
         finish_reason = choice.get("finish_reason") if choice else None
         if not finish_reason:

--- a/plugin/framework/client/llm_client.py
+++ b/plugin/framework/client/llm_client.py
@@ -558,6 +558,12 @@ class LlmClient:
                                 log.exception("streaming_loop: JSON decode error in payload: %s", payload)
                             continue
 
+                        # Valid JSON that is not an object (array / string / number) is not a
+                        # chat chunk. .get would raise and abort the stream; skip so later
+                        # well-formed chunks can still apply.
+                        if type(chunk) is not dict:
+                            continue
+
                         chunk_model = chunk.get("model")
                         if chunk_model and used_model is None:
                             used_model = str(chunk_model)

--- a/tests/framework/test_client_llm.py
+++ b/tests/framework/test_client_llm.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from plugin.framework.client.llm_client import LlmClient, strip_leaked_chat_template_control_tokens
-from plugin.tests.testing_utils import MockContext
+from plugin.framework.errors import NetworkError
+from plugin.tests.testing_utils import MockContext, create_mock_http_response
 
 
 @pytest.fixture
@@ -1170,6 +1171,138 @@ def test_sync_request_with_tools_tracks_used_model(client, caplog):
         assert result["content"] == "Sync response"
         assert result["model"] == "deepseek/deepseek-r1:free"
         assert any("LLM sync response received" in rec.message and "deepseek/deepseek-r1:free" in rec.message for rec in caplog.records)
+
+
+def _sse_content_lines(*parts: str) -> list[bytes]:
+    lines = [f'data: {json.dumps({"choices": [{"delta": {"content": p}}]})}'.encode() for p in parts]
+    lines.append(b"data: [DONE]")
+    return lines
+
+
+def _https_steps(mock_https, *steps):
+    """Wire HTTPSConnection: each step is a response mock or an exception from request()."""
+    conns = []
+    for step in steps:
+        conn = MagicMock()
+        if isinstance(step, BaseException):
+            conn.request.side_effect = step
+        else:
+            conn.getresponse.return_value = step
+        conns.append(conn)
+    mock_https.side_effect = conns
+    return conns
+
+
+@pytest.mark.parametrize("status,reason", [(503, "Service Unavailable"), (429, "Too Many Requests")])
+def test_stream_http_5xx_and_429_do_not_retry(client, status, reason):
+    """HTTP status errors are not retried (connection-management: 429/5xx)."""
+    resp = create_mock_http_response(
+        status,
+        json_data={"error": {"message": "overloaded"}},
+        reason=reason,
+    )
+    with patch("http.client.HTTPSConnection") as mock_https:
+        _https_steps(mock_https, resp)
+        with pytest.raises(NetworkError) as err:
+            client.stream_request_with_tools(
+                messages=[{"role": "user", "content": "Hi"}],
+                max_tokens=100,
+            )
+    assert err.value.code == "HTTP_ERROR"
+    assert err.value.details["status"] == status
+    assert str(status) in str(err.value)
+    assert mock_https.call_count == 1
+
+
+def test_stream_timeout_before_tokens_retries_once(client):
+    """socket.timeout before any token: one fresh-connection retry, then success."""
+    ok = create_mock_http_response(sse_lines=_sse_content_lines("Hello"))
+    with patch("http.client.HTTPSConnection") as mock_https:
+        _https_steps(mock_https, socket.timeout("timed out"), ok)
+        result = client.stream_request_with_tools(
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=100,
+        )
+    assert result["content"] == "Hello"
+    assert mock_https.call_count == 2
+
+
+def test_stream_reset_before_tokens_retries_once(client):
+    """Connection reset with no tokens yet: retry once on a fresh connection."""
+    reset_resp = create_mock_http_response(iter_side_effect=ConnectionResetError("reset"))
+    ok = create_mock_http_response(sse_lines=_sse_content_lines("Recovered"))
+    with patch("http.client.HTTPSConnection") as mock_https:
+        _https_steps(mock_https, reset_resp, ok)
+        result = client.stream_request_with_tools(
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=100,
+        )
+    assert result["content"] == "Recovered"
+    assert mock_https.call_count == 2
+
+
+def test_stream_reset_after_content_is_connection_lost(client):
+    """After the first content token, a reset is CONNECTION_LOST (retry would duplicate text)."""
+    resp = create_mock_http_response(
+        sse_lines=[f'data: {json.dumps({"choices": [{"delta": {"content": "Hello"}}]})}'.encode()],
+        iter_side_effect=ConnectionResetError("reset after tokens"),
+    )
+    chunks: list[str] = []
+    with patch("http.client.HTTPSConnection") as mock_https:
+        _https_steps(mock_https, resp)
+        with pytest.raises(NetworkError) as err:
+            client.stream_chat_response(
+                [{"role": "user", "content": "Hi"}],
+                max_tokens=10,
+                append_callback=chunks.append,
+            )
+    assert err.value.code == "CONNECTION_LOST"
+    assert chunks == ["Hello"]
+    assert mock_https.call_count == 1
+
+
+def test_stream_malformed_and_truncated_chunks_are_skipped(client):
+    """Bad JSON, JSON-but-not-object, unexpected schema: skip; later valid deltas still apply."""
+    lines = [
+        b": ping",
+        b"data: not-json-at-all",
+        b'data: {"choices": [{"delta": {"content": "hel',  # truncated JSON
+        b"data: [1, 2, 3]",  # JSON array, not a chunk object
+        b'data: {"choices": "nope"}',  # choices is a string
+        b'data: {"choices": [null]}',  # non-dict choice
+        b'data: {"choices": [{"delta": "nope"}]}',  # delta is a string
+        b'data: {"choices": []}',  # empty choices (usage-only style)
+        * _sse_content_lines("OK"),
+    ]
+    resp = create_mock_http_response(sse_lines=lines)
+    with patch("http.client.HTTPSConnection") as mock_https:
+        _https_steps(mock_https, resp)
+        result = client.stream_request_with_tools(
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=100,
+        )
+    assert result["content"] == "OK"
+
+
+def test_stream_truncated_tool_arguments_stay_literal(client):
+    """Provider deltas that concatenate to invalid JSON stay a literal string (no crash)."""
+    lines = [
+        b'data: {"choices": [{"delta": {"tool_calls": [{"index": 0, "id": "call_123", "type": "function", "function": {"name": "get_weather", "arguments": "{\\"loc"}}]}}]}',
+        b'data: {"choices": [{"delta": {"tool_calls": [{"index": 0, "function": {"arguments": "ation\\": \\"NY"}}]}}]}',
+        b'data: {"choices": [{"finish_reason": "tool_calls", "delta": {}}]}',
+        b"data: [DONE]",
+    ]
+    resp = create_mock_http_response(sse_lines=lines)
+    with patch("http.client.HTTPSConnection") as mock_https:
+        _https_steps(mock_https, resp)
+        result = client.stream_request_with_tools(
+            messages=[{"role": "user", "content": "Weather?"}],
+            max_tokens=100,
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        )
+    assert len(result["tool_calls"]) == 1
+    assert result["tool_calls"][0]["function"]["arguments"] == '{"location": "NY'
+    assert result["finish_reason"] == "tool_calls"
 
 
 

--- a/tests/framework/test_stream_normalizer.py
+++ b/tests/framework/test_stream_normalizer.py
@@ -5,7 +5,8 @@
 
 
 from plugin.framework.client import stream_normalizer as sn
-from plugin.framework.client.stream_normalizer import _extract_thinking_from_delta
+from plugin.framework.client.stream_normalizer import _extract_thinking_from_delta, iterate_sse
+from plugin.tests.testing_utils import create_mock_http_response
 
 
 def test_extract_thinking_from_delta_reasoning_field():
@@ -340,5 +341,39 @@ def test_streaming_replay_truncates_encrypted_fragments_to_shape_dim():
     assert isinstance(replay, dict)
     details = replay.get("reasoning_details", [])
     assert len(details) == DEAL_MAX_SHAPE_DIM
+
+
+def test_iterate_sse_skips_comments_blanks_and_keeps_data_and_raw_json():
+    """SSE comments / blank lines are dropped; data: and raw JSON lines are payloads."""
+    stream = create_mock_http_response(
+        sse_lines=[
+            b": keep-alive",
+            b"",
+            b'data: {"choices": [{"delta": {"content": "Hi"}}]}',
+            b"data: [DONE]",
+            b'{"choices": [{"delta": {"content": "raw"}}]}',
+        ]
+    )
+    assert list(iterate_sse(stream)) == [
+        '{"choices": [{"delta": {"content": "Hi"}}]}',
+        "[DONE]",
+        '{"choices": [{"delta": {"content": "raw"}}]}',
+    ]
+
+
+def test_iterate_sse_truncated_and_non_utf8_lines_still_yield_later_payloads():
+    """A truncated data: line is still yielded (JSON decode is the client's job)."""
+    stream = create_mock_http_response(
+        sse_lines=[
+            b'data: {"choices": [{"delta": {"content": "hel',
+            b'data: {"choices": [{"delta": {"content": "lo"}}]}',
+            b"data: [DONE]",
+        ]
+    )
+    payloads = list(iterate_sse(stream))
+    assert payloads[0].startswith('{"choices":')
+    assert '"hel' in payloads[0]
+    assert payloads[1] == '{"choices": [{"delta": {"content": "lo"}}]}'
+    assert payloads[2] == "[DONE]"
 
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1300,13 +1300,61 @@ def create_mock_client():
     mock_client.config.get.return_value = False
     return mock_client
 
-def create_mock_http_response(status_code=200, json_data=None):
-    """Creates a mock HTTP response object."""
+def create_mock_http_response(
+    status_code=200,
+    json_data=None,
+    *,
+    reason=None,
+    body=None,
+    sse_lines=None,
+    iter_side_effect=None,
+    headers=None,
+):
+    """Mock ``http.client.HTTPResponse`` for pytest (no UNO, no live HTTP).
+
+    * ``json_data`` / ``body`` feed sync ``response.read()``.
+    * ``sse_lines`` feeds ``for line in response`` / ``iterate_sse`` (bytes or str).
+    * ``iter_side_effect`` is raised after those lines (timeout / connection reset
+      mid-stream). HTTP 4xx/5xx use ``status`` + ``reason`` + body; they are not
+      retried by ``LlmClient``.
+    """
     from unittest.mock import MagicMock
+    import http.client
     import json
 
     mock_resp = MagicMock()
     mock_resp.status = status_code
-    if json_data is not None:
-        mock_resp.read.return_value = json.dumps(json_data).encode()
+    mock_resp.reason = (
+        reason if reason is not None else http.client.responses.get(status_code, "")
+    )
+    header_map = dict(headers or {})
+
+    def _getheader(name, default=None):
+        return header_map.get(name, header_map.get(str(name).lower(), default))
+
+    mock_resp.getheader.side_effect = _getheader
+
+    if body is None and json_data is not None:
+        body = json.dumps(json_data).encode("utf-8")
+    mock_resp.read.return_value = b"" if body is None else body
+
+    lines = []
+    if sse_lines is not None:
+        for line in sse_lines:
+            if isinstance(line, str):
+                line = line.encode("utf-8")
+            if not line.endswith(b"\n"):
+                line = line + b"\n"
+            lines.append(line)
+
+    if iter_side_effect is not None:
+        def _iter():
+            yield from lines
+            raise iter_side_effect
+
+        # return_value (not side_effect): ``for line in response`` matches
+        # existing LlmClient tests that set ``__iter__.return_value = iter(...)``.
+        mock_resp.__iter__.return_value = _iter()
+    else:
+        mock_resp.__iter__.return_value = iter(lines)
     return mock_resp


### PR DESCRIPTION
## Summary

Pytest for the streaming API boundary from [`docs/archive/test_architecture_analysis.md`](docs/archive/test_architecture_analysis.md) §3.1 — **no UNO**.

`create_mock_http_response` now builds SSE streams, HTTP status bodies, and mid-stream `timeout` / `ConnectionResetError`.

Coverage:
- **503 / 429** → `HTTP_ERROR`, no retry
- **timeout / reset before tokens** → one fresh-connection retry, then success
- **reset after first content token** → `CONNECTION_LOST` (retry would duplicate text)
- **malformed / truncated SSE**, JSON-that-is-not-an-object, unexpected `choices`/`delta` schema → skip and keep later valid chunks
- **truncated tool-call arguments** stay a literal string (no crash)

Small production guards so a bad chunk does not abort the rest of the stream (`json.loads` non-dict skip; non-dict `choices`/`delta` in `parse_response_chunk`).

## Test plan
- [x] `pytest tests/framework/test_client_llm.py tests/framework/test_stream_normalizer.py tests/framework/client/test_http_transport.py` — 88 passed