### PR TITLE
Fix sidebar table header emphasis leaking onto body rows

### DIFF
--- a/plugin/chatbot/rich_text_control.py
+++ b/plugin/chatbot/rich_text_control.py
@@ -998,25 +998,37 @@ def _apply_char_color_to_cursor_range(model, start, end, char_color) -> None:
         log.debug("_apply_char_color_to_cursor_range failed: %s", e)
 
 
-def _apply_char_emphasis_to_cursor_range(model, start, end, *, bold=False, underline=False) -> None:
-    if start is None or end is None or not (bold or underline):
+def _apply_char_emphasis_to_cursor_range(model, start, end, *, bold=None, underline=None) -> None:
+    if start is None or end is None or (bold is None and underline is None):
         return
     try:
         sel = model.createTextCursor()
         sel.gotoRange(start, False)
         sel.gotoRange(end, True)
-        if bold:
+        if bold is True:
             sel.CharWeight = 150.0
-        if underline:
+        elif bold is False:
+            sel.CharWeight = CHAT_FONT_WEIGHT
+        if underline is True:
             sel.CharUnderline = 1
+        elif underline is False:
+            sel.CharUnderline = 0
     except Exception as e:
         log.debug("_apply_char_emphasis_to_cursor_range failed: %s", e)
 
 
 def _insert_string_at_rich_cursor(
-    model, cursor, text, char_color=None, *, bold=False, underline=False
+    model, cursor, text, char_color=None, *, bold=None, underline=None
 ) -> None:
-    """Insert *text* at *cursor* on a form RichText model."""
+    """Insert *text* at *cursor* on a form RichText model.
+
+    *bold* / *underline* are tri-state. True paints the inserted range after
+    insert, False forces normal on that range, None leaves weight/underline
+    alone (HTML portion copy sets them on *cursor* first). Do not set
+    CharWeight/CharUnderline on *cursor* before insert: EditEngine treats
+    those as sticky insert attributes, so a table header would paint every
+    following row.
+    """
     if not text:
         return
     start = None
@@ -1027,17 +1039,6 @@ def _insert_string_at_rich_cursor(
     if char_color is not None and not _is_automatic_char_color(char_color):
         try:
             cursor.CharColor = char_color
-        except Exception:
-            pass
-    if bold:
-        try:
-            cursor.CharWeight = 150.0
-        except Exception:
-            pass
-    if underline:
-        try:
-            # com.sun.star.awt.FontUnderline.SINGLE
-            cursor.CharUnderline = 1
         except Exception:
             pass
 
@@ -1077,12 +1078,12 @@ def _insert_string_at_rich_cursor(
                 _apply_char_color_to_cursor_range(model, start, end, char_color)
             except Exception:
                 pass
-        if bold or underline:
+        if bold is not None or underline is not None:
             try:
                 _apply_char_emphasis_to_cursor_range(model, start, end, bold=bold, underline=underline)
             except Exception:
                 pass
-    if bold or underline:
+    if bold is not None or underline is not None:
         try:
             cursor.CharWeight = CHAT_FONT_WEIGHT
             cursor.CharUnderline = 0

--- a/plugin/chatbot/rich_text_paste.py
+++ b/plugin/chatbot/rich_text_paste.py
@@ -370,10 +370,14 @@ def _copy_formatted_from_hidden_doc_to_control(
                         # to abort the whole copy (truncate-then-fail blanked the stream tail).
                         for i, row_text in enumerate(_flatten_text_table_rows(para)):
                             if i:
-                                _insert_string_at_rich_cursor(model, dest_cursor, "\n")
+                                _insert_string_at_rich_cursor(
+                                    model, dest_cursor, "\n", bold=False, underline=False,
+                                )
                                 dest_cursor.gotoEnd(False)
                                 _apply_sidebar_para_margins(dest_cursor)
                             # First row stands in for <th>: no grid, so bold+underline.
+                            # Body rows pass False so the inserted range is forced normal
+                            # (EditEngine otherwise keeps the header run's attributes).
                             is_header = i == 0
                             _insert_string_at_rich_cursor(
                                 model,

--- a/scripts/mock_llm_server.py
+++ b/scripts/mock_llm_server.py
@@ -102,6 +102,7 @@ _SCENARIO_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("think_content", re.compile(r"\bthink tags\b", re.IGNORECASE)),
     ("think", re.compile(r"\b(think out loud|show thinking)\b", re.IGNORECASE)),
     ("flood", re.compile(r"\b(fill the sidebar|very long)\b", re.IGNORECASE)),
+    ("table", re.compile(r"\b(show a table|send a table|table please)\b", re.IGNORECASE)),
     ("delegate", re.compile(r"\b(outline this|use the writer toolset)\b", re.IGNORECASE)),
     ("parallel", re.compile(r"\b(two tools|in parallel)\b", re.IGNORECASE)),
     ("mutate", re.compile(r"\b(insert filler|append a paragraph)\b", re.IGNORECASE)),
@@ -615,6 +616,17 @@ def _html_chat(topic: str, turn: int) -> str:
     return template.format(topic=safe)
 
 
+def _html_table(topic: str) -> str:
+    """Deterministic HTML table for sidebar header-row QA (not the rotating hello templates)."""
+    safe = html.escape((topic or "your message").strip()[:120] or "your message")
+    return (
+        f"<p>A tiny table about {safe} — check that cells survive the hidden-Writer paste.</p>"
+        "<table><tr><th>Col A</th><th>Col B</th></tr><tr><td>stream</td><td>plain</td></tr>"
+        "<tr><td>done</td><td>HTML</td></tr></table>"
+        "<p>Second paragraph after the table so the message is still two blocks tall.</p>"
+    )
+
+
 def _html_research_summary(topic: str, tool_text: str) -> str:
     safe = html.escape((topic or "that query").strip()[:120] or "that query")
     snippet = html.escape((tool_text or "").strip().replace("\n", " ")[:280])
@@ -836,6 +848,8 @@ def _scenario_user_turn(
         return Completion(content=None, finish_reason="length")
     if scenario == "flood":
         return Completion(content=_html_flood(user_text), reasoning=reasoning, finish_reason="stop")
+    if scenario == "table":
+        return Completion(content=_html_table(user_text), reasoning=reasoning, finish_reason="stop")
     if scenario == "think":
         return Completion(
             content=_think_html(user_text, turn),

--- a/tests/chatbot/test_rich_text_control.py
+++ b/tests/chatbot/test_rich_text_control.py
@@ -220,6 +220,28 @@ class TestAppendTextChunk:
         assert cursor.CharWeight == CHAT_FONT_WEIGHT
         assert cursor.CharUnderline == 0
 
+    def test_insert_table_body_forces_normal_weight(self):
+        from plugin.chatbot.rich_text import CHAT_FONT_WEIGHT
+        from plugin.chatbot.rich_text_control import _insert_string_at_rich_cursor
+
+        model = MagicMock()
+        cursor = MagicMock()
+        start = MagicMock(name="start")
+        end = MagicMock(name="end")
+        cursor.getStart.side_effect = [start, end]
+        sel = MagicMock()
+        model.createTextCursor.return_value = sel
+
+        _insert_string_at_rich_cursor(
+            model, cursor, "stream\tplain", 0x1E293B, bold=False, underline=False,
+        )
+
+        model.insertString.assert_called_once_with(cursor, "stream\tplain", False)
+        assert sel.CharWeight == CHAT_FONT_WEIGHT
+        assert sel.CharUnderline == 0
+        assert cursor.CharWeight == CHAT_FONT_WEIGHT
+        assert cursor.CharUnderline == 0
+
     def test_reveal_caret_focuses_without_inserting(self):
         control = MagicMock()
         model = MagicMock(Text="hello", ReadOnly=True)

--- a/tests/scripts/test_mock_llm_server.py
+++ b/tests/scripts/test_mock_llm_server.py
@@ -508,6 +508,8 @@ def test_detect_scenario_phrases_and_force():
     assert detect_scenario("please content filter this") == "content_filter"
     assert detect_scenario("filtered reply please") == "content_filter"
     assert detect_scenario("hello", forced="flood") == "flood"
+    assert detect_scenario("show a table") == "table"
+    assert detect_scenario("send a table please") == "table"
     assert detect_scenario("hello") == ""
 
 


### PR DESCRIPTION
## Summary
- Live Writer QA: HTML tables in the rich-text sidebar painted **every** row bold+underlined, not just the first. The last master commit applied CharWeight/CharUnderline on the insert cursor; EditEngine treats those as sticky insert attributes, so body rows inherited the header run.
- Apply emphasis only to the inserted range after insert. `bold=False` / `underline=False` force that range back to normal. `None` still leaves HTML portion copy alone.
- Mock phrase `show a table` (also `send a table` / `table please`) for a deterministic table reply.

## Test plan
- [x] Unit tests for header True and body False post-apply
- [x] Live sidebar: send `show a table` with mock LLM; only `Col A / Col B` is bold+underlined; `stream / plain` and `done / HTML` are regular