### PR TITLE
Make Packet F mock-sidebar tests green on a live Writer deck

### DIFF
--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -563,7 +563,14 @@ Writer with body text “Welcome to WriterAgent.” unless **empty** is specifie
 
 ### v2 Packet F — HTTP / SSE errors
 
-**Landed (thin):** F1, F2, F14 in [`tests/chatbot/test_mock_llm_sidebar_uno.py`](../../tests/chatbot/test_mock_llm_sidebar_uno.py). Run **`make test-mock-sidebar`**: visible soffice with **your** LibreOffice user profile (`--norestore` so crash-recovery does not block; tests show `WriterAgentDeck` over UNO). Starts like ``make lo-start`` (``--norestore --writer``) plus a UNO pipe — not ``officehelper``'s ``--nodefault`` GUI, which opened then crashed. The child does not inherit the runner ``PYTHONPATH``. Other UNO tests stay `make test-uno` (headless + throwaway profile). Debug-only live panel list: `register_debug_live_panel` in `panel_factory` (gated; strip for release). Harness: [`tests/chatbot/mock_llm_harness.py`](../../tests/chatbot/mock_llm_harness.py).
+**Landed (thin):** F1, F2, F14 in [`tests/chatbot/test_mock_llm_sidebar_uno.py`](../../tests/chatbot/test_mock_llm_sidebar_uno.py). Run **`make test-mock-sidebar`** (not `make test-uno`). Visible soffice with **your** LibreOffice user profile:
+
+- **Bootstrap:** Popen ``--norestore --writer --accept=pipe`` like ``make lo-start``. Do **not** use ``officehelper.bootstrap`` (it appends ``--nodefault`` and the GUI crashed / URP disposed). Child env strips ``PYTHONPATH`` so the OXT is not mixed with the checkout.
+- **Crash recovery:** ``--norestore`` skips the recovery dialog that otherwise blocks the UNO pipe.
+- **View → Sidebar off:** tests dispatch ``.uno:SidebarDeck.WriterAgentDeck`` (shows the sidebar; ``.uno:Sidebar`` *toggles*). Decks come from the controller's ``XSidebarProvider.getDecks()``, not ``controller.Sidebar`` (that is ``XSidebar.requestLayout`` only).
+- **Out-of-process UNO:** the live ``SendButtonListener`` lives in soffice. Drive query/send over URP (``uno_click``); poll Stop ``Enabled`` and transcript text. Do not ``processEventsToIdle`` on the pipe.
+
+Harness: [`tests/chatbot/mock_llm_harness.py`](../../tests/chatbot/mock_llm_harness.py). Hooks: [`plugin/chatbot/sidebar_test_hooks.py`](../../plugin/chatbot/sidebar_test_hooks.py). Other UNO tests stay `make test-uno` (headless + throwaway profile).
 
 Each case ends with **`next_hello_ok()`** unless noted. Prefer phrase triggers so default mock stays up; use `--fail` only for “all requests” cases (then restart mock or toggle fail off before hello).
 

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -567,8 +567,8 @@ Writer with body text “Welcome to WriterAgent.” unless **empty** is specifie
 
 - **Bootstrap:** Popen ``--norestore --writer --accept=pipe`` like ``make lo-start``. Do **not** use ``officehelper.bootstrap`` (it appends ``--nodefault`` and the GUI crashed / URP disposed). Child env strips ``PYTHONPATH`` so the OXT is not mixed with the checkout.
 - **Crash recovery:** ``--norestore`` skips the recovery dialog that otherwise blocks the UNO pipe.
-- **View → Sidebar off:** tests dispatch ``.uno:SidebarDeck.WriterAgentDeck`` (shows the sidebar; ``.uno:Sidebar`` *toggles*). Decks come from the controller's ``XSidebarProvider.getDecks()``, not ``controller.Sidebar`` (that is ``XSidebar.requestLayout`` only).
-- **Out-of-process UNO:** the live ``SendButtonListener`` lives in soffice. Drive query/send over URP (``uno_click``); poll Stop ``Enabled`` and transcript text. Do not ``processEventsToIdle`` on the pipe.
+- **View → Sidebar off:** tests dispatch ``.uno:SidebarDeck.WriterAgentDeck`` (shows the sidebar; ``.uno:Sidebar`` *toggles*). Decks come from ``controller.Sidebar`` (``XSidebarProvider.getDecks`` on SwXTextView). The soffice child sets ``WRITERAGENT_UNO_THREAD_GUARD=0`` so URP deck dispatch can create ChatPanel (otherwise ``getRealInterface`` aborts on Dummy-N).
+- **Out-of-process UNO:** the live ``SendButtonListener`` lives in soffice. Drive query/send over URP (``uno_click``); poll Stop ``Enabled`` and transcript text. Do not ``processEventsToIdle`` on the pipe. A stale ``.lock`` with ``IPCServer=false`` is removed when no soffice.bin is running so ``--accept`` binds.
 
 Harness: [`tests/chatbot/mock_llm_harness.py`](../../tests/chatbot/mock_llm_harness.py). Hooks: [`plugin/chatbot/sidebar_test_hooks.py`](../../plugin/chatbot/sidebar_test_hooks.py). Other UNO tests stay `make test-uno` (headless + throwaway profile).
 

--- a/docs/chat/rich-text-control-sidebar.md
+++ b/docs/chat/rich-text-control-sidebar.md
@@ -565,10 +565,10 @@ Writer with body text “Welcome to WriterAgent.” unless **empty** is specifie
 
 **Landed (thin):** F1, F2, F14 in [`tests/chatbot/test_mock_llm_sidebar_uno.py`](../../tests/chatbot/test_mock_llm_sidebar_uno.py). Run **`make test-mock-sidebar`** (not `make test-uno`). Visible soffice with **your** LibreOffice user profile:
 
-- **Bootstrap:** Popen ``--norestore --writer --accept=pipe`` like ``make lo-start``. Do **not** use ``officehelper.bootstrap`` (it appends ``--nodefault`` and the GUI crashed / URP disposed). Child env strips ``PYTHONPATH`` so the OXT is not mixed with the checkout.
+- **Bootstrap:** Popen ``--norestore --writer --accept=socket,host=127.0.0.1,port=<ephemeral>;urp;`` like ``make lo-start`` (TCP, not a named pipe). Do **not** use ``officehelper.bootstrap`` (it appends ``--nodefault`` and the GUI crashed / URP disposed). Child env strips ``PYTHONPATH`` so the OXT is not mixed with the checkout. A leftover ``.lock`` with ``IPCServer=false`` is removed when no ``soffice.bin`` is running so ``--accept`` binds (OSL pipes under ``tempfile.gettempdir()``, not a hardcoded ``/tmp``).
 - **Crash recovery:** ``--norestore`` skips the recovery dialog that otherwise blocks the UNO pipe.
 - **View → Sidebar off:** tests dispatch ``.uno:SidebarDeck.WriterAgentDeck`` (shows the sidebar; ``.uno:Sidebar`` *toggles*). Decks come from ``controller.Sidebar`` (``XSidebarProvider.getDecks`` on SwXTextView). The soffice child sets ``WRITERAGENT_UNO_THREAD_GUARD=0`` so URP deck dispatch can create ChatPanel (otherwise ``getRealInterface`` aborts on Dummy-N).
-- **Out-of-process UNO:** the live ``SendButtonListener`` lives in soffice. Drive query/send over URP (``uno_click``); poll Stop ``Enabled`` and transcript text. Do not ``processEventsToIdle`` on the pipe. A stale ``.lock`` with ``IPCServer=false`` is removed when no soffice.bin is running so ``--accept`` binds.
+- **Out-of-process UNO:** the live ``SendButtonListener`` lives in soffice. Drive query/send over URP (``uno_click``); poll Stop ``Enabled`` and transcript text. Do not ``processEventsToIdle`` on the pipe.
 
 Harness: [`tests/chatbot/mock_llm_harness.py`](../../tests/chatbot/mock_llm_harness.py). Hooks: [`plugin/chatbot/sidebar_test_hooks.py`](../../plugin/chatbot/sidebar_test_hooks.py). Other UNO tests stay `make test-uno` (headless + throwaway profile).
 

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -115,6 +115,33 @@ def uno_click(control: Any) -> None:
     raise RuntimeError("control has no accessible click")
 
 
+def _query_uno_interface(obj: Any, typename: str) -> Any:
+    """PyUNO ``queryInterface`` needs ``uno.getTypeByName``, not the IDL class."""
+    if obj is None or not hasattr(obj, "queryInterface"):
+        return None
+    try:
+        import uno
+
+        return obj.queryInterface(uno.getTypeByName(typename))
+    except Exception:
+        return None
+
+
+def sidebar_provider(controller: Any) -> Any:
+    """Return ``XSidebarProvider`` (decks / setVisible), or None.
+
+    ``controller.Sidebar`` is ``getSidebar()`` → ``XSidebar`` (requestLayout only).
+    Packet F used that property and never saw decks when View → Sidebar was off.
+    Decks live on the controller's ``XSidebarProvider``.
+    """
+    _require_debug()
+    if controller is None:
+        return None
+    if callable(getattr(controller, "getDecks", None)):
+        return controller
+    return _query_uno_interface(controller, "com.sun.star.ui.XSidebarProvider")
+
+
 def sidebar_deck_names(ctx: Any, doc: Any) -> list[str]:
     """Deck ids from XSidebarProvider, or empty if the API is unavailable."""
     _require_debug()
@@ -122,13 +149,68 @@ def sidebar_deck_names(ctx: Any, doc: Any) -> list[str]:
         return []
     try:
         controller = doc.getCurrentController()
-        sidebar = controller.Sidebar
-        decks = sidebar.getDecks()
+        provider = sidebar_provider(controller)
+        if provider is None:
+            return []
+        decks = provider.getDecks()
         if hasattr(decks, "getElementNames"):
             return [str(n) for n in decks.getElementNames()]
     except Exception:
         return []
     return []
+
+
+def _panel_root_window(panel: Any) -> Any:
+    if panel is None:
+        return None
+    for attr in ("getDialog", "getWindow"):
+        getter = getattr(panel, attr, None)
+        if not callable(getter):
+            continue
+        try:
+            win = getter()
+        except Exception:
+            continue
+        if win is not None:
+            return win
+    return getattr(panel, "Window", None) or getattr(panel, "PanelWindow", None)
+
+
+def _control_container(window: Any) -> Any:
+    if window is None:
+        return None
+    if hasattr(window, "getControl"):
+        return window
+    return _query_uno_interface(window, "com.sun.star.awt.XControlContainer") or window
+
+
+_CHAT_CONTROL_NAMES = (
+    "query",
+    "send",
+    "stop",
+    "response",
+    "response_rich",
+    "status",
+    "model_selector",
+    "chat_mode_selector",
+)
+
+
+def _controls_from_window(window: Any) -> dict[str, Any] | None:
+    root = _control_container(window)
+    if root is None or not hasattr(root, "getControl"):
+        return None
+    out: dict[str, Any] = {}
+    for name in _CHAT_CONTROL_NAMES:
+        try:
+            ctrl = root.getControl(name)
+        except Exception:
+            ctrl = None
+        if ctrl is not None:
+            out[name] = ctrl
+    if "query" in out and "send" in out:
+        return out
+    return None
 
 
 def chat_dialog_controls(ctx: Any, doc: Any) -> dict[str, Any] | None:
@@ -138,13 +220,10 @@ def chat_dialog_controls(ctx: Any, doc: Any) -> dict[str, Any] | None:
         return None
     try:
         controller = doc.getCurrentController()
-        try:
-            sidebar = controller.Sidebar
-        except Exception:
-            sidebar = None
-        if sidebar is None:
+        provider = sidebar_provider(controller)
+        if provider is None:
             return None
-        decks = sidebar.getDecks()
+        decks = provider.getDecks()
         deck = None
         if hasattr(decks, "hasByName") and decks.hasByName("WriterAgentDeck"):
             deck = decks.getByName("WriterAgentDeck")
@@ -156,22 +235,7 @@ def chat_dialog_controls(ctx: Any, doc: Any) -> dict[str, Any] | None:
             panel = panels.getByName("ChatPanel")
         elif hasattr(panels, "getByIndex"):
             panel = panels.getByIndex(0)
-        if panel is None or not hasattr(panel, "getDialog"):
-            return None
-        dialog = panel.getDialog()
-        if dialog is None or not hasattr(dialog, "getControl"):
-            return None
-        names = ("query", "send", "stop", "response", "response_rich", "status")
-        out: dict[str, Any] = {}
-        for name in names:
-            try:
-                ctrl = dialog.getControl(name)
-            except Exception:
-                ctrl = None
-            if ctrl is not None:
-                out[name] = ctrl
-        if "query" in out and "send" in out:
-            return out
+        return _controls_from_window(_panel_root_window(panel))
     except Exception:
         log.debug("chat_dialog_controls failed", exc_info=True)
     return None
@@ -218,7 +282,9 @@ def adopt_runtime_send_listeners() -> int:
 def show_writeragent_chat_deck(ctx: Any, doc: Any) -> None:
     """Make the WriterAgent sidebar deck visible on *doc* (debug tests).
 
-    Used with ``--norestore`` so crash-recovery UI is not required to reopen the deck.
+    ``.uno:SidebarDeck.WriterAgentDeck`` shows the sidebar if View → Sidebar is
+    off. Do not dispatch ``.uno:Sidebar`` — that *toggles*. ``--norestore``
+    skips crash-recovery so this dispatch is what reopens the deck.
     """
     _require_debug()
     if doc is None:
@@ -231,33 +297,28 @@ def show_writeragent_chat_deck(ctx: Any, doc: Any) -> None:
     try:
         smgr = ctx.getServiceManager()
         helper = smgr.createInstanceWithContext("com.sun.star.frame.DispatchHelper", ctx)
-        # Do not dispatch .uno:Sidebar — it *toggles* and can hide a deck that is already on.
         try:
             helper.executeDispatch(frame, ".uno:SidebarDeck.WriterAgentDeck", "", 0, ())
         except Exception:
             log.debug("show_writeragent_chat_deck dispatch WriterAgentDeck failed", exc_info=True)
     except Exception:
         log.debug("show_writeragent_chat_deck DispatchHelper failed", exc_info=True)
-    sidebar = None
-    try:
-        sidebar = controller.Sidebar
-    except Exception:
-        sidebar = None
-    if sidebar is None:
+    provider = sidebar_provider(controller)
+    if provider is None:
         return
     try:
-        if hasattr(sidebar, "isVisible") and not sidebar.isVisible():
-            sidebar.setVisible(True)
-        elif hasattr(sidebar, "setVisible"):
-            sidebar.setVisible(True)
+        if hasattr(provider, "isVisible") and not provider.isVisible():
+            provider.setVisible(True)
+        elif hasattr(provider, "setVisible"):
+            provider.setVisible(True)
     except Exception:
         pass
     try:
-        sidebar.showDecks(True)
+        provider.showDecks(True)
     except Exception:
         pass
     try:
-        decks = sidebar.getDecks()
+        decks = provider.getDecks()
         if decks is None:
             return
         name = "WriterAgentDeck"
@@ -271,6 +332,97 @@ def show_writeragent_chat_deck(ctx: Any, doc: Any) -> None:
                 return
     except Exception:
         log.debug("show_writeragent_chat_deck failed", exc_info=True)
+
+
+def wait_for_chat_dialog_controls(ctx: Any, timeout: float = 20.0) -> dict[str, Any] | None:
+    """Show WriterAgentDeck until query+send exist. Does not pump VCL over URP."""
+    _require_debug()
+    deadline = time.monotonic() + max(0.0, timeout)
+    last: dict[str, Any] | None = None
+    while time.monotonic() <= deadline:
+        try:
+            doc = current_component(ctx)
+            show_writeragent_chat_deck(ctx, doc)
+            last = chat_dialog_controls(ctx, doc)
+            if last is not None:
+                return last
+        except Exception:
+            log.debug("wait_for_chat_dialog_controls attempt failed", exc_info=True)
+        time.sleep(0.4)
+    return last
+
+
+def control_enabled(control: Any) -> bool | None:
+    """``model.Enabled`` over URP, or None if unreadable."""
+    _require_debug()
+    if control is None:
+        return None
+    try:
+        model = control.getModel()
+        return bool(getattr(model, "Enabled"))
+    except Exception:
+        return None
+
+
+def ensure_sidebar_chat_mode(controls: dict[str, Any] | None) -> None:
+    """Select main Chat (not Librarian) so Packet F hits the chat completions path."""
+    _require_debug()
+    if not controls:
+        return
+    sel = controls.get("chat_mode_selector")
+    if sel is None:
+        return
+    from plugin.chatbot.chat_sidebar_mode import CHAT_MODE_CHAT, set_selector_mode_with_flags, sidebar_mode_flags_for_doc_type
+
+    set_selector_mode_with_flags(sel, CHAT_MODE_CHAT, sidebar_mode_flags_for_doc_type("writer"))
+
+
+def set_query_text_via_controls(controls: dict[str, Any], text: str) -> None:
+    """Set the query box over URP so QueryTextListener can enable Send."""
+    _require_debug()
+    from plugin.chatbot.dialogs import set_control_text
+
+    set_control_text(controls["query"], text)
+
+
+def wait_controls_send_finished(
+    controls: dict[str, Any],
+    timeout: float = 60.0,
+    *,
+    transcript_fn: Callable[[], str] | None = None,
+    wait_for: str | None = None,
+    before: str = "",
+) -> bool:
+    """Wait until Stop is idle and optional new transcript text appeared.
+
+    Out-of-process tests cannot read ``SendButtonListener.is_busy``. Stop is
+    enabled while a send is in flight (Packet F HTTP errors included).
+    """
+    _require_debug()
+    deadline = time.monotonic() + max(0.0, timeout)
+    stop = controls.get("stop")
+    # Let the click start; HTTP 500 can finish before the first poll.
+    time.sleep(0.25)
+    while time.monotonic() <= deadline:
+        en = control_enabled(stop) if stop is not None else None
+        busy = en is True
+        body = transcript_fn() if transcript_fn is not None else ""
+        suffix = body[len(before) :] if before and body.startswith(before) else body
+        if wait_for:
+            found = wait_for.lower() in suffix.lower()
+            if not found and body != before:
+                found = wait_for.lower() in body.lower()
+        else:
+            found = True
+        if found and not busy:
+            return True
+        time.sleep(0.15)
+    if wait_for and transcript_fn is not None:
+        body = transcript_fn()
+        suffix = body[len(before) :] if before and body.startswith(before) else body
+        return wait_for.lower() in suffix.lower() or (body != before and wait_for.lower() in body.lower())
+    en = control_enabled(stop) if stop is not None else None
+    return en is not True
 
 
 def _control_label(control: Any) -> str:

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -130,13 +130,17 @@ def _query_uno_interface(obj: Any, typename: str) -> Any:
 def sidebar_provider(controller: Any) -> Any:
     """Return ``XSidebarProvider`` (decks / setVisible), or None.
 
-    ``controller.Sidebar`` is ``getSidebar()`` → ``XSidebar`` (requestLayout only).
-    Packet F used that property and never saw decks when View → Sidebar was off.
-    Decks live on the controller's ``XSidebarProvider``.
+    On ``SwXTextView``, ``getDecks`` is ``controller.Sidebar`` (the property),
+    not a method on the controller. ``queryInterface(XSidebarProvider)`` on
+    the controller is None. Prefer the property, then a controller that
+    already has ``getDecks``.
     """
     _require_debug()
     if controller is None:
         return None
+    sidebar = getattr(controller, "Sidebar", None)
+    if sidebar is not None and callable(getattr(sidebar, "getDecks", None)):
+        return sidebar
     if callable(getattr(controller, "getDecks", None)):
         return controller
     return _query_uno_interface(controller, "com.sun.star.ui.XSidebarProvider")

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -156,9 +156,69 @@ def _user_profile_soffice_argv(soffice: Path, accept: str) -> list[str]:
         "--norestore",
         "--nofirststartwizard",
         "--nocrashreport",
+        "--nologo",
         "--writer",
         "--accept=%s" % accept,
     ]
+
+
+def _libreoffice_user_lock_path() -> Path:
+    if sys.platform.startswith("win"):
+        base = Path(os.environ.get("APPDATA", "")) / "LibreOffice" / "4"
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support" / "LibreOffice" / "4"
+    else:
+        base = Path.home() / ".config" / "libreoffice" / "4"
+    return base / ".lock"
+
+
+def _soffice_bin_running() -> bool:
+    try:
+        import subprocess
+
+        return (
+            subprocess.call(
+                ["pgrep", "-x", "soffice.bin"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            == 0
+        )
+    except Exception:
+        return False
+
+
+def _clear_stale_user_profile_ipc() -> None:
+    """Drop leftover SingleOfficeIPC pipes and ``.lock`` when soffice is not running.
+
+    A stale UserInstallation ``.lock`` with ``IPCServer=false`` makes the next
+    soffice skip ``--accept``, so Packet F cannot connect.
+    """
+    if _soffice_bin_running():
+        return
+    lock = _libreoffice_user_lock_path()
+    try:
+        if lock.is_file():
+            lock.unlink()
+    except OSError:
+        pass
+    if not hasattr(os, "getuid"):
+        return
+    import glob
+
+    for path in glob.glob("/tmp/OSL_PIPE_%s_*" % os.getuid()):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _unused_tcp_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
 
 
 def _resolve_soffice_bin(officehelper_module: Any) -> Path | None:
@@ -186,7 +246,6 @@ def _bootstrap_user_profile_gui(officehelper_module: Any) -> Any:
     That path opened a window and then crashed (URP disposed). This start matches
     ``scripts/launch-lo-debug.sh`` plus an accept string so tests can attach.
     """
-    import random
     import subprocess
     import time
 
@@ -198,8 +257,9 @@ def _bootstrap_user_profile_gui(officehelper_module: Any) -> Any:
     soffice = _resolve_soffice_bin(officehelper_module)
     if soffice is None:
         raise RuntimeError("soffice not found (PATH, officehelper dir, or common install paths)")
-    pipe = "uno%s" % str(random.random())[2:]
-    accept = "pipe,name=%s;urp;" % pipe
+    _clear_stale_user_profile_ipc()
+    port = _unused_tcp_port()
+    accept = "socket,host=127.0.0.1,port=%s;urp;" % port
     cmd = _user_profile_soffice_argv(soffice, accept)
     proc = subprocess.Popen(cmd, env=_child_env_without_runner_python(), start_new_session=True)
     local = uno.getComponentContext()

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -124,8 +124,8 @@ def _soffice_bootstrap_command(officehelper_module: Any) -> str | None:
         quoted = '"%s"' % soffice
         if use_user_profile:
             # Keep the developer's UserInstallation (extension + writeragent.json).
-            # --norestore: crash recovery UI blocks bootstrap (sidebar is shown in tests).
-            return "%s --norestore --nofirststartwizard --nocrashreport" % quoted
+            # Actual GUI start is ``_user_profile_soffice_argv`` (adds --writer, no --nodefault).
+            return "%s --norestore --nofirststartwizard --nocrashreport --writer" % quoted
         profile_url = Path(tempfile.mkdtemp(prefix="writeragent-lo-test-profile-")).as_uri()
         return (
             "%s --headless --norestore --nofirststartwizard --nocrashreport "
@@ -143,6 +143,22 @@ def _child_env_without_runner_python() -> dict[str, str]:
     for key in _SOFFICE_STRIP_ENV:
         env.pop(key, None)
     return env
+
+
+def _user_profile_soffice_argv(soffice: Path, accept: str) -> list[str]:
+    """Visible Writer on the real user profile. No ``--nodefault`` (officehelper crash).
+
+    ``--norestore`` skips the crash-recovery dialog that otherwise blocks the UNO pipe.
+    Tests then show ``WriterAgentDeck`` over UNO (View → Sidebar may be off).
+    """
+    return [
+        str(soffice),
+        "--norestore",
+        "--nofirststartwizard",
+        "--nocrashreport",
+        "--writer",
+        "--accept=%s" % accept,
+    ]
 
 
 def _resolve_soffice_bin(officehelper_module: Any) -> Path | None:
@@ -177,28 +193,30 @@ def _bootstrap_user_profile_gui(officehelper_module: Any) -> Any:
     import uno
     from com.sun.star.connection import NoConnectException
 
+    if sys.platform.startswith("linux") and not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        raise RuntimeError("user-profile sidebar tests need DISPLAY (visible Writer)")
     soffice = _resolve_soffice_bin(officehelper_module)
     if soffice is None:
         raise RuntimeError("soffice not found (PATH, officehelper dir, or common install paths)")
     pipe = "uno%s" % str(random.random())[2:]
     accept = "pipe,name=%s;urp;" % pipe
-    cmd = [
-        str(soffice),
-        "--norestore",
-        "--nofirststartwizard",
-        "--nocrashreport",
-        "--writer",
-        "--accept=%s" % accept,
-    ]
-    subprocess.Popen(cmd, env=_child_env_without_runner_python(), start_new_session=True)
+    cmd = _user_profile_soffice_argv(soffice, accept)
+    proc = subprocess.Popen(cmd, env=_child_env_without_runner_python(), start_new_session=True)
     local = uno.getComponentContext()
     resolver = local.ServiceManager.createInstanceWithContext(
         "com.sun.star.bridge.UnoUrlResolver", local
     )
     url = "uno:%sStarOffice.ComponentContext" % accept
     last_exc: BaseException | None = None
-    for delay in (1, 2, 3, 5, 8):
+    # GUI + extension OnStartApp is slower than headless officehelper.
+    for delay in (0.5, 1, 1, 2, 2, 3, 5, 8, 8):
         time.sleep(delay)
+        code = proc.poll()
+        if code is not None:
+            raise RuntimeError(
+                "user-profile soffice exited %s before UNO connect (crash recovery or mixed PYTHONPATH?)"
+                % code
+            )
         try:
             return resolver.resolve(url)
         except NoConnectException as exc:

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -210,7 +210,8 @@ def _clear_stale_user_profile_ipc() -> None:
         return
     import glob
 
-    for path in glob.glob("/tmp/OSL_PIPE_%s_*" % os.getuid()):
+    tmp = tempfile.gettempdir()
+    for path in glob.glob(os.path.join(tmp, "OSL_PIPE_%s_*" % os.getuid())):
         try:
             os.unlink(path)
         except OSError:

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -138,10 +138,14 @@ def _soffice_bootstrap_command(officehelper_module: Any) -> str | None:
 _SOFFICE_STRIP_ENV = ("PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV")
 
 
-def _child_env_without_runner_python() -> dict[str, str]:
+def _child_env_without_runner_python(*, uno_thread_guard: bool | None = None) -> dict[str, str]:
     env = dict(os.environ)
     for key in _SOFFICE_STRIP_ENV:
         env.pop(key, None)
+    # URP dispatch of WriterAgentDeck runs getRealInterface off the VCL thread.
+    # Dev thread_guard would abort ChatPanel create (Dummy-N). Official opt-out.
+    if uno_thread_guard is False:
+        env["WRITERAGENT_UNO_THREAD_GUARD"] = "0"
     return env
 
 
@@ -261,7 +265,11 @@ def _bootstrap_user_profile_gui(officehelper_module: Any) -> Any:
     port = _unused_tcp_port()
     accept = "socket,host=127.0.0.1,port=%s;urp;" % port
     cmd = _user_profile_soffice_argv(soffice, accept)
-    proc = subprocess.Popen(cmd, env=_child_env_without_runner_python(), start_new_session=True)
+    proc = subprocess.Popen(
+        cmd,
+        env=_child_env_without_runner_python(uno_thread_guard=False),
+        start_new_session=True,
+    )
     local = uno.getComponentContext()
     smgr = getattr(local, "getServiceManager", lambda: None)()
     if smgr is None:

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -203,7 +203,12 @@ def _bootstrap_user_profile_gui(officehelper_module: Any) -> Any:
     cmd = _user_profile_soffice_argv(soffice, accept)
     proc = subprocess.Popen(cmd, env=_child_env_without_runner_python(), start_new_session=True)
     local = uno.getComponentContext()
-    resolver = local.ServiceManager.createInstanceWithContext(
+    smgr = getattr(local, "getServiceManager", lambda: None)()
+    if smgr is None:
+        smgr = getattr(local, "ServiceManager", None)
+    if smgr is None:
+        raise RuntimeError("no ServiceManager on local UNO context")
+    resolver = smgr.createInstanceWithContext(
         "com.sun.star.bridge.UnoUrlResolver", local
     )
     url = "uno:%sStarOffice.ComponentContext" % accept

--- a/tests/chatbot/mock_llm_harness.py
+++ b/tests/chatbot/mock_llm_harness.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
+import os
 import threading
+import time
 import unittest
 from http.server import ThreadingHTTPServer
 from typing import Any
@@ -58,6 +60,9 @@ def start_mock_sidebar_session(*, delay_ms: int = 20, offline: bool = True, **fl
     set_text_model(MOCK_MODEL_ID, update_lru=False)
     if not get_api_key_for_endpoint(base_url):
         set_api_key_for_endpoint(base_url, "mock-key")
+    # Live sidebar is the OXT process. get_config caches mtime checks for 2s.
+    if os.environ.get("WRITERAGENT_UNO_USER_PROFILE") == "1":
+        time.sleep(2.1)
     return MockSidebarSession(httpd, thread, base_url, saved)
 
 

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -12,7 +12,6 @@ import time
 from plugin.testing_runner import native_test, setup, teardown
 
 from tests.chatbot.mock_llm_harness import (
-    require_send_listener,
     start_mock_sidebar_session,
     stop_mock_sidebar_session,
 )
@@ -48,33 +47,20 @@ def _setup_mock(ctx):
 
     from plugin.chatbot.sidebar_test_hooks import (
         adopt_runtime_send_listeners,
-        chat_dialog_controls,
-        current_component,
-        show_writeragent_chat_deck,
+        ensure_sidebar_chat_mode,
+        send_listener,
+        wait_for_chat_dialog_controls,
     )
 
     _ensure_writer_doc(ctx)
-    sl = None
-    controls = None
-    # Do not processEventsToIdle over URP on a visible office — it can hang the pipe.
-    for _attempt in range(12):
-        try:
-            doc = current_component(ctx)
-            show_writeragent_chat_deck(ctx, doc)
-            time.sleep(0.5)
-            adopt_runtime_send_listeners()
-            try:
-                sl = require_send_listener(skip_if_missing=False)
-                break
-            except AssertionError:
-                sl = None
-            controls = chat_dialog_controls(ctx, doc)
-            if controls is not None:
-                break
-        except Exception:
-            time.sleep(0.5)
+    # Point writeragent.json at the mock *before* showing the deck so the live
+    # OXT send path is not still using the user's real endpoint.
+    _session = start_mock_sidebar_session(delay_ms=20, offline=True)
+    controls = wait_for_chat_dialog_controls(ctx, timeout=20.0)
+    adopt_runtime_send_listeners()
+    sl = send_listener()
     if sl is None and controls is None:
-        from plugin.chatbot.sidebar_test_hooks import sidebar_deck_names
+        from plugin.chatbot.sidebar_test_hooks import current_component, sidebar_deck_names
 
         names = []
         try:
@@ -85,7 +71,7 @@ def _setup_mock(ctx):
             "WriterAgent chat sidebar not wired after showing WriterAgentDeck "
             "(View → Sidebar must be on). decks=%s" % (names,)
         )
-    _session = start_mock_sidebar_session(delay_ms=20, offline=True)
+    ensure_sidebar_chat_mode(controls)
     _session.controls = controls
     _session.listener = sl
 
@@ -132,44 +118,59 @@ def _transcript() -> str:
 
 
 def _send_and_wait(text: str, timeout: float = 60.0, *, wait_for: str | None = None):
-    from plugin.chatbot.sidebar_test_hooks import press_send, set_query_text, uno_click, wait_idle
+    from plugin.chatbot.sidebar_test_hooks import (
+        press_send,
+        set_query_text,
+        set_query_text_via_controls,
+        uno_click,
+        wait_controls_send_finished,
+        wait_idle,
+    )
 
+    before = _transcript()
     sl = getattr(_session, "listener", None)
     if sl is not None:
         set_query_text(text, listener=sl)
         press_send(listener=sl)
         assert wait_idle(listener=sl, timeout=timeout), "send did not go idle: %r" % text
+        if wait_for:
+            body = _transcript()
+            suffix = body[len(before) :] if body.startswith(before) else body
+            assert wait_for.lower() in suffix.lower() or wait_for.lower() in body.lower(), (
+                "after send %r expected %r in %r" % (text, wait_for, body[-500:])
+            )
         return sl
     controls = getattr(_session, "controls", None)
     assert controls is not None, "no SendButtonListener and no chat dialog controls"
-    query = controls["query"]
-    model = query.getModel()
-    model.Text = text
+    set_query_text_via_controls(controls, text)
+    time.sleep(0.2)
     uno_click(controls["send"])
-    deadline = time.monotonic() + timeout
-    needle = wait_for
-    while time.monotonic() < deadline:
-        body = _transcript()
-        if needle and needle.lower() in body.lower():
-            time.sleep(0.4)
-            return None
-        time.sleep(0.2)
-    body = _transcript()
-    if needle:
-        assert needle.lower() in body.lower(), "after send %r expected %r in %r" % (text, needle, body[-500:])
+    assert wait_controls_send_finished(
+        controls,
+        timeout=timeout,
+        transcript_fn=_transcript,
+        wait_for=wait_for,
+        before=before,
+    ), "send did not finish: %r transcript=%r" % (text, _transcript()[-500:])
     return None
 
 
 def _hello_ok() -> None:
     sl = getattr(_session, "listener", None)
+    before = _transcript()
     if sl is not None:
         from plugin.chatbot.sidebar_test_hooks import next_hello_ok
 
         assert next_hello_ok(listener=sl, timeout=60.0), "recovery hello failed"
         return
-    _send_and_wait("hello", wait_for="hello")
-    body = _transcript().lower()
-    assert "hello" in body or "<p" in body or "<ul" in body, "hello reply missing: %r" % body[-400:]
+    # User line is "hello"; require mock HTML body ("mock" appears in every template).
+    _send_and_wait("hello", wait_for="mock")
+    body = _transcript()
+    suffix = body[len(before) :] if body.startswith(before) else body
+    blob = suffix if suffix else body
+    assert "mock" in blob.lower() or "<p" in blob.lower() or "<ul" in blob.lower(), (
+        "hello reply missing: %r" % body[-400:]
+    )
 
 
 @native_test

--- a/tests/chatbot/test_sidebar_test_hooks.py
+++ b/tests/chatbot/test_sidebar_test_hooks.py
@@ -18,6 +18,8 @@ from plugin.chatbot.sidebar_state import SidebarCompositeState
 from plugin.chatbot.sidebar_test_hooks import (
     approval_active,
     audio_status,
+    chat_dialog_controls,
+    control_enabled,
     debug_hooks_available,
     inject_wav,
     iter_live_chat_panels,
@@ -36,10 +38,14 @@ from plugin.chatbot.sidebar_test_hooks import (
     send_state,
     set_audio_supported,
     set_query_text,
+    show_writeragent_chat_deck,
+    sidebar_deck_names,
     sidebar_panel,
+    sidebar_provider,
     stub_recorder_child,
     transcript_contains,
     transcript_text,
+    wait_controls_send_finished,
     wait_idle,
 )
 from tests.chatbot.mock_llm_harness import mock_config
@@ -288,3 +294,139 @@ def test_sidebar_panel_none_when_empty() -> None:
     panel = sidebar_panel()
     sl = send_listener()
     assert panel is None or sl is getattr(panel, "send_listener", sl)
+
+
+class _SidebarNoDecks:
+    """controller.Sidebar is XSidebar — requestLayout only, no getDecks."""
+
+
+class _FakeDeck:
+    def __init__(self) -> None:
+        self.activated = False
+        self._panels = _FakePanels()
+
+    def activate(self, on: bool) -> None:
+        self.activated = bool(on)
+
+    def getPanels(self):
+        return self._panels
+
+
+class _FakeDialog:
+    def __init__(self) -> None:
+        self._ctrls = {"query": object(), "send": object(), "stop": object()}
+
+    def getControl(self, name: str):
+        return self._ctrls.get(name)
+
+
+class _FakePanels:
+    def hasByName(self, name: str) -> bool:
+        return name == "ChatPanel"
+
+    def getByName(self, name: str):
+        return SimpleNamespace(getDialog=lambda: _FakeDialog())
+
+
+class _FakeDecks:
+    def __init__(self) -> None:
+        self.writer = _FakeDeck()
+
+    def getElementNames(self):
+        return ["WriterAgentDeck"]
+
+    def hasByName(self, name: str) -> bool:
+        return name == "WriterAgentDeck"
+
+    def getByName(self, name: str):
+        return self.writer
+
+
+class _ProviderController:
+    def __init__(self) -> None:
+        self.Sidebar = _SidebarNoDecks()
+        self._decks = _FakeDecks()
+        self.visible_sets: list[bool] = []
+        self.decks_shown = False
+
+    def getDecks(self):
+        return self._decks
+
+    def isVisible(self) -> bool:
+        return False
+
+    def setVisible(self, value: bool) -> None:
+        self.visible_sets.append(bool(value))
+
+    def showDecks(self, value: bool) -> None:
+        self.decks_shown = bool(value)
+
+    def getCurrentController(self):
+        return self
+
+    def getFrame(self):
+        return SimpleNamespace()
+
+
+def test_sidebar_provider_uses_controller_get_decks_not_sidebar_property() -> None:
+    ctrl = _ProviderController()
+    provider = sidebar_provider(ctrl)
+    assert provider is ctrl
+    assert not hasattr(ctrl.Sidebar, "getDecks")
+    assert "WriterAgentDeck" in sidebar_deck_names(SimpleNamespace(), ctrl)
+
+
+def test_chat_dialog_controls_reads_xdl_from_provider_decks() -> None:
+    doc = _ProviderController()
+    out = chat_dialog_controls(SimpleNamespace(), doc)
+    assert out is not None
+    assert "query" in out and "send" in out
+
+
+def test_show_writeragent_chat_deck_activates_when_sidebar_property_has_no_decks() -> None:
+    class _Helper:
+        def executeDispatch(self, *args):
+            return None
+
+    ctx = SimpleNamespace(
+        getServiceManager=lambda: SimpleNamespace(
+            createInstanceWithContext=lambda *a: _Helper()
+        )
+    )
+    doc = _ProviderController()
+    show_writeragent_chat_deck(ctx, doc)
+    assert doc.visible_sets == [True]
+    assert doc.decks_shown is True
+    assert doc._decks.writer.activated is True
+
+
+class _StopCtrl:
+    def __init__(self) -> None:
+        self._model = SimpleNamespace(Enabled=False)
+
+    def getModel(self):
+        return self._model
+
+
+def test_wait_controls_send_finished_sees_new_transcript(monkeypatch) -> None:
+    stop = _StopCtrl()
+    state = {"body": "old", "n": 0}
+
+    def transcript() -> str:
+        state["n"] += 1
+        if state["n"] >= 2:
+            stop._model.Enabled = False
+            return "old\n[API error: HTTP Error 500]"
+        stop._model.Enabled = True
+        return "old"
+
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.time.sleep", lambda _s: None)
+    ok = wait_controls_send_finished(
+        {"stop": stop},
+        timeout=2.0,
+        transcript_fn=transcript,
+        wait_for="API error",
+        before="old",
+    )
+    assert ok is True
+    assert control_enabled(stop) is False

--- a/tests/chatbot/test_sidebar_test_hooks.py
+++ b/tests/chatbot/test_sidebar_test_hooks.py
@@ -296,10 +296,6 @@ def test_sidebar_panel_none_when_empty() -> None:
     assert panel is None or sl is getattr(panel, "send_listener", sl)
 
 
-class _SidebarNoDecks:
-    """controller.Sidebar is XSidebar — requestLayout only, no getDecks."""
-
-
 class _FakeDeck:
     def __init__(self) -> None:
         self.activated = False
@@ -342,9 +338,10 @@ class _FakeDecks:
         return self.writer
 
 
-class _ProviderController:
+class _SidebarProvider:
+    """Matches SwXTextView.Sidebar (XSidebarProvider), not the controller."""
+
     def __init__(self) -> None:
-        self.Sidebar = _SidebarNoDecks()
         self._decks = _FakeDecks()
         self.visible_sets: list[bool] = []
         self.decks_shown = False
@@ -361,6 +358,11 @@ class _ProviderController:
     def showDecks(self, value: bool) -> None:
         self.decks_shown = bool(value)
 
+
+class _ProviderController:
+    def __init__(self) -> None:
+        self.Sidebar = _SidebarProvider()
+
     def getCurrentController(self):
         return self
 
@@ -368,12 +370,18 @@ class _ProviderController:
         return SimpleNamespace()
 
 
-def test_sidebar_provider_uses_controller_get_decks_not_sidebar_property() -> None:
+def test_sidebar_provider_uses_sidebar_property_not_controller_get_decks() -> None:
     ctrl = _ProviderController()
     provider = sidebar_provider(ctrl)
-    assert provider is ctrl
-    assert not hasattr(ctrl.Sidebar, "getDecks")
+    assert provider is ctrl.Sidebar
+    assert not hasattr(ctrl, "getDecks")
     assert "WriterAgentDeck" in sidebar_deck_names(SimpleNamespace(), ctrl)
+
+
+def test_sidebar_provider_falls_back_to_controller_get_decks() -> None:
+    decks = _FakeDecks()
+    ctrl = SimpleNamespace(getDecks=lambda: decks)
+    assert sidebar_provider(ctrl) is ctrl
 
 
 def test_chat_dialog_controls_reads_xdl_from_provider_decks() -> None:
@@ -383,7 +391,7 @@ def test_chat_dialog_controls_reads_xdl_from_provider_decks() -> None:
     assert "query" in out and "send" in out
 
 
-def test_show_writeragent_chat_deck_activates_when_sidebar_property_has_no_decks() -> None:
+def test_show_writeragent_chat_deck_activates_writeragent_deck() -> None:
     class _Helper:
         def executeDispatch(self, *args):
             return None
@@ -395,9 +403,9 @@ def test_show_writeragent_chat_deck_activates_when_sidebar_property_has_no_decks
     )
     doc = _ProviderController()
     show_writeragent_chat_deck(ctx, doc)
-    assert doc.visible_sets == [True]
-    assert doc.decks_shown is True
-    assert doc._decks.writer.activated is True
+    assert doc.Sidebar.visible_sets == [True]
+    assert doc.Sidebar.decks_shown is True
+    assert doc.Sidebar._decks.writer.activated is True
 
 
 class _StopCtrl:

--- a/tests/scripts/test_testing_runner_cli.py
+++ b/tests/scripts/test_testing_runner_cli.py
@@ -34,3 +34,13 @@ def test_parse_cli_default_is_headless_suite(monkeypatch) -> None:
     assert tr.use_user_profile is False
     assert tr.show_window is True
     assert rest == ["test_charts_uno"]
+
+
+def test_user_profile_soffice_argv_skips_nodefault_and_restore() -> None:
+    from pathlib import Path
+
+    argv = tr._user_profile_soffice_argv(Path("/usr/bin/soffice"), "pipe,name=uno1;urp;")
+    assert "--norestore" in argv
+    assert "--writer" in argv
+    assert "--nodefault" not in argv
+    assert any(a.startswith("--accept=") for a in argv)

--- a/tests/scripts/test_testing_runner_cli.py
+++ b/tests/scripts/test_testing_runner_cli.py
@@ -39,8 +39,15 @@ def test_parse_cli_default_is_headless_suite(monkeypatch) -> None:
 def test_user_profile_soffice_argv_skips_nodefault_and_restore() -> None:
     from pathlib import Path
 
-    argv = tr._user_profile_soffice_argv(Path("/usr/bin/soffice"), "pipe,name=uno1;urp;")
+    argv = tr._user_profile_soffice_argv(Path("/usr/bin/soffice"), "socket,host=127.0.0.1,port=9;urp;")
     assert "--norestore" in argv
     assert "--writer" in argv
+    assert "--nologo" in argv
     assert "--nodefault" not in argv
-    assert any(a.startswith("--accept=") for a in argv)
+    assert any(a.startswith("--accept=socket") for a in argv)
+
+
+def test_libreoffice_user_lock_path_is_under_profile() -> None:
+    lock = tr._libreoffice_user_lock_path()
+    assert lock.name == ".lock"
+    assert "libreoffice" in str(lock).lower() or "LibreOffice" in str(lock)

--- a/tests/scripts/test_testing_runner_cli.py
+++ b/tests/scripts/test_testing_runner_cli.py
@@ -26,6 +26,13 @@ def test_soffice_strip_env_names() -> None:
     assert "PYTHONHOME" in tr._SOFFICE_STRIP_ENV
 
 
+def test_user_profile_child_env_disables_uno_thread_guard(monkeypatch) -> None:
+    monkeypatch.setenv("PYTHONPATH", "/checkout")
+    env = tr._child_env_without_runner_python(uno_thread_guard=False)
+    assert "PYTHONPATH" not in env
+    assert env.get("WRITERAGENT_UNO_THREAD_GUARD") == "0"
+
+
 def test_parse_cli_default_is_headless_suite(monkeypatch) -> None:
     monkeypatch.setattr(tr, "use_user_profile", False)
     monkeypatch.setattr(tr, "show_window", False)

--- a/tests/scripts/test_testing_runner_cli.py
+++ b/tests/scripts/test_testing_runner_cli.py
@@ -58,3 +58,22 @@ def test_libreoffice_user_lock_path_is_under_profile() -> None:
     lock = tr._libreoffice_user_lock_path()
     assert lock.name == ".lock"
     assert "libreoffice" in str(lock).lower() or "LibreOffice" in str(lock)
+
+
+def test_clear_stale_user_profile_ipc_globs_os_tempdir(monkeypatch, tmp_path) -> None:
+    import glob
+    import tempfile
+
+    monkeypatch.setattr(tr, "_soffice_bin_running", lambda: False)
+    monkeypatch.setattr(tr, "_libreoffice_user_lock_path", lambda: tmp_path / "missing.lock")
+    seen: list[str] = []
+
+    def fake_glob(pattern: str) -> list[str]:
+        seen.append(pattern)
+        return []
+
+    monkeypatch.setattr(glob, "glob", fake_glob)
+    tr._clear_stale_user_profile_ipc()
+    assert seen == [
+        os.path.join(tempfile.gettempdir(), "OSL_PIPE_%s_*" % os.getuid())
+    ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

F1, F2, and F14 in `tests/chatbot/test_mock_llm_sidebar_uno.py` were written but never shown green on a live sidebar. `make test-uno` still skips this file; `make test-mock-sidebar` is the runner (visible Writer, **your** user profile).

This only hardens that path so those three tests can complete:

1. **Bootstrap** — start soffice like `make lo-start` (`--norestore --writer` + TCP `--accept=socket,host=127.0.0.1,port=<ephemeral>;urp;`). Do not use `officehelper.bootstrap` (`--nodefault` opened then crashed). Fail if soffice dies before connect. Strip child `PYTHONPATH` / `PYTHONHOME` / `VIRTUAL_ENV`. Linux needs `DISPLAY`.
2. **Crash recovery / View → Sidebar off** — `--norestore` skips the recovery dialog. Show the deck with `.uno:SidebarDeck.WriterAgentDeck` (does not toggle). On `SwXTextView`, `XSidebarProvider` is `controller.Sidebar` (`getDecks` / `setVisible` / `showDecks`). The soffice child sets `WRITERAGENT_UNO_THREAD_GUARD=0` so URP deck dispatch can create ChatPanel (`getRealInterface` otherwise aborts on Dummy-N).
3. **Out-of-process UNO** — the live `SendButtonListener` is in soffice. Drive query/send over URP (`uno_click`), poll Stop `Enabled` and transcript text, and do not `processEventsToIdle` on the pipe. Point `writeragent.json` at the in-process mock **before** showing the deck so the OXT does not keep the user’s real endpoint. Drop a stale UserInstallation `.lock` (`IPCServer=false`) and `OSL_PIPE_*` under `tempfile.gettempdir()` when no `soffice.bin` is running so `--accept` binds.

F3–F18 are **not** in this PR.

## Test plan

- [x] `pytest tests/chatbot/test_sidebar_test_hooks.py tests/scripts/test_testing_runner_cli.py` — 32 passed
- [x] `make test-mock-sidebar` (live visible Writer + mock LLM): F1/F2/F14 `passed=3 failed=0`
- [x] Bandit / mypy / ty / basedpyright / ruff clean
- [ ] Full `make typecheck` still fails on **pre-existing** opengrep `tests.semgrep.uno-off-main-thread` in `plugin/scripting/venv_probe_ui.py` (not touched here)

## Live mock-sidebar traffic

- F1: POST 500 then 200 hello
- F2: 500, 429, 200
- F14: 429 then 200

After the suite, the live sidebar transcript shows `crash the stream` → HTTP 500, `rate limit` / `error 429` → 429, then mock hello replies, with **AI Model** = `writeragent-mock`.

[WriterAgent sidebar after F1/F2/F14 with 429 and mock hello](https://cursor.com/agents/bc-b0898414-dd4e-408d-9bbd-59a7bfb57dec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpacket_f_sidebar_full_transcript.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0898414-dd4e-408d-9bbd-59a7bfb57dec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0898414-dd4e-408d-9bbd-59a7bfb57dec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

