### PR TITLE
Temporarily off formula_edit cover-all sinks after 33314946731

### DIFF
--- a/plugin/calc/python/formula_edit.py
+++ b/plugin/calc/python/formula_edit.py
@@ -395,8 +395,11 @@ def sanitize_inline_py_code(code: str) -> str:
     return sanitized
 
 
+@deal.pre(lambda code: str_bounded(code, DEAL_MAX_SOURCE + 256))
+@deal.post(lambda result: isinstance(result, list) and all(isinstance(x, str) for x in result))
 def inline_py_code_has_lexer_collisions(code: str) -> list[str]:
     """Return token names still present that ``sanitize_inline_py_code`` would rewrite."""
+    # crosshair: off  # four regex searches on free strings (cover-all 33314946731: ~5.3h, 500k lines). Same rewrite-regex class as sanitize. Doable later with a tiny token alphabet.
     hits: list[str] = []
     if _LEXER_COLLISION_FLOAT_RE.search(code):
         hits.append("float")
@@ -650,6 +653,7 @@ def py_code_arg_is_cell_ref(code: str) -> bool:
     ``=PY($A$1; data)`` / ``=PY(Sheet.A1)`` store source in that cell. Ranges
     (``A1:B10``) and unquoted Python (``sp.prime(100)``) return False.
     """
+    # crosshair: off  # parse_address/split_sheet_prefix on free strings (cover-all 33314946731: ~14m, 22k lines). Doable later with the closed A1/_deal_range_addr_ok domain.
     if type(code) is not str:
         return False
     s = code.strip()


### PR DESCRIPTION
Cover-all deep [33314946731](https://github.com/KeithCu/writeragent/actions/runs/33314946731) on `3434e124` (PR 514, start-at 31) hit the 6h wall at **4/26** in the remaining slice (sandbox → mcp_state → formula_edit → send_state). 0 COVER FAILs.

## Wall spend

| Module | Time | Notes |
|---|---|---|
| `sandbox.py` | 59.9m | leftover after PR 514 offs (`_strip_surrounding_quotes` still the fattest) |
| `mcp_state.py` | 0.0s | all callables off |
| `formula_edit.py` | 5.63h | almost all `inline_py_code_has_lexer_collisions` |
| `send_state.py` | 1.1s | finished; wall killed immediately after |

## Changes (same style as PR 512/514)

**Off with doable-later comments** (bounded in principle; combinatoric today):

| FQN | Why |
|---|---|
| `formula_edit.inline_py_code_has_lexer_collisions` | four regex searches on free strings (~5.3h, 500k lines). Same rewrite-regex class as `sanitize_inline_py_code`. Doable later with a tiny token alphabet. Kept `@deal.pre`/`@deal.post` for pytest. |
| `formula_edit.py_code_arg_is_cell_ref` | `parse_address` / `split_sheet_prefix` on free strings (~14m, 22k lines). Doable later with the closed A1 / `_deal_range_addr_ok` domain. |

Left covered: formula parsers/formatters with existing `str_bounded` / `_deal_range_addr_ok` pres, sandbox leftovers, send_state.

Do not stack a cover-all from here — pull when ready and pick start-at yourself.
