### PR TITLE
test(llm): Hypothesis SSE line-partition and readline-fragment oracles

### DIFF
--- a/docs/chat/connection-management.md
+++ b/docs/chat/connection-management.md
@@ -48,7 +48,7 @@ LocalHttpsCertificateFallback     # local HTTPS verified-to-unverified retry pol
 6. **SSL Handling**: Public HTTPS is always verified. Local HTTPS starts verified and retries unverified only after a certificate verification failure (self-signed Ollama/LM Studio).
 7. **Transient Retry**: Retries one connection failure on a fresh connection if no stream tokens have been delivered yet. After the first content/thinking token, a reset is surfaced as connection-lost (retrying would duplicate text). User stop still exits without retry. HTTP 429/5xx are not retried.
 
-Pytest (no UNO): [`tests/framework/test_client_llm.py`](../../tests/framework/test_client_llm.py) drives this with [`create_mock_http_response`](../../tests/testing_utils.py) — 503/429 do not retry, one timeout/reset retry before tokens, `CONNECTION_LOST` after the first token, and malformed / truncated SSE chunks are skipped. Parser unit tests: [`tests/framework/test_stream_normalizer.py`](../../tests/framework/test_stream_normalizer.py) (`iterate_sse`).
+Pytest (no UNO): [`tests/framework/test_client_llm.py`](../../tests/framework/test_client_llm.py) drives this with [`create_mock_http_response`](../../tests/testing_utils.py) — 503/429 do not retry, one timeout/reset retry before tokens, `CONNECTION_LOST` after the first token, and malformed / truncated SSE chunks are skipped. Parser unit tests: [`tests/framework/test_stream_normalizer.py`](../../tests/framework/test_stream_normalizer.py) (`iterate_sse`). Well-formed SSE fragmentation (line-partition + readline-wrapper identity) is Hypothesis/VHS in [`tests/framework/test_stream_normalizer_verification.py`](../../tests/framework/test_stream_normalizer_verification.py), not CrossHair.
 
 ### Current Limitations
 

--- a/docs/framework/formal-verification.md
+++ b/docs/framework/formal-verification.md
@@ -233,7 +233,7 @@ Deep CrossHair sweeps are also available on GitHub Actions via manual dispatch (
 | Target | Hypothesis budget | Scope |
 |--------|-------------------|--------|
 | **`make verify`** | Light defaults in each suite | All `*_verification.py` (deal oracles + light `@given`; `-m "not slow"` so CrossHair pytest hooks stay on `crosshair-check-all`) |
-| **`make vhs`** | `WRITERAGENT_VHS_EXTENSIVE=1` (alias: `WRITERAGENT_SERIALIZATION_EXTENSIVE`) | Deep fuzz (`-k hypothesis`): serialization A/B; chat/MCP FSMs; Phase 8 domains (done: `formula_edit`, `cors`, `word_diff_split`, `embeddings_split`); stream/response normalizers; sandbox path + scrub env; payload_codec policy; `address_utils` |
+| **`make vhs`** | `WRITERAGENT_VHS_EXTENSIVE=1` (alias: `WRITERAGENT_SERIALIZATION_EXTENSIVE`) | Deep fuzz (`-k hypothesis`): serialization A/B; chat/MCP FSMs; Phase 8 domains (done: `formula_edit`, `cors`, `word_diff_split`, `embeddings_split`); stream/response normalizers (SSE line-partition + readline-fragment); sandbox path + scrub env; payload_codec policy; `address_utils` |
 | **`make slowtests`** | Extensive | Serialization fixture pass, then `vhs` |
 
 Shared helpers: [`tests/vhs_budget.py`](../../tests/vhs_budget.py) (`vhs_extensive` / `vhs_max_examples`), FSM strategies [`tests/chatbot/fsm_hyp_support.py`](../../tests/chatbot/fsm_hyp_support.py).
@@ -337,9 +337,14 @@ CrossHair's Z3 engine will not just throw random fuzzing data at the function; i
 When CrossHair finds a counterexample, it provides the exact symbolic input required to break our algorithm. We patch the code, and the state space is secured.
 
 ### Phase 4: SMT-Driven Protocol Verification
-Beyond utility functions, we can apply FV to state machines. For example, our LLM streaming chunk normalizer (in `plugin/framework/async_stream.py`). 
 
-By defining contracts that assert *"No matter how a JSON delta stream is arbitrarily chunked or fragmented over the network, the final assembled output string will exactly match the output of a synchronous, unfragmented payload,"* we can use CrossHair to mathematically prove our streaming parser's resilience against arbitrary network fragmentation.
+The LLM stream stack is line-oriented. We do **not** ask CrossHair to prove `iterate_sse` (generator + `bytes.decode` — engine-hostile). Hypothesis covers the well-formed fragmentation claim; pytest covers malformed chunks.
+
+1. **Transport** (`http.client.HTTPResponse` / `readline`) reassembles TCP fragments into complete lines. `iterate_sse` itself has no leftover buffer — feeding raw byte chunks into it is not a supported API.
+2. **`iterate_sse`** maps complete lines to payload strings (comments/blanks dropped). Each `data:` line is its own payload — we do **not** coalesce consecutive `data:` lines the way the SSE spec does. Oracles in [`test_stream_normalizer_verification.py`](../../tests/framework/test_stream_normalizer_verification.py): line-list homomorphism and readline-fragment identity (`test_hypothesis_iterate_sse_*`).
+3. **`accumulate_delta`** (already verified) concatenates JSON delta `content` / tool-call arguments so chunked deltas match the unfragmented payload.
+
+Malformed / truncated SSE is pytest ([`test_client_llm.py`](../../tests/framework/test_client_llm.py) / [`test_stream_normalizer.py`](../../tests/framework/test_stream_normalizer.py)), not VHS.
 
 ## Why we refactored orchestration into pure state machines
 
@@ -537,7 +542,7 @@ Named deep domains (oracles + `test_hypothesis_*` so `-k hypothesis` selects the
 | Writer word diff / redline split | [`word_diff_split.py`](../../plugin/writer/word_diff_split.py) | [`test_writer_diff_and_html_verification.py`](../../tests/writer/test_writer_diff_and_html_verification.py) |
 | Embeddings sentence chunking | [`embeddings_split.py`](../../plugin/embeddings/embeddings_split.py) | [`test_embeddings_split_verification.py`](../../tests/embeddings/test_embeddings_split_verification.py) |
 
-Also on the same `make vhs` line (same budget helper): serialization A/B Hypothesis; chat/MCP FSM oracles; stream/response normalizers; sandbox path + `scrub_subprocess_env`; payload_codec policy; `address_utils` column/address round-trips.
+Also on the same `make vhs` line (same budget helper): serialization A/B Hypothesis; chat/MCP FSM oracles; stream/response normalizers (including `iterate_sse` line-partition + readline-fragment); sandbox path + `scrub_subprocess_env`; payload_codec policy; `address_utils` column/address round-trips.
 
 **Not the same as “verified” in `verification_status.json`:** several of these modules remain **`partial`** because CrossHair is engine-limited or `ci_integration` is still false—Phase 8 only means **deep Hypothesis is in place and selected by `vhs`**. Closing those partials is Phase 9.
 

--- a/tests/framework/test_stream_normalizer_verification.py
+++ b/tests/framework/test_stream_normalizer_verification.py
@@ -8,6 +8,8 @@
 from __future__ import annotations
 
 import copy
+import io
+import json
 import re
 import shutil
 import subprocess
@@ -28,6 +30,7 @@ from plugin.framework.client.stream_normalizer import (
     _thinking_text_from_delta,
     accumulate_streaming_thinking,
     extract_reasoning_replay_from_response,
+    iterate_sse,
     new_streaming_thinking_meta,
     strip_think_tags,
 )
@@ -49,6 +52,59 @@ def _find_crosshair() -> str | None:
     if venv_bin_ch.exists():
         return str(venv_bin_ch)
     return None
+
+
+def _sse_lines_from_byte_chunks(chunks: list[bytes]) -> list[bytes]:
+    """Reassemble complete lines the way ``HTTPResponse.readline`` does.
+
+    ``iterate_sse`` is line-oriented and has no leftover buffer — arbitrary TCP
+    cuts are valid only after this step (tests only; not plugin code).
+    """
+    buf = b""
+    lines: list[bytes] = []
+    for chunk in chunks:
+        buf += chunk
+        while True:
+            idx = buf.find(b"\n")
+            if idx < 0:
+                break
+            lines.append(buf[: idx + 1])
+            buf = buf[idx + 1 :]
+    if buf:
+        lines.append(buf)
+    return lines
+
+
+def _chat_delta_json(content: str) -> str:
+    return json.dumps({"choices": [{"delta": {"content": content}}]}, ensure_ascii=False)
+
+
+def _data_json_line(content: str) -> bytes:
+    return ("data: " + _chat_delta_json(content)).encode("utf-8")
+
+
+def _raw_json_line(content: str) -> bytes:
+    return _chat_delta_json(content).encode("utf-8")
+
+
+_SSE_CONTENT = st.text(
+    alphabet=st.characters(blacklist_categories=("Cs",), min_codepoint=32),
+    max_size=20,
+)
+_SSE_LINE = st.one_of(
+    st.just(b": ping"),
+    st.just(b""),
+    st.just(b"data: [DONE]"),
+    _SSE_CONTENT.map(_data_json_line),
+    _SSE_CONTENT.map(_raw_json_line),
+)
+_SSE_LINES = st.lists(_SSE_LINE, min_size=1, max_size=12)
+
+
+def _split_seq(seq: list[bytes], cuts: list[int]) -> list[list[bytes]]:
+    n = len(seq)
+    pts = sorted({0, n, *(min(max(0, c), n) for c in cuts)})
+    return [seq[a:b] for a, b in zip(pts, pts[1:]) if a < b]
 
 
 @given(parts=st.lists(st.text(min_size=1, max_size=12), min_size=1, max_size=5))
@@ -97,6 +153,42 @@ def test_hypothesis_merge_reasoning_details_chunked_equals_full(a: str, b: str, 
     assert chunked == full
     assert len(chunked) == 1
     assert chunked[0]["text"] == a + b
+
+
+@given(left=_SSE_LINES, right=_SSE_LINES)
+@settings(max_examples=vhs_max_examples(40, 400), deadline=None)
+def test_hypothesis_iterate_sse_concat_homomorphism(left: list[bytes], right: list[bytes]) -> None:
+    """``iterate_sse`` is stateless per line: no multi-``data:`` coalescing (unlike SSE spec)."""
+    assert list(iterate_sse(left)) + list(iterate_sse(right)) == list(iterate_sse(left + right))
+
+
+@given(
+    lines=_SSE_LINES,
+    cuts=st.lists(st.integers(min_value=0, max_value=12), max_size=6),
+)
+@settings(max_examples=vhs_max_examples(40, 400), deadline=None)
+def test_hypothesis_iterate_sse_line_partition(lines: list[bytes], cuts: list[int]) -> None:
+    got: list[str] = []
+    for group in _split_seq(lines, cuts):
+        got.extend(iterate_sse(group))
+    assert got == list(iterate_sse(lines))
+
+
+@given(
+    lines=_SSE_LINES,
+    cuts=st.lists(st.integers(min_value=0, max_value=800), min_size=0, max_size=8),
+)
+@settings(max_examples=vhs_max_examples(40, 400), deadline=None)
+def test_hypothesis_iterate_sse_readline_fragments_match_whole(lines: list[bytes], cuts: list[int]) -> None:
+    """TCP-style byte cuts + readline == unsplit line list / BytesIO of the joined blob."""
+    blob = b"\n".join(lines)
+    n = len(blob)
+    pts = sorted({0, n, *(min(max(0, c), n) for c in cuts)})
+    fragments = [blob[a:b] for a, b in zip(pts, pts[1:]) if a < b]
+    reassembled = _sse_lines_from_byte_chunks(fragments)
+    expected = list(iterate_sse(lines))
+    assert list(iterate_sse(reassembled)) == expected
+    assert list(iterate_sse(io.BytesIO(blob))) == expected
 
 
 def test_normalize_stream_delta_unwraps_choices() -> None:

--- a/verification_status.json
+++ b/verification_status.json
@@ -203,7 +203,7 @@
       "crosshair_last_run": "2026-08-06",
       "crosshair_result": "no_counterexamples",
       "ci_integration": true,
-      "notes": "Hypothesis: thinking concat, merge chunked==full, think-tag chunk round-trip, streaming replay keys. CrossHair FQN: _merge_reasoning_details, _thinking_text_from_delta. ThinkTagStreamSplitter.feed and _normalize_stream_delta are not CrossHair. make verify picks up test_stream_normalizer_verification.py."
+      "notes": "Hypothesis: thinking concat, merge chunked==full, think-tag chunk round-trip, streaming replay keys, iterate_sse line-partition + readline-fragment (no @deal on iterate_sse). CrossHair FQN: _merge_reasoning_details, _thinking_text_from_delta. ThinkTagStreamSplitter.feed and _normalize_stream_delta are not CrossHair. make verify picks up test_stream_normalizer_verification.py."
     },
     "client/response_normalizers.py": {
       "status": "verified",


### PR DESCRIPTION
## Summary

Phase 4 well-formed dual of [#497](https://github.com/KeithCu/writeragent/pull/497). `iterate_sse` is line-oriented (no leftover buffer); HTTP `readline` reassembles TCP cuts. Hypothesis — not CrossHair, no `@deal` on `iterate_sse`:

- **Concat homomorphism:** `f(a)+f(b)==f(a+b)` — consecutive `data:` lines are **not** coalesced (locks current semantics vs the SSE spec).
- **Line-partition:** grouping complete lines yields the same payloads.
- **Readline-fragment:** arbitrary byte cuts of a well-formed blob, reassembled like `HTTPResponse.readline`, match the unsplit line list / `BytesIO(whole)`.

Malformed / truncated chunks stay pytest (#497). `accumulate_delta` already covers JSON-delta concat.

Docs: Phase 4 claim in `formal-verification.md` rewritten to match; `verification_status.json` notes only (status stays `verified`). Already on the `vhs` recipe via `test_stream_normalizer_verification.py`.

## Test plan
- [x] `pytest tests/framework/test_stream_normalizer_verification.py -k 'hypothesis and iterate_sse'` — 3 passed
- [x] `pytest tests/framework/test_stream_normalizer_verification.py -m 'not slow'` — 18 passed