### PR TITLE
Add a PR CI checkbox for make test-mock-sidebar

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -14,6 +14,11 @@ on:
           - "macos-latest"
           - "windows-latest"
           - "all"
+      test_mock_sidebar:
+        description: "Run make test-mock-sidebar only (skip typecheck, pytest/UNO, packaging)"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -21,9 +26,9 @@ concurrency:
 
 jobs:
   test:
-    name: Test & Typecheck (${{ matrix.os }})
+    name: ${{ inputs.test_mock_sidebar == true && format('Mock LLM Sidebar ({0})', matrix.os) || format('Test & Typecheck ({0})', matrix.os) }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.test_mock_sidebar == true && 60 || 30 }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +54,10 @@ jobs:
           sudo apt-get update
           # libreoffice-dev ships unoidl-write; make build-core / rdb-core needs it.
           sudo apt-get install -y libreoffice libreoffice-dev python3-uno gettext
+          # Visible Writer for make test-mock-sidebar (testing_runner requires DISPLAY).
+          if [ "${{ inputs.test_mock_sidebar }}" = "true" ]; then
+            sudo apt-get install -y xvfb dbus-x11
+          fi
           curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
@@ -88,6 +97,7 @@ jobs:
           make vendor manifest compile-translations
 
       - name: Run typecheck
+        if: ${{ inputs.test_mock_sidebar != true }}
         run: |
           make typecheck
 
@@ -98,10 +108,12 @@ jobs:
           unopkg list | grep -q "org.extension.writeragent"
 
       - name: Run tests (Pytest + UNO)
+        if: ${{ inputs.test_mock_sidebar != true }}
         run: |
           make test
 
       - name: Verify Core & Grammar Extension Packaging Lifecycles (LibrePy, LibreHarper)
+        if: ${{ inputs.test_mock_sidebar != true }}
         run: |
           # 1. Build and install LibrePy (removes WriterAgent as both share addin namespace)
           make build-core
@@ -116,3 +128,14 @@ jobs:
           # 3. Clean up installed packages
           unopkg remove org.extension.libreharper || true
           unopkg remove org.extension.librepy || true
+
+      - name: Run mock LLM sidebar tests
+        if: ${{ inputs.test_mock_sidebar == true }}
+        run: |
+          make ensure-uno
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
+              dbus-run-session -- make test-mock-sidebar
+          else
+            make test-mock-sidebar
+          fi

--- a/docs/tests/mock-llm-sidebar.md
+++ b/docs/tests/mock-llm-sidebar.md
@@ -98,6 +98,19 @@ make test-mock-sidebar FILTER=b13      # Run a single case by ID
 make test-mock-sidebar FILTER="B E"    # Run multiple packets
 ```
 
+#### GitHub Actions (PR CI option)
+
+[`.github/workflows/pr-ci.yml`](../../.github/workflows/pr-ci.yml) exposes this as a **Run workflow** checkbox, default off. Pull requests never set it.
+
+From the Actions tab → **PR CI** → **Run workflow**:
+
+| Input | Meaning |
+|-------|---------|
+| `os` | Ubuntu / macOS / Windows / `all` (same picker as the rest of PR CI) |
+| `test_mock_sidebar` | Off (default): typecheck + pytest/UNO + packaging. On: skip those and run `make test-mock-sidebar` only |
+
+Linux starts a virtual framebuffer (`xvfb-run` + `dbus-run-session`) because `testing_runner` refuses `--user-profile` without `DISPLAY`. WriterAgent is still built and registered first.
+
 #### Test Runner Architecture & UNO Invariants
 - **Bootstrap:** LibreOffice is launched via `Popen` with `--norestore --writer --accept=socket,host=127.0.0.1,port=<port>;urp;` (TCP socket). `officehelper.bootstrap` is avoided because its `--nodefault` flag can cause GUI crashes.
 - **Crash Recovery:** `--norestore` suppresses document recovery dialogs that would block the URP pipe.

--- a/tests/scripts/test_pr_ci_mock_sidebar.py
+++ b/tests/scripts/test_pr_ci_mock_sidebar.py
@@ -1,0 +1,47 @@
+"""PR CI mock-sidebar option stays off by default and skips the other jobs when on."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "pr-ci.yml"
+
+
+def _workflow() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pr_ci_exposes_test_mock_sidebar_checkbox_default_off() -> None:
+    text = _workflow()
+    assert "test_mock_sidebar:" in text
+    inputs = text.split("workflow_dispatch:", 1)[1].split("jobs:", 1)[0]
+    assert "type: boolean" in inputs
+    assert "default: false" in inputs
+
+
+def test_pr_ci_mock_sidebar_uses_existing_make_target() -> None:
+    text = _workflow()
+    assert "make test-mock-sidebar" in text
+    assert "make mock-llm-sidebar" not in text
+
+
+def test_pr_ci_mock_sidebar_skips_other_suites() -> None:
+    text = _workflow()
+    assert "if: ${{ inputs.test_mock_sidebar != true }}" in text
+    assert "if: ${{ inputs.test_mock_sidebar == true }}" in text
+    typecheck = text.split("Run typecheck", 1)[1]
+    typecheck = typecheck.split("Build & install WriterAgent", 1)[0]
+    assert "inputs.test_mock_sidebar != true" in typecheck
+    pytest_block = text.split("Run tests (Pytest + UNO)", 1)[1]
+    pytest_block = pytest_block.split("Verify Core", 1)[0]
+    assert "inputs.test_mock_sidebar != true" in pytest_block
+    packaging = text.split("Verify Core & Grammar", 1)[1]
+    packaging = packaging.split("Run mock LLM sidebar", 1)[0]
+    assert "inputs.test_mock_sidebar != true" in packaging
+
+
+def test_pr_ci_linux_mock_sidebar_provides_display() -> None:
+    text = _workflow()
+    assert "xvfb-run" in text
+    assert "dbus-run-session" in text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `test_mock_sidebar` to the existing **PR CI → Run workflow** form (boolean, default off). It is not a new workflow.

## Behavior

- **Pull requests:** unchanged. The checkbox is only on `workflow_dispatch`, so PRs keep typecheck + pytest/UNO + packaging.
- **Run workflow, checkbox off (default):** same as today.
- **Run workflow, checkbox on:** skip typecheck, `make test`, and the LibrePy/LibreHarper packaging step. Still install LibreOffice, build/register WriterAgent, then run `make test-mock-sidebar`.
- **`os`:** same picker as the rest of PR CI (`ubuntu-latest` / `macos-latest` / `windows-latest` / `all`).
- Linux wraps the sidebar suite in `xvfb-run` + `dbus-run-session` because `testing_runner --user-profile` requires `DISPLAY`.

To run it: Actions → **PR CI** → **Run workflow** → turn on **Run make test-mock-sidebar only** → pick OS → Run.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

