### PR TITLE
Add stopped-latched tool-loop FSM legality oracles

### DIFF
--- a/docs/framework/formal-verification.md
+++ b/docs/framework/formal-verification.md
@@ -440,7 +440,7 @@ def next_state(state: ToolLoopState, event: ToolLoopEvent) -> Tuple[ToolLoopStat
 
 **Reference implementation:** [`plugin/scripting/payload_codec.py`](../../plugin/scripting/payload_codec.py) — see [`../scripting/serialization-verification.md`](../scripting/serialization-verification.md).
 
-**Status (partial):** `deal` on `send_state.next_state` (send/stop mutual exclusion), `audio_recorder_state.next_state` (valid status + error path), thin ensures on `tool_loop_state.next_state` (STOP→`ExitLoopEffect`, round bound), and `mcp_state.next_state` (missing tool_name → `SendErrorEffect`, `TOOL_COMPLETED` → `StreamResponseEffect`, `REQUEST_ERROR` sets `is_error`). Pytest oracles + Hypothesis (light in `make verify`, deep in `make vhs`) + slow CrossHair hooks in [`tests/chatbot/test_fsm_verification.py`](../../tests/chatbot/test_fsm_verification.py) and [`tests/mcp/test_mcp_state_verification.py`](../../tests/mcp/test_mcp_state_verification.py). Strategies: [`tests/chatbot/fsm_hyp_support.py`](../../tests/chatbot/fsm_hyp_support.py). Tracking: [`verification_status.json`](../verification_status.json).
+**Status (partial):** `deal` on `send_state.next_state` (send/stop mutual exclusion), `audio_recorder_state.next_state` (valid status + error path), `tool_loop_state.next_state` (STOP→`ExitLoopEffect`; **stopped-latched pending tools never spawn**; `is_stopped` sticky; pending length never shrinks while stopped; round bound), and `mcp_state.next_state` (missing tool_name → `SendErrorEffect`, `TOOL_COMPLETED` → `StreamResponseEffect`, `REQUEST_ERROR` sets `is_error`). Pytest oracles + Hypothesis (light in `make verify`, deep in `make vhs`) + slow CrossHair hooks in [`tests/chatbot/test_fsm_verification.py`](../../tests/chatbot/test_fsm_verification.py) and [`tests/mcp/test_mcp_state_verification.py`](../../tests/mcp/test_mcp_state_verification.py). Strategies: [`tests/chatbot/fsm_hyp_support.py`](../../tests/chatbot/fsm_hyp_support.py). Tracking: [`verification_status.json`](../verification_status.json). `next_state` stays `# crosshair: off`.
 
 ### Step 1: Add Design by Contract to State Machines
 
@@ -555,7 +555,11 @@ Snapshot **2026-08-27**: **48 verified / 8 partial** in [`verification_status.js
 
 #### 2. FSM partials (Phase 6 catch-up — do not fight engine)
 
-[`send_state`](../../plugin/chatbot/send_state.py), [`audio_recorder_state`](../../plugin/chatbot/audio_recorder_state.py), [`mcp_state`](../../plugin/mcp/mcp_state.py), [`tool_loop_state`](../../plugin/chatbot/tool_loop_state.py) / [`state_machine`](../../plugin/chatbot/state_machine.py) helpers: deal + Hypothesis already on `vhs`. **`next_state` stays `# crosshair: off`** (`event.data` is unbounded `dict[str, Any]`, plus Exception/JSON/host paths). Next work = stronger pure ensures / more FSM strategies in [`fsm_hyp_support.py`](../../tests/chatbot/fsm_hyp_support.py), not removing offs.
+[`send_state`](../../plugin/chatbot/send_state.py), [`audio_recorder_state`](../../plugin/chatbot/audio_recorder_state.py), [`mcp_state`](../../plugin/mcp/mcp_state.py), [`tool_loop_state`](../../plugin/chatbot/tool_loop_state.py) / [`state_machine`](../../plugin/chatbot/state_machine.py) helpers: deal + Hypothesis already on `vhs`. **`next_state` stays `# crosshair: off`** (`event.data` is unbounded `dict[str, Any]`, plus Exception/JSON/host paths). Do not promote these rows to `verified`.
+
+**Done:** **stopped-latched pending tools never spawn** (`stopped_effects_exclude_tool_spawns`; `is_stopped` sticky; pending length never shrinks while stopped). Biased strategies in [`fsm_hyp_support.py`](../../tests/chatbot/fsm_hyp_support.py).
+
+**Still thin:** send-button Stop-while-idle as Hypothesis/`@deal.ensure`; MCP `REQUEST_ERROR` latch-until-reset (needs a defined reset — `TOOL_COMPLETED` currently overwrites `is_error`).
 
 #### 3. Engine-hostile partials (shim or accept partial)
 
@@ -574,7 +578,7 @@ Highest unused pure surface: **[`plugin/calc/spreadsheet_import/translate.py`](.
 - Keep `CROSSHAIR_*_SKIP` empty; hostility = shim / `# crosshair: off` / refactor.
 - Stale “Practical Implementation Guide” samples below still mention old paths—treat Phase 9 + this section as source of truth over the illustrative CI YAML.
 
-**Suggested next session (single track):** optional new Tier-0 [`translate.py`](../../plugin/calc/spreadsheet_import/translate.py) contracts, or one named FSM legality property (do not remove `next_state` offs). Do not reopen json_utils / errors / payload_codec to “force verified.”
+**Suggested next session (single track):** optional new Tier-0 [`translate.py`](../../plugin/calc/spreadsheet_import/translate.py) contracts, or one remaining named FSM legality property (send idle-Stop no-op, or MCP error latch once reset is defined). Do not remove `next_state` offs. Do not reopen json_utils / errors / payload_codec to “force verified.”
 
 ---
 

--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -388,10 +388,7 @@ def stopped_effects_exclude_tool_spawns(state: object, effects: object) -> bool:
 )
 @deal.ensure(lambda state, event, result: event.kind != EventKind.STOP_REQUESTED or result.state.is_stopped)
 @deal.ensure(lambda state, event, result: not state.is_stopped or result.state.is_stopped)
-@deal.ensure(
-    lambda state, event, result: not state.is_stopped
-    or len(result.state.pending_tools) >= len(state.pending_tools)
-)
+@deal.ensure(lambda state, event, result: not state.is_stopped or len(result.state.pending_tools) >= len(state.pending_tools))
 @deal.ensure(lambda state, event, result: stopped_effects_exclude_tool_spawns(result.state, result.effects))
 @deal.ensure(lambda state, event, result: result.state.round_num <= max(state.round_num + 1, state.max_rounds))
 def next_state(state: ToolLoopState, event: ToolLoopEvent) -> FsmTransition[ToolLoopState]:

--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -362,6 +362,23 @@ class CleanupAudioEffect:
     pass
 
 
+@deal.post(lambda result: type(result) is bool)
+def stopped_effects_exclude_tool_spawns(state: object, effects: object) -> bool:
+    """True unless *state* is stopped and *effects* contain a tool-worker spawn.
+
+    Named legality: stopped-latched pending tools never spawn. NEXT_TOOL while
+    ``is_stopped`` must not emit ``SpawnToolWorkerEffect`` (the
+    ``or state.is_stopped`` guard). STREAM_DONE after stop may still append
+    pending and emit ``TriggerNextToolEffect`` — the interpreter queues
+    NEXT_TOOL; the FSM must still not spawn a tool worker.
+    """
+    if not getattr(state, "is_stopped", False):
+        return True
+    if type(effects) is not list and type(effects) is not tuple:
+        return True
+    return not any(isinstance(e, SpawnToolWorkerEffect) for e in effects)
+
+
 # --- State Machine Transition ---
 @deal.pre(lambda state, event: isinstance(state.max_rounds, int) and state.max_rounds > 0 and state.round_num >= 0)
 @deal.post(lambda result: result.state.round_num >= 0)
@@ -369,6 +386,13 @@ class CleanupAudioEffect:
     lambda state, event, result: event.kind != EventKind.STOP_REQUESTED
     or any(isinstance(e, ExitLoopEffect) for e in result.effects)
 )
+@deal.ensure(lambda state, event, result: event.kind != EventKind.STOP_REQUESTED or result.state.is_stopped)
+@deal.ensure(lambda state, event, result: not state.is_stopped or result.state.is_stopped)
+@deal.ensure(
+    lambda state, event, result: not state.is_stopped
+    or len(result.state.pending_tools) >= len(state.pending_tools)
+)
+@deal.ensure(lambda state, event, result: stopped_effects_exclude_tool_spawns(result.state, result.effects))
 @deal.ensure(lambda state, event, result: result.state.round_num <= max(state.round_num + 1, state.max_rounds))
 def next_state(state: ToolLoopState, event: ToolLoopEvent) -> FsmTransition[ToolLoopState]:
     """Pure transition function for the tool-calling loop."""

--- a/tests/chatbot/fsm_hyp_support.py
+++ b/tests/chatbot/fsm_hyp_support.py
@@ -98,16 +98,44 @@ def audio_recorder_events(draw):
     return ErrorOccurredEvent(error_message=draw(st.sampled_from(("boom", "device", ""))))
 
 
+def pending_tool_call() -> st.SearchStrategy[dict]:
+    """One OpenAI-shaped tool_call dict matching ``pending_tool_call_fields``."""
+    return st.fixed_dictionaries(
+        {
+            "id": st.sampled_from(("c1", "c2", "c3")),
+            "function": st.fixed_dictionaries(
+                {
+                    "name": st.sampled_from(("noop", "web_search")),
+                    "arguments": st.just("{}"),
+                }
+            ),
+        }
+    )
+
+
+def pending_tool_call_list(*, min_size: int = 0, max_size: int = 3) -> st.SearchStrategy[list]:
+    return st.lists(pending_tool_call(), min_size=min_size, max_size=max_size)
+
+
 @st.composite
 def tool_loop_states(draw):
     max_rounds = draw(st.integers(min_value=1, max_value=8))
     round_num = draw(st.integers(min_value=0, max_value=max_rounds))
+    is_stopped = draw(st.booleans())
+    # st.lists(min_size=0) is empty-heavy; one_of keeps leftover pending visible
+    # under the light verify budget (60). When stopped, extra nonempty draws so
+    # NEXT_TOOL hits the spawn-exclusion hole instead of mostly pending=[].
+    nonempty = pending_tool_call_list(min_size=1, max_size=3)
+    if is_stopped:
+        pending = draw(st.one_of(st.just([]), nonempty, nonempty))
+    else:
+        pending = draw(st.one_of(st.just([]), nonempty))
     return ToolLoopState(
         round_num=round_num,
-        pending_tools=[],
+        pending_tools=pending,
         max_rounds=max_rounds,
         status=draw(st.sampled_from(("Thinking...", "Running tool...", "Stopped", "Ready"))),
-        is_stopped=draw(st.booleans()),
+        is_stopped=is_stopped,
     )
 
 
@@ -131,7 +159,8 @@ def tool_loop_events(draw):
     if kind == ToolEventKind.ERROR:
         return ToolLoopEvent(kind, {"message": draw(st.sampled_from(("err", "")))})
     if kind == ToolEventKind.STREAM_DONE:
-        return ToolLoopEvent(kind, {"response": {"tool_calls": [], "content": "", "finish_reason": "stop"}})
+        tool_calls = draw(st.one_of(st.just([]), pending_tool_call_list(min_size=1, max_size=2)))
+        return ToolLoopEvent(kind, {"response": {"tool_calls": tool_calls, "content": "", "finish_reason": "stop"}})
     if kind == ToolEventKind.TOOL_RESULT:
         return ToolLoopEvent(
             kind,

--- a/tests/chatbot/test_fsm_verification.py
+++ b/tests/chatbot/test_fsm_verification.py
@@ -44,9 +44,11 @@ from plugin.chatbot.state_machine import (
 from plugin.chatbot.tool_loop_state import (
     EventKind,
     ExitLoopEffect,
+    SpawnToolWorkerEffect,
     ToolLoopEvent,
     ToolLoopState,
     next_state as tool_loop_next_state,
+    stopped_effects_exclude_tool_spawns,
 )
 from tests.chatbot.fsm_hyp_support import (
     audio_recorder_events,
@@ -138,7 +140,9 @@ def test_tool_loop_stop_emits_exit_loop() -> None:
     )
     tr = tool_loop_next_state(state, ToolLoopEvent(EventKind.STOP_REQUESTED, {}))
     assert any(isinstance(e, ExitLoopEffect) for e in tr.effects)
+    assert tr.state.is_stopped
     assert tr.state.round_num <= max(state.round_num + 1, state.max_rounds)
+    assert stopped_effects_exclude_tool_spawns(tr.state, tr.effects)
 
 
 def test_tool_loop_formatting_helpers() -> None:
@@ -203,12 +207,37 @@ def test_hypothesis_audio_recorder_invariants(state: AudioRecorderState, event) 
 @given(state=tool_loop_states(), event=tool_loop_events())
 @settings(max_examples=_hyp_n("tool_loop"), deadline=None)
 def test_hypothesis_tool_loop_invariants(state: ToolLoopState, event: ToolLoopEvent) -> None:
+    """Stopped-latched pending tools never spawn; is_stopped is sticky; pending never shrinks while stopped."""
     tr = tool_loop_next_state(state, event)
     assert tr.state.round_num >= 0
     assert tr.state.round_num <= max(state.round_num + 1, state.max_rounds)
+    if state.is_stopped:
+        assert tr.state.is_stopped
+        assert len(tr.state.pending_tools) >= len(state.pending_tools)
+    assert stopped_effects_exclude_tool_spawns(tr.state, tr.effects)
     if event.kind == EventKind.STOP_REQUESTED:
         assert any(isinstance(e, ExitLoopEffect) for e in tr.effects)
         assert tr.state.is_stopped
+        assert not any(isinstance(e, SpawnToolWorkerEffect) for e in tr.effects)
+
+
+@given(state=tool_loop_states(), events=st.lists(tool_loop_events(), min_size=1, max_size=5))
+@settings(max_examples=_hyp_n("sequences"), deadline=None)
+def test_hypothesis_tool_loop_stop_sequences(state: ToolLoopState, events) -> None:
+    """Forced STOP, then a short walk: latch sticks and leftover pending never spawn."""
+    stop_tr = tool_loop_next_state(state, ToolLoopEvent(EventKind.STOP_REQUESTED, {}))
+    assert stop_tr.state.is_stopped
+    assert any(isinstance(e, ExitLoopEffect) for e in stop_tr.effects)
+    assert stopped_effects_exclude_tool_spawns(stop_tr.state, stop_tr.effects)
+    cur = stop_tr.state
+    pending_floor = len(cur.pending_tools)
+    for event in events:
+        tr = tool_loop_next_state(cur, event)
+        assert tr.state.is_stopped
+        assert len(tr.state.pending_tools) >= pending_floor
+        assert stopped_effects_exclude_tool_spawns(tr.state, tr.effects)
+        pending_floor = len(tr.state.pending_tools)
+        cur = tr.state
 
 
 @given(state=send_handler_states(), event=send_handler_events())

--- a/tests/chatbot/test_tool_loop_state.py
+++ b/tests/chatbot/test_tool_loop_state.py
@@ -23,6 +23,7 @@ from plugin.chatbot.tool_loop_state import (
     next_state,
     object_dict_or_empty,
     pending_tool_call_fields,
+    stopped_effects_exclude_tool_spawns,
 )
 
 # --- Helpers ---
@@ -388,6 +389,21 @@ def test_apply_document_content_no_debug_when_replaced():
     )
 
 
+def test_stopped_effects_exclude_tool_spawns_predicate():
+    spawn = SpawnToolWorkerEffect(
+        call_id="c1",
+        func_name="noop",
+        func_args_str="{}",
+        func_args={},
+        is_async=False,
+    )
+    running = create_base_state(is_stopped=False)
+    stopped = create_base_state(is_stopped=True)
+    assert stopped_effects_exclude_tool_spawns(running, [spawn]) is True
+    assert stopped_effects_exclude_tool_spawns(stopped, [spawn]) is False
+    assert stopped_effects_exclude_tool_spawns(stopped, []) is True
+
+
 def test_next_tool_when_stopped():
     # If is_stopped=True but empty pending_tools, it shouldn't update status
     state = create_base_state(is_stopped=True)
@@ -397,6 +413,38 @@ def test_next_tool_when_stopped():
     
     assert not any(isinstance(e, ToolLoopUIEffect) and e.kind == "status" for e in effects)
     assert any(isinstance(e, SpawnLLMWorkerEffect) for e in effects)
+
+
+def test_next_tool_when_stopped_with_pending_does_not_spawn_tool():
+    """Stopped-latched pending tools never spawn.
+
+    Deleting ``or state.is_stopped`` from NEXT_TOOL fails this. STREAM_DONE after
+    STOP may still append pending and emit TriggerNextToolEffect (see
+    test_stream_done_after_stop_may_append_and_trigger_next); that is allowed.
+    """
+    tool_calls = [{"id": "call_1", "function": {"name": "test_tool", "arguments": "{}"}}]
+    state = create_base_state(pending_tools=tool_calls, is_stopped=True)
+    tr = next_state(state, create_event(EventKind.NEXT_TOOL))
+    assert not any(isinstance(e, SpawnToolWorkerEffect) for e in tr.effects)
+    assert tr.state.pending_tools == tool_calls
+    assert tr.state.is_stopped is True
+
+
+def test_stream_done_after_stop_may_append_and_trigger_next():
+    """After STOP, STREAM_DONE with tool_calls may append + TriggerNextToolEffect.
+
+    The interpreter queues NEXT_TOOL; the FSM must still not emit SpawnToolWorkerEffect.
+    """
+    state = create_base_state(is_stopped=True)
+    tool_calls = [{"id": "1", "function": {"name": "test", "arguments": "{}"}}]
+    tr = next_state(
+        state,
+        create_event(EventKind.STREAM_DONE, response={"tool_calls": tool_calls, "content": "x"}),
+    )
+    assert tr.state.is_stopped is True
+    assert len(tr.state.pending_tools) == 1
+    assert any(isinstance(e, TriggerNextToolEffect) for e in tr.effects)
+    assert not any(isinstance(e, SpawnToolWorkerEffect) for e in tr.effects)
 
 def test_tool_result_parsing():
     state = create_base_state()

--- a/verification_status.json
+++ b/verification_status.json
@@ -672,10 +672,11 @@
           "format_tool_running_ui",
           "format_tool_result_chat_text",
           "is_replaced_zero_result",
+          "stopped_effects_exclude_tool_spawns",
           "next_state"
         ],
         "crosshair_result": "helpers_analyzed_next_state_off",
-        "notes": "next_state has # crosshair: off (safe_json_loads); pure helpers are CrossHair targets; Hypothesis STOP/round oracles in test_fsm_verification (deep via make vhs)",
+        "notes": "next_state has # crosshair: off (safe_json_loads); stopped-latched pending tools never spawn (stopped_effects_exclude_tool_spawns; is_stopped sticky; pending monotonic while stopped); Hypothesis in test_fsm_verification (deep via make vhs); stay partial",
         "ci_integration": true
       }
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Phase 6/9 named FSM legality property: **stopped-latched pending tools never spawn**.

`next_state` stays `# crosshair: off` (`event.data` is an unbounded dict). This is deal + pytest/Hypothesis, not “CrossHair proved the FSM.” `tool_loop_state.py` stays **partial**.

### Property
Once the tool loop is stopped, `next_state` never emits `SpawnToolWorkerEffect`. Leftover `pending_tools` may stay in the queue (and STREAM_DONE may still append + emit `TriggerNextToolEffect`); they must not be consumed or run.

Also locked:
- `is_stopped` is sticky (only set True, never cleared)
- While stopped, `len(pending_tools)` never decreases

### What changed
- `stopped_effects_exclude_tool_spawns` + `@deal.ensure` on `tool_loop_state.next_state`
- Biased Hypothesis strategies (`st.one_of` empty vs nonempty; extra nonempty when stopped) and a shared `pending_tool_call` builder matching `pending_tool_call_fields`
- Unit tripwire: `NEXT_TOOL` while stopped with leftover pending does not spawn
- Sequence Hypothesis: forced STOP, then a short walk
- Docs / `verification_status.json` name the oracle; status stays partial

Does not change product Stop behavior (empty-queue stopped `NEXT_TOOL` still spawns an LLM worker).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bd67907-5559-4c79-886c-74c4fb7b01cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bd67907-5559-4c79-886c-74c4fb7b01cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

