### PR TITLE
Off cover-all 33418536119 leftovers (payload_codec, sandbox_cache, address_utils)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -63,7 +63,9 @@ jobs:
           if [ "${{ inputs.test_mock_sidebar }}" = "true" ]; then
             sudo apt-get install -y xvfb dbus-x11
           fi
-          curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
+          # Fatal here (unlike macOS/Windows), so ride out transient resets from raw.githubusercontent.com.
+          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
+            https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install LibreOffice and system tools (macOS)

--- a/plugin/calc/address_utils.py
+++ b/plugin/calc/address_utils.py
@@ -108,6 +108,7 @@ def split_sheet_prefix(ref: str) -> tuple[str | None, str]:
     >>> split_sheet_prefix("A1:C5")
     (None, 'A1:C5')
     """
+    # crosshair: off  # _SHEET_PREFIX regex (cover-all 33418536119: address_utils in-flight leftover, no COVER TIMING). Engine-hostile; keep off.
     if not ref:
         return None, ref
     match = _SHEET_PREFIX.match(ref)

--- a/plugin/scripting/payload_codec.py
+++ b/plugin/scripting/payload_codec.py
@@ -305,6 +305,7 @@ ColumnKind = Literal["int", "float", "bool"]
 
 def _is_grid_sequence(grid: object) -> bool:
     """True for empty, 1D, or 2D list/tuple grids (jagged 2D allowed; flatten raises ValueError)."""
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     if not isinstance(grid, (list, tuple)):
         return False
     if len(grid) == 0:
@@ -427,10 +428,12 @@ def _is_multi_data_envelope(envelope: object) -> bool:
     )
 )
 def is_multi_data(obj: Any) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     return _is_multi_data_envelope(obj)
 
 
 def _is_image_payload_envelope(envelope: object) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     if not isinstance(envelope, dict):
         return False
     env_dict = cast("dict[str, Any]", envelope)
@@ -453,6 +456,7 @@ def _is_image_payload_envelope(envelope: object) -> bool:
     )
 )
 def is_image_payload(obj: Any) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     return _is_image_payload_envelope(obj)
 
 
@@ -491,6 +495,7 @@ def write_image_payload_to_temp(payload: dict[str, Any]) -> str:
 
 
 def _is_dataframe_envelope(envelope: object) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     if not isinstance(envelope, dict):
         return False
     env_dict = cast("dict[str, Any]", envelope)
@@ -520,10 +525,12 @@ def _is_dataframe_envelope(envelope: object) -> bool:
     )
 )
 def is_dataframe_payload(obj: Any) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     return _is_dataframe_envelope(obj)
 
 
 def _is_calc_range_envelope(envelope: object) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     if not isinstance(envelope, dict):
         return False
     env_dict = cast("dict[str, Any]", envelope)
@@ -551,11 +558,13 @@ def _is_calc_range_envelope(envelope: object) -> bool:
     )
 )
 def is_calc_range_payload(obj: Any) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     # Canonical wire guard. calc_range.py re-exports this; do not add a second copy.
     return _is_calc_range_envelope(obj)
 
 
 def _is_split_grid_envelope(envelope: object) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     if not isinstance(envelope, dict):
         return False
     env_dict = cast("dict[str, Any]", envelope)
@@ -572,6 +581,7 @@ def _is_split_grid_envelope(envelope: object) -> bool:
 @deal.pre(lambda obj: _deal_dict_ok(obj))
 @deal.post(lambda result: isinstance(result, bool))
 def _is_any_payload_envelope(obj: object) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     # Body already ORs the five family detectors; a matching ensure re-ran all
     # five on every CrossHair post (check-all deep 32900105768, 8:14).
     return (
@@ -615,6 +625,7 @@ def _uniform_column_kind(kinds: list[str]) -> str | None:
 )
 def envelope_column_kinds(envelope: dict[str, Any], *, ncols: int) -> list[str]:
     """Per-column unpack kinds from wire ``column_kinds``."""
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     kinds = envelope.get("column_kinds")
     if isinstance(kinds, list) and len(kinds) == ncols:
         return ["int" if k == "int" else ("bool" if k == "bool" else "float") for k in kinds]
@@ -623,6 +634,7 @@ def envelope_column_kinds(envelope: dict[str, Any], *, ncols: int) -> list[str]:
 
 def envelope_uniform_column_kind(envelope: dict[str, Any], *, ncols: int) -> str | None:
     """Decode-only: all-int or all-float fast path when ``column_kinds`` are uniform; None if mixed."""
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     return _uniform_column_kind(envelope_column_kinds(envelope, ncols=ncols))
 
 
@@ -789,6 +801,7 @@ def binary_envelope_skip_reason(
 
 def _is_numeric_coercible_impl(value: Any) -> bool:
     """Body of ``is_numeric_coercible`` without ``@deal.pre`` (used by ``is_numeric_grid``)."""
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     if value is None or isinstance(value, (bool, int, float)):
         return True
     # Fast direct type inspection for NumPy scalar types on the child side without module-level imports
@@ -818,6 +831,7 @@ def is_numeric_coercible(value: Any) -> bool:
     mixed grids stay lists after child split_grid unpack (zip codes and labels preserved).
     Empty strings match Calc empty cells (``None``).
     """
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     return _is_numeric_coercible_impl(value)
 
 
@@ -826,6 +840,7 @@ def is_numeric_coercible(value: Any) -> bool:
 @deal.ensure(lambda grid, *a, result=_DEAL_RETURN, **k: len(grid) > 0 or _deal_return(*a, result=result) is True)
 def is_numeric_grid(grid: list[Any] | list[list[Any]]) -> bool:
     """True when every cell is numeric-coercible (safe for numeric-only split_grid fast-path)."""
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     if len(grid) == 0:
         return True
     if type(grid[0]) in (list, tuple):
@@ -867,6 +882,7 @@ def wire_cell_count(data: Any) -> int:
 @deal.post(lambda result: isinstance(result, list))
 def grid_from_nested_list(grid: list[Any] | list[list[Any]]) -> list[Any] | list[list[Any]]:
     """Normalize to flat or 2D Python lists for small grids (below BINARY_MIN_CELLS) or non-split_grid results."""
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     if len(grid) == 0:
         return []
     if type(grid[0]) in (list, tuple) and all(isinstance(r, (list, tuple)) for r in grid):
@@ -1409,6 +1425,7 @@ def host_unpack_data(wire: Any, *, as_nested_list: bool = True) -> Any:
     )
 )
 def is_split_grid(obj: Any) -> bool:
+    # crosshair: off  # combinatoric Any/envelope detector (cover-all 33418536119: payload_codec 11581s after PR 523). Doable later with a closed envelope alphabet.
     return _is_split_grid_envelope(obj)
 
 

--- a/plugin/scripting/sandbox_cache.py
+++ b/plugin/scripting/sandbox_cache.py
@@ -124,11 +124,13 @@ _max_entries = _DEFAULT_MAX_ENTRIES
 
 @deal.pre(lambda authorized_imports: _deal_sandbox_imports_ok(authorized_imports))
 def _imports_fingerprint(authorized_imports: list[str]) -> str:
+    # crosshair: off  # sorted join over symbolic import lists (cover-all 33418536119: sandbox_cache 20906s after PR 523). Doable later with a closed import-alphabet fingerprint.
     return "\n".join(sorted(set(authorized_imports)))
 
 
 @deal.pre(lambda code, authorized_imports: _deal_sandbox_code_ok(code) and _deal_sandbox_imports_ok(authorized_imports))
 def _cache_key(code: str, authorized_imports: list[str]) -> str:
+    # crosshair: off  # sha256 on symbolic code+NUL (cover-all 33418536119: sandbox_cache 20906s after PR 523). Engine-hostile; keep off.
     material = code + "\0" + _imports_fingerprint(authorized_imports)
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
@@ -156,6 +158,7 @@ def _build_entry(code: str, authorized_imports: list[str]) -> HotEntry:
 @deal.pre(lambda code, authorized_imports: _deal_sandbox_code_ok(code) and _deal_sandbox_imports_ok(authorized_imports))
 def get_hot_entry(code: str, authorized_imports: list[str]) -> HotEntry:
     """Return cached or freshly built parse + static validation for *code*."""
+    # crosshair: off  # threading.Lock + OrderedDict hot cache (cover-all 33418536119: sandbox_cache 20906s after PR 523). Engine-hostile; keep off.
     key = _cache_key(code, authorized_imports)
     with _lock:
         if key in _cache:

--- a/plugin/writer/xhtml_style_postprocess.py
+++ b/plugin/writer/xhtml_style_postprocess.py
@@ -315,6 +315,7 @@ def xhtml_to_semantic_html(full_xhtml, autostyle_parents=None):
     index. Recovers the base style **name** after StarWriter write→read when CSS fingerprint
     fails; does not recover whole-paragraph Para* overrides (v1 limitation — see plan doc).
     """
+    # crosshair: off  # HTMLParser over unbounded XHTML (cover-all 33418536119: xhtml_style_postprocess 1141s). Doable later with UNDER_CROSSHAIR dual-profile + DEAL_MAX_HTML_CHUNK (pytest fixtures exceed 512).
     raw_map, norm_map = parse_style_block(full_xhtml)
     body = _strip_body(full_xhtml)
     tr = _SemanticTransformer(raw_map, norm_map, autostyle_parents)


### PR DESCRIPTION
## Cover-all settle (run 33418536119)

- Run: https://github.com/KeithCu/writeragent/actions/runs/33418536119
- Workflow: CrossHair Verification (Deep / On-Demand), cover-all, 2 workers, start-at 39, SHA 801ea7c3 (PR 523 merged) on master
- Wall: created 2026-08-31T17:15:03Z, cancelled 2026-08-31T23:15:28Z (~6h0m, timeout-minutes 360)
- **0 COVER FAIL / CHECK FAIL / COVER ERROR**

### Flushed COVER TIMING (completion order)

| Module | Seconds | Notes |
| --- | ---: | --- |
| `plugin/scripting/payload_codec.py` | 11581.3 (~3.22h) | W1 |
| `plugin/writer/xhtml_style_postprocess.py` | 1141.2 (~19.0m) | W1 |
| `plugin/framework/client/response_normalizers.py` | 289.9 | W1 |
| `plugin/scripting/sandbox_cache.py` | 20906.7 (~5.81h) | W2 whole wall |
| `plugin/chatbot/audio_recorder_state.py` | 2.7 | W2 |
| `plugin/scripting/config_limits.py` | 100.2 | W2 |
| `plugin/framework/openrouter_model_id.py` | 235.8 | W2 |
| `plugin/framework/constants.py` | 1.6 | W2 |

`address_utils` and `html_stripper` had **no** COVER TIMING (W1 still in-flight on `address_utils` when the wall hit). Branch is off current master `3c213088` (PR 528); the four edited blobs match cover-all SHA content.

## What changed

### `plugin/scripting/payload_codec.py`
PR 523 offs (Cython/sys.modules, flatten, recursive Any walkers) were not enough — envelope/grid detectors still dominated 11581s. `# crosshair: off` on first body statement for:
`_is_any_payload_envelope`, `is_calc_range_payload`, `grid_from_nested_list`, `is_split_grid`, `_is_grid_sequence`, `_is_split_grid_envelope`, `_is_dataframe_envelope`, `is_dataframe_payload`, `is_multi_data`, `_is_calc_range_envelope`, `is_image_payload`, `_is_numeric_coercible_impl`, `is_numeric_coercible`, `is_numeric_grid`, `_is_image_payload_envelope`, `envelope_uniform_column_kind`, `envelope_column_kinds`.

Left fast FQNs alone (cython status, `_is_ndarray`, `_cell_for_json`, `cell_count`, binary-envelope helpers, `_uniform_column_kind`, `image_payload_suffix`). Did **not** module-off `payload_codec`. Kept `_deal_*` helpers.

### `plugin/scripting/sandbox_cache.py`
Tiny deal.pre from PR 523 was not enough (`get_hot_entry` bulk of 20906s). Offed engine-hostile / combinatoric:
`get_hot_entry`, `_cache_key`, `_imports_fingerprint` (threading.Lock + sha256 on symbolic code).

Kept `_build_entry` + existing deal.pre, and the UNDER_CROSSHAIR dual-profile helpers (production `VENV_AUTHORIZED_IMPORTS` ~99-item tuple still allowed under pytest).

### `plugin/calc/address_utils.py`
In-flight leftover (~2.45h on W1). `parse_address` / `parse_range_string` already off (regex). Offed `split_sheet_prefix` (`_SHEET_PREFIX` regex, no prior off/pre). Empty-string `if not ref` behavior unchanged (no deal.pre that would reject `""`).

### `plugin/writer/xhtml_style_postprocess.py`
~19m mostly `xhtml_to_semantic_html`. Prefer deal.pre, but pytest fixtures (`REFERENCE_XHTML` ~2k) exceed `DEAL_MAX_HTML_CHUNK` (512/16), so offed only `xhtml_to_semantic_html` with a doable-later dual-profile note. Did not mass-off `_SemanticTransformer` methods.

## Next cover-all

- **start-at 43** → `plugin/calc/address_utils.py` (NOT 47).
- 8 flushed is completion-count with 2 workers; `address_utils` was in-flight and unflushed. Re-running 44–47 is cheap.
- Keith kicks the next cover-all himself after pull. Hang-check stays paused. Do not stack a run.