### PR TITLE
Temporarily off cover-all sinks after 33293627157

### DIFF
--- a/plugin/scripting/editor_ipc.py
+++ b/plugin/scripting/editor_ipc.py
@@ -104,6 +104,7 @@ _deal_ipc_dict_ok = _deal_ipc_dict_ok_crosshair if UNDER_CROSSHAIR else _deal_ip
 @deal.pre(lambda target: target is None or _deal_ipc_dict_ok(target))
 def normalize_target(target: Mapping[str, Any] | None) -> dict[str, str]:
     """Keep only string identity fields; drop empty values and UNO objects."""
+    # crosshair: off  # nested IPC dict domain still combinatoric despite _deal_ipc_dict_ok (cover-all 33293627157: ~7m, 113k lines). Doable later with a constructor domain.
     if not target:
         return {}
     out: dict[str, str] = {}
@@ -120,6 +121,7 @@ def normalize_target(target: Mapping[str, Any] | None) -> dict[str, str]:
 @deal.pre(lambda msg: _deal_ipc_dict_ok(msg))
 def target_from_load(msg: Mapping[str, Any]) -> dict[str, str]:
     """Build ``target`` from an explicit dict plus top-level load aliases."""
+    # crosshair: off  # nested IPC dict + alias merges (cover-all 33293627157: ~9m, 148k lines). Doable later with a constructor domain.
     raw = msg.get("target")
     target = normalize_target(raw if isinstance(raw, Mapping) else None)
     aliases = (
@@ -148,6 +150,7 @@ def target_from_load(msg: Mapping[str, Any]) -> dict[str, str]:
 )
 def target_identity_key(mode: str, target: Mapping[str, str] | None) -> tuple[str, str, str, str, str]:
     """Stable key so reopening the same cell/script reuses ``session_id``."""
+    # crosshair: off  # nested IPC dict domain (cover-all 33293627157: ~9m, 159k lines). Doable later; thin wrapper over normalize_target.
     t = normalize_target(target)
     return (
         str(mode or ""),
@@ -177,6 +180,7 @@ def stamp_session(
     target: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Copy *msg* and attach ``session_id``, ``mode``, and ``target`` (always)."""
+    # crosshair: off  # nested IPC dict copy/merge (cover-all 33293627157: ~11m, 157k lines). Doable later with a constructor domain.
     out = dict(msg)
     out["session_id"] = str(session_id or "")
     use_mode = str(mode or out.get("mode") or "")
@@ -203,6 +207,7 @@ _deal_exc_ok = _deal_exc_ok_crosshair if UNDER_CROSSHAIR else _deal_exc_ok_pytes
 @deal.pre(lambda exc: _deal_exc_ok(exc))
 def exception_traceback(exc: BaseException) -> str:
     """Full traceback string for *exc*."""
+    # crosshair: off  # BaseException/traceback formatting; CrossHair pre forces exc is None so covering is circular (cover-all 33293627157: ~11m, 92k lines). Doable later.
     return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
 
@@ -213,6 +218,7 @@ def exception_traceback(exc: BaseException) -> str:
 @deal.post(lambda result: isinstance(result, str))
 def failure_detail(*, detail: str | None = None, exc: BaseException | None = None) -> str:
     """Combine subprocess stderr, probe output, and/or an exception traceback."""
+    # crosshair: off  # detail/traceback join still slow with bounds (cover-all 33293627157: ~4m, 61k lines). Doable later.
     chunks: list[str] = []
     detail_text = (detail or "").strip()
     if detail_text:
@@ -230,6 +236,7 @@ def failure_detail(*, detail: str | None = None, exc: BaseException | None = Non
 @deal.post(lambda result: isinstance(result, str))
 def failure_message(summary: str, *, detail: str | None = None, exc: BaseException | None = None) -> str:
     """Build a msgbox body: *summary* plus optional detail/traceback blocks."""
+    # crosshair: off  # thin wrapper over failure_detail (cover-all 33293627157: ~2m, 40k lines). Doable later.
     body = failure_detail(detail=detail, exc=exc)
     if body:
         return f"{summary}\n\n{body}"

--- a/plugin/scripting/sandbox.py
+++ b/plugin/scripting/sandbox.py
@@ -313,6 +313,7 @@ def _reset_cache() -> None:  # pyright: ignore[reportUnusedFunction]  # test hel
 # --- Interpreter resolution ---
 
 
+@deal.pre(lambda path: str_bounded(path, DEAL_MAX_PATH))
 def _strip_surrounding_quotes(path: str) -> str:
     """Strip one layer of matching quotes (Windows Explorer \"Copy as path\")."""
     s = path.strip()
@@ -323,6 +324,7 @@ def _strip_surrounding_quotes(path: str) -> str:
 
 def _path_from_file_url(raw: str) -> str | None:
     """Convert a ``file://`` / ``file:/`` URL to a filesystem path (stdlib only)."""
+    # crosshair: off  # urlparse/unquote/url2pathname combinatorics on free strings (cover-all 33293627157: ~2.0h, 190k lines / 108k examples). Doable later with a tiny file-URL alphabet.
     from urllib.parse import unquote, urlparse
     from urllib.request import url2pathname
 
@@ -345,6 +347,7 @@ def _path_from_file_url(raw: str) -> str | None:
 
 def _normalize_venv_path_input(venv_dir: str) -> str:
     """Strip quotes, convert file URLs, then expand ``~`` and env vars."""
+    # crosshair: off  # expandvars/file-URL path still combinatoric as an entry (cover-all 33293627157: ~4.5m, 139k lines). Doable later with DEAL_MAX_PATH + opaque URL helper.
     cleaned = _strip_surrounding_quotes(venv_dir.strip())
     if cleaned.lower().startswith("file:"):
         from_url = _path_from_file_url(cleaned)
@@ -497,4 +500,3 @@ def is_safe_workspace_path(target_path: str, root_dir: str) -> bool:
         return os.path.commonpath([abs_target, abs_root]) == abs_root
     except Exception:
         return False
-


### PR DESCRIPTION
Cover-all deep [33293627157](https://github.com/KeithCu/writeragent/actions/runs/33293627157) on `73f50845` (PR 512, start-at 28) hit the 6h wall at **3/29** in the remaining slice (duckdb_sql → editor_ipc → sandbox). 0 COVER FAILs. formula_edit / cors / payload_codec never started.

## Wall spend

| Module | Time | Notes |
|---|---|---|
| `duckdb_sql.py` | 1.0m | fine |
| `editor_ipc.py` | 54.2m | nested IPC dicts + traceback helpers |
| `sandbox.py` | 130.6m | almost all `_path_from_file_url` (~2.0h, 108k examples) |

## Changes (same style as PR 512)

**Off with doable-later comments** (bounded in principle; combinatoric today):

| FQN | Why |
|---|---|
| `sandbox._path_from_file_url` | urlparse/unquote/url2pathname on free strings (~2.0h) |
| `sandbox._normalize_venv_path_input` | expandvars + file-URL path as entry (~4.5m) |
| `editor_ipc.normalize_target` / `target_from_load` / `target_identity_key` / `stamp_session` | nested IPC dict domain despite `_deal_ipc_dict_ok` (~7–11m each) |
| `editor_ipc.exception_traceback` | BaseException/traceback; CrossHair pre forces `exc is None` (circular, ~11m) |
| `editor_ipc.failure_detail` / `failure_message` | still slow with bounds (~4m / ~2m) |

**Easy deal.pre** (closed unbounded str):

| FQN | Change |
|---|---|
| `sandbox._strip_surrounding_quotes` | `@deal.pre(str_bounded(..., DEAL_MAX_PATH))` |

Left covered: scrub_subprocess_env, wrap_command_for_sandbox, python basename/candidates helpers, is_safe_workspace_path, message_type, new_session_id, session_id_of, duckdb templates.

Do not stack a cover-all from here — pull when ready and pick start-at yourself.