### PR TITLE
fix(calc): Monaco follows =PY($A$1) into the code cell

### DIFF
--- a/docs/enabling_numpy_in_libreoffice.md
+++ b/docs/enabling_numpy_in_libreoffice.md
@@ -675,7 +675,7 @@ Do not wrap returns in `float()` / `int()` / `str()` for Calc’s sake — [`to_
 | Pattern | When to use | Example |
 | ------- | ----------- | ------- |
 | **Bare NumPy / expression** | Default for short inline code | `=PY("np.sum(data)"; B1:B10)` |
-| **Code in a cell** | Multi-line / huge scripts (avoids `MAXSTRLEN`) | `A1` = script text; `=PY($A$1; B1:B10)` |
+| **Code in a cell** | Multi-line / huge scripts (avoids `MAXSTRLEN`) | `A1` = script text (**Save without =PY()**); `=PY($A$1; B1:B10)`. Opening the formula cell in Monaco edits **A1**. |
 | **ASCII quotes only** | Always when pasting / generating formulas | Normalize curly `“”` → `"` (WriterAgent does this on parse) |
 | **Comma vs semicolon** | Match file/locale | XLSX OOXML → commas; Calc UI often `;` |
 | **XLSX test sheets** | Manual serialization regression | See [`scripts/generate_serialization_spreadsheet.py`](../scripts/generate_serialization_spreadsheet.py) |
@@ -687,8 +687,8 @@ Do not wrap returns in `float()` / `int()` / `str()` for Calc’s sake — [`to_
 
 These are **not** implemented; kept so design discussions do not rediscover the same traps.
 
-1. **Cell-reference-first UX** — Settings or formula wizard default: “put script in one cell, reference it from `=PY`” (already supported by IDL; needs prompts/UI). Best mitigation for huge scripts until LO raises `MAXSTRLEN`.
-2. **LLM / `=PROMPT()` guardrails** — Prefer cell refs for long code; emit ASCII `"` only; avoid unquoted Python in the formula.
+1. **Cell-reference-first UX** — Shipped for the editor: opening `=PY($A$1; …)` edits A1’s text and saves back to A1 (formula stays a ref). A Settings/wizard default to *create* that pattern is still not implemented. Best mitigation for huge scripts until LO raises `MAXSTRLEN`.
+2. **LLM / `=PROMPT()` guardrails** — Deferred. Auto-imports and helpers usually fit in 1024 chars; do not lengthen `CALC_FORMULA_SYNTAX` unless generated `=PY("…")` hits `Err:513`. Monaco already follows cell-ref formulas.
 3. **Native ODS fixtures** — Shipped: [`tests/fixtures/numpy_domains_demo.ods`](../tests/fixtures/numpy_domains_demo.ods). Use ODS for manual `=PY()` QA (preserves uppercase add-in name; semicolon args). Serialization fixtures use bare `np.sum` / `np.max` (no `float()` wrapper).
 
 ### Future LibreOffice formula-string work {#future-libreoffice-formula-string-work}

--- a/plugin/calc/python/cell_editor_ui.py
+++ b/plugin/calc/python/cell_editor_ui.py
@@ -56,11 +56,15 @@ class NativePythonCellEditorDialog:
         cell: Any,
         initial_code: str,
         parsed_parts: Any,
+        code_cell: Any | None = None,
+        code_ref: str | None = None,
     ) -> None:
         self._ctx = ctx
         self._doc = doc
         self._cell = cell
         self._parsed_parts = parsed_parts
+        self._code_cell = code_cell if code_cell is not None else cell
+        self._code_ref = code_ref
         self._dlg: Any | None = None
         self._closed = False
         self._dirty = False
@@ -80,10 +84,14 @@ class NativePythonCellEditorDialog:
         cell: Any,
         initial_code: str,
         parsed_parts: Any,
+        code_cell: Any | None = None,
+        code_ref: str | None = None,
     ) -> None:
         self._doc = doc
         self._cell = cell
         self._parsed_parts = parsed_parts
+        self._code_cell = code_cell if code_cell is not None else cell
+        self._code_ref = code_ref
         self._apply_load(initial_code)
         self._dirty = False
 
@@ -132,7 +140,7 @@ class NativePythonCellEditorDialog:
         ctrl = self._ctrl("CellAddr")
         if ctrl is None:
             return
-        addr = format_cell_a1(self._cell)
+        addr = format_cell_a1(self._code_cell if self._following_ref() else self._cell)
         try:
             if hasattr(ctrl, "setText"):
                 ctrl.setText(addr)
@@ -141,6 +149,9 @@ class NativePythonCellEditorDialog:
                 model.Label = addr
         except Exception:
             log.debug("native cell editor: CellAddr failed", exc_info=True)
+
+    def _following_ref(self) -> bool:
+        return bool(self._code_ref) and self._code_cell is not None and self._code_cell is not self._cell
 
     def _apply_load(self, initial_code: str) -> None:
         from plugin.calc.python.editor import editor_load_save_as_plain
@@ -164,7 +175,9 @@ class NativePythonCellEditorDialog:
             except Exception:
                 log.debug("native cell editor: DataEdit HelpText failed", exc_info=True)
         plain = editor_load_save_as_plain(
-            parsed_parts=self._parsed_parts, initial_code=initial_code or ""
+            parsed_parts=self._parsed_parts,
+            initial_code=initial_code or "",
+            follow_code_ref=self._following_ref(),
         )
         set_checkbox_state(self._ctrl("ChkPlainText"), 1 if plain else 0)
         self._sync_data_enabled()
@@ -178,8 +191,9 @@ class NativePythonCellEditorDialog:
                 pass
 
     def _sync_data_enabled(self) -> None:
-        # Twin of editor.js updateDataBindingEnabled: Data: is off when Save without =PY().
-        disabled = bool(get_checkbox_state(self._ctrl("ChkPlainText")))
+        # Twin of editor.js updateDataBindingEnabled: Data: is off when Save
+        # without =PY(), except when following =PY($A$1) (data lives on the formula cell).
+        disabled = bool(get_checkbox_state(self._ctrl("ChkPlainText"))) and not self._following_ref()
         for name in ("DataEdit", "DataLbl"):
             ctrl = self._ctrl(name)
             if ctrl is None:
@@ -239,7 +253,8 @@ class NativePythonCellEditorDialog:
 
         self._set_status(_("Saving…"))
         save_as_plain = bool(get_checkbox_state(self._ctrl("ChkPlainText")))
-        binding = None if save_as_plain else self._data_text()
+        follow = self._following_ref()
+        binding = self._data_text() if follow or not save_as_plain else None
         outcome = _apply_cell_save(
             self._doc,
             self._cell,
@@ -247,6 +262,8 @@ class NativePythonCellEditorDialog:
             new_code=self._code_text(),
             save_as_plain=save_as_plain,
             data_binding_text=binding,
+            code_cell=self._code_cell if follow else None,
+            code_ref=self._code_ref if follow else None,
         )
         if outcome.get("type") == "error":
             self._set_status(str(outcome.get("message") or _("Error")))
@@ -374,6 +391,8 @@ def show_native_python_cell_editor(
     cell: Any,
     initial_code: str,
     parsed_parts: Any,
+    code_cell: Any | None = None,
+    code_ref: str | None = None,
 ) -> tuple[bool, str | None]:
     """Open or retarget the native cell editor. Returns (opened, failure_detail)."""
     global _active
@@ -393,6 +412,8 @@ def show_native_python_cell_editor(
             cell=cell,
             initial_code=initial_code,
             parsed_parts=parsed_parts,
+            code_cell=code_cell,
+            code_ref=code_ref,
         )
         return True, None
     inst = NativePythonCellEditorDialog(
@@ -401,6 +422,8 @@ def show_native_python_cell_editor(
         cell=cell,
         initial_code=initial_code,
         parsed_parts=parsed_parts,
+        code_cell=code_cell,
+        code_ref=code_ref,
     )
     if inst._opened:
         _active = inst

--- a/plugin/calc/python/editor.py
+++ b/plugin/calc/python/editor.py
@@ -29,7 +29,9 @@ from plugin.calc.python.formula_edit import (
     format_data_binding_text,
     parse_data_binding_text,
     parse_python_formula,
+    py_formula_has_unquoted_code_ref,
     rebuild_python_formula,
+    rebuild_python_formula_with_code_ref,
     rebuild_python_formula_with_data,
 )
 from plugin.calc.python.xl_static_rewrite import apply_xl_static_rewrite
@@ -78,6 +80,38 @@ def _parse_cell_python_formula(cell: Any) -> tuple[str, PythonFormulaParts | Non
         if parts is not None:
             return parts.code, parts, raw
     return "", None, None
+
+
+def _same_calc_cell(left: Any, right: Any) -> bool:
+    if left is right:
+        return True
+    try:
+        a = left.getCellAddress()
+        b = right.getCellAddress()
+        return int(a.Column) == int(b.Column) and int(a.Row) == int(b.Row) and int(a.Sheet) == int(b.Sheet)
+    except Exception:
+        return False
+
+
+def _resolve_code_ref_cell(doc: Any, code_ref: str) -> Any | None:
+    """Resolve ``$A$1`` / ``Sheet.A1`` to a cell, or None if the address is bad."""
+    try:
+        from plugin.calc.address_utils import split_sheet_prefix
+        from plugin.calc.bridge import CalcBridge
+
+        sheet, rest = split_sheet_prefix(code_ref.strip())
+        bare = rest.replace("$", "").strip()
+        if not bare:
+            return None
+        if sheet:
+            needs_quotes = any(not (c.isalnum() or c == "_") for c in sheet) or sheet[:1].isdigit()
+            addr = f"'{sheet}'.{bare}" if needs_quotes else f"{sheet}.{bare}"
+        else:
+            addr = bare
+        return CalcBridge(doc).get_cell_by_address(addr)
+    except Exception:
+        log.debug("python_editor: could not resolve code ref %r", code_ref, exc_info=True)
+        return None
 
 
 def _load_cell_editor_code(cell: Any) -> tuple[str, PythonFormulaParts | None, str | None]:
@@ -303,8 +337,38 @@ def _apply_plain_text_save(doc: Any, cell: Any, *, new_code: str) -> dict[str, A
     }
 
 
-def editor_load_save_as_plain(*, parsed_parts: PythonFormulaParts | None, initial_code: str) -> bool:
+def _apply_followed_ref_save(
+    doc: Any,
+    formula_cell: Any,
+    *,
+    code_cell: Any,
+    code_ref: str,
+    new_code: str,
+    data_binding_text: str | None,
+) -> dict[str, Any]:
+    """Write Python to the referenced code cell; keep ``=PY($A$1; …)`` as a ref."""
+    code_cell.setString(new_code)
+    if data_binding_text is not None:
+        data_args = parse_data_binding_text(data_binding_text)
+        formula_cell.setFormula(rebuild_python_formula_with_code_ref(code_ref, data_args))
+    _recalculate_after_save(doc)
+    return {
+        "type": "saved",
+        "ok": True,
+        "save_as_plain": True,
+        "status_ok_text": _("Saved without =PY()."),
+    }
+
+
+def editor_load_save_as_plain(
+    *,
+    parsed_parts: PythonFormulaParts | None,
+    initial_code: str,
+    follow_code_ref: bool = False,
+) -> bool:
     """Default plain-text checkbox on editor load: on for plain cells, off for ``=PY()`` or empty."""
+    if follow_code_ref:
+        return True
     return parsed_parts is None and bool(initial_code.strip())
 
 
@@ -316,7 +380,22 @@ def _apply_cell_save(
     new_code: str,
     save_as_plain: bool,
     data_binding_text: str | None = None,
+    code_cell: Any | None = None,
+    code_ref: str | None = None,
 ) -> dict[str, Any]:
+    if (
+        code_cell is not None
+        and code_ref
+        and not _same_calc_cell(code_cell, cell)
+    ):
+        return _apply_followed_ref_save(
+            doc,
+            cell,
+            code_cell=code_cell,
+            code_ref=code_ref,
+            new_code=new_code,
+            data_binding_text=data_binding_text,
+        )
     if save_as_plain:
         return _apply_plain_text_save(doc, cell, new_code=new_code)
     return _apply_formula_save(
@@ -336,10 +415,25 @@ def _launch_editor_with_code(
     initial_code: str,
     parsed_parts: PythonFormulaParts | None,
     exe: str,
+    code_cell: Any | None = None,
+    code_ref: str | None = None,
 ) -> None:
+    follow = bool(code_ref and code_cell is not None and not _same_calc_cell(code_cell, cell))
     data_binding = format_data_binding_display(parsed_parts.data_suffix) if parsed_parts else ""
+    display_cell = code_cell if follow else cell
 
     def on_save(code: str, save_as_plain: bool, data_binding: str | None = None, _action: str = "cell_save") -> dict[str, Any]:
+        if follow:
+            return _apply_cell_save(
+                doc,
+                cell,
+                parsed_parts=parsed_parts,
+                new_code=code,
+                save_as_plain=True,
+                data_binding_text=data_binding,
+                code_cell=code_cell,
+                code_ref=code_ref,
+            )
         binding = None if save_as_plain else data_binding
         return _apply_cell_save(
             doc,
@@ -360,14 +454,17 @@ def _launch_editor_with_code(
         "code": initial_code,
         "title": _("Python cell editor"),
         "plain_text_label": _("Save without =PY()"),
-        "save_as_plain": editor_load_save_as_plain(parsed_parts=parsed_parts, initial_code=initial_code),
+        "save_as_plain": editor_load_save_as_plain(
+            parsed_parts=parsed_parts, initial_code=initial_code, follow_code_ref=follow
+        ),
         "save_label": _("Save"),
         "show_plain_text": True,
         "show_data_binding": True,
+        "follow_code_ref": follow,
         "data_binding": data_binding,
-        "cell_address": format_cell_a1(cell),
+        "cell_address": format_cell_a1(display_cell),
         "doc_url": "",
-        "resource": format_cell_a1(cell),
+        "resource": format_cell_a1(display_cell),
     }
     try:
         from plugin.scripting.document_scripts import document_scripts_identity
@@ -416,12 +513,37 @@ def _open_python_cell_editor_impl(ctx: Any) -> None:
         return
     doc, cell, _formula = resolved
 
+    # Follow =PY($A$1) into A1 (plain code cell). Do not quote the ref on save.
+    # Prompting the LLM to emit this two-cell pattern is deferred: auto-imports
+    # and helpers usually fit in Calc MAXSTRLEN (1024). Revisit CALC_FORMULA_SYNTAX
+    # if Err:513 shows up for generated =PY("…").
     initial_code, parsed_parts, source_formula = _load_cell_editor_code(cell)
+    code_cell: Any | None = None
+    code_ref: str | None = None
+    if parsed_parts is not None and source_formula and py_formula_has_unquoted_code_ref(source_formula):
+        followed = _resolve_code_ref_cell(doc, parsed_parts.code)
+        if followed is None:
+            msgbox(
+                ctx,
+                product_display_name(ctx),
+                _("Could not open the code cell {0}.").format(parsed_parts.code),
+            )
+            return
+        if not _same_calc_cell(followed, cell):
+            try:
+                initial_code = str(followed.getString() or "")
+            except Exception:
+                log.debug("python_editor: code-cell getString failed", exc_info=True)
+                initial_code = ""
+            code_cell = followed
+            code_ref = parsed_parts.code
+
     log.info(
-        "python_editor: initial_code len=%s parsed=%s source=%r",
+        "python_editor: initial_code len=%s parsed=%s source=%r follow=%s",
         len(initial_code),
         parsed_parts is not None,
         (source_formula or "")[:80],
+        code_ref,
     )
 
     if parsed_parts is None and _cell_has_unparsed_python(cell):
@@ -447,6 +569,8 @@ def _open_python_cell_editor_impl(ctx: Any) -> None:
             initial_code=initial_code,
             parsed_parts=parsed_parts,
             exe=exe,
+            code_cell=code_cell,
+            code_ref=code_ref,
         )
         log.info("python_editor: editor session started")
         return
@@ -460,6 +584,8 @@ def _open_python_cell_editor_impl(ctx: Any) -> None:
         cell=cell,
         initial_code=initial_code,
         parsed_parts=parsed_parts,
+        code_cell=code_cell,
+        code_ref=code_ref,
     )
     if opened:
         return

--- a/plugin/calc/python/formula_edit.py
+++ b/plugin/calc/python/formula_edit.py
@@ -635,6 +635,45 @@ def rebuild_python_formula_with_data(
     return f'{prefix}"{escaped}"{build_data_suffix(data_args, separator=separator, excel_ranges=excel_escape or separator == ",")}'
 
 
+def py_code_arg_is_cell_ref(code: str) -> bool:
+    """True when ``=PY``'s first argument is a single cell address, not Python.
+
+    ``=PY($A$1; data)`` / ``=PY(Sheet.A1)`` store source in that cell. Ranges
+    (``A1:B10``) and unquoted Python (``sp.prime(100)``) return False.
+    """
+    if type(code) is not str:
+        return False
+    s = code.strip()
+    if not s or ":" in s or "\n" in s:
+        return False
+    from plugin.calc.address_utils import parse_address, split_sheet_prefix
+
+    _sheet, rest = split_sheet_prefix(s)
+    bare = rest.replace("$", "").strip()
+    if not bare:
+        return False
+    try:
+        parse_address(bare)
+    except ValueError:
+        return False
+    return True
+
+
+def py_formula_has_unquoted_code_ref(formula: str) -> bool:
+    """True when the formula is ``=PY($A$1; …)`` (unquoted), not ``=PY(\"A1\")``."""
+    parts = parse_python_formula(formula)
+    if parts is None or not py_code_arg_is_cell_ref(parts.code):
+        return False
+    raw = normalize_formula_string(formula)
+    start = _py_call_open_end(raw, require_equals=True)
+    if start is None:
+        return False
+    body = raw[start:]
+    if body.endswith(")"):
+        body = body[:-1]
+    return not body.strip().startswith('"')
+
+
 def rebuild_python_formula_with_code_ref(
     code_ref: str,
     data_args: list[str],

--- a/plugin/contrib/scripting/assets/editor/editor.js
+++ b/plugin/contrib/scripting/assets/editor/editor.js
@@ -33,6 +33,7 @@
   var suppressDirty = false;
   var dataBindingTitle = "Calc injects `data` and `ranges` from these range(s) at runtime.";
   var dataBindingDisabledTitle = "Data ranges apply only when saving as a =PYTHON() formula.";
+  var followCodeRef = false;
   var completeTimer = null;
   var completeSeq = 0;
 
@@ -179,6 +180,7 @@
     sessionTarget = msg.target && typeof msg.target === "object" ? msg.target : {};
     var isRunScript = currentMode === "run_script";
     var isCalcCell = currentMode === "calc_cell";
+    followCodeRef = !!msg.follow_code_ref;
 
     setToolbarVisible("btn-run", isRunScript);
     setToolbarVisible("cell-addr", isCalcCell);
@@ -259,7 +261,7 @@
     var plainEl = getPlainTextCheckbox();
     var input = getDataBindingInput();
     var label = document.getElementById("data-binding-label");
-    var disabled = !!plainEl && plainEl.checked;
+    var disabled = !!plainEl && plainEl.checked && !followCodeRef;
     if (input) {
       input.disabled = disabled;
       input.title = disabled ? dataBindingDisabledTitle : dataBindingTitle;

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -134,6 +134,11 @@ Prioritize what reduces future user steering."""
 
 
 # Shared venv Python prompt text (run_venv_python_script, =PY(), delegate domain=python).
+# CALC_FORMULA_SYNTAX still shows inline =PY("…"; range). Typical scripts fit in
+# Calc MAXSTRLEN (1024) because of auto-imports and domain helpers. If Err:513
+# becomes common for generated formulas, prefer the two-cell pattern
+# (=PY($A$1; range) — Monaco already follows that ref) instead of lengthening
+# this prompt. Not scheduled.
 PYTHON_VENV_AUTO_IMPORTS_ALIASES = "`numpy` (as `np`), `sympy` (as `sp`), `pandas` (as `pd`), `scipy.stats` (as `st`), `matplotlib.pyplot` (as `plt`), `plugin.scripting.calc_functions` (as `calc`), standard library `math`, `datetime` (as `dt`), `re`, `random`, `statistics`, `collections`, `itertools`, `json`, and `csv`. When `=PY` has data range args, a binding-only `xl(\"%Pn%\")` helper is also injected (Excel import; not a live sheet read)"
 
 # Populated at module end (after full constants init) to avoid import cycles via smolagents.

--- a/tests/calc/python/test_editor_save_modes.py
+++ b/tests/calc/python/test_editor_save_modes.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 from plugin.calc.python.editor import (
     _apply_cell_save,
+    _resolve_code_ref_cell,
     build_editor_formula_save,
     editor_load_save_as_plain,
 )
-from plugin.calc.python.formula_edit import parse_python_formula
+from plugin.calc.python.formula_edit import parse_python_formula, py_code_arg_is_cell_ref
 from plugin.tests.testing_utils import CalcCellStub, CalcDocStub
 
 
@@ -28,6 +29,14 @@ def test_editor_load_save_as_plain_plain_string_cell():
 def test_editor_load_save_as_plain_empty_cell():
     assert editor_load_save_as_plain(parsed_parts=None, initial_code="") is False
     assert editor_load_save_as_plain(parsed_parts=None, initial_code="   ") is False
+
+
+def test_editor_load_save_as_plain_follow_code_ref():
+    parts = parse_python_formula("=PY($A$1; C1:C10)")
+    assert parts is not None
+    assert editor_load_save_as_plain(
+        parsed_parts=parts, initial_code="result = 1", follow_code_ref=True
+    ) is True
 
 
 def test_build_editor_formula_save_new_cell_with_data_binding():
@@ -167,3 +176,38 @@ def test_apply_cell_save_plain_text_mode():
     assert cell.getString() == code
     assert cell.getFormula() == ""
     assert doc.calculate_all_count == 1
+
+def test_follow_code_ref_save_writes_a1_keeps_formula_ref():
+    doc = CalcDocStub()
+    sheet = doc.getSheets().getByIndex(0)
+    code_cell = sheet.getCellByPosition(0, 0)
+    formula_cell = sheet.getCellByPosition(1, 0)
+    code_cell.setString("result = 42")
+    formula_cell.setFormula("=PY($A$1; C1:C10)")
+    parts = parse_python_formula(formula_cell.getFormula())
+    assert parts is not None
+    assert parts.code == "$A$1"
+
+    resolved = _resolve_code_ref_cell(doc, parts.code)
+    assert resolved is code_cell
+
+    result = _apply_cell_save(
+        doc,
+        formula_cell,
+        parsed_parts=parts,
+        new_code="result = 99",
+        save_as_plain=False,
+        data_binding_text="C1:C10",
+        code_cell=code_cell,
+        code_ref=parts.code,
+    )
+    assert result["ok"] is True
+    assert result["save_as_plain"] is True
+    assert code_cell.getString() == "result = 99"
+    reparsed = parse_python_formula(formula_cell.getFormula())
+    assert reparsed is not None
+    assert py_code_arg_is_cell_ref(reparsed.code)
+    assert "C1:C10" in formula_cell.getFormula()
+    assert "result = 99" not in formula_cell.getFormula()
+    assert doc.calculate_all_count == 1
+

--- a/tests/calc/python/test_formula_edit.py
+++ b/tests/calc/python/test_formula_edit.py
@@ -18,6 +18,8 @@ from plugin.calc.python.formula_edit import (
     normalize_formula_string,
     parse_data_binding_text,
     parse_python_formula,
+    py_code_arg_is_cell_ref,
+    py_formula_has_unquoted_code_ref,
     rebuild_python_formula,
     rebuild_python_formula_with_data,
     replace_python_code,
@@ -94,6 +96,26 @@ def test_parse_unquoted_code():
     parts = parse_python_formula("=PYTHON(sp.prime(100))")
     assert parts is not None
     assert parts.code == "sp.prime(100)"
+
+
+def test_py_code_arg_is_cell_ref():
+    assert py_code_arg_is_cell_ref("A1") is True
+    assert py_code_arg_is_cell_ref("$A$1") is True
+    assert py_code_arg_is_cell_ref("Sheet1.A1") is True
+    assert py_code_arg_is_cell_ref("Sheet1!$B$2") is True
+    assert py_code_arg_is_cell_ref("A1:B10") is False
+    assert py_code_arg_is_cell_ref("sp.prime(100)") is False
+    assert py_code_arg_is_cell_ref('result = 1') is False
+    assert py_code_arg_is_cell_ref("np.sum(data)") is False
+    assert py_code_arg_is_cell_ref("") is False
+
+
+def test_py_formula_has_unquoted_code_ref():
+    assert py_formula_has_unquoted_code_ref("=PY($A$1; C1:C10)") is True
+    assert py_formula_has_unquoted_code_ref("=PY(A1)") is True
+    assert py_formula_has_unquoted_code_ref('=PY("A1")') is False
+    assert py_formula_has_unquoted_code_ref('=PY("result = 1"; A1)') is False
+    assert py_formula_has_unquoted_code_ref("=PY(sp.prime(100))") is False
 
 
 def test_normalize_array_and_no_equals():


### PR DESCRIPTION
## Summary

A real user keeps Python in a plain cell (**Save without =PY()**) and writes `=PY($A$1; data)` next to it. Opening the formula cell used to treat `$A$1` as source and quote it on save (`=PY("$A$1")`).

Now the editor (Monaco + native) **follows the unquoted ref**: edit A1’s text, save writes A1, formula stays a ref. Data binding still lives on the formula cell. Quoted `=PY("A1")` is not followed.

`py_code_*` bank sheets are **not** used (Excel-import hack only).

LLM prompt is unchanged. Comment on `CALC_FORMULA_SYNTAX`: typical scripts fit Calc MAXSTRLEN via auto-imports/helpers; revisit if generated `=PY("…")` hits Err:513.

## Test plan
- [x] `pytest tests/calc/python/test_formula_edit.py` — 30 passed
- [x] follow-ref save + detector tests in `test_editor_save_modes.py`