### PR TITLE
Temporarily off leftover cover-all sinks after 33258921875

### DIFF
--- a/plugin/calc/excel_py_convert/to_dag.py
+++ b/plugin/calc/excel_py_convert/to_dag.py
@@ -518,6 +518,7 @@ def _normalize_bindings(
     ``excel_deps`` is parallel to ``data_args`` (original Excel tokens for export fidelity).
     Unresolved deps produce issues and an empty a1 — caller must fail-closed.
     """
+    # crosshair: off  # ResolvedDep objects still explode SMT; tiny pre is not enough (cover-all 33258921875: 255k lines). Doable later.
     issues: list[str] = []
     bindings: list[BindingInfo] = []
     index_map: dict[int, int] = {}

--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -64,6 +64,7 @@ def _describe_empty_response_content(content: Any) -> str:
     )
 )
 def _describe_empty_response_tool_calls(tool_calls: Any) -> str:
+    # crosshair: off  # dict values still Any; three-line helper. Doable later with value bounds (cover-all 33258921875: 311k lines).
     if tool_calls is None:
         return "none"
     if isinstance(tool_calls, list):

--- a/plugin/embeddings/embeddings_split.py
+++ b/plugin/embeddings/embeddings_split.py
@@ -119,6 +119,7 @@ def _sentences_spans_ok(sentences: object) -> bool:
 
     Successive starts must be ``>=`` the previous end (production splitters are sequential).
     """
+    # crosshair: off  # deal.pre predicate; covering it is circular (cover-all 33258921875: 267k lines). Doable later.
     if not isinstance(sentences, list) or len(sentences) > DEAL_MAX_SHAPE_DIM:
         return False
     prev_end: int | None = None

--- a/plugin/framework/client/auth.py
+++ b/plugin/framework/client/auth.py
@@ -152,6 +152,7 @@ def _resolve_provider_id(endpoint: str, provider_hint: Optional[str] = None) -> 
     Map an endpoint URL + optional hint to a provider id from PROVIDERS.
     Falls back to "custom" when nothing matches.
     """
+    # crosshair: off  # substring fragment-in-url; finite endpoint enum still 61k examples (pre filters, does not construct). Doable later with a constructor domain (cover-all 33258921875).
     if provider_hint:
         normalized = provider_hint.strip().lower()
         if normalized in PROVIDERS:

--- a/plugin/scripting/calc_range.py
+++ b/plugin/scripting/calc_range.py
@@ -355,93 +355,116 @@ class CalcRange:
     # Binary arithmetic
     @deal.pre(_deal_binary_op_pre)
     def __add__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.add)
 
     @deal.pre(_deal_binary_op_pre)
     def __radd__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.add, is_reverse=True)
 
     @deal.pre(_deal_binary_op_pre)
     def __sub__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.sub)
 
     @deal.pre(_deal_binary_op_pre)
     def __rsub__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.sub, is_reverse=True)
 
     @deal.pre(_deal_binary_op_pre)
     def __mul__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.mul)
 
     @deal.pre(_deal_binary_op_pre)
     def __rmul__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.mul, is_reverse=True)
 
     @deal.pre(_deal_binary_op_pre)
     def __truediv__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.truediv)
 
     @deal.pre(_deal_binary_op_pre)
     def __rtruediv__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.truediv, is_reverse=True)
 
     @deal.pre(_deal_binary_op_pre)
     def __floordiv__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.floordiv)
 
     @deal.pre(_deal_binary_op_pre)
     def __rfloordiv__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.floordiv, is_reverse=True)
 
     @deal.pre(_deal_binary_op_pre)
     def __mod__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.mod)
 
     @deal.pre(_deal_binary_op_pre)
     def __rmod__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.mod, is_reverse=True)
 
     @deal.pre(_deal_binary_op_pre)
     def __pow__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.pow)
 
     @deal.pre(_deal_binary_op_pre)
     def __rpow__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.pow, is_reverse=True)
 
     # Unary
     def __neg__(self) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._unary_op(operator.neg)
 
     def __pos__(self) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._unary_op(operator.pos)
 
     def __abs__(self) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._unary_op(operator.abs)
 
     # Rich comparisons (aligned through _binary_op: 1x1 returns bool; multi-cell returns bool ndarray)
     @deal.pre(_deal_binary_op_pre)
     def __eq__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.eq)
 
     @deal.pre(_deal_binary_op_pre)
     def __ne__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.ne)
 
     @deal.pre(_deal_binary_op_pre)
     def __lt__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.lt)
 
     @deal.pre(_deal_binary_op_pre)
     def __le__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.le)
 
     @deal.pre(_deal_binary_op_pre)
     def __gt__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.gt)
 
     @deal.pre(_deal_binary_op_pre)
     def __ge__(self, other: Any) -> Any:
+        # crosshair: off  # thin wrapper around _binary_op/_unary_op; doable later (cover-all 33258921875)
         return self._binary_op(other, operator.ge)
 
 
@@ -523,6 +546,7 @@ _deal_json_list_of_grids_arg_ok = (
 )
 def _materialize_inner_grid(inner: Any) -> list[list[Any]]:
     """Unpack split_grid / ndarray / nested lists to a rectangular ``list[list]``."""
+    # crosshair: off  # Any/numpy/split_grid combinatorics; tiny list domain later (cover-all 33258921875: 575k lines)
     from plugin.scripting.payload_codec import child_unpack_data, is_split_grid
 
     if is_split_grid(inner):

--- a/scripts/crosshair_stream.py
+++ b/scripts/crosshair_stream.py
@@ -490,6 +490,9 @@ def cover_fqns_for_module(path: Path, *, require_deal: bool = False) -> list[str
     Cover-all uses this list so hostile hosts marked off are not entry points, while
     sibling pure helpers in the same file still get covered.
 
+    Names starting with ``_deal_`` are skipped: they are contract predicates, and
+    covering the pytest-wide ``object`` variants is circular (cover-all 33258921875).
+
     A column-0 module ``# crosshair: off`` yields an empty list (same as check skipping the file).
     ``require_deal=True`` keeps only callables that have ``@deal.`` (check-all).
     """
@@ -514,6 +517,8 @@ def cover_fqns_for_module(path: Path, *, require_deal: bool = False) -> list[str
         return False
 
     def _maybe_add(qual: str, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        if node.name.startswith("_deal_"):
+            return
         segment = ast.get_source_segment(text, node)
         if segment is None or source_has_crosshair_off(segment):
             return

--- a/scripts/tests/test_crosshair_stream.py
+++ b/scripts/tests/test_crosshair_stream.py
@@ -441,6 +441,28 @@ def test_cover_fqns_skip_crosshair_off_callables(tmp_path: Path) -> None:
     assert not any(f.endswith(".Host.run") for f in fqns)
 
 
+
+def test_cover_fqns_skips_deal_predicate_helpers(tmp_path: Path) -> None:
+    from scripts.crosshair_stream import cover_fqns_for_module
+
+    mod = tmp_path / "plugin" / "deal_helpers.py"
+    mod.parent.mkdir(parents=True)
+    mod.write_text(
+        "def _deal_foo_ok_pytest(x):\n"
+        "    return True\n"
+        "\n"
+        "def _deal_foo_ok_crosshair(x):\n"
+        "    return True\n"
+        "\n"
+        "def real_product(x):\n"
+        "    return x\n",
+        encoding="utf-8",
+    )
+    fqns = cover_fqns_for_module(mod)
+    assert any(f.endswith(".real_product") for f in fqns)
+    assert not any("._deal_" in f for f in fqns)
+
+
 def test_cover_fqns_require_deal_drops_bare_helpers(tmp_path: Path) -> None:
     from scripts.crosshair_stream import cover_fqns_for_module
 


### PR DESCRIPTION
Cover-all deep [33258921875](https://github.com/KeithCu/writeragent/actions/runs/33258921875) on `616c9aea` hit the 6h wall at **27/56**, 0 fails. json_utils is actually done (46m → 49s). These leftover FQNs are bounded in principle; covering them today is combinatorics.

Off with **doable later** comments (not unbounded-by-design):

| FQN | Why |
|---|---|
| CalcRange operator dunders (`__add__` / `__eq__` / …) | one-line wrappers; keep `_binary_op` / `_unary_op` covered |
| `_materialize_inner_grid` | Any/numpy/split_grid; 575k lines; tiny list domain later |
| `_describe_empty_response_tool_calls` | 3-line helper; dict values still Any; 311k lines |
| `_sentences_spans_ok` | deal.pre predicate; covering it is circular; 267k lines |
| `_normalize_bindings` | tiny pre already; `ResolvedDep` still explodes; 255k lines |
| `_resolve_provider_id` | substring `fragment in url`; finite enum still 61k examples |

Also skip `_deal_*` names in `cover_fqns_for_module` (pytest-wide `object` helpers are circular).

Start-at **28** still skips modules 1–27 for this next run. These offs are so the next from-1 does not lose another 2h on calc_range. Do not stack a cover-all from here.