### PR TITLE
docs: mark spreadsheet import as a low-priority prototype

### DIFF
--- a/docs/calc/spreadsheet-to-python-import.md
+++ b/docs/calc/spreadsheet-to-python-import.md
@@ -1,6 +1,6 @@
 ---
 name: Calc Spreadsheet → Python Import
-overview: Import or convert an open Calc workbook so cell data stays the same while spreadsheet formulas become =PY() Python (venv-backed), targeting ~90% automated conversion on typical business sheets.
+overview: Prototype (low priority). Import or convert an open Calc workbook so cell data stays the same while spreadsheet formulas become =PY() Python. Not a product pillar; Phase 6 LLM fallback is not scheduled.
 todos:
   - id: phase0-spec
     content: "Phase 0: Spec + benchmark corpus + coverage metrics (this doc)"
@@ -22,7 +22,7 @@ todos:
     status: completed
   - id: phase6-llm-fallback
     content: "Phase 6: LLM assist for remaining cells + cross-sheet edge cases"
-    status: pending
+    status: cancelled
 isProject: false
 ---
 
@@ -30,7 +30,7 @@ isProject: false
 
 Back to [Enabling NumPy & Python in LibreOffice](../enabling_numpy_in_libreoffice.md).
 
-**Status: Shipped.**
+**Status: Prototype — low priority.** An interesting in-workbook rewrite (Phases 0–5 exist). It is **not** a product pillar and is **not** next engineering work. Do not pick Phase 6 (LLM fallback), extra function coverage, or `translate.py` formal verification unless this is explicitly revived.
 
 ## Executive summary
 
@@ -428,7 +428,7 @@ flowchart TB
 | [Sheet2Code](https://sheet2code.com/) | Sheets / Excel | Parser design reference | DAG + codegen patterns |
 | [excel_in_python](https://github.com/ncalm/excel_in_python) | pandas | Function semantics | P2 lookup helpers |
 | Mito / FlyingKoala | Excel UI | UX only | Column vectorization ideas |
-| LLM + `CALC_PYTHON_FORMULA_LLM_HINT` | In-doc context | **High** | Phase 6 long tail |
+| LLM + `CALC_PYTHON_FORMULA_LLM_HINT` | In-doc context | **Low** (not scheduled) | Prototype long tail |
 
 **Recommendation:** Phase 3 — hand-rolled parser for P1; parallel spike on `formulas` ODS load. Do **not** add PyPI deps to OXT without vendoring review.
 
@@ -1089,7 +1089,9 @@ If 50 cells share one pattern `=A{row}*2`, one matrix `=PY()` counts as **50 con
 
 ## 10. Phased dev plan
 
-### Phase 6 — LLM fallback (optional)
+### Phase 6 — LLM fallback (not scheduled)
+
+Prototype long-tail only. Do not start this unless spreadsheet import is explicitly revived.
 
 **Deliverables**
 
@@ -1162,6 +1164,6 @@ Run with `make test`. New tests follow module naming in [AGENTS.md](../../AGENTS
 
 ## Implementation status
 
-All core components (Ingest, Preservation, Parser, Translators, Vectorization, Dialog, Chat tool) are **Shipped**.
+All core components (Ingest, Preservation, Parser, Translators, Vectorization, Dialog, Chat tool) exist in-tree as a **prototype**.
 
-**Next engineering step:** Phase 6 — LLM fallback.
+**Not scheduled:** Phase 6 LLM fallback, more builtin coverage, or promoting this to a product feature.

--- a/docs/enabling_numpy_in_libreoffice.md
+++ b/docs/enabling_numpy_in_libreoffice.md
@@ -35,7 +35,7 @@ These Python / NumPy features also now ship in **LibrePy.oxt**. The WriterAgent 
 | [LibrePy-surface live QA plan](librepy-manual-qa-plan.md) | Real-scenario Calc/RPS/domain checks (`=PY("1 + 1")` upward). Either OXT; do not test chat/`=PROMPT()`. |
 | [Monaco editor dev plan](scripting/monaco-editor-dev-plan.md) | IPC, phases 2B–2F |
 | [Collabora Online / jail-safe](scripting/numpy-jailsafe.md) | Thin C++ Add-In + compute service |
-| [Calc spreadsheet → Python import](calc/spreadsheet-to-python-import.md) | Convert formulas to `=PY()` |
+| [Calc spreadsheet → Python import](calc/spreadsheet-to-python-import.md) | Prototype / low priority — convert formulas to `=PY()` |
 | [Jupyter notebook import](writer/jupyter-notebook-import.md) | Writer `.ipynb` import + ▶ run (shared `notebook:…` kernel; not Calc `=PY()`) |
 
 ---
@@ -834,7 +834,7 @@ Complex returns (DataFrame, dict, class) should show a compact cell label (e.g. 
 | **Formula-bar Jedi** | [Monaco 2D](scripting/monaco-editor-dev-plan.md#phase-2d--jedi-autocompletion-child-only-performance-sensitive) |
 | **Named ranges / structured tables / `headers` in `data`** | [`calc_addin_data.py`](../plugin/calc/calc_addin_data.py) |
 | **Label preservation** | First row/column as pandas Index when requested |
-| **Spreadsheet → Python import** | [calc/spreadsheet-to-python-import.md](calc/spreadsheet-to-python-import.md) |
+| **Spreadsheet → Python import** | Prototype / low priority — [calc/spreadsheet-to-python-import.md](calc/spreadsheet-to-python-import.md) |
 | **Worker idle shutdown / per-formula `timeout_sec`** | Global timeout is Settings → Python; per-cell timeout and idle worker teardown are not shipped |
 | **Python edit dialog tiers 1–3** | [§6 deferred UX](#optional-python-edit-dialog-deferred-ux) |
 | **Range alignment for multi-range NumPy** | Mismatched shapes before `np.corrcoef` — [data shapes deferred](calc/py-data-shapes.md#deferred-upgrades) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -32,7 +32,7 @@ Product overview lives in the root [README](../README.md). This page maps each a
 | Domain helpers (Viz, Math, Quant, …) | [scripting/numpy-domains.md](scripting/numpy-domains.md) |
 | Analysis tools | [calc/analysis-tools.md](calc/analysis-tools.md) · [calc/analysis-sub-agent.md](calc/analysis-sub-agent.md) |
 | Specialized toolsets | [calc/specialized-toolsets.md](calc/specialized-toolsets.md) |
-| Sheet → Python | [calc/spreadsheet-to-python-import.md](calc/spreadsheet-to-python-import.md) |
+| Sheet → Python | [calc/spreadsheet-to-python-import.md](calc/spreadsheet-to-python-import.md) (prototype, low priority) |
 | Conditional formatting | [calc/conditional-formatting.md](calc/conditional-formatting.md) |
 | Sheet filters | [calc/sheet-filter.md](calc/sheet-filter.md) |
 | Serialization | [scripting/numpy-serialization.md](scripting/numpy-serialization.md) |

--- a/docs/framework/formal-verification.md
+++ b/docs/framework/formal-verification.md
@@ -575,7 +575,7 @@ Snapshot **2026-08-27**: **48 verified / 8 partial** in [`verification_status.js
 
 #### 4. Optional new Tier-0 slice (only after 1–2)
 
-Highest unused pure surface: **[`plugin/calc/spreadsheet_import/translate.py`](../../plugin/calc/spreadsheet_import/translate.py)** (formula → Python codegen, no UNO). Secondary: pure color/units in [`plugin/doc/visual_helpers.py`](../../plugin/doc/visual_helpers.py) (`parse_color_to_uno_int`, mm/px helpers)—extract if mixed with UNO. Skip vendored `plugin/lib/**`.
+[`plugin/calc/spreadsheet_import/translate.py`](../../plugin/calc/spreadsheet_import/translate.py) is **not** the next slice — spreadsheet import is a low-priority prototype. Secondary if needed: pure color/units in [`plugin/doc/visual_helpers.py`](../../plugin/doc/visual_helpers.py) (`parse_color_to_uno_int`, mm/px helpers)—extract if mixed with UNO. Skip vendored `plugin/lib/**`.
 
 #### 5. Tooling (low code, high leverage)
 
@@ -583,7 +583,7 @@ Highest unused pure surface: **[`plugin/calc/spreadsheet_import/translate.py`](.
 - Keep `CROSSHAIR_*_SKIP` empty; hostility = shim / `# crosshair: off` / refactor.
 - Stale “Practical Implementation Guide” samples below still mention old paths—treat Phase 9 + this section as source of truth over the illustrative CI YAML.
 
-**Suggested next session (single track):** optional new Tier-0 [`translate.py`](../../plugin/calc/spreadsheet_import/translate.py) contracts, or one remaining named FSM legality property (send idle-Stop no-op, or MCP error latch once reset is defined). Do not remove `next_state` offs. Do not reopen json_utils / errors / payload_codec to “force verified.”
+**Suggested next session (single track):** one remaining named FSM legality property (send idle-Stop no-op, or MCP error latch once reset is defined). Do not remove `next_state` offs. Do not reopen json_utils / errors / payload_codec to “force verified.” Do not start `translate.py` contracts (spreadsheet import is a low-priority prototype).
 
 ---
 

--- a/docs/scripting/librepy-split.md
+++ b/docs/scripting/librepy-split.md
@@ -62,7 +62,7 @@ Aligned with [../enabling_numpy_in_libreoffice.md](../enabling_numpy_in_libreoff
 
 #### Calc-parity `xl` helpers (deferred from LibrePy) {#calc-parity-xl-helpers-deferred-from-librepy}
 
-WriterAgent ships [`plugin/scripting/calc_functions.py`](../../plugin/scripting/calc_functions.py) and [`plugin/scripting/venv/calc_functions_*.py`](../../plugin/scripting/venv/) — **259** Calc/Excel formula parity helpers auto-imported as **`calc`** in the venv (e.g. `calc.sumif(...)`, `calc.xlookup(...)`). They exist so spreadsheet import can emit compact Python instead of pasting inline `def` blocks per workbook ([../calc/spreadsheet-to-python-import.md](../calc/spreadsheet-to-python-import.md)). This is **not** the same as Microsoft Python in Excel’s `xl()` range bridge ([comparison](../calc/spreadsheet-to-python-import.md#microsoft-xl-vs-writeragent-calc)).
+WriterAgent ships [`plugin/scripting/calc_functions.py`](../../plugin/scripting/calc_functions.py) and [`plugin/scripting/venv/calc_functions_*.py`](../../plugin/scripting/venv/) — **259** Calc/Excel formula parity helpers auto-imported as **`calc`** in the venv (e.g. `calc.sumif(...)`, `calc.xlookup(...)`). They were built so the **prototype** spreadsheet import could emit compact Python instead of pasting inline `def` blocks per workbook ([../calc/spreadsheet-to-python-import.md](../calc/spreadsheet-to-python-import.md), low priority). This is **not** the same as Microsoft Python in Excel’s `xl()` range bridge ([comparison](../calc/spreadsheet-to-python-import.md#microsoft-xl-vs-writeragent-calc)).
 
 **LibrePy (core OXT) excludes them for now** (~134 KB source; filtered in [`scripts/librepy_bundle_paths.py`](../../scripts/librepy_bundle_paths.py) via `LIBREPY_CALC_FUNCTIONS_EXCLUDES`). Rationale:
 

--- a/docs/writer/jupyter-notebook-import.md
+++ b/docs/writer/jupyter-notebook-import.md
@@ -12,7 +12,7 @@ WriterAgent and LibrePy can **read** Jupyter notebooks (nbformat v4) and **impor
 |------------|------------|--------------|---------------|
 | **Jupyter Notebook (`.ipynb`)** | **Writer** | Flowing text document, in-flow code `TextField`s, ▶ push buttons, `notebook:…` shared venv kernel | **This document** |
 | **Formula Python (`=PY()`)** | **Calc** | In-cell spreadsheet formula execution, native Calc dependency DAG | [`../enabling_numpy_in_libreoffice.md`](../enabling_numpy_in_libreoffice.md) |
-| **Convert Sheet to Python** | **Calc** | Translates Calc workbook formulas into `=PY()` Python formulas | [`../calc/spreadsheet-to-python-import.md`](../calc/spreadsheet-to-python-import.md) |
+| **Convert Sheet to Python** | **Calc** | Prototype / low priority — translates Calc formulas into `=PY()` | [`../calc/spreadsheet-to-python-import.md`](../calc/spreadsheet-to-python-import.md) |
 
 > [!NOTE]
 > **Why Writer for `.ipynb` notebooks?**

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -743,6 +743,7 @@ Other-sheet refs use a dot (Orders.A1), never Excel bang (Orders!A1 → #NAME?).
 - Example: =PY("result = np.sum(data)"; Orders.A1:H500).
 - For tables with headers, use data.to_pandas() instead of pd.DataFrame(data) so row 0 becomes column headers rather than synthetic numeric columns (0..N).
 - {CALC_PYTHON_DATA_SHAPE_LLM_HINT}"""
-    # Phase 6 spreadsheet-import LLM fallback; not a second prompt.
+    # Alias of CALC_FORMULA_SYNTAX only. Spreadsheet-import LLM fallback is a
+    # low-priority prototype — not a second prompt and not scheduled work.
     CALC_PYTHON_FORMULA_LLM_HINT = CALC_FORMULA_SYNTAX
     DEFAULT_CALC_CHAT_SYSTEM_PROMPT_TEMPLATE = _build_calc_chat_system_prompt_template()


### PR DESCRIPTION
## Summary

Spreadsheet → Python import is an **interesting prototype**, not a product pillar.

- Plan doc status: prototype / low priority; Phase 6 LLM fallback **not scheduled**
- Hub, features, LibrePy split, Jupyter comparison, FV Phase 9: do not pick `translate.py` contracts as next work
- `CALC_PYTHON_FORMULA_LLM_HINT` comment: alias only, not a scheduled fallback

No code behavior change.