### PR TITLE
Fix Windows PR CI typecheck (pyspector cp1252 and missing Opengrep)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -43,6 +43,11 @@ jobs:
       run:
         shell: bash
 
+    # Windows runners default Python stdio to cp1252; pyspector prints U+1F4A1.
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: utf-8
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -75,7 +80,12 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install libreoffice-fresh gettext make -y || true
-          echo "C:\Program Files\LibreOffice\program" >> $GITHUB_PATH
+          echo "C:\\Program Files\\LibreOffice\\program" >> $GITHUB_PATH
+          # typecheck runs opengrep-lint; Linux/macOS install this, Windows did not.
+          powershell -NoProfile -ExecutionPolicy Bypass -Command \
+            "irm https://raw.githubusercontent.com/opengrep/opengrep/main/install.ps1 | iex" || true
+          echo "$USERPROFILE/.opengrep/cli/latest" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -105,7 +115,9 @@ jobs:
         run: |
           make build
           make register-built-oxt
-          unopkg list | grep -q "org.extension.writeragent"
+          # grep -q + pipefail: unopkg dies of SIGPIPE (exit 141) after the first match.
+          unopkg list > "$RUNNER_TEMP/unopkg-list.txt"
+          grep "org.extension.writeragent" "$RUNNER_TEMP/unopkg-list.txt"
 
       - name: Run tests (Pytest + UNO)
         if: ${{ inputs.test_mock_sidebar != true }}
@@ -118,12 +130,14 @@ jobs:
           # 1. Build and install LibrePy (removes WriterAgent as both share addin namespace)
           make build-core
           make register-librepy-oxt
-          unopkg list | grep -q "org.extension.librepy"
+          unopkg list > "$RUNNER_TEMP/unopkg-list.txt"
+          grep "org.extension.librepy" "$RUNNER_TEMP/unopkg-list.txt"
 
           # 2. Build and install LibreHarper
           make build-harper
           make register-libreharper-oxt
-          unopkg list | grep -q "org.extension.libreharper"
+          unopkg list > "$RUNNER_TEMP/unopkg-list.txt"
+          grep "org.extension.libreharper" "$RUNNER_TEMP/unopkg-list.txt"
 
           # 3. Clean up installed packages
           unopkg remove org.extension.libreharper || true

--- a/docs/framework/type-checking.md
+++ b/docs/framework/type-checking.md
@@ -21,7 +21,7 @@ Static checking does **not** prove LibreOffice runtime behavior: UNO remains hig
 - **`pyproject.toml`** — `[tool.ty.src]`: `include = ["plugin", "compute_service"]`, `exclude = ["plugin/contrib", "plugin/lib", "plugin/tests"]`. Mypy / Basedpyright / Pyrefly use the same include set.
 - **`Makefile`** — `make ty`: ensures `import uno` (via `make fix-uno` if needed), then `python -m ty check --exclude plugin/contrib/ --exclude plugin/lib/`.
 - **Dev dependency**: **`types-unopy`** (LibreOffice API stubs). **`make fix-uno`** links system UNO into `.venv` so `uno` and `com.sun.star` resolve; without that, the checker cannot see extension types.
-- **Windows / ARM64 note**: **`make fix-uno`** is a static-analysis helper, not proof that external Python can run PyUNO. On Windows, especially ARM64, LibreOffice's `pyuno.pyd` still depends on matching Python ABI and native DLL loading; the extension runtime uses LibreOffice's own Python.
+- **Windows / ARM64 note**: **`make fix-uno`** is a static-analysis helper, not proof that external Python can run PyUNO. On Windows, especially ARM64, LibreOffice's `pyuno.pyd` still depends on matching Python ABI and native DLL loading; the extension runtime uses LibreOffice's own Python. **`scripts/run_pyspector.py`** and **`scripts/run_timed.py`** pin stdio to UTF-8 so PySpector's banner (U+1F4A1) does not crash a cp1252 console; PR CI also sets `PYTHONUTF8=1` and installs Opengrep on Windows (Linux/macOS already did).
 
 ### mypy (optional)
 

--- a/scripts/run_pyspector.py
+++ b/scripts/run_pyspector.py
@@ -30,6 +30,25 @@ _DISABLED_RULE_IDS = (
 )
 
 
+def _configure_utf8_stdio() -> None:
+    """Pin stdout/stderr to UTF-8 so PySpector's emoji banner can print on Windows.
+
+    WHAT WAS WRONG: ``make typecheck`` on Windows CI crashed in pyspector
+    ``_print_banner`` with ``UnicodeEncodeError: 'charmap' codec can't encode
+    character '\\U0001f4a1'`` (cp1252).
+
+    HOW IT HAPPENED: GitHub's Windows runner leaves Python stdio on the ANSI
+    code page. The banner is cosmetic; the encode happens before any scan.
+
+    WHY THIS FIXES IT: ``TextIOWrapper.reconfigure`` switches the existing
+    handles to UTF-8. Tests (and any StringIO stub) have no ``reconfigure``.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
 def _inject_disabled_rules(rules_toml: str) -> str:
     """Extend the built-in [defaults].disabled_rule_ids list."""
     marker = "disabled_rule_ids = ["
@@ -83,6 +102,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if not argv:
         argv = ["scan", "plugin", "--ai", "-c", "pyspector.toml", "--msg=False"]
+
+    # PySpector 0.2.1 prints U+1F4A1 in _print_banner. Windows CI defaults to
+    # cp1252, so click.echo raises UnicodeEncodeError before the scan starts.
+    _configure_utf8_stdio()
 
     try:
         pyspector_cli.cli.main(args=argv, prog_name="pyspector")

--- a/scripts/run_timed.py
+++ b/scripts/run_timed.py
@@ -21,11 +21,22 @@ def main(argv: list[str]) -> int:
         return 2
     label, cmd = argv[0], argv[1:]
     t0 = time.monotonic()
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    # UTF-8: Windows typecheck children (pyspector banner) emit non-cp1252 text.
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
     body = proc.stdout or ""
     if body and not body.endswith("\n"):
         body += "\n"
     elapsed = time.monotonic() - t0
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding="utf-8", errors="replace")
     # One write so a finishing sibling cannot splice into this block.
     sys.stdout.write(f"=== {label} ===\n{body}=== {label}: {elapsed:.1f}s ===\n")
     sys.stdout.flush()

--- a/tests/scripts/test_pr_ci_libreoffice_sdk.py
+++ b/tests/scripts/test_pr_ci_libreoffice_sdk.py
@@ -24,3 +24,13 @@ def test_ubuntu_ci_installs_libreoffice_dev_for_rdb_core() -> None:
 def test_rdb_script_names_ubuntu_sdk_package() -> None:
     text = _RDB_SCRIPT.read_text(encoding="utf-8")
     assert "libreoffice-dev" in text
+
+
+def test_windows_ci_installs_opengrep_and_forces_utf8() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    windows_block = text.split("Install LibreOffice and system tools (Windows)", 1)[1]
+    windows_block = windows_block.split("Install uv", 1)[0]
+    assert "install.ps1" in windows_block
+    assert ".opengrep/cli/latest" in windows_block
+    assert "PYTHONUTF8" in text
+    assert 'unopkg list | grep -q' not in text

--- a/tests/scripts/test_run_pyspector.py
+++ b/tests/scripts/test_run_pyspector.py
@@ -1,0 +1,32 @@
+"""Windows typecheck: PySpector banner must not crash on cp1252 stdio."""
+
+from __future__ import annotations
+
+import io
+import sys
+
+from scripts.run_pyspector import _configure_utf8_stdio
+
+_LIGHTBULB = "\U0001f4a1"
+
+
+def test_configure_utf8_stdio_allows_pyspector_banner_emoji(monkeypatch) -> None:
+    buf = io.BytesIO()
+    stream = io.TextIOWrapper(buf, encoding="cp1252", errors="strict")
+    monkeypatch.setattr(sys, "stdout", stream)
+    monkeypatch.setattr(sys, "stderr", stream)
+
+    stream.write("ok\n")
+    stream.flush()
+    try:
+        stream.write(_LIGHTBULB)
+        stream.flush()
+        raised = False
+    except UnicodeEncodeError:
+        raised = True
+    assert raised is True
+
+    _configure_utf8_stdio()
+    stream.write(_LIGHTBULB)
+    stream.flush()
+    assert _LIGHTBULB.encode("utf-8") in buf.getvalue()

--- a/tests/scripts/test_run_timed.py
+++ b/tests/scripts/test_run_timed.py
@@ -1,0 +1,16 @@
+"""run_timed must decode child UTF-8 even when the host locale is cp1252."""
+
+from __future__ import annotations
+
+import sys
+
+from scripts.run_timed import main
+
+_LIGHTBULB = "\U0001f4a1"
+
+
+def test_run_timed_captures_utf8_child_output(capsys) -> None:
+    code = "import sys; sys.stdout.buffer.write('\\U0001f4a1'.encode('utf-8'))"
+    rc = main(["pyspector", sys.executable, "-c", code])
+    assert rc == 0
+    assert _LIGHTBULB in capsys.readouterr().out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Windows `workflow_dispatch` of PR CI ([run 33359472808](https://github.com/KeithCu/writeragent/actions/runs/33359472808)) died in **Run typecheck** before build/tests ran.

## What failed

PySpector 0.2.1 prints 💡 (`U+1F4A1`) in `_print_banner`. The Windows runner’s Python stdio is **cp1252**, so `click.echo` raises `UnicodeEncodeError` and `make typecheck` exits 2.

The next typecheck sibling would have failed too: Linux/macOS install Opengrep, the Windows step did not, and `opengrep-lint` hard-fails when the binary is missing.

## Change

- `scripts/run_pyspector.py` reconfigures stdout/stderr to UTF-8 before calling the CLI.
- `scripts/run_timed.py` decodes the child as UTF-8 and reconfigures its own stdout (so the captured banner can be printed).
- PR CI sets `PYTHONUTF8=1` / `PYTHONIOENCODING=utf-8` on the job.
- Windows install step runs the official Opengrep `install.ps1` and adds `~/.opengrep/cli/latest` to `PATH`.
- `unopkg list | grep -q` replaced with a temp file + `grep` (avoids SIGPIPE 141 under `pipefail`).

## How to verify

Actions → **PR CI** → **Run workflow** → this branch → `os=windows-latest`, leave `test_mock_sidebar` off. After merge, the same dispatch from `master` is the Windows check you already used.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

