### PR TITLE
Fix remaining PR CI: LibreHarper allowlist and stderr-drain flake

### DIFF
--- a/docs/archive/harper-grammar-linter-dev-plan.md
+++ b/docs/archive/harper-grammar-linter-dev-plan.md
@@ -354,7 +354,7 @@ Inverse of LibrePy’s filter: LibrePy omits Harper (`writer/locale/harper*.py`)
 
 | Artifact | LibreHarper |
 |----------|-------------|
-| Path list | `scripts/libreharper_bundle_paths.py` |
+| Path list | `scripts/libreharper_bundle_paths.py` (`LIBREHARPER_PLUGIN_FILES`). `unopkg add` executes `harper_proofreader.py`, so every module reached at import time must be listed — including `from plugin.framework import config_schema` and relative `from .errors import …`, not only a plain `import plugin.x.y`. |
 | Builder | `scripts/build_libreharper_oxt.py` → `build/bundle-libreharper/` → `build/LibreHarper.oxt` |
 | Skeleton | `extension-harper/` |
 | Makefile | `manifest-harper`, `build-harper`, `deploy-harper` |

--- a/scripts/libreharper_bundle_paths.py
+++ b/scripts/libreharper_bundle_paths.py
@@ -25,6 +25,8 @@ LIBREHARPER_PLUGIN_FILES: tuple[str, ...] = (
     "plugin/version.py",
     "plugin/framework/__init__.py",
     "plugin/framework/config.py",
+    # config.py does ``from plugin.framework import config_schema`` at import time.
+    "plugin/framework/config_schema.py",
     "plugin/framework/constants.py",
     "plugin/framework/deal_shim.py",
     "plugin/framework/errors.py",
@@ -42,6 +44,8 @@ LIBREHARPER_PLUGIN_FILES: tuple[str, ...] = (
     "plugin/framework/queue_executor.py",
     "plugin/framework/uno_listeners.py",
     "plugin/framework/client/requests.py",
+    # requests.py does ``from .errors import _format_http_error_response``.
+    "plugin/framework/client/errors.py",
     "plugin/framework/client/ssl_helpers.py",
     "plugin/framework/client/provider_detection.py",
     "plugin/chatbot/dialogs.py",

--- a/tests/scripting/test_venv_worker.py
+++ b/tests/scripting/test_venv_worker.py
@@ -239,7 +239,18 @@ while True:
         assert result["status"] == "ok"
         assert result["result"] == 42
         assert drain is not None
-        assert "x" * 1024 in drain.text()
+        # optimize_popen_pipes raises Linux stderr toward 1 MiB, so the child
+        # can write 128 KiB and reply before the drain thread is scheduled.
+        # execute() returning already proves we did not deadlock on the pipe.
+        # Wait for the drain to catch that flood (CI failed with text() == "").
+        deadline = time.monotonic() + 2.0
+        captured = ""
+        while time.monotonic() < deadline:
+            captured = drain.text()
+            if "x" * 1024 in captured:
+                break
+            time.sleep(0.01)
+        assert "x" * 1024 in captured
     finally:
         mgr._terminate_worker()
     assert drain is not None

--- a/tests/writer/locale/test_libreharper_oxt.py
+++ b/tests/writer/locale/test_libreharper_oxt.py
@@ -102,10 +102,67 @@ def test_grammar_work_queue_has_no_top_level_framework_client_package_import() -
     assert "plugin.framework.client.model_fetcher" not in top_level
 
 
+def test_libreharper_bundle_covers_top_level_plugin_imports() -> None:
+    """Every ``plugin.*`` a shipped module imports at load time must also ship.
+
+    ``unopkg add`` executes ``harper_proofreader.py``, so a module missing from
+    the allowlist fails installation rather than degrading at runtime. Two were
+    missing this way: ``config.py`` reaches ``config_schema`` via
+    ``from plugin.framework import config_schema`` and ``client/requests.py``
+    reaches ``client/errors.py`` via ``from .errors import ...`` — neither is a
+    plain ``import plugin.x.y``, so both need submodule-aware resolution.
+    """
+    from pathlib import Path
+
+    from scripts.libreharper_bundle_paths import collect_libreharper_plugin_paths
+    from tests.scripts.test_librepy_import_graph import (
+        _is_shipped_plugin_module,
+        _module_level_import_nodes,
+        _plugin_mod_to_candidates,
+        _resolved_import_from_module,
+    )
+
+    root = Path(_repo_root())
+    shipped = set(collect_libreharper_plugin_paths(str(root)))
+    missing: list[str] = []
+
+    for rel in sorted(shipped):
+        if not rel.endswith(".py"):
+            continue
+        path = root / rel
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+        for node in _module_level_import_nodes(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith("plugin.") and not _is_shipped_plugin_module(alias.name, shipped):
+                        missing.append(f"{rel} -> import {alias.name}")
+                continue
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            mod = _resolved_import_from_module(path, node)
+            if not mod or not (mod == "plugin" or mod.startswith("plugin.")):
+                continue
+            if not _is_shipped_plugin_module(mod, shipped):
+                missing.append(f"{rel} -> from {mod}")
+                continue
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                sub = f"{mod}.{alias.name}"
+                if not any((root / cand).is_file() for cand in _plugin_mod_to_candidates(sub)):
+                    continue  # an attribute, not a submodule
+                if not _is_shipped_plugin_module(sub, shipped):
+                    missing.append(f"{rel} -> from {mod} import {alias.name}")
+
+    assert missing == []
+
+
 def test_collect_libreharper_plugin_paths() -> None:
     from scripts.libreharper_bundle_paths import collect_libreharper_plugin_paths
 
     paths = collect_libreharper_plugin_paths(_repo_root())
+    assert "plugin/framework/config_schema.py" in paths
+    assert "plugin/framework/client/errors.py" in paths
     assert "plugin/writer/locale/harper.py" in paths
     assert not any(p.endswith("harper_host.py") for p in paths)
     assert "plugin/doc/udprops.py" in paths


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two remaining `master` PR CI failures after #518 / #520 / #521:

## 1. LibreHarper `unopkg add` (every default Ubuntu run)

`unopkg add build/LibreHarper.oxt` dies with:

```
ImportError: cannot import name 'config_schema' from 'plugin.framework'
```

`unopkg` executes `harper_proofreader.py` at install time. Two modules were reachable at import but missing from the hand-maintained `LIBREHARPER_PLUGIN_FILES` allowlist:

- `config.py`: `from plugin.framework import config_schema`
- `client/requests.py`: `from .errors import _format_http_error_response`

Neither is a plain `import plugin.x.y`, so a naive scan missed them. This is the same fix as #519, which never reached `master`.

Latest `master` example: [33360834164](https://github.com/KeithCu/writeragent/actions/runs/33360834164) (typecheck + WriterAgent + pytest/UNO passed; packaging died here).

## 2. Flaky `test_manager_real_spawn_drains_stderr_flood`

[33360390007](https://github.com/KeithCu/writeragent/actions/runs/33360390007) failed pytest with `assert ('x' * 1024) in ''`.

`optimize_popen_pipes` raises Linux stderr toward 1 MiB, so the child can write 128 KiB and reply before the drain thread is scheduled. `execute()` returning already proves we did not deadlock; the test now waits briefly for the drain to capture the flood.

## Out of scope (already on `master`)

- #518 Ubuntu `libreoffice-dev` / `unoidl-write`
- #520 `test-mock-sidebar` dispatch checkbox
- #521 Windows UTF-8 typecheck + Opengrep

Default `pull_request` CI is Ubuntu only. Windows/macOS remain `workflow_dispatch`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-457e7c8e-f841-4cfd-be07-744a5eb5de3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

