### PR TITLE
Fix Packet F mock-LLM soak: hang drop, error display, Chat mode selection

### DIFF
--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -265,7 +265,7 @@ make mock-llm
 
 Default bind is **`http://127.0.0.1:18766`** (not `8765` / `18765`, which are MCP). In Settings: that endpoint, model `writeragent-mock`, Rich Text Control Sidebar on. **Record** sends native `input_audio` on chat completions; the mock replies with canned HTML (`Hello from the mock microphone.`, `--transcript` to change it). `GET /v1/models` advertises audio input and lists `writeragent-mock-whisper` for the STT combobox. `POST /v1/audio/transcriptions` (JSON or multipart) returns `{"text": …}` for the fallback path.
 
-Plain “hello” streams two HTML paragraphs (rotating lists/tables/code). Phrases like “look up …” emit `web_research`; the same server scripts the smol `web_search` → `visit_webpage` → `final_answer` steps. `--offline` skips live DuckDuckGo (`final_answer` only). `--scenario` forces a journey on user turns; `--fail` fails every request. Tests: `tests/scripts/test_mock_llm_server.py`.
+Plain “hello” streams two HTML paragraphs (rotating lists/tables/code). Phrases like “look up …” emit `web_research`; the same server scripts the smol `web_search` → `visit_webpage` → `final_answer` steps. `--offline` skips live DuckDuckGo (`final_answer` only). `--scenario` forces a journey on user turns; `--fail` fails every request. Phrase matching uses the last `### CURRENT QUERY:` suffix when librarian/smol wraps the task, so a recovery `hello` after `crash the stream` does not keep matching conversation history. Tests: `tests/scripts/test_mock_llm_server.py`.
 
 **Phrase table** (case-insensitive; first match wins; missing tools fall back to HTML):
 
@@ -371,7 +371,7 @@ Assign by packet id (`A`–`H`). Do not skip the “why hard” line — that is
 
 | ID | Mock | Steps | Pass | Watch |
 |----|------|-------|------|-------|
-| F1 | `crash the stream` | Send, then `hello` | Error surfaced (not a hang); hello recovers | HTTP 500 JSON `error` object |
+| F1 | `crash the stream` | Send, then `hello` | Error surfaced (not a hang); hello recovers | HTTP 500 JSON `error` object; match **current query** only, not librarian history |
 | F2 | `rate limit` / `error 429` | Send | Distinct 429 handling or at least a visible error; recover with hello | |
 | F3 | `hang the stream` or `--fail hang --fail-after-chunks 4` | Send | UI does **not** freeze forever; Stop or timeout/error; next send works | no `[DONE]`; worker must not block VCL |
 | F4 | `--sse-comments` or `sse pings` | hello | Stream still parses; comments ignored | `: ping` between `data:` lines |

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -372,7 +372,7 @@ Assign by packet id (`A`–`H`). Do not skip the “why hard” line — that is
 | ID | Mock | Steps | Pass | Watch |
 |----|------|-------|------|-------|
 | F1 | `crash the stream` | Send, then `hello` | Error surfaced (not a hang); hello recovers | HTTP 500 JSON `error` object; match **current query** only, not librarian history |
-| F2 | `rate limit` / `error 429` | Send | Distinct 429 handling or at least a visible error; recover with hello | |
+| F2 | `rate limit` / `error 429` | Send | Distinct 429 handling or at least a visible error; recover with hello | Do not HTML-rerender the previous assistant over `[API error: …]` |
 | F3 | `hang the stream` or `--fail hang --fail-after-chunks 4` | Send | UI does **not** freeze forever; Stop or timeout/error; next send works | no `[DONE]`; worker must not block VCL |
 | F4 | `--sse-comments` or `sse pings` | hello | Stream still parses; comments ignored | `: ping` between `data:` lines |
 | F5 | `--fail http500` for **all** requests | Open sidebar send | Consistent error path; Settings still usable | |

--- a/plugin/chatbot/chat_sidebar_mode.py
+++ b/plugin/chatbot/chat_sidebar_mode.py
@@ -150,10 +150,29 @@ def mode_from_label(label: str, *, include_brainstorming: bool = False, include_
 
 
 def mode_from_selector(ctrl: Any, *, include_brainstorming: bool = False, include_writing_plan: bool = True, include_ppt_master: bool = False) -> str:
-    """Read the selected sidebar mode from a combobox control."""
+    """Read the selected sidebar mode from a combobox control.
+
+    Prefer ``getSelectedItemPos`` over ``getText``. The ChatPanel ComboBox is
+    ``spin=true``; the edit field can keep the XDL default ``Chat`` while the
+    selected index is Librarian (last ``addItems`` entry). Send then ran the
+    librarian path despite the visible label.
+    """
     # crosshair: off
     if not ctrl:
         return CHAT_MODE_CHAT
+    flags = SidebarModeFlags(
+        include_brainstorming=include_brainstorming,
+        include_writing_plan=include_writing_plan,
+        include_ppt_master=include_ppt_master,
+    )
+    modes = _modes_for(flags)
+    try:
+        if hasattr(ctrl, "getSelectedItemPos"):
+            idx = int(ctrl.getSelectedItemPos())
+            if 0 <= idx < len(modes):
+                return modes[idx]
+    except Exception:
+        pass
     try:
         if hasattr(ctrl, "getText"):
             return mode_from_label(
@@ -271,7 +290,7 @@ def set_selector_mode(ctrl: Any, mode: str, *, include_brainstorming: bool = Fal
     try:
         if hasattr(ctrl, "selectItemPos"):
             ctrl.selectItemPos(idx, True)
-        elif hasattr(ctrl, "setText"):
+        if hasattr(ctrl, "setText"):
             ctrl.setText(label)
     except Exception as e:
         log.debug("chat_mode_selector: set selection failed: %s", e)

--- a/plugin/chatbot/rich_text.py
+++ b/plugin/chatbot/rich_text.py
@@ -303,7 +303,16 @@ def append_rich_text(doc, text, role="assistant", style_window=None):
 
 
 def finalize_sidebar_assistant_response(listener) -> None:
-    """Re-import the last assistant message as HTML when rich sidebar is active."""
+    """Re-import the last assistant message as HTML when rich sidebar is active.
+
+    Skip HTML rerender after an API error. Drain ERROR appends ``[API error: …]``
+    after ``_assistant_stream_start_len``; rerender looks up the previous HTML
+    assistant message and ``truncate_control_from`` would delete that error line
+    (Packet F HTTP 429/500 looked like a leftover hello).
+    """
+    if getattr(listener, "_terminal_status", None) == "Error":
+        listener._plain_text_stripper = None
+        return
     listener.rerender_rich_text_session()
     stripper = getattr(listener, "_plain_text_stripper", None)
     if stripper is not None:

--- a/plugin/chatbot/tool_loop.py
+++ b/plugin/chatbot/tool_loop.py
@@ -577,8 +577,15 @@ class ToolCallingMixin:
                     log.exception("STT fallback after native-audio error failed")
                 return None
 
-        # If we reached here, it's either not a modality error or STT is not configured
-        err_msg = format_error_message(e)
+        # If we reached here, it's either not a modality error or STT is not configured.
+        # Drain ERROR items are format_error_payload dicts (see _spawn_llm_worker),
+        # not Exception — format_error_message() requires Exception (deal.pre).
+        if isinstance(e, dict):
+            err_msg = str(e.get("message") or e)
+        elif isinstance(e, Exception):
+            err_msg = format_error_message(e)
+        else:
+            err_msg = str(e)
         self._append_response("\n[API error: %s]\n" % err_msg)
         self._terminal_status = "Error"
         self._set_status("Error")

--- a/plugin/framework/client/errors.py
+++ b/plugin/framework/client/errors.py
@@ -66,6 +66,12 @@ def format_error_for_display(e):
     """Return user-friendly error string for display in cells or dialogs."""
     from plugin.framework.errors import format_error_payload
 
+    # Drain loop ERROR items are format_error_payload dicts, not Exception.
+    # format_error_payload(dict) would wrap the whole mapping as INTERNAL_ERROR.
+    if isinstance(e, dict):
+        msg = e.get("message")
+        if msg:
+            return _("Error: {0}").format(msg)
     payload = format_error_payload(e)
     return _("Error: {0}").format(payload.get("message", format_error_message(e)))
 

--- a/plugin/framework/errors.py
+++ b/plugin/framework/errors.py
@@ -374,6 +374,8 @@ def format_error_message(e: Exception) -> str:
             return _("API access Forbidden. Your key may lack permissions for this model.")
         if code == 404:
             return _("Endpoint not found (404). Check your URL and Model name.")
+        if code == 429:
+            return _("Rate limited (429). Wait a moment and try again.")
         if code >= 500:
             return _("Server error ({0}). The AI provider is having issues.").format(code)
         return _("HTTP Error {0}: {1}").format(code, reason)

--- a/scripts/mock_llm_server.py
+++ b/scripts/mock_llm_server.py
@@ -29,6 +29,7 @@ import html
 import io
 import json
 import re
+import socket
 import sys
 import threading
 import time
@@ -142,11 +143,28 @@ def completion_tool_calls(completion: Completion) -> list[tuple[str, dict[str, A
     return calls
 
 
+_CURRENT_QUERY_MARK = "### CURRENT QUERY:"
+
+
+def current_query_text(user_text: str) -> str:
+    """Phrase-match the current user turn, not librarian/smol conversation history.
+
+    Sub-agents wrap the task as ``### CONVERSATION HISTORY:`` plus
+    ``### CURRENT QUERY:``. Matching the whole blob would keep firing
+    ``crash the stream`` / ``hang the stream`` on a later ``hello``.
+    """
+    text = user_text or ""
+    idx = text.rfind(_CURRENT_QUERY_MARK)
+    if idx >= 0:
+        return text[idx + len(_CURRENT_QUERY_MARK) :].strip()
+    return text.strip()
+
+
 def detect_scenario(user_text: str, forced: str = "none") -> str:
     forced = (forced or "none").strip().lower()
     if forced and forced != "none":
         return forced
-    text = user_text or ""
+    text = current_query_text(user_text)
     for sid, pattern in _SCENARIO_PATTERNS:
         if pattern.search(text):
             return sid
@@ -933,8 +951,20 @@ def make_handler_class(config: MockLLMConfig, turns: _TurnState | None = None) -
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
+                self._drop_client_socket()
                 return True
             return False
+
+        def _drop_client_socket(self) -> None:
+            """Packet F hang: drop the socket (no [DONE]). Returning from
+            do_POST on HTTP/1.1 keep-alive would leave the client blocked
+            on readline until request_timeout.
+            """
+            self.close_connection = True
+            try:
+                self.connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
 
         def do_POST(self) -> None:  # noqa: N802
             path = urlparse(self.path).path
@@ -1002,6 +1032,7 @@ def make_handler_class(config: MockLLMConfig, turns: _TurnState | None = None) -
                 self.wfile.flush()
                 written += 1
                 if max_chunks is not None and written >= max_chunks:
+                    self._drop_client_socket()
                     return
                 if delay:
                     time.sleep(delay)

--- a/tests/chatbot/test_chat_sidebar_mode.py
+++ b/tests/chatbot/test_chat_sidebar_mode.py
@@ -62,14 +62,29 @@ def test_mode_labels_ppt_master_for_impress():
 def test_mode_from_selector_reads_combobox_text():
     ctrl = MagicMock()
     labels = get_mode_labels(include_brainstorming=True)
+    ctrl.getSelectedItemPos.return_value = -1
     ctrl.getText.return_value = labels[1]
     assert mode_from_selector(ctrl, include_brainstorming=True) == CHAT_MODE_IMAGE
 
 
+def test_mode_from_selector_prefers_selected_index_over_stale_text():
+    """XDL ComboBox spin=true can keep the default Chat text while index is Librarian."""
+    ctrl = MagicMock()
+    labels = get_mode_labels(include_brainstorming=True, include_writing_plan=True)
+    ctrl.getSelectedItemPos.return_value = len(labels) - 1
+    ctrl.getText.return_value = labels[0]
+    assert (
+        mode_from_selector(ctrl, include_brainstorming=True, include_writing_plan=True)
+        == CHAT_MODE_LIBRARIAN
+    )
+
+
 def test_set_selector_mode_selects_by_index():
     ctrl = MagicMock()
+    labels = get_mode_labels(include_brainstorming=True)
     set_selector_mode(ctrl, CHAT_MODE_WEB_RESEARCH, include_brainstorming=True)
     ctrl.selectItemPos.assert_called_once_with(2, True)
+    ctrl.setText.assert_called_once_with(labels[2])
 
 
 def test_populate_mode_selector_sets_string_item_list_on_model():

--- a/tests/chatbot/test_panel_html_stripper.py
+++ b/tests/chatbot/test_panel_html_stripper.py
@@ -87,3 +87,13 @@ class TestPanelHTMLStripper:
             
             # Should have appended "<b" to response
             mock_set_text.assert_called_with(send.response_control, "Current: a <b")
+
+    def test_finalize_skips_rerender_on_api_error(self):
+        """Packet F: HTTP 429/500 must not be replaced by the previous HTML reply."""
+        send = _make_plain_send_listener()
+        send.rerender_rich_text_session = MagicMock()
+        send._terminal_status = "Error"
+        send._plain_text_stripper = StreamingHTMLStripper()
+        finalize_sidebar_assistant_response(send)
+        send.rerender_rich_text_session.assert_not_called()
+        assert send._plain_text_stripper is None

--- a/tests/chatbot/test_tool_loop_errors.py
+++ b/tests/chatbot/test_tool_loop_errors.py
@@ -223,3 +223,24 @@ def test_stream_error_stt_fallback_does_not_reenter_send(test_instance):
     assert test_instance.session.messages[-1]["role"] == "user"
     assert test_instance.session.messages[-1]["content"] == "hello\nspoken words"
     assert test_instance._spawn_llm_worker.call_args.kwargs["query_text"] == "hello\nspoken words"
+
+
+def test_handle_stream_error_payload_dict(test_instance):
+    """Drain ERROR items are format_error_payload dicts, not Exception."""
+    payload = {
+        "status": "error",
+        "code": "HTTP_ERROR",
+        "message": "HTTP Error 500 from AI Provider: Internal Server Error. mock LLM soak failure",
+    }
+    with (
+        patch("plugin.chatbot.tool_loop.get_text_model", return_value="chat-model"),
+        patch("plugin.chatbot.tool_loop.get_current_endpoint", return_value="https://example"),
+        patch("plugin.chatbot.tool_loop.get_stt_model", return_value=""),
+    ):
+        recovered = test_instance._handle_stream_error(payload)
+    assert recovered is None
+    joined = "".join(test_instance.responses)
+    assert "[API error:" in joined
+    assert "500" in joined
+    assert "mock LLM soak failure" in joined
+    assert test_instance._terminal_status == "Error"

--- a/tests/framework/test_client_llm_modality.py
+++ b/tests/framework/test_client_llm_modality.py
@@ -35,6 +35,10 @@ def test_format_error_message():
     err = urllib.error.HTTPError("url", 403, "Forbidden", {}, None)
     assert "Forbidden" in format_error_message(err)
 
+    err = urllib.error.HTTPError("url", 429, "Too Many Requests", {}, None)
+    assert "429" in format_error_message(err)
+    assert "Rate limited" in format_error_message(err)
+
     # Socket / Connection errors
     err = urllib.error.URLError("Connection refused")
     assert "Connection Refused" in format_error_message(err)

--- a/tests/framework/test_errors.py
+++ b/tests/framework/test_errors.py
@@ -66,6 +66,12 @@ class TestErrorHandling(unittest.TestCase):
         display_str_generic = format_error_for_display(exc_generic)
         self.assertEqual(display_str_generic, 'Error: System error')
 
+    def test_format_error_for_display_payload_dict(self):
+        display_str = format_error_for_display(
+            {"status": "error", "code": "HTTP_ERROR", "message": "HTTP Error 500 from AI Provider"}
+        )
+        self.assertEqual(display_str, "Error: HTTP Error 500 from AI Provider")
+
     def test_librepy_exceptions_hierarchy_and_codes(self):
         from plugin.framework.errors import (
             CalcError,

--- a/tests/scripts/test_mock_llm_server.py
+++ b/tests/scripts/test_mock_llm_server.py
@@ -20,6 +20,7 @@ from scripts.mock_llm_server import (
     MockLLMConfig,
     _TurnState,
     completion_tool_calls,
+    current_query_text,
     decide_completion,
     detect_scenario,
     iter_sse_payloads,
@@ -581,6 +582,25 @@ def test_fail_and_hang_completions():
     assert hung.hang is True
 
 
+def test_current_query_ignores_librarian_history_phrases():
+    """Packet F recovery: hello after crash must not keep matching crash the stream."""
+    wrapped = (
+        "New task:\n### CONVERSATION HISTORY:\nUser: crash the stream\n\n"
+        "Assistant HTML leftover\n\n### CURRENT QUERY:\nhello"
+    )
+    assert current_query_text(wrapped) == "hello"
+    assert detect_scenario(wrapped) == ""
+    still_crash = wrapped.replace("### CURRENT QUERY:\nhello", "### CURRENT QUERY:\ncrash the stream")
+    assert detect_scenario(still_crash) == "fail_http"
+    hello_after = decide_completion(
+        {"messages": [{"role": "user", "content": wrapped}], "tools": _tools("web_research")},
+        MockLLMConfig(delay_ms=0),
+    )
+    assert hello_after.http_error is None
+    assert hello_after.hang is False
+    assert hello_after.content is not None
+
+
 def test_forced_scenario_overrides_phrase():
     out = decide_completion(
         {"messages": [{"role": "user", "content": "look up cats"}], "tools": _tools("web_research")},
@@ -613,8 +633,11 @@ def test_http_500_and_429(mock_http_fail):
 
 
 def test_http_hang_stream_incomplete(mock_http_hang):
+    from urllib.error import URLError
     from urllib.request import Request, urlopen
+    import http.client
     import json as json_mod
+    import socket as socket_mod
 
     req = Request(
         mock_http_hang + "/v1/chat/completions",
@@ -628,8 +651,18 @@ def test_http_hang_stream_incomplete(mock_http_hang):
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urlopen(req, timeout=2) as resp:
-        raw = resp.read().decode("utf-8")
+    raw = ""
+    try:
+        with urlopen(req, timeout=2) as resp:
+            raw = resp.read().decode("utf-8")
+    except (http.client.IncompleteRead, URLError, ConnectionResetError, socket_mod.timeout, BrokenPipeError) as err:
+        # SHUT_RDWR can surface as IncompleteRead, URLError(reason=IncompleteRead),
+        # or a reset. Keep whatever SSE the mock flushed before the drop.
+        for obj in (err, getattr(err, "reason", None)):
+            partial = getattr(obj, "partial", None)
+            if isinstance(partial, bytes) and partial:
+                raw = partial.decode("utf-8", errors="replace")
+                break
     assert "[DONE]" not in raw
     assert raw.count("data:") >= 1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Packet F of the rich-text sidebar soak (`docs/chat/rich-text-control-sidebar.md`) failed in live Writer against `scripts/mock_llm_server.py`.

**What broke**

- Librarian/smol wraps the user turn as `### CONVERSATION HISTORY:` plus `### CURRENT QUERY:`. Phrase matching scanned the whole blob, so a recovery `hello` after `crash the stream` kept returning HTTP 500.
- Hang (`hang the stream` / `--fail hang`) returned from `do_POST` without dropping the socket. HTTP/1.1 keep-alive left the client blocked on `readline` until `request_timeout` instead of a dropped stream with no `[DONE]`.
- Chat drain ERROR items are `format_error_payload` dicts, but `format_error_message()` requires `Exception`. HTTP 500/429 did not show a readable `[API error: …]` in the sidebar.
- After an HTTP error, `finalize_sidebar_assistant_response` HTML-rerendered the **previous** assistant message from `_assistant_stream_start_len`, which truncated the `[API error: …]` line (429 looked like leftover hello HTML).
- The mode ComboBox is `spin=true`. `addItems` can leave the selected index on Librarian while the edit field still shows the XDL default `Chat`, so Send ran the librarian path.
- HTTP 429 fell through to a generic HTTP error string.

**Fixes**

- Match soak phrases on the last `### CURRENT QUERY:` suffix.
- Shut down the client socket after hang chunks (and on non-stream hang).
- Display payload `message` for drain ERROR dicts; map 429 to a rate-limit sentence.
- Skip HTML rerender when `_terminal_status` is Error.
- Read mode from `getSelectedItemPos`; set both index and text when applying a mode.

**Tests**

- `tests/scripts/test_mock_llm_server.py` — librarian wrap recovery; hang stream has chunks and no `[DONE]`
- `tests/chatbot/test_chat_sidebar_mode.py` — index vs stale Chat text
- `tests/chatbot/test_tool_loop_errors.py` — ERROR payload dict
- `tests/chatbot/test_panel_html_stripper.py` — skip rerender on Error
- `tests/framework/test_errors.py` / `test_client_llm_modality.py` — display dict and 429
- Targeted pytest: 122 passed. `make typecheck` basedpyright/mypy/ruff/ty/bandit/pyspector clean; opengrep reported a pre-existing finding in `plugin/scripting/venv_probe_ui.py` (unchanged here).

**Manual Packet F (Chat mode, mock `http://127.0.0.1:18766`, Rich Text Control Sidebar on)**

- F1 `crash the stream` → visible `[API error: … 500 …]`; `hello` recovers
- F2 `rate limit` → visible `[API error: … 429 … Too Many Requests …]`; `hello` recovers
- F3 `hang the stream` → `word0 word1 word2 word3`, UI does not freeze; `hello` recovers
- F4 `sse pings` → normal HTML reply
- F5 `--fail http500` → consistent 500 on two sends; Settings dialog opens and closes
- F6 `--scenario ramble --fail hang` → truncated ramble, soffice stays usable, query box still accepts input
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5208c3ac-fa89-4ae9-890d-6e6780982036?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5208c3ac-fa89-4ae9-890d-6e6780982036&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

