### PR TITLE
Fix Draw CustomShape abort: apply geometry before page.add

### DIFF
--- a/docs/draw/impress-specialized-toolsets.md
+++ b/docs/draw/impress-specialized-toolsets.md
@@ -484,7 +484,7 @@ When using shape tools in Writer:
 In Draw/Impress:
 - Shapes have absolute positioning
 - No anchoring required
-- Custom shapes work without special handling
+- Custom shapes still need engine + `CustomShapeGeometry` **before** `page.add` (post-add Type swap can abort soffice)
 
 The current `create_shape` implementation handles both cases with conditional logic.
 

--- a/docs/draw/shape-support.md
+++ b/docs/draw/shape-support.md
@@ -19,9 +19,11 @@ Instead of having a unique UNO class for every single geometric possibility (e.g
 
 To create one of these specific shapes:
 1. Instantiate `com.sun.star.drawing.CustomShape`.
-2. Add it to the drawing page.
-3. Configure its `CustomShapeGeometry` property. This property accepts a sequence of `com.sun.star.beans.PropertyValue`.
-4. Set a `PropertyValue` with `Name="Type"` and `Value="<shape_name>"`.
+2. Set `CustomShapeEngine` to `com.sun.star.drawing.EnhancedCustomShapeEngine` and configure `CustomShapeGeometry` **before** `page.add`. This property accepts a sequence of `com.sun.star.beans.PropertyValue`.
+3. Set a `PropertyValue` with `Name="Type"` and `Value="<shape_name>"`.
+4. Add the shape to the drawing page. Do **not** set `CustomShapeGeometry` again after add — swapping Type on a live inserted shape (default CustomShape is an `SdrRectObj`) can abort LibreOffice in `SfxItemPool::unregisterNameOrIndex`.
+
+Writer-only: set `AnchorType=AT_PAGE` before add (already inside `safe_create_shape`). Fill/line properties stay after add.
 
 Commonly supported `<shape_name>` values include:
 - `octagon`

--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -408,9 +408,10 @@ class DrawShapes:
         Shapes are created via the document's factory (``doc.createInstance``);
         ``XDrawPage`` is not a reliable ``createInstance`` source in UNO.
 
-        For Writer, ``CustomShape`` + ``EnhancedCustomShapeGeometry`` must be applied **before**
-        ``page.add`` (after position/size). Applying geometry only after add breaks display while
-        ``RectangleShape`` etc. are unaffected.
+        For CustomShape, ``EnhancedCustomShapeGeometry`` must be applied **before**
+        ``page.add`` (after position/size). Applying Type after add replaces the live
+        ``SdrRectObj`` and can abort LibreOffice; Writer also fails to display the
+        shape. ``RectangleShape`` etc. are unaffected.
         """
         try:
             if doc is None:
@@ -677,13 +678,16 @@ class UpsertShape(ToolDrawShapeBase):
             draw_shapes = DrawShapes()
 
             try:
+                # Apply EnhancedCustomShapeGeometry *inside* safe_create_shape (before
+                # page.add). Setting Type=octagon after add replaces the live SdrRectObj
+                # and can abort in SfxItemPool::unregisterNameOrIndex (soffice SIGABRT).
                 shape, geometry_applied, geometry_error = draw_shapes.safe_create_shape(
                     ctx.doc,
                     page,
                     uno_type,
                     position,
                     size,
-                    custom_shape_type=None,
+                    custom_shape_type=custom_shape_type if is_custom_shape else None,
                 )
                 if is_custom_shape and geometry_applied:
                     _log_shape_uno_snapshot("after_custom_geometry", shape)
@@ -692,12 +696,6 @@ class UpsertShape(ToolDrawShapeBase):
 
             _try_writer_at_page_shape_finalize(ctx.doc, bridge, page, shape)
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
-
-            # Apply geometry securely AFTER anchoring
-            if is_custom_shape and custom_shape_type:
-                geometry_applied, geometry_error = _apply_enhanced_custom_shape_type(shape, custom_shape_type)
-                if not geometry_applied:
-                    log.warning("shape_upsert (create): Failed to apply EnhancedCustomShapeGeometry post-anchor")
 
             _apply_shape_properties(shape, kwargs)
             _try_writer_invalidate_and_pump(ctx.doc)

--- a/tests/draw/test_shapes.py
+++ b/tests/draw/test_shapes.py
@@ -1,0 +1,141 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for Draw/Impress shape create (no live soffice)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from plugin.draw.shapes import UpsertShape, _ENHANCED_CUSTOM_SHAPE_ENGINE
+
+
+class _Pos:
+    def __init__(self, x, y):
+        self.X = x
+        self.Y = y
+
+
+class _Size:
+    def __init__(self, w, h):
+        self.Width = w
+        self.Height = h
+
+
+class _RecordingShape:
+    """Shape stand-in that records property sets for order assertions."""
+
+    def __init__(self, events: list):
+        self._events = events
+        self._props: dict = {}
+
+    def setPosition(self, position):
+        self._events.append(("setPosition", position.X, position.Y))
+
+    def setSize(self, size):
+        self._events.append(("setSize", size.Width, size.Height))
+
+    def setPropertyValue(self, name, value):
+        self._events.append(("setPropertyValue", name, value))
+        self._props[name] = value
+
+    def getPropertyValue(self, name):
+        return self._props.get(name)
+
+    def getShapeType(self):
+        return "com.sun.star.drawing.CustomShape"
+
+    def getPosition(self):
+        return _Pos(1000, 1000)
+
+    def getSize(self):
+        return _Size(5000, 5000)
+
+    def getPropertySetInfo(self):
+        info = MagicMock()
+        info.getProperties.return_value = []
+        return info
+
+
+def _invoke_set_property(obj, method, args):
+    """Stand-in for ``uno.invoke(shape, 'setPropertyValue', (name, value))``."""
+    getattr(obj, method)(*args)
+
+
+def test_shape_upsert_octagon_sets_geometry_before_page_add():
+    """CustomShape Type/engine must be set before page.add; never again after.
+
+    Post-add CustomShapeGeometry Type=octagon replaces the live SdrRectObj and
+    can abort soffice (SfxItemPool::unregisterNameOrIndex).
+    """
+    events: list = []
+    shape = _RecordingShape(events)
+
+    page = MagicMock()
+    page_shapes: list = []
+
+    def page_add(added):
+        events.append(("page.add",))
+        page_shapes.append(added)
+
+    page.add.side_effect = page_add
+    page.getCount.side_effect = lambda: len(page_shapes)
+    page.getByIndex.side_effect = lambda i: page_shapes[i]
+
+    pages = MagicMock()
+    pages.getCount.return_value = 1
+    pages.getByIndex.return_value = page
+
+    doc = MagicMock()
+    doc.supportsService.return_value = False
+    doc.createInstance.side_effect = lambda _type: shape
+
+    ctx = MagicMock()
+    ctx.doc = doc
+    ctx.active_page_index = 0
+
+    with (
+        patch("plugin.draw.bridge.DrawBridge") as bridge_cls,
+        patch("uno.invoke", side_effect=_invoke_set_property),
+        patch("uno.Any", side_effect=lambda _type, value: value),
+    ):
+        bridge = bridge_cls.return_value
+        bridge.get_pages.return_value = pages
+        bridge.get_active_page_index.return_value = 0
+
+        result = UpsertShape().execute(
+            ctx,
+            action="create",
+            shape_type="octagon",
+            x=1000,
+            y=1000,
+            width=5000,
+            height=5000,
+            fill_color="none",
+            line_color="black",
+            line_width=100,
+        )
+
+    assert result["status"] == "ok"
+    assert result["geometry_applied"] is True
+    assert "warning" not in result
+    doc.createInstance.assert_called_once_with("com.sun.star.drawing.CustomShape")
+    page.add.assert_called_once_with(shape)
+
+    add_idx = next(i for i, ev in enumerate(events) if ev[0] == "page.add")
+    engine_idxs = [i for i, ev in enumerate(events) if ev[0] == "setPropertyValue" and ev[1] == "CustomShapeEngine"]
+    geom_idxs = [i for i, ev in enumerate(events) if ev[0] == "setPropertyValue" and ev[1] == "CustomShapeGeometry"]
+
+    assert engine_idxs, events
+    assert geom_idxs, events
+    assert engine_idxs[0] < add_idx, events
+    assert geom_idxs[0] < add_idx, events
+    assert events[engine_idxs[0]][2] == _ENHANCED_CUSTOM_SHAPE_ENGINE
+    geom_value = events[geom_idxs[0]][2]
+    geom_props = geom_value if isinstance(geom_value, tuple) else (geom_value,)
+    assert any(getattr(p, "Name", None) == "Type" and getattr(p, "Value", None) == "octagon" for p in geom_props), events
+
+    # Double-apply after add is the crashy swap; fill/line may still set after add.
+    assert not any(i > add_idx for i in engine_idxs), events
+    assert not any(i > add_idx for i in geom_idxs), events


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug
CI aborted LibreOffice (signal 6) in `tests/draw/test_draw_uno.py::test_create_custom_shape_octagon` (`SvxShape` dtor → `SfxItemPool::unregisterNameOrIndex`). The other `draw.test_draw_uno` failures in that run were the cascade after soffice died.

## Cause
`shape_upsert` create called `safe_create_shape(..., custom_shape_type=None)`, then set `CustomShapeEngine` + `CustomShapeGeometry` Type=octagon **after** `page.add`. That post-add Type swap replaces the live default CustomShape (`SdrRectObj`) while its pool items are still registered.

`safe_create_shape` already applies EnhancedCustomShapeGeometry **before** add (and Writer `AT_PAGE` anchoring). The post-add apply was leftover; the `if is_custom_shape and geometry_applied` check right after `custom_shape_type=None` could never be true.

## Fix
- Pass the real catalog type (`octagon`, etc.) into `safe_create_shape`.
- Do not set `CustomShapeGeometry` a second time after add. Writer-only post-add helpers and `_apply_shape_properties` stay.
- No other CustomShape **create** path set geometry after add (`DrawBridge.create_shape` and PPT clone are not this create path).

## Tests
- Keep live UNO `test_create_custom_shape_octagon`.
- Add headless `tests/draw/test_shapes.py` that mocks `createInstance` / `page.add` / `setPropertyValue` and asserts engine + geometry are set before add, and not again after.

Local verification:
- 14 unit tests passed (new order test + existing shape helpers / `safe_create_shape`)
- Live UNO: `test_create_custom_shape_octagon` and `test_upsert_and_verify_shape` both OK (no soffice abort)
- ruff clean on touched files
- basedpyright / mypy / ty / bandit / pyspector clean; `make typecheck` still exits 2 on a pre-existing opengrep finding in `plugin/scripting/venv_probe_ui.py` (unrelated)

## Docs
Update `docs/draw/shape-support.md` and the Writer vs Draw notes in `docs/draw/impress-specialized-toolsets.md` so the documented order matches (geometry before add).

No OXT version bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36d75aaa-d6a4-4450-98f0-eb699e04641c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36d75aaa-d6a4-4450-98f0-eb699e04641c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

