### PR TITLE
Fix mock LLM Packet E nested smol and specialized soak

### DIFF
--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -288,7 +288,7 @@ Plain “hello” streams two HTML paragraphs (rotating lists/tables/code). Phra
 | `hang the stream` | a few SSE chunks, then the socket drops (no `[DONE]`) |
 | `sse pings` | `: ping` comments between events (`--sse-comments` does this for every stream) |
 
-Specialized inner HTTP (when the request advertises `get_document_tree` plus `final_answer` / `specialized_workflow_finished`): `get_document_tree` then `final_answer`. That is how a writer-delegate soak continues after the gateway call.
+Specialized inner HTTP (when the request advertises `specialized_workflow_finished`, or `get_document_tree` plus `final_answer`): call `get_document_tree` when that tool is on the list, otherwise `specialized_workflow_finished` / `final_answer` with a canned outline. Phrase “outline this” must not fall through to the main-chat delegate scenario on the inner request. Smolagents nested memory is Action JSON in user/assistant **content** (not `assistant.tool_calls`); the mock reads those Actions and `### CURRENT QUERY:` so online research is `web_search` → `visit_webpage` → `final_answer` instead of looping search.
 
 ### Mock LLM agent test plan
 
@@ -356,13 +356,13 @@ Assign by packet id (`A`–`H`). Do not skip the “why hard” line — that is
 
 | ID | Mock | Steps | Pass | Watch |
 |----|------|-------|------|-------|
-| E1 | `--offline`, `look up latest Python` | Web research | Status/thinking for search steps; final HTML summary in main chat; DuckDuckGo not required | smol `web_search` → `visit_webpage` → `final_answer`; `_record_assistant_start` only on final report |
-| E2 | omit `--offline`, same phrase | Live search optional | If network ok, visit_webpage uses a URL from hits; still ends in HTML | |
+| E1 | `--offline`, `look up latest Python` | Web research | Status/thinking for search steps; final HTML summary in main chat; DuckDuckGo not required | smol `final_answer` uses `### CURRENT QUERY:` (not the “Step budget” banner); `_record_assistant_start` only on final report |
+| E2 | omit `--offline`, same phrase | Live search optional | `web_search` once, then `visit_webpage` on a hit URL, then HTML wrap-up — not 15× search | smol Action JSON in content, not native `tool_calls` |
 | E3 | Doc with text “Welcome…”, type `add a comment` | Comment tool | Comment anchored on first word; sidebar “Comment inserted” | `add_comment`; undo stack has the comment |
 | E4 | **Empty** Writer doc, `insert a comment` | apply then comment | Text inserted at beginning, then comment on `Hello` | two-round tool loop; document context refresh |
 | E5 | `insert filler` | Mutate end | Paragraph appended; **next** hello’s system prompt sees new length (not stale snapshot) | `apply_document_content`; `refresh_document_context` |
 | E6 | `two tools` / `in parallel` | One send | `search_in_document` **and** `get_document_tree` run; one HTML wrap-up | `accumulate_delta` two `index` values |
-| E7 | `outline this` | Delegate | Nested agent status while main drain stays alive; then main-chat HTML; Stop still works mid-delegate | `delegate_to_specialized_writer_toolset` domain `document_research`; inner `get_document_tree` then `final_answer` |
+| E7 | `outline this` | Delegate | Nested agent status while main drain stays alive; then main-chat HTML; Stop still works mid-delegate | `delegate_to_specialized_writer_toolset` domain `document_research`; inner `specialized_workflow_finished` (canned outline), or `get_document_tree` then finish when that tool is advertised |
 | E8 | E7 + click Stop during nested work | Cancel | Nested work stops; UI recovers; next hello works | `resolve_stop_checker()`, not a panel boolean alone |
 
 #### Packet F — HTTP errors, hang, SSE quirks

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -260,6 +260,7 @@ To chat without a real model (streaming HTML, scroll, tool loops, Stop, empty re
 make mock-llm
 # or: .venv/bin/python scripts/mock_llm_server.py --delay-ms 30 --offline
 # Soak Stop:     .venv/bin/python scripts/mock_llm_server.py --delay-ms 40 --scenario ramble
+# Nested Stop (E8): --delay-ms also pauses stream=False inner HTTP (smol / specialized)
 # Soak errors:   .venv/bin/python scripts/mock_llm_server.py --fail hang --fail-after-chunks 4
 ```
 
@@ -362,8 +363,8 @@ Assign by packet id (`A`–`H`). Do not skip the “why hard” line — that is
 | E4 | **Empty** Writer doc, `insert a comment` | apply then comment | Text inserted at beginning, then comment on `Hello` | two-round tool loop; document context refresh |
 | E5 | `insert filler` | Mutate end | Paragraph appended; **next** hello’s system prompt sees new length (not stale snapshot) | `apply_document_content`; `refresh_document_context` |
 | E6 | `two tools` / `in parallel` | One send | `search_in_document` **and** `get_document_tree` run; one HTML wrap-up | `accumulate_delta` two `index` values |
-| E7 | `outline this` | Delegate | Nested agent status while main drain stays alive; then main-chat HTML; Stop still works mid-delegate | `delegate_to_specialized_writer_toolset` domain `document_research`; inner `specialized_workflow_finished` (canned outline), or `get_document_tree` then finish when that tool is advertised |
-| E8 | E7 + click Stop during nested work | Cancel | Nested work stops; UI recovers; next hello works | `resolve_stop_checker()`, not a panel boolean alone |
+| E7 | `outline this` | Delegate | Nested agent status while main drain stays alive; then main-chat HTML; Stop still works mid-delegate | `delegate_to_specialized_writer_toolset` domain `document_research`; inner discovery tool (often `list_nearby_files`, or `get_document_tree` when advertised) then `specialized_workflow_finished` (canned outline) — not main-chat HTML as the specialized `answer` |
+| E8 | E7 + click Stop during nested work (`--delay-ms` 1500+ so inner `stream=False` POSTs are clickable) | Cancel | Nested work stops; UI recovers; next hello works | `resolve_stop_checker()`, not a panel boolean alone |
 
 #### Packet F — HTTP errors, hang, SSE quirks
 

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -260,7 +260,7 @@ To chat without a real model (streaming HTML, scroll, tool loops, Stop, empty re
 make mock-llm
 # or: .venv/bin/python scripts/mock_llm_server.py --delay-ms 30 --offline
 # Soak Stop:     .venv/bin/python scripts/mock_llm_server.py --delay-ms 40 --scenario ramble
-# Nested Stop (E8): --delay-ms also pauses stream=False inner HTTP (smol / specialized)
+# Nested Stop (E8): --delay-ms 80 --sync-delay-ms 8000 (snappy SSE, long nested stream=False POSTs)
 # Soak errors:   .venv/bin/python scripts/mock_llm_server.py --fail hang --fail-after-chunks 4
 ```
 
@@ -364,7 +364,7 @@ Assign by packet id (`A`–`H`). Do not skip the “why hard” line — that is
 | E5 | `insert filler` | Mutate end | Paragraph appended; **next** hello’s system prompt sees new length (not stale snapshot) | `apply_document_content`; `refresh_document_context` |
 | E6 | `two tools` / `in parallel` | One send | `search_in_document` **and** `get_document_tree` run; one HTML wrap-up | `accumulate_delta` two `index` values |
 | E7 | `outline this` | Delegate | Nested agent status while main drain stays alive; then main-chat HTML; Stop still works mid-delegate | `delegate_to_specialized_writer_toolset` domain `document_research`; inner discovery tool (often `list_nearby_files`, or `get_document_tree` when advertised) then `specialized_workflow_finished` (canned outline) — not main-chat HTML as the specialized `answer` |
-| E8 | E7 + click Stop during nested work (`--delay-ms` 1500+ so inner `stream=False` POSTs are clickable) | Cancel | Nested work stops; UI recovers; next hello works | `resolve_stop_checker()`, not a panel boolean alone |
+| E8 | E7 + click Stop during nested work (`--delay-ms 80 --sync-delay-ms 8000` so inner `stream=False` POSTs stay clickable without a slow main SSE eating the window) | Cancel | Nested work stops; UI recovers; next hello works | `resolve_stop_checker()`, not a panel boolean alone |
 
 #### Packet F — HTTP errors, hang, SSE quirks
 

--- a/scripts/mock_llm_server.py
+++ b/scripts/mock_llm_server.py
@@ -128,6 +128,8 @@ _DELEGATE_WRITER = "delegate_to_specialized_writer_toolset"
 @dataclass
 class MockLLMConfig:
     delay_ms: int = 25
+    # None means use delay_ms. Packet E8: keep SSE snappy, stretch nested stream=False POSTs.
+    sync_delay_ms: int | None = None
     offline: bool = False
     always_research: bool = False
     scenario: str = "none"
@@ -136,6 +138,15 @@ class MockLLMConfig:
     fail_after_chunks: int = DEFAULT_FAIL_AFTER_CHUNKS
     sse_comments: bool = False
     transcript: str = DEFAULT_TRANSCRIPT
+
+
+def response_delay_s(config: MockLLMConfig, *, stream: bool) -> float:
+    """Seconds to sleep between SSE chunks, or once before a non-streaming JSON body."""
+    if stream:
+        ms = config.delay_ms
+    else:
+        ms = config.delay_ms if config.sync_delay_ms is None else config.sync_delay_ms
+    return max(0, int(ms)) / 1000.0
 
 
 @dataclass
@@ -1081,11 +1092,12 @@ def make_handler_class(config: MockLLMConfig, turns: _TurnState | None = None) -
             unused_status, hang = _effective_fail(config, completion)
             if unused_status is not None:
                 return
-            delay = max(0, int(config.delay_ms)) / 1000.0
+            delay = response_delay_s(config, stream=stream)
             if not stream:
                 # Nested smol / specialized agents use stream=False. Without this
-                # sleep, Packet E7/E8 nested work finishes in a few milliseconds
-                # and Stop cannot be clicked (delay_ms only applied to SSE).
+                # sleep, Packet E7/E8 nested work finishes in a few milliseconds.
+                # --sync-delay-ms stretches only that path so Stop is clickable
+                # without slowing main-chat SSE (which would eat the nested window).
                 if delay:
                     time.sleep(delay)
                 self._send_json(200, sync_response_body(completion, model))
@@ -1120,7 +1132,8 @@ def serve(host: str, port: int, config: MockLLMConfig) -> None:
     print(
         f"Mock LLM on http://{host}:{port}/v1 (model {MOCK_MODEL_ID}; "
         f"offline={config.offline} always_research={config.always_research} "
-        f"scenario={config.scenario} fail={config.fail} delay_ms={config.delay_ms})",
+        f"scenario={config.scenario} fail={config.fail} delay_ms={config.delay_ms} "
+        f"sync_delay_ms={config.sync_delay_ms})",
         flush=True,
     )
     httpd.serve_forever()
@@ -1134,7 +1147,13 @@ def main(argv: list[str] | None = None) -> int:
         "--delay-ms",
         type=int,
         default=25,
-        help="Pause between SSE chunks and before each non-streaming JSON response",
+        help="Pause between SSE chunks (and before sync JSON unless --sync-delay-ms is set)",
+    )
+    parser.add_argument(
+        "--sync-delay-ms",
+        type=int,
+        default=None,
+        help="Pause before each non-streaming JSON response (nested smol/specialized). Default: --delay-ms",
     )
     parser.add_argument(
         "--offline",
@@ -1173,6 +1192,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     config = MockLLMConfig(
         delay_ms=args.delay_ms,
+        sync_delay_ms=args.sync_delay_ms,
         offline=args.offline,
         always_research=args.always_research,
         scenario=args.scenario,

--- a/scripts/mock_llm_server.py
+++ b/scripts/mock_llm_server.py
@@ -65,9 +65,19 @@ _HTTP_URL_RE = re.compile(r"https?://[^\s)>\"]+", re.IGNORECASE)
 # re-issues web_search (or skips get_document_tree).
 _ACTION_NAME_RE = re.compile(
     r'"name"\s*:\s*"(web_search|visit_webpage|get_document_tree|final_answer|'
-    r'specialized_workflow_finished)"'
+    r'specialized_workflow_finished|list_nearby_files|search_nearby_files|'
+    r'grep_nearby_files|delegate_read_document)"'
 )
 _CURRENT_QUERY_MARKER = "### CURRENT QUERY:"
+# Inner document_research often has no get_document_tree. Call one discovery
+# tool first so Packet E7 shows nested status and E8 has time to click Stop.
+_SPECIALIZED_INNER_PRE_FINISH = (
+    "get_document_tree",
+    "list_nearby_files",
+    "search_nearby_files",
+    "grep_nearby_files",
+    "delegate_read_document",
+)
 
 # Phrase → scenario. First match wins. Keep distinct from research/comment keywords.
 _SCENARIO_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -562,19 +572,31 @@ def _smol_research_completion(messages: list[Any], tool_names: set[str], config:
     )
 
 
+def _specialized_inner_args(name: str) -> dict[str, Any]:
+    if name == "get_document_tree":
+        return {"strategy": "heading_only", "depth": 1}
+    if name == "search_nearby_files":
+        return {"query": "outline"}
+    if name == "grep_nearby_files":
+        return {"pattern": "outline"}
+    if name == "delegate_read_document":
+        return {"path": ""}
+    return {}
+
+
 def _specialized_inner_completion(messages: list[Any], tool_names: set[str]) -> Completion:
     called = _called_tool_names(messages)
     finish_name = "final_answer" if "final_answer" in tool_names else "specialized_workflow_finished"
-    # Inner document_research often has no get_document_tree; finish immediately.
-    if "get_document_tree" not in tool_names or "get_document_tree" in called:
-        return Completion(
-            tool_name=finish_name,
-            tool_args={"answer": "Mock outline complete. Headings were read via get_document_tree."},
-            finish_reason="tool_calls",
-        )
+    for name in _SPECIALIZED_INNER_PRE_FINISH:
+        if name in tool_names and name not in called:
+            return Completion(
+                tool_name=name,
+                tool_args=_specialized_inner_args(name),
+                finish_reason="tool_calls",
+            )
     return Completion(
-        tool_name="get_document_tree",
-        tool_args={"strategy": "heading_only", "depth": 1},
+        tool_name=finish_name,
+        tool_args={"answer": "Mock outline complete. Nested document_research tools finished."},
         finish_reason="tool_calls",
     )
 
@@ -1052,14 +1074,19 @@ def make_handler_class(config: MockLLMConfig, turns: _TurnState | None = None) -
             unused_status, hang = _effective_fail(config, completion)
             if unused_status is not None:
                 return
+            delay = max(0, int(config.delay_ms)) / 1000.0
             if not stream:
+                # Nested smol / specialized agents use stream=False. Without this
+                # sleep, Packet E7/E8 nested work finishes in a few milliseconds
+                # and Stop cannot be clicked (delay_ms only applied to SSE).
+                if delay:
+                    time.sleep(delay)
                 self._send_json(200, sync_response_body(completion, model))
                 return
             self.send_response(200)
             self.send_header("Content-Type", "text/event-stream")
             self.send_header("Cache-Control", "no-cache")
             self.end_headers()
-            delay = max(0, int(config.delay_ms)) / 1000.0
             comments = bool(config.sse_comments or completion.sse_comments)
             max_chunks = int(config.fail_after_chunks) if hang else None
             written = 0
@@ -1096,7 +1123,12 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="WriterAgent mock OpenAI chat endpoint")
     parser.add_argument("--host", default=DEFAULT_HOST)
     parser.add_argument("--port", type=int, default=DEFAULT_PORT)
-    parser.add_argument("--delay-ms", type=int, default=25, help="Pause between SSE chunks")
+    parser.add_argument(
+        "--delay-ms",
+        type=int,
+        default=25,
+        help="Pause between SSE chunks and before each non-streaming JSON response",
+    )
     parser.add_argument(
         "--offline",
         action="store_true",

--- a/scripts/mock_llm_server.py
+++ b/scripts/mock_llm_server.py
@@ -69,14 +69,15 @@ _ACTION_NAME_RE = re.compile(
     r'grep_nearby_files|delegate_read_document)"'
 )
 _CURRENT_QUERY_MARKER = "### CURRENT QUERY:"
-# Inner document_research often has no get_document_tree. Call one discovery
+# Inner document_research often has no get_document_tree. Call *one* discovery
 # tool first so Packet E7 shows nested status and E8 has time to click Stop.
+# Do not walk every discovery tool — delegate_read_document with an empty path
+# opens junk files and never reaches specialized_workflow_finished.
 _SPECIALIZED_INNER_PRE_FINISH = (
     "get_document_tree",
     "list_nearby_files",
     "search_nearby_files",
     "grep_nearby_files",
-    "delegate_read_document",
 )
 
 # Phrase → scenario. First match wins. Keep distinct from research/comment keywords.
@@ -579,16 +580,22 @@ def _specialized_inner_args(name: str) -> dict[str, Any]:
         return {"query": "outline"}
     if name == "grep_nearby_files":
         return {"pattern": "outline"}
-    if name == "delegate_read_document":
-        return {"path": ""}
     return {}
 
 
 def _specialized_inner_completion(messages: list[Any], tool_names: set[str]) -> Completion:
     called = _called_tool_names(messages)
     finish_name = "final_answer" if "final_answer" in tool_names else "specialized_workflow_finished"
+    # One discovery step, then finish. Calling every advertised tool (especially
+    # delegate_read_document with path="") loops the inner agent (Packet E7 soak).
+    if any(name in called for name in _SPECIALIZED_INNER_PRE_FINISH):
+        return Completion(
+            tool_name=finish_name,
+            tool_args={"answer": "Mock outline complete. Nested document_research tools finished."},
+            finish_reason="tool_calls",
+        )
     for name in _SPECIALIZED_INNER_PRE_FINISH:
-        if name in tool_names and name not in called:
+        if name in tool_names:
             return Completion(
                 tool_name=name,
                 tool_args=_specialized_inner_args(name),

--- a/scripts/mock_llm_server.py
+++ b/scripts/mock_llm_server.py
@@ -59,6 +59,15 @@ _RESEARCH_RE = re.compile(
     re.IGNORECASE,
 )
 _HTTP_URL_RE = re.compile(r"https?://[^\s)>\"]+", re.IGNORECASE)
+# Smolagents records prior steps as Action JSON in user/assistant *content*,
+# not OpenAI assistant.tool_calls. The system prompt also has example Actions —
+# never scan role=system. Packet E live soak: without this, every nested round
+# re-issues web_search (or skips get_document_tree).
+_ACTION_NAME_RE = re.compile(
+    r'"name"\s*:\s*"(web_search|visit_webpage|get_document_tree|final_answer|'
+    r'specialized_workflow_finished)"'
+)
+_CURRENT_QUERY_MARKER = "### CURRENT QUERY:"
 
 # Phrase → scenario. First match wins. Keep distinct from research/comment keywords.
 _SCENARIO_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -282,12 +291,50 @@ def _assistant_tool_names(messages: list[Any]) -> list[str]:
     return names
 
 
+def _action_tool_names(messages: list[Any]) -> list[str]:
+    """Tool names from smolagents Action JSON in non-system message content."""
+    names: list[str] = []
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") == "system":
+            continue
+        text = _as_text(msg.get("content"))
+        names.extend(_ACTION_NAME_RE.findall(text))
+    return names
+
+
+def _called_tool_names(messages: list[Any]) -> list[str]:
+    """Native tool_calls plus smolagents Action-in-content history."""
+    return _assistant_tool_names(messages) + _action_tool_names(messages)
+
+
+def _current_query(messages: list[Any], fallback: str = "") -> str:
+    """Prefer ``### CURRENT QUERY:`` from any message over the last user blob.
+
+    Smolagents prefixes each step with ``Step budget: N step(s) used…``. Using
+    `_last_user_text` as the research query made DuckDuckGo search that banner
+    (Packet E2) and stuffed it into offline `final_answer` (Packet E1).
+    """
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        text = _as_text(msg.get("content"))
+        if _CURRENT_QUERY_MARKER in text:
+            return text.split(_CURRENT_QUERY_MARKER, 1)[-1].strip()
+    return (fallback or "").strip()
+
+
 def _is_smol_research(tool_names: set[str]) -> bool:
     # final_answer alone is also used by specialized inner agents; require search tools.
     return bool(tool_names & {"web_search", "visit_webpage"})
 
 
 def _is_specialized_inner(tool_names: set[str]) -> bool:
+    # Live document_research inner HTTP advertises specialized_workflow_finished
+    # plus domain tools; get_document_tree is often *not* on that list (core
+    # tree is not a specialized_domain tool). Phrase "outline this" must not
+    # fall through to the main-chat delegate scenario (Packet E7).
+    if "specialized_workflow_finished" in tool_names:
+        return True
     return "get_document_tree" in tool_names and bool(
         tool_names & {"final_answer", "specialized_workflow_finished"}
     )
@@ -339,7 +386,7 @@ def _extract_document_words(messages: list[Any]) -> list[str]:
 def _first_url(text: str) -> str:
     match = _HTTP_URL_RE.search(text or "")
     if match:
-        return match.group(0).rstrip(".,;")
+        return match.group(0).rstrip(".,;\"'")
     return "https://example.com/mock-research"
 
 
@@ -407,6 +454,27 @@ def _html_research_summary(topic: str, tool_text: str) -> str:
     )
 
 
+def _html_tool_wrapup(user_text: str, tool_name: str, tool_text: str) -> str:
+    """Main-chat HTML after a tool round. Research wording is only for web_research."""
+    if tool_name == "web_research":
+        return _html_research_summary(user_text, tool_text)
+    snippet = html.escape((tool_text or "").strip().replace("\n", " ")[:280])
+    safe_user = html.escape((user_text or "that request").strip()[:80] or "that request")
+    if tool_name == "apply_document_content":
+        return f"<p>Inserted content into the document.</p><p>{snippet or '(empty)'}</p>"
+    if tool_name.startswith("delegate_to_specialized"):
+        return (
+            f"<p>Specialized agent finished <strong>{safe_user}</strong>.</p>"
+            f"<p>{snippet or '(empty)'}</p>"
+        )
+    if tool_name in {"search_in_document", "get_document_tree", "list_sheets", "list_pages"}:
+        return (
+            f"<p>Ran <code>{html.escape(tool_name)}</code>.</p>"
+            f"<p>{snippet or '(empty)'}</p>"
+        )
+    return _html_research_summary(user_text, tool_text)
+
+
 def _html_flood(topic: str) -> str:
     safe = html.escape((topic or "flood").strip()[:80] or "flood")
     paras = "".join(f"<p>Flood paragraph {i} about {safe}. Padding for VisArea and caret-follow.</p>" for i in range(1, FLOOD_PARAS + 1))
@@ -458,45 +526,47 @@ def _tool_or_html(
 
 
 def _smol_research_completion(messages: list[Any], tool_names: set[str], config: MockLLMConfig, user_text: str) -> Completion:
-    called = _assistant_tool_names(messages)
+    called = _called_tool_names(messages)
+    query = _current_query(messages, user_text) or "mock research"
     if config.offline:
         return Completion(
             tool_name="final_answer",
-            tool_args={"answer": _plain_research_report(user_text)},
+            tool_args={"answer": _plain_research_report(query)},
             finish_reason="tool_calls",
         )
     if "visit_webpage" in called:
         return Completion(
             tool_name="final_answer",
-            tool_args={"answer": _plain_research_report(user_text)},
+            tool_args={"answer": _plain_research_report(query)},
             finish_reason="tool_calls",
         )
     if "web_search" in called:
         last_tool_text = ""
         for msg in reversed(messages):
-            if isinstance(msg, dict) and msg.get("role") == "tool":
-                last_tool_text = _as_text(msg.get("content"))
-                break
+            if not isinstance(msg, dict):
+                continue
+            blob = _as_text(msg.get("content"))
+            if msg.get("role") == "tool" or "Observation:" in blob or "<h2>Search Results</h2>" in blob:
+                last_tool_text = blob
+                if _first_url(last_tool_text) != "https://example.com/mock-research":
+                    break
         return Completion(
             tool_name="visit_webpage",
             tool_args={"url": _first_url(last_tool_text)},
             finish_reason="tool_calls",
         )
-    query = user_text
-    marker = "### CURRENT QUERY:"
-    if marker in user_text:
-        query = user_text.split(marker, 1)[-1].strip()
     return Completion(
         tool_name="web_search",
-        tool_args={"query": query or "mock research", "recency": "any"},
+        tool_args={"query": query, "recency": "any"},
         finish_reason="tool_calls",
     )
 
 
 def _specialized_inner_completion(messages: list[Any], tool_names: set[str]) -> Completion:
-    called = _assistant_tool_names(messages)
+    called = _called_tool_names(messages)
     finish_name = "final_answer" if "final_answer" in tool_names else "specialized_workflow_finished"
-    if "get_document_tree" in called:
+    # Inner document_research often has no get_document_tree; finish immediately.
+    if "get_document_tree" not in tool_names or "get_document_tree" in called:
         return Completion(
             tool_name=finish_name,
             tool_args={"answer": "Mock outline complete. Headings were read via get_document_tree."},
@@ -647,7 +717,7 @@ def decide_completion(payload: dict[str, Any], config: MockLLMConfig, turns: _Tu
                 tool_text = _as_text(msg.get("content"))
                 break
         return Completion(
-            content=_html_research_summary(user_text, tool_text),
+            content=_html_tool_wrapup(user_text, last_called_tool, tool_text),
             reasoning=reasoning,
             finish_reason="stop",
         )

--- a/tests/scripts/test_mock_llm_server.py
+++ b/tests/scripts/test_mock_llm_server.py
@@ -629,6 +629,31 @@ def test_specialized_inner_finish_only_when_no_discovery_tools():
     assert "outline" in ((out.tool_args or {}).get("answer") or "").lower()
 
 
+def test_specialized_inner_does_not_walk_delegate_read_document():
+    """Empty-path delegate_read_document loops the inner agent (Packet E7 soak)."""
+    tools = _tools("list_nearby_files", "delegate_read_document", "specialized_workflow_finished")
+    first = decide_completion(
+        {"messages": [{"role": "user", "content": "outline this"}], "tools": tools},
+        MockLLMConfig(delay_ms=0),
+    )
+    assert first.tool_name == "list_nearby_files"
+    second = decide_completion(
+        {
+            "messages": [
+                {"role": "user", "content": "outline this"},
+                {
+                    "role": "user",
+                    "content": 'Action:\n{"name": "list_nearby_files", "arguments": {}}\nObservation:\n[]',
+                },
+            ],
+            "tools": tools,
+        },
+        MockLLMConfig(delay_ms=0),
+    )
+    assert second.tool_name == "specialized_workflow_finished"
+    assert second.content is None
+
+
 def test_mutate_wrapup_is_not_research_wording():
     out = decide_completion(
         {

--- a/tests/scripts/test_mock_llm_server.py
+++ b/tests/scripts/test_mock_llm_server.py
@@ -107,6 +107,35 @@ def test_smol_offline_final_answer_plain():
     assert "<p>" not in answer
     assert "Python 3.13" in answer
     assert "- " in answer
+    assert "Step budget" not in answer
+
+
+def test_smol_offline_ignores_step_budget_banner():
+    """Live smolagents prefixes each turn with a step-budget user blob (Packet E1)."""
+    out = decide_completion(
+        {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": 'Example Action:\n{"name": "web_search", "arguments": "Population Guangzhou"}',
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Step budget: 0 step(s) used, 15 step(s) remaining (maximum 15). "
+                        "You are on step 1 of 15.\nNew task:\n### CONVERSATION HISTORY:\nNone\n\n"
+                        "### CURRENT QUERY:\nlook up latest Python"
+                    ),
+                },
+            ],
+            "tools": _tools("web_search", "visit_webpage", "final_answer"),
+        },
+        MockLLMConfig(offline=True),
+    )
+    assert out.tool_name == "final_answer"
+    answer = (out.tool_args or {}).get("answer") or ""
+    assert "look up latest Python" in answer
+    assert "Step budget" not in answer
 
 
 def test_smol_online_sequence():
@@ -168,6 +197,63 @@ def test_smol_online_sequence():
         cfg,
     )
     assert third.tool_name == "final_answer"
+
+
+def test_smol_action_in_content_advances_search_then_visit():
+    """smolagents memory is Action JSON in user content, not assistant.tool_calls (Packet E2)."""
+    tools = _tools("web_search", "visit_webpage", "final_answer")
+    cfg = MockLLMConfig(offline=False)
+    system = 'Example Action:\n{"name": "web_search", "arguments": "Population Guangzhou"}'
+    task = (
+        "Step budget: 0 step(s) used, 15 remaining.\nNew task:\n"
+        "### CURRENT QUERY:\nlook up latest Python"
+    )
+    first = decide_completion(
+        {"messages": [{"role": "system", "content": system}, {"role": "user", "content": task}], "tools": tools},
+        cfg,
+    )
+    assert first.tool_name == "web_search"
+    assert (first.tool_args or {}).get("query") == "look up latest Python"
+
+    obs = (
+        "Step budget: 1 step(s) used, 14 remaining.\n"
+        'Action:\n{"name": "web_search", "arguments": {"query": "look up latest Python"}}\n'
+        "Observation:\n<h2>Search Results</h2>"
+        "<a href='https://www.python.org/downloads/'>Download Python</a>"
+    )
+    second = decide_completion(
+        {
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": task},
+                {"role": "user", "content": obs},
+            ],
+            "tools": tools,
+        },
+        cfg,
+    )
+    assert second.tool_name == "visit_webpage"
+    assert (second.tool_args or {}).get("url") == "https://www.python.org/downloads/"
+
+    visited = (
+        obs
+        + '\nAction:\n{"name": "visit_webpage", "arguments": {"url": "https://www.python.org/downloads/"}}\n'
+        "Observation:\nPython 3.14 notes"
+    )
+    third = decide_completion(
+        {
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": task},
+                {"role": "user", "content": visited},
+            ],
+            "tools": tools,
+        },
+        cfg,
+    )
+    assert third.tool_name == "final_answer"
+    assert "look up latest Python" in ((third.tool_args or {}).get("answer") or "")
+    assert "Step budget" not in ((third.tool_args or {}).get("answer") or "")
 
 
 def test_sync_tool_call_arguments_are_json_string():
@@ -503,6 +589,45 @@ def test_specialized_inner_tree_then_final_answer():
     )
     assert second.tool_name == "final_answer"
     assert "outline" in ((second.tool_args or {}).get("answer") or "").lower()
+
+
+def test_specialized_inner_without_tree_finishes_immediately():
+    """Live document_research inner HTTP has specialized_workflow_finished, often no tree tool (Packet E7)."""
+    tools = _tools("search_nearby_files", "specialized_workflow_finished")
+    out = decide_completion(
+        {"messages": [{"role": "user", "content": "outline this"}], "tools": tools},
+        MockLLMConfig(delay_ms=0),
+    )
+    assert out.tool_name == "specialized_workflow_finished"
+    assert "outline" in ((out.tool_args or {}).get("answer") or "").lower()
+    assert out.content is None
+
+
+def test_mutate_wrapup_is_not_research_wording():
+    out = decide_completion(
+        {
+            "messages": [
+                {"role": "user", "content": "insert filler"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "apply_document_content", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": '{"status": "ok", "message": "Inserted content at end."}'},
+            ],
+            "tools": _tools("apply_document_content", "web_research"),
+        },
+        MockLLMConfig(delay_ms=0),
+    )
+    assert out.tool_name is None
+    assert out.content is not None
+    assert "Inserted content" in out.content
+    assert "I looked that up" not in out.content
 
 
 def test_parallel_two_core_tools():

--- a/tests/scripts/test_mock_llm_server.py
+++ b/tests/scripts/test_mock_llm_server.py
@@ -591,16 +591,42 @@ def test_specialized_inner_tree_then_final_answer():
     assert "outline" in ((second.tool_args or {}).get("answer") or "").lower()
 
 
-def test_specialized_inner_without_tree_finishes_immediately():
+def test_specialized_inner_without_tree_calls_discovery_then_finishes():
     """Live document_research inner HTTP has specialized_workflow_finished, often no tree tool (Packet E7)."""
     tools = _tools("search_nearby_files", "specialized_workflow_finished")
-    out = decide_completion(
+    first = decide_completion(
         {"messages": [{"role": "user", "content": "outline this"}], "tools": tools},
+        MockLLMConfig(delay_ms=0),
+    )
+    assert first.tool_name == "search_nearby_files"
+    second = decide_completion(
+        {
+            "messages": [
+                {"role": "user", "content": "outline this"},
+                {
+                    "role": "user",
+                    "content": 'Action:\n{"name": "search_nearby_files", "arguments": {"query": "outline"}}\nObservation:\n[]',
+                },
+            ],
+            "tools": tools,
+        },
+        MockLLMConfig(delay_ms=0),
+    )
+    assert second.tool_name == "specialized_workflow_finished"
+    assert "outline" in ((second.tool_args or {}).get("answer") or "").lower()
+    assert second.content is None
+
+
+def test_specialized_inner_finish_only_when_no_discovery_tools():
+    out = decide_completion(
+        {
+            "messages": [{"role": "user", "content": "outline this"}],
+            "tools": _tools("specialized_workflow_finished"),
+        },
         MockLLMConfig(delay_ms=0),
     )
     assert out.tool_name == "specialized_workflow_finished"
     assert "outline" in ((out.tool_args or {}).get("answer") or "").lower()
-    assert out.content is None
 
 
 def test_mutate_wrapup_is_not_research_wording():

--- a/tests/scripts/test_mock_llm_server.py
+++ b/tests/scripts/test_mock_llm_server.py
@@ -25,6 +25,7 @@ from scripts.mock_llm_server import (
     iter_sse_payloads,
     make_handler_class,
     models_list_body,
+    response_delay_s,
     sync_response_body,
 )
 
@@ -40,6 +41,15 @@ def test_models_list_includes_mock_id():
     assert MOCK_STT_MODEL_ID in ids
     chat = next(row for row in body["data"] if row["id"] == MOCK_MODEL_ID)
     assert "audio" in chat["architecture"]["input_modalities"]
+
+
+def test_response_delay_s_sync_override():
+    """Packet E8: stretch nested stream=False POSTs without slowing main SSE."""
+    cfg = MockLLMConfig(delay_ms=80, sync_delay_ms=8000)
+    assert response_delay_s(cfg, stream=True) == 0.08
+    assert response_delay_s(cfg, stream=False) == 8.0
+    inherit = MockLLMConfig(delay_ms=1500)
+    assert response_delay_s(inherit, stream=False) == 1.5
 
 
 def test_chit_chat_html():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Packet E soak against the mock LLM found scripted-journey bugs (not product bugs). This PR fixes the mock server and documents the watch items.

## What was wrong

Smolagents does not send prior steps as OpenAI `assistant.tool_calls`. It puts Action JSON in user/assistant **content**, and prefixes each turn with a `Step budget:` banner. The mock treated that banner as the search query (Packet **E1**/**E2**) and re-issued `web_search` until the 15-step cap.

The document_research inner HTTP advertises `specialized_workflow_finished` **without** `get_document_tree`. Phrase `outline this` fell through to the main-chat delegate scenario, so the specialized `answer` was HTML chat (**E7**). Inner work was one `stream=False` POST with no sleep, so **E8** Stop was unclickable. Walking every discovery tool then called `delegate_read_document` with an empty path. Raising `--delay-ms` for E8 made main-chat SSE so slow the nested window ended before Stop.

## Fixes

- Scan Action JSON in non-system content (`_called_tool_names`) and prefer `### CURRENT QUERY:` over the step-budget blob.
- Treat `specialized_workflow_finished` as inner-agent; call **one** discovery tool then finish with a canned outline. Never empty-path `delegate_read_document`.
- Honor delay on non-streaming JSON; `--sync-delay-ms` stretches only nested POSTs (E8 soak: `--delay-ms 80 --sync-delay-ms 8000`).
- Distinct main-chat wrap-up HTML for mutate / delegate / tree vs research.

## Tests

`tests/scripts/test_mock_llm_server.py` (45 cases). `make typecheck` still reports a pre-existing opengrep hit in `plugin/scripting/venv_probe_ui.py` (unrelated).

## Packet E soak (manual)

| ID | Result |
|----|--------|
| E1 | Pass (offline `final_answer` topic is the Python query) |
| E2 | Pass after Action-JSON fix (`web_search` once → `visit_webpage` https://www.python.org/downloads/ → wrap-up) |
| E3–E6 | Pass |
| E7 | Pass (`list_nearby_files` then `specialized_workflow_finished` / Mock outline complete) |
| E8 | Pass (`LlmClient.stop` during nested `list_nearby_files`; Assistant “No response.”; next `hello` HTML recovers) |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3bcc41e-0a4f-40ff-bccf-8e19a5cb9910?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3bcc41e-0a4f-40ff-bccf-8e19a5cb9910&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

