### PR TITLE
Align sidebar tables with max-width tab stops

### DIFF
--- a/plugin/chatbot/rich_text_paste.py
+++ b/plugin/chatbot/rich_text_paste.py
@@ -20,7 +20,8 @@ into the control (preferred), then transferable / SystemClipboard / Ctrl+V fallb
 
 The direct-copy path walks Writer body enumeration (paragraphs and TextTables) and inserts
 via insertString on the form TextField model. RichTextControl is EditEngine — no table grid —
-so TextTables are flattened to tab-separated rows. EditEngine paste does not preserve Writer
+so TextTables are flattened to tab-separated rows with ParaTabStops at the max
+column width (EditEngine has no table grid). EditEngine paste does not preserve Writer
 NumberingRules, so list bullets and ordered numbers are reconstructed manually — see
 _list_prefix_for_paragraph.
 """
@@ -107,11 +108,11 @@ def _is_writer_text_table(element) -> bool:
         return False
 
 
-def _flatten_text_table_rows(table) -> list[str]:
-    """Cell strings as tab-separated rows. EditEngine cannot host a Writer table."""
+def _text_table_cell_rows(table) -> list[list[str]]:
+    """Cell strings for a Writer TextTable, row-major."""
     n_rows = int(table.getRows().getCount())
     n_cols = int(table.getColumns().getCount())
-    rows: list[str] = []
+    rows: list[list[str]] = []
     for row_idx in range(n_rows):
         cells: list[str] = []
         for col_idx in range(n_cols):
@@ -119,8 +120,65 @@ def _flatten_text_table_rows(table) -> list[str]:
                 cells.append(table.getCellByPosition(col_idx, row_idx).getString() or "")
             except Exception:
                 cells.append("")
-        rows.append("\t".join(cells))
+        rows.append(cells)
     return rows
+
+
+def _flatten_text_table_rows(table) -> list[str]:
+    """Cell strings as tab-separated rows. EditEngine cannot host a Writer table."""
+    return ["\t".join(row) for row in _text_table_cell_rows(table)]
+
+
+# Tab stops are 1/100 mm from the paragraph left. Liberation Sans ~0.6em, plus a
+# 2-character gap, so a body cell longer than the header cannot overrun the next stop.
+_TAB_CHAR_EM = 0.6
+_TAB_GAP_CHARS = 2
+_MM100_PER_PT = 35.28
+
+
+def _max_column_chars(rows: list[list[str]]) -> list[int]:
+    n_cols = max((len(row) for row in rows), default=0)
+    widths = [0] * n_cols
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell or ""))
+    return widths
+
+
+def _column_width_mm100(max_chars: int) -> int:
+    n = max(0, int(max_chars)) + _TAB_GAP_CHARS
+    return max(1, int(round(n * CHAT_FONT_HEIGHT * _MM100_PER_PT * _TAB_CHAR_EM)))
+
+
+def _tab_stop_positions_mm100(max_chars: list[int]) -> tuple[int, ...]:
+    """Stop after each column except the last (the last column has no following tab)."""
+    if len(max_chars) < 2:
+        return ()
+    acc = 0
+    stops: list[int] = []
+    for width in max_chars[:-1]:
+        acc += _column_width_mm100(width)
+        stops.append(acc)
+    return tuple(stops)
+
+
+def _apply_table_tab_stops(cursor, positions_mm100) -> None:
+    if cursor is None or not positions_mm100:
+        return
+    try:
+        import uno
+
+        stops = []
+        for pos in positions_mm100:
+            ts = uno.createUnoStruct("com.sun.star.style.TabStop")
+            ts.Position = int(pos)
+            ts.Alignment = 0  # com.sun.star.style.TabAlign.LEFT
+            ts.DecimalChar = "."
+            ts.FillChar = " "
+            stops.append(ts)
+        cursor.ParaTabStops = tuple(stops)
+    except Exception as e:
+        log.debug("_apply_table_tab_stops failed: %s", e)
 
 
 def _role_color_for_text(text: str, user_color: int, assistant_color: int, default_role: str = "assistant") -> int:
@@ -368,13 +426,16 @@ def _copy_formatted_from_hidden_doc_to_control(
                     if _is_writer_text_table(para):
                         # HTML import creates a real TextTable; portion enum throws and used
                         # to abort the whole copy (truncate-then-fail blanked the stream tail).
-                        for i, row_text in enumerate(_flatten_text_table_rows(para)):
+                        cell_rows = _text_table_cell_rows(para)
+                        tab_stops = _tab_stop_positions_mm100(_max_column_chars(cell_rows))
+                        for i, cells in enumerate(cell_rows):
                             if i:
                                 _insert_string_at_rich_cursor(
                                     model, dest_cursor, "\n", bold=False, underline=False,
                                 )
                                 dest_cursor.gotoEnd(False)
                                 _apply_sidebar_para_margins(dest_cursor)
+                            _apply_table_tab_stops(dest_cursor, tab_stops)
                             # First row stands in for <th>: no grid, so bold+underline.
                             # Body rows pass False so the inserted range is forced normal
                             # (EditEngine otherwise keeps the header run's attributes).
@@ -382,7 +443,7 @@ def _copy_formatted_from_hidden_doc_to_control(
                             _insert_string_at_rich_cursor(
                                 model,
                                 dest_cursor,
-                                row_text,
+                                "\t".join(cells),
                                 default_color,
                                 bold=is_header,
                                 underline=is_header,

--- a/plugin/chatbot/rich_text_paste.py
+++ b/plugin/chatbot/rich_text_paste.py
@@ -129,11 +129,13 @@ def _flatten_text_table_rows(table) -> list[str]:
     return ["\t".join(row) for row in _text_table_cell_rows(table)]
 
 
-# Tab stops are 1/100 mm from the paragraph left. Liberation Sans ~0.6em, plus a
-# 2-character gap, so a body cell longer than the header cannot overrun the next stop.
-_TAB_CHAR_EM = 0.6
-_TAB_GAP_CHARS = 2
-_MM100_PER_PT = 35.28
+# RichTextControl is EditEngine: ParaTabStops Position is twips (1/20 pt), not
+# Writer's 1/100 mm (EE_PARA_TABS has no CONVERT_TWIPS). 0.5em tracks Liberation
+# Sans; a fixed 8pt slack covers a short wide word (Bananas is ~0.56em) so the
+# tab does not jump, without padding a long Description column by a quarter inch.
+_TAB_CHAR_EM = 0.5
+_TAB_SLACK_PT = 8.0
+_TWIPS_PER_PT = 20
 
 
 def _max_column_chars(rows: list[list[str]]) -> list[int]:
@@ -145,31 +147,47 @@ def _max_column_chars(rows: list[list[str]]) -> list[int]:
     return widths
 
 
-def _column_width_mm100(max_chars: int) -> int:
-    n = max(0, int(max_chars)) + _TAB_GAP_CHARS
-    return max(1, int(round(n * CHAT_FONT_HEIGHT * _MM100_PER_PT * _TAB_CHAR_EM)))
+def _column_width_twips(max_chars: int) -> int:
+    content_pt = max(0, int(max_chars)) * CHAT_FONT_HEIGHT * _TAB_CHAR_EM
+    return max(1, int(round((content_pt + _TAB_SLACK_PT) * _TWIPS_PER_PT)))
 
 
-def _tab_stop_positions_mm100(max_chars: list[int]) -> tuple[int, ...]:
-    """Stop after each column except the last (the last column has no following tab)."""
+def _tab_stop_positions_twips(max_chars: list[int]) -> tuple[int, ...]:
+    """Stop after each column except the last, in twips (EditEngine ParaTabStops)."""
     if len(max_chars) < 2:
         return ()
     acc = 0
     stops: list[int] = []
     for width in max_chars[:-1]:
-        acc += _column_width_mm100(width)
+        acc += _column_width_twips(width)
         stops.append(acc)
     return tuple(stops)
 
 
-def _apply_table_tab_stops(cursor, positions_mm100) -> None:
-    if cursor is None or not positions_mm100:
+# Tiny bump above the first table row and below the last. Same 1/100 mm unit as
+# CHAT_PARA_SIDE_MARGIN (EditEngine para margins are METRIC_ITEM). Body rows
+# force 0 so a newline does not inherit the first-row top pad.
+_TABLE_V_PAD_MM100 = 150
+
+
+def _apply_table_row_vpad(cursor, *, top: int = 0, bottom: int = 0) -> None:
+    if cursor is None:
+        return
+    try:
+        cursor.ParaTopMargin = int(top)
+        cursor.ParaBottomMargin = int(bottom)
+    except Exception as e:
+        log.debug("_apply_table_row_vpad failed: %s", e)
+
+
+def _apply_table_tab_stops(cursor, positions_twips) -> None:
+    if cursor is None or not positions_twips:
         return
     try:
         import uno
 
         stops = []
-        for pos in positions_mm100:
+        for pos in positions_twips:
             ts = uno.createUnoStruct("com.sun.star.style.TabStop")
             ts.Position = int(pos)
             ts.Alignment = 0  # com.sun.star.style.TabAlign.LEFT
@@ -427,7 +445,7 @@ def _copy_formatted_from_hidden_doc_to_control(
                         # HTML import creates a real TextTable; portion enum throws and used
                         # to abort the whole copy (truncate-then-fail blanked the stream tail).
                         cell_rows = _text_table_cell_rows(para)
-                        tab_stops = _tab_stop_positions_mm100(_max_column_chars(cell_rows))
+                        tab_stops = _tab_stop_positions_twips(_max_column_chars(cell_rows))
                         for i, cells in enumerate(cell_rows):
                             if i:
                                 _insert_string_at_rich_cursor(
@@ -436,6 +454,12 @@ def _copy_formatted_from_hidden_doc_to_control(
                                 dest_cursor.gotoEnd(False)
                                 _apply_sidebar_para_margins(dest_cursor)
                             _apply_table_tab_stops(dest_cursor, tab_stops)
+                            last = i == len(cell_rows) - 1
+                            _apply_table_row_vpad(
+                                dest_cursor,
+                                top=_TABLE_V_PAD_MM100 if i == 0 else 0,
+                                bottom=_TABLE_V_PAD_MM100 if last else 0,
+                            )
                             # First row stands in for <th>: no grid, so bold+underline.
                             # Body rows pass False so the inserted range is forced normal
                             # (EditEngine otherwise keeps the header run's attributes).

--- a/tests/chatbot/test_rich_text_paste.py
+++ b/tests/chatbot/test_rich_text_paste.py
@@ -17,11 +17,14 @@ setup_uno_mocks()
 
 from plugin.chatbot.rich_text_control import HISTORY_RENDER_BATCH_CHARS
 from plugin.chatbot.rich_text_paste import (
+    _column_width_mm100,
     _copy_formatted_from_hidden_doc_to_control,
     _flatten_text_table_rows,
     _is_writer_text_table,
     _list_prefix_for_paragraph,
+    _max_column_chars,
     _resolve_portion_char_color,
+    _tab_stop_positions_mm100,
     append_rich_messages_via_clipboard,
     append_rich_text_via_clipboard,
     build_message_html,
@@ -385,6 +388,24 @@ class TestFlattenTextTableCopy:
         table = _body_table([["a", "b"], ["c", "d"]])
         assert _flatten_text_table_rows(table) == ["a\tb", "c\td"]
 
+    def test_tab_stops_use_max_column_width_not_header(self):
+        rows = [
+            ["Item", "Description", "Quantity"],
+            ["Apples", "Fresh red apples", "12"],
+            ["Bananas", "Ripe yellow bananas", "8"],
+            ["Oranges", "Juicy orange citrus", "15"],
+        ]
+        max_chars = _max_column_chars(rows)
+        assert max_chars == [7, 19, 8]  # Bananas, Ripe yellow bananas, Quantity
+        stops = _tab_stop_positions_mm100(max_chars)
+        assert stops == (
+            _column_width_mm100(7),
+            _column_width_mm100(7) + _column_width_mm100(19),
+        )
+        # Header-only widths would overrun column 1 (Item=4 < Bananas=7).
+        header_only = _tab_stop_positions_mm100([4, 11, 8])
+        assert header_only[0] < stops[0]
+
     def test_copy_flattens_table_between_paragraphs(self):
         control = MagicMock()
         model = MagicMock()
@@ -427,6 +448,42 @@ class TestFlattenTextTableCopy:
         assert ("stream\tplain", False, False) in header_flags
         assert ("before", False, False) in header_flags
         assert ("after", False, False) in header_flags
+
+    def test_copy_applies_tab_stops_from_max_width(self):
+        control = MagicMock()
+        model = MagicMock()
+        dest_cursor = MagicMock()
+        model.createTextCursor.return_value = dest_cursor
+        control.getModel.return_value = model
+        src_doc = MagicMock()
+        cells = [
+            ["Item", "Description", "Quantity"],
+            ["Bananas", "Ripe yellow bananas", "8"],
+        ]
+        src_doc.getText.return_value.createEnumeration.return_value = _uno_enum(
+            [_body_table(cells)]
+        )
+        theme = MagicMock(user_color=1, assistant_color=2)
+        applied: list[tuple[int, ...]] = []
+
+        with patch("plugin.chatbot.rich_text_paste.focus_preserved", _immediate_focus), \
+             patch("plugin.chatbot.rich_text_paste.ChatTheme.resolve", return_value=theme), \
+             patch("plugin.chatbot.rich_text_paste._rich_control_bg_color", return_value=0), \
+             patch("plugin.chatbot.rich_text_paste.get_control_text_length", return_value=1), \
+             patch("plugin.chatbot.rich_text_paste._apply_sidebar_para_margins"), \
+             patch("plugin.chatbot.rich_text_paste._scroll_rich_to_tail"), \
+             patch("plugin.chatbot.rich_text_paste._insert_string_at_rich_cursor"), \
+             patch(
+                 "plugin.chatbot.rich_text_paste._apply_table_tab_stops",
+                 side_effect=lambda _cursor, positions: applied.append(tuple(positions)),
+             ):
+            ok, reason = _copy_formatted_from_hidden_doc_to_control(
+                src_doc, control, MagicMock(), role="assistant", auto_scroll=False,
+            )
+
+        assert ok is True, reason
+        expected = _tab_stop_positions_mm100(_max_column_chars(cells))
+        assert applied == [expected, expected]
 
     def test_copy_ok_when_table_portion_enum_would_throw(self):
         control = MagicMock()

--- a/tests/chatbot/test_rich_text_paste.py
+++ b/tests/chatbot/test_rich_text_paste.py
@@ -17,14 +17,15 @@ setup_uno_mocks()
 
 from plugin.chatbot.rich_text_control import HISTORY_RENDER_BATCH_CHARS
 from plugin.chatbot.rich_text_paste import (
-    _column_width_mm100,
+    _column_width_twips,
     _copy_formatted_from_hidden_doc_to_control,
     _flatten_text_table_rows,
     _is_writer_text_table,
     _list_prefix_for_paragraph,
     _max_column_chars,
     _resolve_portion_char_color,
-    _tab_stop_positions_mm100,
+    _TABLE_V_PAD_MM100,
+    _tab_stop_positions_twips,
     append_rich_messages_via_clipboard,
     append_rich_text_via_clipboard,
     build_message_html,
@@ -397,13 +398,13 @@ class TestFlattenTextTableCopy:
         ]
         max_chars = _max_column_chars(rows)
         assert max_chars == [7, 19, 8]  # Bananas, Ripe yellow bananas, Quantity
-        stops = _tab_stop_positions_mm100(max_chars)
+        stops = _tab_stop_positions_twips(max_chars)
         assert stops == (
-            _column_width_mm100(7),
-            _column_width_mm100(7) + _column_width_mm100(19),
+            _column_width_twips(7),
+            _column_width_twips(7) + _column_width_twips(19),
         )
         # Header-only widths would overrun column 1 (Item=4 < Bananas=7).
-        header_only = _tab_stop_positions_mm100([4, 11, 8])
+        header_only = _tab_stop_positions_twips([4, 11, 8])
         assert header_only[0] < stops[0]
 
     def test_copy_flattens_table_between_paragraphs(self):
@@ -482,8 +483,49 @@ class TestFlattenTextTableCopy:
             )
 
         assert ok is True, reason
-        expected = _tab_stop_positions_mm100(_max_column_chars(cells))
+        expected = _tab_stop_positions_twips(_max_column_chars(cells))
         assert applied == [expected, expected]
+
+    def test_copy_applies_vertical_pad_on_first_and_last_row(self):
+        control = MagicMock()
+        model = MagicMock()
+        dest_cursor = MagicMock()
+        model.createTextCursor.return_value = dest_cursor
+        control.getModel.return_value = model
+        src_doc = MagicMock()
+        cells = [
+            ["Item", "Description"],
+            ["Apples", "Fresh red apples"],
+            ["Bananas", "Ripe yellow bananas"],
+        ]
+        src_doc.getText.return_value.createEnumeration.return_value = _uno_enum(
+            [_body_table(cells)]
+        )
+        theme = MagicMock(user_color=1, assistant_color=2)
+        pads: list[tuple[int, int]] = []
+
+        def _capture_vpad(cursor, *, top=0, bottom=0):
+            pads.append((top, bottom))
+
+        with patch("plugin.chatbot.rich_text_paste.focus_preserved", _immediate_focus), \
+             patch("plugin.chatbot.rich_text_paste.ChatTheme.resolve", return_value=theme), \
+             patch("plugin.chatbot.rich_text_paste._rich_control_bg_color", return_value=0), \
+             patch("plugin.chatbot.rich_text_paste.get_control_text_length", return_value=1), \
+             patch("plugin.chatbot.rich_text_paste._apply_sidebar_para_margins"), \
+             patch("plugin.chatbot.rich_text_paste._scroll_rich_to_tail"), \
+             patch("plugin.chatbot.rich_text_paste._insert_string_at_rich_cursor"), \
+             patch("plugin.chatbot.rich_text_paste._apply_table_tab_stops"), \
+             patch(
+                 "plugin.chatbot.rich_text_paste._apply_table_row_vpad",
+                 side_effect=_capture_vpad,
+             ):
+            ok, reason = _copy_formatted_from_hidden_doc_to_control(
+                src_doc, control, MagicMock(), role="assistant", auto_scroll=False,
+            )
+
+        assert ok is True, reason
+        pad = _TABLE_V_PAD_MM100
+        assert pads == [(pad, 0), (0, 0), (0, pad)]
 
     def test_copy_ok_when_table_portion_enum_would_throw(self):
         control = MagicMock()


### PR DESCRIPTION
## Summary
- Flattened HTML tables in the rich-text sidebar still use tabs (EditEngine has no grid).
- ParaTabStops on RichTextControl are twips, not Writer's 1/100 mm (EE_PARA_TABS has no CONVERT_TWIPS). Column width is 0.5em of the widest cell plus 8pt of fixed slack, so a short wide word like Bananas does not skip a stop and a long Description column is not padded by a quarter inch.
- Tiny 1.5mm pad above the first row and below the last (body rows stay tight).
- Mock "show a table" now returns the produce inventory table for live QA.

## Test plan
- [x] Unit tests: max chars is Bananas/Ripe yellow bananas/Quantity; first/last row get vertical pad, middle rows do not
- [x] Live sidebar at ~500px docked: show a table — header bold+underline, columns aligned, ~8px air above/below the table
- [ ] Try on a 4K docked sidebar (this PR)