### PR TITLE
Shrink cover-all domains after 33180040863 6h wall

### DIFF
--- a/plugin/calc/excel_py_convert/to_dag.py
+++ b/plugin/calc/excel_py_convert/to_dag.py
@@ -94,13 +94,13 @@ _deal_excel_src_ok = _deal_excel_src_ok_crosshair if UNDER_CROSSHAIR else _deal_
 # ast_source_offset lineno: CrossHair uses 4 so SMT stays tiny. Pytest must
 # accept real multiline ``xl(`` (AST ``end_lineno`` can exceed 4). Cap at
 # DEAL_MAX_SOURCE — a ``str_bounded`` script cannot have more lines than chars.
-_AST_OFFSET_MAX_LINENO = 4 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
-_AST_OFFSET_MAX_SRC = 4 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
-_AST_OFFSET_MAX_COL = 4 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
-# Tiny alphabet: cover-all 33127995861 still read 1.05M lines at SOURCE=16 with
-# the Excel placeholder alphabet. splitlines/encode only needs a newline.
+_AST_OFFSET_MAX_LINENO = 2 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
+_AST_OFFSET_MAX_SRC = 2 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
+_AST_OFFSET_MAX_COL = 2 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
+# Tiny alphabet: 33127995861 1.05M lines at SOURCE=16; 33180040863 still ~44m at len=4.
 _AST_OFFSET_CHARS = frozenset("AB \n")
 _DEAL_BINDING_A1_LEN = DEAL_MAX_CELL_REF if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
+_DEAL_RESOLVED_LEN = 2 if UNDER_CROSSHAIR else DEAL_MAX_CMD_ARGS
 
 
 def _deal_ast_offset_src_ok_pytest(src: object) -> bool:
@@ -459,6 +459,10 @@ def _excel_execution_order(model: ExcelWorkbookModel) -> list[ExcelPyCell]:
     return cells
 
 
+@deal.pre(
+    lambda current, candidate: ascii_bounded(current or "", _DEAL_BINDING_A1_LEN)
+    and ascii_bounded(candidate or "", _DEAL_BINDING_A1_LEN)
+)
 def _prefer_excel_dep_token(current: str, candidate: str) -> str:
     """When merging deps that snap to the same A1, keep the Excel-native token if any.
 
@@ -475,7 +479,7 @@ def _prefer_excel_dep_token(current: str, candidate: str) -> str:
 
 @deal.pre(
     lambda resolved, header_modes: type(resolved) is list
-    and len(resolved) <= DEAL_MAX_CMD_ARGS
+    and len(resolved) <= _DEAL_RESOLVED_LEN
     and all(
         isinstance(r, ResolvedDep)
         and (r.a1 is None or ascii_bounded(r.a1, _DEAL_BINDING_A1_LEN))
@@ -483,7 +487,7 @@ def _prefer_excel_dep_token(current: str, candidate: str) -> str:
         for r in resolved
     )
     and type(header_modes) is dict
-    and len(header_modes) <= DEAL_MAX_CMD_ARGS
+    and len(header_modes) <= _DEAL_RESOLVED_LEN
     and all(
         type(k) is int
         and 0 <= k <= DEAL_MAX_CMD_ARGS

--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -28,6 +28,10 @@ DELEGATE_TASK_CHAT_MAX = 120
 # cover-all 33127995861: max_len 1..120 * SOURCE=16 ascii ate 114k lines on truncate.
 _DEAL_TRUNCATE_TASK_LEN = 8 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
 _DEAL_TRUNCATE_MAX_LEN = 8 if UNDER_CROSSHAIR else DELEGATE_TASK_CHAT_MAX
+# cover-all 33180040863: describe_empty / domain_from_delegate still multi-10m at TOKEN=16.
+_DEAL_EMPTY_TC_LEN = 2 if UNDER_CROSSHAIR else DEAL_MAX_CMD_ARGS
+_DEAL_EMPTY_TOKEN_LEN = 4 if UNDER_CROSSHAIR else DEAL_MAX_TOKEN
+_DEAL_FUNC_ARG_TOKEN_LEN = 4 if UNDER_CROSSHAIR else DEAL_MAX_TOKEN
 _EMPTY_MODEL_DEBUG_CONTENT_PREVIEW_MAX = 120
 
 
@@ -48,12 +52,12 @@ def _describe_empty_response_content(content: Any) -> str:
     lambda tool_calls, *_unused, **__: tool_calls is None
     or (
         type(tool_calls) is list
-        and len(tool_calls) <= DEAL_MAX_CMD_ARGS
+        and len(tool_calls) <= _DEAL_EMPTY_TC_LEN
         and all(
             type(item) is dict
-            and len(item) <= DEAL_MAX_CMD_ARGS
-            and all(type(k) is str and ascii_bounded(k, DEAL_MAX_TOKEN) for k in item)
-            and all(v is None or (isinstance(v, str) and ascii_bounded(v, DEAL_MAX_TOKEN)) for v in item.values())
+            and len(item) <= _DEAL_EMPTY_TC_LEN
+            and all(type(k) is str and ascii_bounded(k, _DEAL_EMPTY_TOKEN_LEN) for k in item)
+            and all(v is None or (isinstance(v, str) and ascii_bounded(v, _DEAL_EMPTY_TOKEN_LEN)) for v in item.values())
             for item in tool_calls
         )
     )
@@ -108,7 +112,7 @@ def _deal_func_args_ok_pytest(func_args: object) -> bool:
 
 def _deal_func_args_ok_crosshair(func_args: object) -> bool:
     return type(func_args) is dict and len(func_args) <= DEAL_MAX_CMD_ARGS and all(
-        type(k) is str and ascii_bounded(k, DEAL_MAX_TOKEN) and (v is None or (isinstance(v, str) and ascii_bounded(v, DEAL_MAX_TOKEN)))
+        type(k) is str and ascii_bounded(k, _DEAL_FUNC_ARG_TOKEN_LEN) and (v is None or (isinstance(v, str) and ascii_bounded(v, _DEAL_FUNC_ARG_TOKEN_LEN)))
         for k, v in func_args.items()
     )
 
@@ -124,6 +128,7 @@ def domain_from_delegate_args(func_args: Mapping[str, Any]) -> str:
     return "?"
 
 
+@deal.pre(lambda func_args: _deal_func_args_ok(func_args))
 def delegate_status_label(func_args: Mapping[str, Any]) -> str:
     return f"delegate ({domain_from_delegate_args(func_args)})"
 
@@ -164,6 +169,13 @@ def format_delegate_running_chat_line(func_args: Mapping[str, Any]) -> str:
     return f"[Running delegate ({domain})...]\n"
 
 
+@deal.pre(
+    lambda func_args, result_data: _deal_func_args_ok(func_args)
+    and type(result_data) is dict
+    and len(result_data) <= DEAL_MAX_CMD_ARGS
+    and all(type(k) is str and ascii_bounded(k, _DEAL_FUNC_ARG_TOKEN_LEN) for k in result_data)
+    and all(v is None or (isinstance(v, str) and ascii_bounded(v, _DEAL_FUNC_ARG_TOKEN_LEN)) for v in result_data.values())
+)
 def format_delegate_result_chat_line(func_args: Mapping[str, Any], result_data: Mapping[str, Any]) -> str:
     """Completion line for delegate gateway tools (domain shown; success is short)."""
     domain = domain_from_delegate_args(func_args)

--- a/plugin/embeddings/embeddings_split.py
+++ b/plugin/embeddings/embeddings_split.py
@@ -7,12 +7,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from plugin.framework.deal_shim import DEAL_MAX_SHAPE_DIM, DEAL_MAX_SOURCE, DEAL_MAX_TOKEN, ascii_bounded, str_bounded, deal
+from plugin.framework.deal_shim import DEAL_MAX_SHAPE_DIM, DEAL_MAX_SOURCE, DEAL_MAX_TOKEN, UNDER_CROSSHAIR, ascii_bounded, str_bounded, deal
 
 CHUNK_SIZE = 512
 CHUNK_OVERLAP = 64
 MIN_CHUNK = 120
 DEFAULT_SENTENCE_LOCALE = "en@ss=standard"
+
+# cover-all 33180040863: _sentences_spans_ok ~15m / _split_passage_whitespace ~24m (regex).
+_DEAL_SENT_LIST_LEN = 2 if UNDER_CROSSHAIR else DEAL_MAX_SHAPE_DIM
+_DEAL_SENT_SPAN = 4 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
+_DEAL_SENT_TEXT_LEN = 4 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
 
 
 def _embeddings_pip_install_hint() -> str:
@@ -95,16 +100,16 @@ def _meta_chunks_from_spans(
 
 @deal.pre(
     lambda sentences: type(sentences) is list
-    and len(sentences) <= DEAL_MAX_SHAPE_DIM
+    and len(sentences) <= _DEAL_SENT_LIST_LEN
     and all(
         type(s) is tuple
         and len(s) == 3
         and type(s[0]) is int
         and type(s[1]) is int
-        and 0 <= s[0] <= DEAL_MAX_SOURCE
-        and 0 <= s[1] <= DEAL_MAX_SOURCE
+        and 0 <= s[0] <= _DEAL_SENT_SPAN
+        and 0 <= s[1] <= _DEAL_SENT_SPAN
         and type(s[2]) is str
-        and ascii_bounded(s[2], DEAL_MAX_SOURCE)
+        and ascii_bounded(s[2], _DEAL_SENT_TEXT_LEN)
         for s in sentences
     )
 )
@@ -208,6 +213,8 @@ def _merge_small_sentences_to_spans(
 
 @deal.pre(lambda passage: ascii_bounded(passage, DEAL_MAX_SOURCE))
 def _split_passage_whitespace_to_sentences(passage: str) -> list[tuple[int, int, str]]:
+    # Regex splitter is engine-hostile under CrossHair (cover-all 33180040863 ~24m).
+    # crosshair: off
     from plugin.writer.locale.grammar_proofread_locale import GRAMMAR_WHITESPACE_RUN_RE, split_sentence_chunks_by_separator_regex
 
     sentences: list[tuple[int, int, str]] = []

--- a/plugin/framework/appearance.py
+++ b/plugin/framework/appearance.py
@@ -67,7 +67,17 @@ def get_style_window(doc: Any = None, style_window: Any = None, ctx: Any = None)
     return win
 
 
-@deal.pre(lambda color: type(color) is int and 0 <= color <= 0xFFFFFF)
+# cover-all 33180040863: _darken ~11m wandering 24-bit RGB even with factor in {0,0.5,0.94,1}.
+_DEAL_THEME_COLORS = (0, 1, 0x808080, 0xFFFFFF)
+
+
+def _deal_theme_color_ok(color: object) -> bool:
+    if UNDER_CROSSHAIR:
+        return type(color) is int and color in _DEAL_THEME_COLORS
+    return type(color) is int and 0 <= color <= 0xFFFFFF
+
+
+@deal.pre(lambda color: _deal_theme_color_ok(color))
 @deal.post(lambda result: isinstance(result, float) and 0.0 <= result <= 255.0)
 def _luminance(color: int) -> float:
     # No deal.pre used to let CrossHair wander on unbounded ints (3:24 on
@@ -78,7 +88,7 @@ def _luminance(color: int) -> float:
     return 0.2126 * r + 0.7152 * g + 0.0722 * b
 
 
-@deal.pre(lambda color, factor: type(color) is int and 0 <= color <= 0xFFFFFF and factor in (0.0, 0.5, 0.94, 1.0))
+@deal.pre(lambda color, factor: _deal_theme_color_ok(color) and factor in (0.0, 0.5, 0.94, 1.0))
 def _darken(color: int, factor: float) -> int:
     r = int(((color >> 16) & 0xFF) * factor)
     g = int(((color >> 8) & 0xFF) * factor)

--- a/plugin/framework/client/auth.py
+++ b/plugin/framework/client/auth.py
@@ -102,14 +102,15 @@ PROVIDERS: Dict[str, ProviderConfig] = {
 
 
 _URL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._:/")
-# cover-all 33127995861: _resolve_provider_id 231k lines at URL=32 (substring scan).
-_DEAL_RESOLVE_URL_LEN = 8 if UNDER_CROSSHAIR else DEAL_MAX_URL
+# cover-all 33127995861: 231k at URL=32; 33180040863 still ~53m / 230k at URL=8.
+_DEAL_RESOLVE_URL_LEN = 3 if UNDER_CROSSHAIR else DEAL_MAX_URL
+_DEAL_RESOLVE_HINT_LEN = 4 if UNDER_CROSSHAIR else DEAL_MAX_TOKEN
 
 
 @deal.pre(
     lambda endpoint, provider_hint=None: ascii_bounded(endpoint, _DEAL_RESOLVE_URL_LEN)
     and all(c in _URL_CHARS for c in endpoint)
-    and (provider_hint is None or ascii_bounded(provider_hint, DEAL_MAX_TOKEN))
+    and (provider_hint is None or ascii_bounded(provider_hint, _DEAL_RESOLVE_HINT_LEN))
 )
 def _resolve_provider_id(endpoint: str, provider_hint: Optional[str] = None) -> str:
     """

--- a/plugin/framework/json_utils.py
+++ b/plugin/framework/json_utils.py
@@ -173,8 +173,8 @@ def _deal_json_text_ok_pytest(text: object) -> bool:
 
 
 def _deal_json_text_ok_crosshair(text: object) -> bool:
-    # cover-all 33127995861: identity repair still 103k lines at SOURCE=16.
-    return isinstance(text, str) and len(text) <= 4 and all(
+    # cover-all 33127995861: 103k at SOURCE=16; 33180040863 still ~16m/15m at len=4.
+    return isinstance(text, str) and len(text) <= 2 and all(
         c in _JSON_CHARS for c in text
     )
 

--- a/plugin/mcp/wire_types.py
+++ b/plugin/mcp/wire_types.py
@@ -61,7 +61,10 @@ class JsonRpcParseError:
 
 @deal.pre(
     lambda msg: not isinstance(msg, dict)
-    or len(msg) <= DEAL_MAX_CMD_ARGS
+    or (
+        len(msg) <= DEAL_MAX_CMD_ARGS
+        and all(type(k) is str and ascii_bounded(k, DEAL_MAX_TOKEN) for k in msg)
+    )
 )
 @deal.post(lambda result: isinstance(result, (ParsedJsonRpcRequest, JsonRpcParseError)))
 def parse_jsonrpc_request(msg: object) -> ParsedJsonRpcRequest | JsonRpcParseError:
@@ -70,6 +73,8 @@ def parse_jsonrpc_request(msg: object) -> ParsedJsonRpcRequest | JsonRpcParseErr
     Notifications (missing ``id`` or ``id`` is null) are not requests — callers should
     treat ``req_id is None`` before calling this, or check ``"id" not in msg``.
     """
+    # sys.modules["crosshair"] sniff is engine-hostile (cover-all 33180040863 ~7m).
+    # crosshair: off
     if not isinstance(msg, dict):
         return JsonRpcParseError("Invalid JSON-RPC 2.0 request")
     raw = cast("dict[str, Any]", msg)
@@ -207,15 +212,35 @@ class CallToolRequestParams:
 
     @classmethod
     def from_params(cls, params: dict[str, Any]) -> CallToolRequestParams:
-        name = params.get("name")
-        if not isinstance(name, str) or not name:
-            raise ValueError("tools/call requires params.name")
-        arguments = params.get("arguments", {})
-        if arguments is None:
-            arguments = {}
-        if not isinstance(arguments, dict):
-            raise ValueError("tools/call params.arguments must be an object")
-        return cls(name=name, arguments=dict(arguments))
+        return _call_tool_request_params_from_dict(params)
+
+
+def _deal_call_tool_params_ok(params: object) -> bool:
+    # cover-all 33180040863: unbounded params → 3400 examples on from_params.
+    return (
+        type(params) is dict
+        and len(params) <= DEAL_MAX_CMD_ARGS
+        and all(type(k) is str and ascii_bounded(k, DEAL_MAX_TOKEN) for k in params)
+        and all(
+            v is None
+            or (isinstance(v, str) and str_bounded(v, DEAL_MAX_SOURCE))
+            or (type(v) is dict and len(v) <= DEAL_MAX_CMD_ARGS)
+            for v in params.values()
+        )
+    )
+
+
+@deal.pre(lambda params: _deal_call_tool_params_ok(params))
+def _call_tool_request_params_from_dict(params: dict[str, Any]) -> CallToolRequestParams:
+    name = params.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("tools/call requires params.name")
+    arguments = params.get("arguments", {})
+    if arguments is None:
+        arguments = {}
+    if not isinstance(arguments, dict):
+        raise ValueError("tools/call params.arguments must be an object")
+    return CallToolRequestParams(name=name, arguments=dict(arguments))
 
 
 def call_tool_result(text: str, *, is_error: bool = False) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
Cover-all deep [33180040863](https://github.com/KeithCu/writeragent/actions/runs/33180040863) on `1d9b003d` (post-#494) hit the 360-minute GitHub wall at **25/56**. Same unscheduled sinks still ate the clock; formula_edit / cors / payload_codec never started.

| module | wall | hole |
|---|---|---|
| to_dag | 153m | `_normalize_bindings` ~59m; `ast_source_offset` ~44m at len=4 |
| tool_loop_state | 57m | `format_delegate_result_chat_line` ~16m (no pre); `domain_from_delegate` / describe_empty still multi-10m at TOKEN=16 |
| auth | 53m | `_resolve_provider_id` still ~53m / 230k at URL=8 |
| embeddings_split | 48m | `_split_passage_whitespace_to_sentences` ~24m (regex); `_sentences_spans_ok` ~15m |
| json_utils | 46m | identity `repair_json` / `repair_json_object` still ~16m each at len=4 |
| appearance | 14m | `_darken` ~11m on full 24-bit RGB |
| wire_types | 11m | `parse_jsonrpc_request` sys.modules sniff ~7m; `from_params` 3400 examples |

## Changes (WRITERAGENT_CROSSHAIR=1 only unless noted)
- **to_dag**: ast offset caps 4→2; `_prefer_excel_dep_token` deal.pre; resolved/header list cap 2
- **auth**: resolve URL len 8→3; hint len 4
- **json_utils**: repair text len 4→2
- **embeddings_split**: tinier sentence-span domain; `# crosshair: off` on regex whitespace splitter
- **tool_loop_state**: tinier empty-tool-call / func-arg tokens; deal.pre on `delegate_status_label` + `format_delegate_result_chat_line`
- **appearance**: finite theme color set under CrossHair
- **wire_types**: `# crosshair: off` on `parse_jsonrpc_request` (sys.modules); deal.pre helper for `CallToolRequestParams.from_params`

No auto cover-all kick — pull when green, then restart cover-all from 1.