### PR TITLE
Temporarily off leftover cover-all sinks after 33337516899

### DIFF
--- a/plugin/calc/sheet_filter_criteria.py
+++ b/plugin/calc/sheet_filter_criteria.py
@@ -46,6 +46,7 @@ _NAME_TO_CODE: dict[str, int] = {name: idx for idx, name in enumerate(_FILTER_OP
 FILTER_OPERATOR2_LABELS: tuple[str, ...] = _FILTER_OPERATOR2_CODE_NAMES
 
 
+@deal.pre(lambda code: isinstance(code, int) and -8 <= code < 32)
 def filter_operator2_code_to_name(code: int) -> str:
     """Map UNO ``FilterOperator2`` *code* (long) to a stable string label."""
     if 0 <= code < len(_FILTER_OPERATOR2_CODE_NAMES):
@@ -53,6 +54,7 @@ def filter_operator2_code_to_name(code: int) -> str:
     return str(int(code))
 
 
+@deal.pre(lambda name: isinstance(name, str) and ascii_bounded(name, DEAL_MAX_TOKEN))
 def filter_operator2_name_to_code(name: str) -> int | None:
     """Resolve case-insensitive operator name to code, or ``None`` if unknown."""
     key = name.strip().upper().replace("-", "_")
@@ -110,6 +112,7 @@ def parse_sheet_filter_criterion(raw: dict[str, Any], is_first: bool) -> tuple[i
     Later rows: missing ``connection`` defaults to AND; ``OR`` links this row to the
     previous condition only (linear chain — not arbitrary parentheses).
     """
+    # crosshair: off  # nested dict Any (field/value) still combinatoric (cover-all 33337516899: 86k lines, 1559 examples). Doable later with a closed criterion schema.
     if "field" not in raw:
         raise UnoObjectError("Each criterion needs 'field' (0-based column index within range).")
     try:

--- a/plugin/scripting/audio_silence_detector.py
+++ b/plugin/scripting/audio_silence_detector.py
@@ -113,6 +113,7 @@ class SilenceDetector:
         return self._silence_ms
 
     def process_chunk(self, pcm: bytes, *, frame_count: int) -> SilenceDetectorResult:
+        # crosshair: off  # stateful RMS/float SMT wrapping already-off pcm_energy_int16 (cover-all 33337516899: 52k lines, 3205 examples). Doable later with a tiny PCM/frame domain.
         if not self._config.enabled:
             return SilenceDetectorResult(
                 rms=0.0, peak=0.0, is_speech=False, silence_ms=0, speech_ms=0, should_stop=False, heard_speech=False

--- a/plugin/writer/word_diff_split.py
+++ b/plugin/writer/word_diff_split.py
@@ -98,10 +98,12 @@ class Token:
         self.is_word = is_word
 
     def __repr__(self):
+        # crosshair: off  # format of free Token.text/offsets (cover-all 33337516899: 8.5k lines). Doable later with a tiny Token domain.
         kind = "W" if self.is_word else "S"
         return "Token(%s %r @%d:%d)" % (kind, self.text, self.start, self.end)
 
     def __eq__(self, other):
+        # crosshair: off  # fieldwise == on free Token (cover-all 33337516899: 154k lines, 6.6k examples). Same combinatoric dunder class as calc_range. Doable later with a tiny Token domain.
         return (
             isinstance(other, Token)
             and self.text == other.text
@@ -137,11 +139,13 @@ class SubEdit:
         self.new_text = new_text
 
     def __repr__(self):
+        # crosshair: off  # format of free SubEdit strings/offsets (cover-all 33337516899: 9.6k lines). Doable later with a tiny SubEdit domain.
         return "SubEdit(%s old[%d:%d]=%r -> %r)" % (
             self.op, self.old_start, self.old_end, self.old_text, self.new_text,
         )
 
     def __eq__(self, other):
+        # crosshair: off  # fieldwise == on free SubEdit (cover-all 33337516899: 281k lines, 12k examples). Doable later with a tiny SubEdit domain.
         return (
             isinstance(other, SubEdit)
             and self.op == other.op
@@ -175,13 +179,16 @@ class SplitResult:
 
     @property
     def is_block(self):
+        # crosshair: off  # symbolic mode str (cover-all 33337516899: 23k lines, 1493 examples). Doable later with closed {block,surgical} alphabet.
         return self.mode == "block"
 
     @property
     def is_surgical(self):
+        # crosshair: off  # symbolic mode str (cover-all 33337516899: 23k lines, 1493 examples). Doable later with closed {block,surgical} alphabet.
         return self.mode == "surgical"
 
     def __repr__(self):
+        # crosshair: off  # format of symbolic mode/frac/list (cover-all 33337516899: 6.9k lines). Doable later with a tiny SplitResult domain.
         return "SplitResult(mode=%s frac=%.4f, %d sub-edit(s))" % (
             self.mode, self.fraction_changed, len(self.sub_edits),
         )
@@ -327,6 +334,7 @@ def _build_surgical_edits(old, new, old_words, new_words, opcodes):
 
     Returns sub-edits sorted by ``old_start`` (non-overlapping by construction).
     """
+    # crosshair: off  # opcodes + Token lists combinatorics (cover-all 33337516899: 24k lines). split_change already off; doable later with a tiny token/opcode alphabet.
     # Pair up matched words: list of (old_word_index, new_word_index) for every equal
     # word, in order. These are the anchors.
     anchors = []
@@ -359,6 +367,7 @@ def _build_surgical_edits(old, new, old_words, new_words, opcodes):
 
 def _emit_segment(out, old, new, old_lo, old_hi, new_lo, new_hi):
     """Append a (possibly trimmed) :class:`SubEdit` for one segment, if it changed."""
+    # crosshair: off  # isspace-trim loops on free strings (cover-all 33337516899: 12.7k lines). Same class as tokenize (already off). Doable later with a tiny string domain.
     old_seg = old[old_lo:old_hi]
     new_seg = new[new_lo:new_hi]
     if old_seg == new_seg:
@@ -401,6 +410,7 @@ def apply_sub_edits(old, sub_edits):
     :func:`split_change` emits them). This mirrors what the LO integration will do --
     splice each surgical span -- and is the property used by the reconstruction tests.
     """
+    # crosshair: off  # SubEdit list + free old string splice (cover-all 33337516899: 44k lines). Doable later with a tiny edit list domain.
     out = []
     cursor = 0
     for e in sorted(sub_edits, key=lambda x: (x.old_start, x.old_end)):


### PR DESCRIPTION
## Summary

Cover-all deep [33337516899](https://github.com/KeithCu/writeragent/actions/runs/33337516899) (`2260f704`, PR 516) **wall-cancelled at 360 minutes**. Remaining slice was 22 files starting at `send_state`. Cover-all prints completion-order `[n/22]` and buffers per module, so only finished files landed in the artifact.

**Completed (0 COVER FAILs / 0 engine crashes):**
| module | wall | dominant FQNs |
|---|---|---|
| `plugin/chatbot/send_state.py` | 1.2s | `_get_send_label` (fine) |
| `plugin/scripting/audio_silence_detector.py` | 1152s (~19m) | `SilenceDetector.process_chunk` 52k lines / 3205 examples |
| `plugin/calc/sheet_filter_criteria.py` | 3289s (~55m) | `filter_operator2_code_to_name` 228k / 18k examples (unbounded int); `parse_sheet_filter_criterion` 86k / 1559 examples (dict Any) |
| `plugin/writer/word_diff_split.py` | 5636s (~94m) | `SubEdit.__eq__` 281k / 12k; `Token.__eq__` 154k / 6.6k; plus `__repr__` / `is_block` / `is_surgical` / `_build_surgical_edits` / `_emit_segment` / `apply_sub_edits` |

`formula_edit` was not in this remaining 22 (already offed in PR 516). `cors` did not start. `payload_codec` / `sandbox_cache` were the next submit-order files and were almost certainly still running when the wall hit (no flushed log).

## This PR

Same strategy as 512/514/516: leftover combinatoric sinks get `# crosshair: off` with a doable-later comment citing this run. Easy closed-domain `deal.pre` where the hole is an unbounded int/name.

- **word_diff_split**: off `Token`/`SubEdit` `__eq__`/`__repr__`, `SplitResult.is_block`/`is_surgical`/`__repr__`, `_build_surgical_edits`, `_emit_segment`, `apply_sub_edits`. Keep `__init__`s and `_word_tokens` (already cheap). `tokenize` / `split_change` already off.
- **sheet_filter_criteria**: `@deal.pre` tiny int on `filter_operator2_code_to_name` (`-8 <= code < 32`) and `ascii_bounded` on `filter_operator2_name_to_code`. Off `parse_sheet_filter_criterion` (nested dict Any). Leave `filter_connection_code` / `resolve_filter_operator_code` (already bounded).
- **audio_silence_detector**: off `SilenceDetector.process_chunk` (stateful RMS/float wrapping already-off `pcm_energy_int16`). Leave `_is_speech` / `_adapt_pre_speech_floor` / `should_emit_silence_progress`.

No new cover-all kicked from this PR. After merge, next start-at is `plugin/scripting/payload_codec.py` (5th of this remaining 22).
