### PR TITLE
Bundle config_schema and client/errors in the LibreHarper OXT

### DIFF
--- a/scripts/libreharper_bundle_paths.py
+++ b/scripts/libreharper_bundle_paths.py
@@ -25,6 +25,8 @@ LIBREHARPER_PLUGIN_FILES: tuple[str, ...] = (
     "plugin/version.py",
     "plugin/framework/__init__.py",
     "plugin/framework/config.py",
+    # config.py does ``from plugin.framework import config_schema`` at import time.
+    "plugin/framework/config_schema.py",
     "plugin/framework/constants.py",
     "plugin/framework/deal_shim.py",
     "plugin/framework/errors.py",
@@ -42,6 +44,8 @@ LIBREHARPER_PLUGIN_FILES: tuple[str, ...] = (
     "plugin/framework/queue_executor.py",
     "plugin/framework/uno_listeners.py",
     "plugin/framework/client/requests.py",
+    # requests.py does ``from .errors import _format_http_error_response``.
+    "plugin/framework/client/errors.py",
     "plugin/framework/client/ssl_helpers.py",
     "plugin/framework/client/provider_detection.py",
     "plugin/chatbot/dialogs.py",

--- a/tests/writer/locale/test_libreharper_oxt.py
+++ b/tests/writer/locale/test_libreharper_oxt.py
@@ -102,10 +102,67 @@ def test_grammar_work_queue_has_no_top_level_framework_client_package_import() -
     assert "plugin.framework.client.model_fetcher" not in top_level
 
 
+def test_libreharper_bundle_covers_top_level_plugin_imports() -> None:
+    """Every ``plugin.*`` a shipped module imports at load time must also ship.
+
+    ``unopkg add`` executes ``harper_proofreader.py``, so a module missing from
+    the allowlist fails installation rather than degrading at runtime. Two were
+    missing this way: ``config.py`` reaches ``config_schema`` via
+    ``from plugin.framework import config_schema`` and ``client/requests.py``
+    reaches ``client/errors.py`` via ``from .errors import ...`` — neither is a
+    plain ``import plugin.x.y``, so both need submodule-aware resolution.
+    """
+    from pathlib import Path
+
+    from scripts.libreharper_bundle_paths import collect_libreharper_plugin_paths
+    from tests.scripts.test_librepy_import_graph import (
+        _is_shipped_plugin_module,
+        _module_level_import_nodes,
+        _plugin_mod_to_candidates,
+        _resolved_import_from_module,
+    )
+
+    root = Path(_repo_root())
+    shipped = set(collect_libreharper_plugin_paths(str(root)))
+    missing: list[str] = []
+
+    for rel in sorted(shipped):
+        if not rel.endswith(".py"):
+            continue
+        path = root / rel
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+        for node in _module_level_import_nodes(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith("plugin.") and not _is_shipped_plugin_module(alias.name, shipped):
+                        missing.append(f"{rel} -> import {alias.name}")
+                continue
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            mod = _resolved_import_from_module(path, node)
+            if not mod or not (mod == "plugin" or mod.startswith("plugin.")):
+                continue
+            if not _is_shipped_plugin_module(mod, shipped):
+                missing.append(f"{rel} -> from {mod}")
+                continue
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                sub = f"{mod}.{alias.name}"
+                if not any((root / cand).is_file() for cand in _plugin_mod_to_candidates(sub)):
+                    continue  # an attribute, not a submodule
+                if not _is_shipped_plugin_module(sub, shipped):
+                    missing.append(f"{rel} -> from {mod} import {alias.name}")
+
+    assert missing == []
+
+
 def test_collect_libreharper_plugin_paths() -> None:
     from scripts.libreharper_bundle_paths import collect_libreharper_plugin_paths
 
     paths = collect_libreharper_plugin_paths(_repo_root())
+    assert "plugin/framework/config_schema.py" in paths
+    assert "plugin/framework/client/errors.py" in paths
     assert "plugin/writer/locale/harper.py" in paths
     assert not any(p.endswith("harper_host.py") for p in paths)
     assert "plugin/doc/udprops.py" in paths


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on [#518](https://github.com/KeithCu/writeragent/pull/518) (that PR unblocks CI far enough to reach this failure).

## Problem

`unopkg add build/LibreHarper.oxt` fails outright:

```
ERROR: Exception occurred: <class 'ImportError'>: cannot import name 'config_schema'
from 'plugin.framework' (.../LibreHarper.oxt/plugin/framework/__init__.py)
  File ".../plugin/framework/config.py", line 65, in <module>
    from plugin.framework import config_schema as _config_schema
ERROR: unopkg failed.
```

`unopkg` executes `harper_proofreader.py` at install time, so a module missing from the hand-maintained allowlist in `libreharper_bundle_paths.py` breaks installation rather than degrading at runtime.

## Cause

Two modules are reachable at import time but were not listed. Both use forms that are not a plain `import plugin.x.y`, which is why they were easy to miss:

- `plugin/framework/config.py` → `from plugin.framework import config_schema`
- `plugin/framework/client/requests.py` → `from .errors import _format_http_error_response`

Only the first surfaced in CI; `client/errors.py` would have broken `sync_request` (used by the weekly update check) the same way.

## Change

- Add `plugin/framework/config_schema.py` and `plugin/framework/client/errors.py` to `LIBREHARPER_PLUGIN_FILES`.
- Add a closure test asserting every `plugin.*` imported at module load by a shipped file is itself shipped. It resolves relative imports and treats `from pkg import name` as a submodule reference when a matching source file exists — the gap that hid both modules. It reuses the AST helpers already in `tests/scripts/test_librepy_import_graph.py` rather than duplicating them.

## Verification

Rebuilt and installed the OXT locally with the same LibreOffice build CI uses (`4:26.2.5.2-...~lo1` from `ppa:libreoffice/ppa`):

```
############ BEFORE FIX ############
$ unopkg add build/LibreHarper.oxt
exit=1
ERROR: Exception occurred: <class 'ImportError'>: cannot import name 'config_schema' ...
    from plugin.framework import config_schema as _config_schema
ERROR: unopkg failed.

############ AFTER FIX ############
$ unopkg add build/LibreHarper.oxt
exit=0
$ unopkg list | grep -c org.extension.libreharper
1
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

