### PR TITLE
Install libreoffice-dev so Ubuntu CI can rebuild LibrePy RDBs

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -47,7 +47,8 @@ jobs:
         run: |
           sudo add-apt-repository -y ppa:libreoffice/ppa
           sudo apt-get update
-          sudo apt-get install -y libreoffice python3-uno gettext
+          # libreoffice-dev ships unoidl-write; make build-core / rdb-core needs it.
+          sudo apt-get install -y libreoffice libreoffice-dev python3-uno gettext
           curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 

--- a/docs/scripting/librepy-split.md
+++ b/docs/scripting/librepy-split.md
@@ -597,7 +597,7 @@ Do **not** reuse `org.extension.writeragent` for the core OXT — `unopkg` must 
 | Extension id | `org.extension.writeragent` | `org.extension.librepy` |
 | `description.xml` | [`extension/description.xml.tpl`](../../extension/description.xml.tpl) | `extension-core/description.xml` (new identifier + display name) |
 | UNO add-in impl | `org.extension.writeragent.PythonFunction` | **`org.extension.writeragent.PythonFunction`** (alias — same namespace as WriterAgent so `ORG.EXTENSION.WRITERAGENT.PYTHONFUNCTION.*` formulas are portable; extension id stays `org.extension.librepy`) |
-| IDL / RDB | `org.extension.writeragent.PythonFunction.XPythonFunction` | Same IDL module path as WriterAgent ([`extension-core/idl/XPythonFunction.idl`](../extension-core/idl/XPythonFunction.idl)); rebuild via `make rdb-core` |
+| IDL / RDB | `org.extension.writeragent.PythonFunction.XPythonFunction` | Same IDL module path as WriterAgent ([`extension-core/idl/XPythonFunction.idl`](../extension-core/idl/XPythonFunction.idl)); rebuild via `make rdb-core` (needs `unoidl-write` from `libreoffice-dev` on Ubuntu / Debian, or `libreoffice-fresh-sdk` on Arch) |
 | CalcAddIns node | `org.extension.writeragent.PythonFunction` | **`org.extension.writeragent.PythonFunction`** — keep function names **`py`** and **`python`** (users still type `=PY()`) |
 | Protocol handler | `org.extension.writeragent:*` | `org.extension.librepy:*` |
 | Menu URLs | `org.extension.writeragent:scripting.run_python_dialog` | `org.extension.librepy:scripting.run_python_dialog` |

--- a/scripts/rebuild_librepy_rdb.sh
+++ b/scripts/rebuild_librepy_rdb.sh
@@ -2,7 +2,8 @@
 # Rebuild LibrePy Calc add-in typelibrary from extension-core IDL.
 # IDL uses org.extension.writeragent.PythonFunction (shared namespace with WriterAgent
 # for formula portability); extension id remains org.extension.librepy.
-# Requires LibreOffice SDK (libreoffice-fresh-sdk): unoidl-write
+# Requires LibreOffice SDK: unoidl-write (Ubuntu/Debian: libreoffice-dev;
+# Arch: libreoffice-fresh-sdk).
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 IDL_PYTHON="$ROOT/extension-core/idl/XPythonFunction.idl"
@@ -11,7 +12,7 @@ SDK_HOME="${OO_SDK_HOME:-/usr/lib/libreoffice/sdk}"
 UNOIDLWRITE="${SDK_HOME}/bin/unoidl-write"
 
 if [[ ! -x "$UNOIDLWRITE" ]]; then
-  echo "error: unoidl-write not found at $UNOIDLWRITE (install libreoffice-fresh-sdk)." >&2
+  echo "error: unoidl-write not found at $UNOIDLWRITE (install libreoffice-dev on Ubuntu/Debian, or libreoffice-fresh-sdk on Arch)." >&2
   exit 1
 fi
 

--- a/tests/scripts/test_pr_ci_libreoffice_sdk.py
+++ b/tests/scripts/test_pr_ci_libreoffice_sdk.py
@@ -1,0 +1,26 @@
+"""Ubuntu PR CI must ship unoidl-write so ``make rdb-core`` can run.
+
+``make build-core`` always rebuilds ``extension-core/XPythonFunction.rdb``.
+That step calls ``unoidl-write`` from the LibreOffice SDK. On Ubuntu the
+binary is in ``libreoffice-dev``, not the ``libreoffice`` metapackage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "pr-ci.yml"
+_RDB_SCRIPT = _REPO_ROOT / "scripts" / "rebuild_librepy_rdb.sh"
+
+
+def test_ubuntu_ci_installs_libreoffice_dev_for_rdb_core() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    ubuntu_block = text.split("Install LibreOffice and system tools (Ubuntu)", 1)[1]
+    ubuntu_block = ubuntu_block.split("Install LibreOffice and system tools (macOS)", 1)[0]
+    assert "libreoffice-dev" in ubuntu_block
+
+
+def test_rdb_script_names_ubuntu_sdk_package() -> None:
+    text = _RDB_SCRIPT.read_text(encoding="utf-8")
+    assert "libreoffice-dev" in text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Ubuntu PR CI failed at `make build-core` with:

```
error: unoidl-write not found at /usr/lib/libreoffice/sdk/bin/unoidl-write (install libreoffice-fresh-sdk).
make: *** [Makefile:402: rdb-core] Error 1
```

`make build-core` always runs `rdb-core` → `scripts/rebuild_librepy_rdb.sh`, which needs `unoidl-write`. Ubuntu CI installed the `libreoffice` metapackage only. That package does not ship the SDK tools. The error text named Arch’s `libreoffice-fresh-sdk`; on Ubuntu / Debian the package is `libreoffice-dev`.

## Approach considered

1. **Install `libreoffice-dev` in Ubuntu CI** (this PR). Matches `build-core` as written (always regenerate the typelibrary) and lets CI compile IDL.
2. Skip `rdb-core` when the committed `.rdb` already exists. Would unblock CI without the SDK, but would not catch IDL/RDB drift.
3. Drop `rdb-core` from `build-core` (WriterAgent `make build` already uses committed RDBs). Same drift risk.

## Change

- Install `libreoffice-dev` next to `libreoffice` in `.github/workflows/pr-ci.yml`.
- Point the rebuild script error and `docs/scripting/librepy-split.md` at the Ubuntu package name.
- Add a small regression test so the Ubuntu install step keeps `libreoffice-dev`.

## Verification

With this change CI gets past `rdb-core`; typecheck, the test suite, the WriterAgent build/install, and the LibrePy build/install all pass.

## Follow-up required for a fully green run

This PR alone does not turn the job green — it unblocks CI far enough to reach a second, unrelated defect: the LibreHarper OXT is missing two modules it imports at install time, so `unopkg add build/LibreHarper.oxt` fails. That is fixed in [#519](https://github.com/KeithCu/writeragent/pull/519), which is stacked on this branch and [runs fully green](https://github.com/KeithCu/writeragent/actions/runs/33358879210). Merge this PR first, then #519.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

