### PR TITLE
Fix macOS test-uno segfault; add opt-in Windows pytest hang diagnostics

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -19,6 +19,16 @@ on:
         required: false
         default: false
         type: boolean
+      ci_debug:
+        description: "Opt-in hang diagnostics (nodeid trail, faulthandler, --max-worker-restart=0, process dump, artifacts). Off by default."
+        required: false
+        default: false
+        type: boolean
+      pytest_serial:
+        description: "Disable xdist (PYTEST_WORKERS=0). Use with ci_debug to get a serial traceback."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -28,7 +38,9 @@ jobs:
   test:
     name: ${{ inputs.test_mock_sidebar == true && format('Mock LLM Sidebar ({0})', matrix.os) || format('Test & Typecheck ({0})', matrix.os) }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ inputs.test_mock_sidebar == true && 60 || 30 }}
+    # 30 is the budget that cancelled 33447705893 after the xdist replace wedge.
+    # Debug runs get 40 so dump + artifact upload still run after a 25-min test step.
+    timeout-minutes: ${{ inputs.test_mock_sidebar == true && 60 || (inputs.ci_debug == true && 40 || 30) }}
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +59,8 @@ jobs:
     env:
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
+      WRITERAGENT_CI_DEBUG: ${{ inputs.ci_debug == true && '1' || '' }}
+      WRITERAGENT_CI_DEBUG_DIR: ${{ runner.temp }}/pytest-ci-debug
 
     steps:
       - name: Checkout repository
@@ -123,8 +137,36 @@ jobs:
 
       - name: Run tests (Pytest + UNO)
         if: ${{ inputs.test_mock_sidebar != true }}
+        timeout-minutes: 25
         run: |
+          if [ "${{ inputs.pytest_serial }}" = "true" ]; then
+            export PYTEST_WORKERS=0
+          fi
+          if [ "$WRITERAGENT_CI_DEBUG" = "1" ]; then
+            mkdir -p "$WRITERAGENT_CI_DEBUG_DIR"
+          fi
           make test
+
+      - name: Dump leftover processes (CI debug)
+        if: ${{ always() && inputs.ci_debug == true }}
+        run: |
+          mkdir -p "$WRITERAGENT_CI_DEBUG_DIR"
+          dump="$WRITERAGENT_CI_DEBUG_DIR/processes.txt"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            tasklist > "$dump" || true
+          else
+            ps -ef > "$dump" || true
+          fi
+          echo "=== harper-ls / soffice.bin ==="
+          grep -E 'harper-ls|soffice(\.bin)?' "$dump" || echo "(none)"
+
+      - name: Upload CI debug artifacts
+        if: ${{ always() && inputs.ci_debug == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-debug-${{ matrix.os }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/pytest-ci-debug/
+          if-no-files-found: warn
 
       - name: Verify Core & Grammar Extension Packaging Lifecycles (LibrePy, LibreHarper)
         if: ${{ inputs.test_mock_sidebar != true }}

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ ifeq ($(OS),Windows_NT)
         LO_PYTHON ?= $(LO_PROGRAM)/python.exe
     else
         UNOPKG := unopkg
-        LO_PYTHON ?= python
+        # No LibreOffice program dir: leave LO_PYTHON unset. A random
+        # python.exe cannot host pyuno; test-uno must fail loudly instead.
     endif
 else
     SCRIPTS = $(PROJECT_ROOT)/scripts
@@ -96,6 +97,18 @@ else
     UNAME_S := $(shell uname -s 2>/dev/null)
     ifeq ($(UNAME_S),Darwin)
     LO_CONF := $(HOME)/Library/Application Support/LibreOffice/4
+    # pyuno is a CPython extension built for LibreOffice's bundled interpreter.
+    # Hosting it in an arbitrary CPython (the project .venv is 3.13) segfaults
+    # during import with no output — macOS CI 33447724981 died in ~150ms after
+    # falling through to $(PYTHON). Prefer Current, then any Versions/*, then
+    # Homebrew Caskroom copies of the same app bundle.
+    LO_PYTHON ?= $(firstword $(wildcard \
+        /Applications/LibreOffice.app/Contents/Frameworks/LibreOfficePython.framework/Versions/Current/bin/python3 \
+        /Applications/LibreOffice.app/Contents/Frameworks/LibreOfficePython.framework/Versions/*/bin/python3 \
+        /opt/homebrew/Caskroom/libreoffice/*/LibreOffice.app/Contents/Frameworks/LibreOfficePython.framework/Versions/Current/bin/python3 \
+        /opt/homebrew/Caskroom/libreoffice/*/LibreOffice.app/Contents/Frameworks/LibreOfficePython.framework/Versions/*/bin/python3 \
+        /usr/local/Caskroom/libreoffice/*/LibreOffice.app/Contents/Frameworks/LibreOfficePython.framework/Versions/Current/bin/python3 \
+        /usr/local/Caskroom/libreoffice/*/LibreOffice.app/Contents/Frameworks/LibreOfficePython.framework/Versions/*/bin/python3))
     else
     LO_CONF := $(HOME)/.config/libreoffice/4
     endif
@@ -152,7 +165,7 @@ endif
         dev-deploy dev-deploy-remove \
         lo-start lo-start-full lo-kill lo-restart \
         clean-cache nuke-cache nuke-cache-force unbundle \
-        log log-tail lo-log test pytest test-uno test-mock-sidebar test-run test-durations slowtests vhs test-visible lo-test-threadguard lo-test-threadguard-visible typecheck typecheck-full check-ext check-setup deploy ensure-uno \
+        log log-tail lo-log test pytest test-uno test-mock-sidebar test-run test-durations slowtests vhs test-visible lo-test-threadguard lo-test-threadguard-visible typecheck typecheck-full check-ext check-setup deploy ensure-uno _check-lo-python \
         verify crosshair-check crosshair-cover crosshair-check-all crosshair-check-all-deep \
         crosshair-cover-all crosshair-cover-all-deep \
         lo-start-log opengrep-lint opengrep-lint-advisory opengrep-rules-sync opengrep-rules-audit uno-thread-lint uno-thread-lint-advisory opengrep-install \
@@ -219,7 +232,8 @@ help:
 	@echo "  make check-ext              Verify extension is registered"
 	@echo "  make set-config             List all config keys"
 	@echo "  make test                   Run ty, mypy, pyright, pyspector, bandit, pytest + LO tests + excel-py-roundtrip"
-	@echo "  make pytest                 Unit pytest only (xdist -n -1; PYTEST_WORKERS=0 for serial)"
+	@echo "  make pytest                 Unit pytest only (xdist -n auto; PYTEST_WORKERS=0 for serial)"
+	@echo "  WRITERAGENT_CI_DEBUG=1      Opt-in hang diagnostics (nodeid trail, faulthandler, --max-worker-restart=0)"
 	@echo "  make mock-llm               Fake OpenAI chat server on :18766 (sidebar soak: scroll, tools, Stop, errors)"
 	@echo "  make test-uno               UNO tests only via testing_runner (serial live soffice)"
 	@echo "  make test-uno FILTER=…      Same; FILTER=path or test_* name (native runner)"
@@ -664,10 +678,13 @@ check-ext:
 	@echo "---"
 	@"$(PYTHON)" -c "from plugin._manifest import MODULES; print('Manifest OK: %d modules, %d with config' % (len(MODULES), len([m for m in MODULES if m.get('config')])))"
 
-# For LO tests: use Python that has uno/officehelper (LibreOffice's Python on Windows;
-# otherwise same as "python -m plugin.testing_runner").
-# We try to detect one that has the 'uno' module available, falling back to 'python' if none found.
-LO_PYTHON ?= $(shell python3 -c "import uno" 2>/dev/null && echo python3 || (python -c "import uno" 2>/dev/null && echo python || echo $(PYTHON)))
+# Host Python that can import the real pyuno bridge.
+# Windows / Darwin set LO_PYTHON above to LibreOffice's bundled interpreter.
+# Linux (and any platform that left it unset) probes system python3, then python.
+# Do NOT fall back to the project venv: on macOS that CPython 3.13 loads pyuno
+# and segfaults with no output (CI 33447724981). If nothing can import uno,
+# LO_PYTHON stays empty and _check-lo-python fails with the paths we looked for.
+LO_PYTHON ?= $(shell python3 -c "import uno" 2>/dev/null && echo python3 || (python -c "import uno" 2>/dev/null && echo python))
 
 # -j6 leaves a core free. Do not pass basedpyright --threads: it nests workers on this pool.
 typecheck: manifest ruff-for-build
@@ -692,10 +709,24 @@ PYTEST_XDIST :=
 else
 PYTEST_XDIST := -n $(PYTEST_WORKERS) --dist=loadgroup
 endif
-# --timeout is a backstop so a hung worker cannot sit ~19 min (Windows CI).
-# Per-test 300s (5 min) is well above unit-test runtime; hang points (Harper close, MCP
-# 400 body) are fixed in code. Not in pyproject addopts — vhs/slowtests need longer.
-PYTEST_UNIT = WRITERAGENT_PYTEST_PROGRESS=1 PYTHONUNBUFFERED=1 "$(PYTHON)" -u -m pytest tests -m "not slow and not integration" --ignore-glob="*_uno.py" --timeout=300 --timeout-method=thread $(PYTEST_XDIST)
+# Opt-in hang diagnostics (WRITERAGENT_CI_DEBUG=1). Off by default so PR CI stays
+# unchanged. --max-worker-restart=0 is the highest-value Windows knob: xdist
+# then prints the crashitem nodeid in the session summary instead of cloning
+# the dead worker (default restart budget is numprocesses*4). The clone must
+# re-collect ~6k items; the controller loop_once has a 2s poll and no deadline,
+# which is the 15-minute wedge after "replacing crashed worker gw3"
+# (33447705893). pytest-timeout did not fire — gw3 vanished at 261s with no
+# "Failed: Timeout" line.
+ifeq ($(WRITERAGENT_CI_DEBUG),1)
+PYTEST_CI_DEBUG_FLAGS := --max-worker-restart=0
+else
+PYTEST_CI_DEBUG_FLAGS :=
+endif
+# Per-test 300s thread-method backstop. It does not bound worker collection,
+# sessionstart, or the xdist controller wait, and it cannot abort a native or
+# subprocess block (33447705893: 261s gap, no Failed: Timeout). Not in
+# pyproject addopts — vhs/slowtests need longer.
+PYTEST_UNIT = WRITERAGENT_PYTEST_PROGRESS=1 PYTHONUNBUFFERED=1 "$(PYTHON)" -u -m pytest tests -m "not slow and not integration" --ignore-glob="*_uno.py" --timeout=300 --timeout-method=thread $(PYTEST_XDIST) $(PYTEST_CI_DEBUG_FLAGS)
 
 pytest:
 	@echo "=== pytest ==="
@@ -708,11 +739,29 @@ mock-llm:
 # Optional native-runner selectors: packet letter (B/C/D/E/F/G), case id (f3a), or test_* name.
 FILTER ?=
 
-test-uno:
+# Fail before launching a doomed interpreter. The old silent venv fallback
+# cost hours: macOS CI segfaulted in ~150ms with PYTHONUNBUFFERED=1 and no
+# _progress() output because it crashed during import, not during tests.
+_check-lo-python:
+	@if [ -z "$(strip $(LO_PYTHON))" ]; then \
+		echo >&2 "error: LO_PYTHON is empty — no interpreter that can import uno was found."; \
+		echo >&2 "LibreOffice pyuno cannot be hosted by an arbitrary CPython (macOS CI"; \
+		echo >&2 "segfaulted in ~150ms with no output when the project venv was used)."; \
+		echo >&2 "Looked for:"; \
+		echo >&2 "  macOS: /Applications/LibreOffice.app/Contents/Frameworks/LibreOfficePython.framework/Versions/Current/bin/python3"; \
+		echo >&2 "         (also Versions/*/bin/python3 and Homebrew Caskroom LibreOffice.app)"; \
+		echo >&2 "  Linux: python3 or python with a working 'import uno' (apt: python3-uno)"; \
+		echo >&2 "  Windows: LibreOffice/program/python.exe"; \
+		echo >&2 "Set LO_PYTHON to LibreOffice's bundled interpreter — not the project .venv."; \
+		exit 1; \
+	fi
+	@echo "LO_PYTHON=$(LO_PYTHON)"
+
+test-uno: _check-lo-python
 	@$(MAKE) -C "$(PROJECT_ROOT)" lo-kill
 	PYTHONUNBUFFERED=1 "$(LO_PYTHON)" -u -m plugin.testing_runner $(FILTER); EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
 
-test-mock-sidebar:
+test-mock-sidebar: _check-lo-python
 	@$(MAKE) -C "$(PROJECT_ROOT)" lo-kill
 	PYTHONUNBUFFERED=1 "$(LO_PYTHON)" -u -m plugin.testing_runner --user-profile tests/chatbot/test_mock_llm_sidebar_uno.py $(FILTER); EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
 
@@ -752,13 +801,13 @@ vhs:
 		tests/calc/test_address_utils_verification.py \
 		-k hypothesis -s --hypothesis-verbosity=verbose
 
-test-visible:
+test-visible: _check-lo-python
 	PYTHONUNBUFFERED=1 "$(LO_PYTHON)" -u -m plugin.testing_runner --visible test_charts_uno test_enhanced_charts_uno test_document_research_grep_uno test_rich_html_uno; EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
 
 lo-test-threadguard:
 	WRITERAGENT_UNO_THREAD_GUARD=1 $(MAKE) test-uno
 
-lo-test-threadguard-visible:
+lo-test-threadguard-visible: _check-lo-python
 	WRITERAGENT_UNO_THREAD_GUARD=1 PYTHONUNBUFFERED=1 "$(LO_PYTHON)" -u -m plugin.testing_runner --visible test_charts_uno test_enhanced_charts_uno test_document_research_grep_uno test_rich_html_uno; EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
 
 opengrep-lint:

--- a/docs/archive/test_architecture_analysis.md
+++ b/docs/archive/test_architecture_analysis.md
@@ -75,6 +75,10 @@ PYTHONUNBUFFERED=1 $(PYTHON) -u -m pytest tests -m "not slow and not integration
 
 `make test-run` is: `make pytest`, then `lo-kill`, then `PYTHONUNBUFFERED=1 $(LO_PYTHON) -u -m plugin.testing_runner` (serial UNO; do not parallelize). The runner prints flushed `SUITE start` / `TEST start` / `TEST end` lines on stderr so a glibc `soffice.bin` abort still names the last native test. `test_read_range_format_info_performance` uses a 40×40 grid (not 100×100) so the default suite does not copy tens of 10k-cell PyUNO arrays.
 
+`LO_PYTHON` is LibreOffice's bundled interpreter on Windows (`program/python.exe`) and macOS (`LibreOfficePython.framework/.../python3`). Linux probes `python3` then `python` for a working `import uno`. There is no silent fallback to the project `.venv`: that CPython 3.13 cannot host pyuno and segfaults during import on macOS (CI 33447724981, ~150ms, no output). If nothing is found, `make test-uno` fails with the paths it looked for (`_check-lo-python`).
+
+Opt-in hang diagnostics (`WRITERAGENT_CI_DEBUG=1`, or PR CI `workflow_dispatch` `ci_debug`): per-worker `start`/`end` nodeid trail + faulthandler dump at 240s under `WRITERAGENT_CI_DEBUG_DIR`, and `--max-worker-restart=0` so xdist prints the crashitem nodeid instead of replacing the worker and wedging on re-collection (Windows CI 33447705893: gw3 vanished at 261s with no `Failed: Timeout`; pytest-timeout did not fire). `pytest_serial` sets `PYTEST_WORKERS=0`. This is instrumentation, not a hang fix.
+
 Profile hotspots without the LO native suite:
 
 ```bash

--- a/docs/tests/mock-llm-sidebar.md
+++ b/docs/tests/mock-llm-sidebar.md
@@ -108,6 +108,8 @@ From the Actions tab → **PR CI** → **Run workflow**:
 |-------|---------|
 | `os` | Ubuntu / macOS / Windows / `all` (same picker as the rest of PR CI) |
 | `test_mock_sidebar` | Off (default): typecheck + pytest/UNO + packaging. On: skip those and run `make test-mock-sidebar` only |
+| `ci_debug` | Off (default). On: `WRITERAGENT_CI_DEBUG=1` — per-worker nodeid trail, faulthandler dump at 240s, `--max-worker-restart=0`, leftover process dump, upload `ci-debug-<os>-<run_id>`. Does **not** fix the Windows hang; it is how we get the crashed-worker nodeid. |
+| `pytest_serial` | Off (default). On: `PYTEST_WORKERS=0` (no xdist). Use with `ci_debug` when you want a serial traceback. |
 
 Linux starts a virtual framebuffer (`xvfb-run` + `dbus-run-session`) because `testing_runner` refuses `--user-profile` without `DISPLAY`. WriterAgent is still built and registered first.
 

--- a/tests/ci_debug.py
+++ b/tests/ci_debug.py
@@ -1,0 +1,99 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Opt-in pytest hang diagnostics for CI (WRITERAGENT_CI_DEBUG=1).
+
+Off by default. When enabled, each xdist worker (or the controller) appends a
+flushed ``start <nodeid>`` / ``end <nodeid>`` trail and schedules a
+faulthandler dump at 240s. Windows CI 33447705893 lost gw3 at 261s with no
+``Failed: Timeout`` line — pytest-timeout did not fire (thread method cannot
+abort a native/subprocess block). Dump while the worker is still alive so a
+later unclean death still names the hung test and dumps every thread's stack.
+
+This does not fix the Windows hang. ``--max-worker-restart=0`` (Makefile,
+same flag) is what lets the session summary print
+``worker 'gw3' crashed while running '<nodeid>'`` instead of replacing the
+worker and wedging on re-collection.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import os
+from typing import IO, Optional
+
+# Observed hang-to-crash is ~261s (under --timeout=300, which did not fire).
+# Dump at 240s while the worker is still alive. pytest-timeout only bounds a
+# test function; it does not cover collection, sessionstart, or the xdist
+# controller wait after "replacing crashed worker".
+_FAULT_DUMP_SECONDS = 240
+
+_log_fh: Optional[IO[str]] = None
+
+
+def ci_debug_enabled() -> bool:
+    return os.environ.get("WRITERAGENT_CI_DEBUG") == "1"
+
+
+def ci_debug_dir() -> str:
+    return os.environ.get("WRITERAGENT_CI_DEBUG_DIR") or os.path.join("build", "ci-debug")
+
+
+def ci_debug_worker_id() -> str:
+    return os.environ.get("PYTEST_XDIST_WORKER") or "controller"
+
+
+def ci_debug_log_path(directory: str | None = None, worker_id: str | None = None) -> str:
+    return os.path.join(directory or ci_debug_dir(), f"{worker_id or ci_debug_worker_id()}.log")
+
+
+def write_ci_debug_line(fh: IO[str], line: str) -> None:
+    """Append one line and flush so a SIGKILL cannot lose the tail."""
+    fh.write(line + "\n")
+    fh.flush()
+    try:
+        os.fsync(fh.fileno())
+    except OSError:
+        pass
+
+
+def start_ci_debug() -> Optional[IO[str]]:
+    """Open the per-worker log and arm faulthandler. Idempotent."""
+    global _log_fh
+    if not ci_debug_enabled():
+        return None
+    if _log_fh is not None:
+        return _log_fh
+    directory = ci_debug_dir()
+    os.makedirs(directory, exist_ok=True)
+    _log_fh = open(ci_debug_log_path(directory), "a", encoding="utf-8", buffering=1)
+    write_ci_debug_line(_log_fh, f"session pid={os.getpid()} worker={ci_debug_worker_id()}")
+    faulthandler.dump_traceback_later(
+        _FAULT_DUMP_SECONDS,
+        repeat=True,
+        exit=False,
+        file=_log_fh,
+    )
+    return _log_fh
+
+
+def log_ci_debug(line: str) -> None:
+    if _log_fh is None:
+        return
+    write_ci_debug_line(_log_fh, line)
+
+
+def stop_ci_debug() -> None:
+    """Cancel the watchdog and close the log. Safe if start was never called."""
+    global _log_fh
+    try:
+        faulthandler.cancel_dump_traceback_later()
+    except Exception:
+        pass
+    if _log_fh is not None:
+        try:
+            _log_fh.close()
+        except Exception:
+            pass
+        _log_fh = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,6 +340,25 @@ def _make_pytest_progress_enabled() -> bool:
     )
 
 
+def pytest_configure(config):
+    """Arm opt-in CI hang diagnostics (no-op unless WRITERAGENT_CI_DEBUG=1)."""
+    from tests.ci_debug import start_ci_debug
+
+    start_ci_debug()
+
+
+def pytest_runtest_logstart(nodeid, location):
+    from tests.ci_debug import log_ci_debug
+
+    log_ci_debug(f"start {nodeid}")
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    from tests.ci_debug import log_ci_debug
+
+    log_ci_debug(f"end {nodeid}")
+
+
 def pytest_sessionstart(session):
     """Clean leftover ``MagicMock/`` dirs from accidental mock stringification.
 
@@ -397,6 +416,9 @@ def _shutdown_harper_runtime_after_test():
 
 def pytest_sessionfinish(session, exitstatus):
     """Fail the run if isolation leaked a ``MagicMock/`` tree under the repo root."""
+    from tests.ci_debug import stop_ci_debug
+
+    stop_ci_debug()
     _shutdown_harper_if_loaded()
     if _is_xdist_worker(session):
         return

--- a/tests/scripts/test_makefile.py
+++ b/tests/scripts/test_makefile.py
@@ -46,3 +46,45 @@ def test_lo_kill_when_cwd_has_no_makefile(tmp_path: Path) -> None:
 
     text = MAKEFILE.read_text(encoding="utf-8")
     assert '$(MAKE) -C "$(PROJECT_ROOT)" lo-kill' in text
+
+
+def test_makefile_darwin_lo_python_uses_bundled_interpreter() -> None:
+    """macOS must not fall through to the project venv (CI 33447724981)."""
+    text = MAKEFILE.read_text(encoding="utf-8")
+    darwin = text.split("ifeq ($(UNAME_S),Darwin)", 1)[1].split("else", 1)[0]
+    assert "LibreOfficePython.framework" in darwin
+    assert "Versions/Current/bin/python3" in darwin
+    assert "Caskroom/libreoffice" in darwin
+    assert "echo $(PYTHON)" not in darwin
+
+
+def test_makefile_lo_python_probe_does_not_silently_use_venv() -> None:
+    """The old `|| echo $(PYTHON)` launched .venv and segfaulted on macOS."""
+    text = MAKEFILE.read_text(encoding="utf-8")
+    assert "echo $(PYTHON)" not in text
+    assert "_check-lo-python" in text
+    assert "test-uno: _check-lo-python" in text
+
+
+def test_makefile_ci_debug_max_worker_restart_is_opt_in() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    assert "ifeq ($(WRITERAGENT_CI_DEBUG),1)" in text
+    assert "--max-worker-restart=0" in text
+    unit_line = [ln for ln in text.splitlines() if ln.startswith("PYTEST_UNIT")][0]
+    assert "$(PYTEST_CI_DEBUG_FLAGS)" in unit_line
+
+
+@pytest.mark.skipif(shutil.which("make") is None, reason="make not on PATH")
+def test_test_uno_empty_lo_python_fails_loudly() -> None:
+    """Empty LO_PYTHON must name the search paths, not launch testing_runner."""
+    proc = subprocess.run(
+        ["make", "-C", str(PROJECT_ROOT), "test-uno", "LO_PYTHON="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, combined
+    assert "LO_PYTHON is empty" in combined
+    assert "LibreOfficePython.framework" in combined
+    assert "plugin.testing_runner" not in combined

--- a/tests/scripts/test_pr_ci_debug.py
+++ b/tests/scripts/test_pr_ci_debug.py
@@ -1,0 +1,62 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""PR CI hang-diagnostics inputs stay off by default and upload artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "pr-ci.yml"
+
+
+def _workflow() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+def _dispatch_inputs() -> str:
+    return _workflow().split("workflow_dispatch:", 1)[1].split("jobs:", 1)[0]
+
+
+def test_pr_ci_debug_inputs_default_off() -> None:
+    inputs = _dispatch_inputs()
+    assert "ci_debug:" in inputs
+    assert "pytest_serial:" in inputs
+    assert inputs.count("default: false") >= 3
+
+
+def test_pr_ci_debug_env_only_when_input_true() -> None:
+    text = _workflow()
+    assert "WRITERAGENT_CI_DEBUG:" in text
+    assert "inputs.ci_debug == true && '1' || ''" in text
+    assert "WRITERAGENT_CI_DEBUG_DIR:" in text
+    assert "pytest-ci-debug" in text
+
+
+def test_pr_ci_debug_uploads_artifacts_and_process_dump() -> None:
+    text = _workflow()
+    assert "actions/upload-artifact@v4" in text
+    assert "ci-debug-${{ matrix.os }}" in text
+    assert "Dump leftover processes" in text
+    assert "tasklist" in text
+    assert "ps -ef" in text
+    assert "harper-ls" in text
+    assert "soffice" in text
+    assert "if: ${{ always() && inputs.ci_debug == true }}" in text
+
+
+def test_pr_ci_test_step_has_timeout_and_serial_escape() -> None:
+    text = _workflow()
+    test_step = text.split("Run tests (Pytest + UNO)", 1)[1].split(
+        "Dump leftover processes", 1
+    )[0]
+    assert "timeout-minutes: 25" in test_step
+    assert "PYTEST_WORKERS=0" in test_step
+    assert "inputs.pytest_serial" in test_step
+
+
+def test_pr_ci_job_timeout_grows_only_for_debug() -> None:
+    text = _workflow()
+    assert "inputs.ci_debug == true && 40 || 30" in text

--- a/tests/test_ci_debug.py
+++ b/tests/test_ci_debug.py
@@ -1,0 +1,68 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for opt-in CI hang diagnostics (WRITERAGENT_CI_DEBUG)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests import ci_debug
+
+
+@pytest.fixture(autouse=True)
+def _reset_ci_debug_handle():
+    """Module-level file handle must not leak between tests."""
+    ci_debug.stop_ci_debug()
+    yield
+    ci_debug.stop_ci_debug()
+
+
+def test_ci_debug_disabled_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WRITERAGENT_CI_DEBUG", raising=False)
+    monkeypatch.setenv("WRITERAGENT_CI_DEBUG_DIR", str(tmp_path))
+    assert ci_debug.ci_debug_enabled() is False
+    assert ci_debug.start_ci_debug() is None
+    ci_debug.log_ci_debug("start should-not-write")
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_ci_debug_trail_flushes_start_and_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WRITERAGENT_CI_DEBUG", "1")
+    monkeypatch.setenv("WRITERAGENT_CI_DEBUG_DIR", str(tmp_path))
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    assert ci_debug.ci_debug_enabled() is True
+    assert ci_debug.ci_debug_worker_id() == "gw3"
+    fh = ci_debug.start_ci_debug()
+    assert fh is not None
+    ci_debug.log_ci_debug("start tests/foo.py::test_hang")
+    ci_debug.log_ci_debug("end tests/foo.py::test_hang")
+    path = tmp_path / "gw3.log"
+    assert path.is_file()
+    text = path.read_text(encoding="utf-8")
+    assert "worker=gw3" in text
+    assert "start tests/foo.py::test_hang" in text
+    assert "end tests/foo.py::test_hang" in text
+
+
+def test_ci_debug_last_start_without_end_names_hung_test(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WRITERAGENT_CI_DEBUG", "1")
+    monkeypatch.setenv("WRITERAGENT_CI_DEBUG_DIR", str(tmp_path))
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    ci_debug.start_ci_debug()
+    ci_debug.log_ci_debug("start tests/a.py::test_ok")
+    ci_debug.log_ci_debug("end tests/a.py::test_ok")
+    ci_debug.log_ci_debug("start tests/b.py::test_hung")
+    ci_debug.stop_ci_debug()
+    lines = (tmp_path / "controller.log").read_text(encoding="utf-8").splitlines()
+    starts = [ln for ln in lines if ln.startswith("start ")]
+    ends = [ln for ln in lines if ln.startswith("end ")]
+    assert starts[-1] == "start tests/b.py::test_hung"
+    assert "end tests/b.py::test_hung" not in ends


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two CI failures on master today, one PR.

## (a) macOS `make test-uno` segfault — real fix

[Run 33447724981](https://github.com/KeithCu/writeragent/actions/runs/33447724981) (`Test & Typecheck (macos-latest)`): pytest was clean (`6292 passed` in 225s). Then:

```
PYTHONUNBUFFERED=1 "/Users/runner/work/writeragent/writeragent/.venv/bin/python" -u -m plugin.testing_runner
/bin/sh: line 1: 20167 Segmentation fault: 11
```

~150ms, zero output, despite `-u` / `PYTHONUNBUFFERED=1` and `testing_runner._progress()` flushing stderr. That is import-time, not a test or teardown crash.

**Evidence matches the venv-fallback hypothesis.** The logged interpreter is the project `.venv` (the `$(PYTHON)` fallback). Both `import uno` probes failed, so Make silently launched CPython 3.13. `scripts/fix_uno_import.py` already documents that macOS pyuno cannot be hosted by an arbitrary CPython (it only links `uno.py` into the venv for type checkers). Loading the real bridge from that venv segfaults instead of raising `ImportError`.

**What changed**
- Darwin sets `LO_PYTHON` to LibreOffice’s bundled interpreter (`LibreOfficePython.framework`, `Current` then `Versions/*`, plus Homebrew Caskroom copies). Same idea as Windows `LO_PROGRAM/python.exe`.
- The silent `|| echo $(PYTHON)` fallback is gone. If no interpreter that can `import uno` is found, `make test-uno` fails immediately with the paths it looked for (`_check-lo-python`).
- Linux still probes `python3` then `python` (Ubuntu CI installs `python3-uno`; this box resolves `LO_PYTHON=python3`). Windows still uses `program/python.exe` and no longer falls back to a random `python.exe` when LibreOffice is missing.

## (b) Windows pytest hang — diagnostics only, not a fix

[Run 33447705893](https://github.com/KeithCu/writeragent/actions/runs/33447705893) (job `99670410245`):

| Time (UTC) | What |
|---|---|
| 22:56:47 | last progress `pytest: 6300` |
| 23:01:08 | `[gw3] node down: Not properly terminated` + `F` + `replacing crashed worker gw3` (261s gap, **under 300s**) |
| 23:16:05 | `##[error]The operation was canceled.` — this is the job `timeout-minutes: 30` (job started ~22:45:56), not a human cancel |

**pytest-timeout did not fire.** There is no `Failed: Timeout` line. `--timeout=300 --timeout-method=thread` was on the path (`timeout-2.4.0`, log says `timeout: 300.0s`) and cannot abort a native/subprocess block. It also does not bound worker collection, `sessionstart`, or the xdist controller wait.

Two distinct problems we still cannot see:

1. A test hung ~4 min on gw3; the worker then vanished uncleanly. xdist only printed `F`. The `worker 'gw3' crashed while running '<nodeid>'` line lives in the session summary, which never printed.
2. After replace, xdist cloned gw3 (default `--max-worker-restart` = `numprocesses*4` = 16). The clone re-collects ~6325 items; the controller `loop_once` waits with a 2s poll and no deadline. That is the 15-minute wedge.

Nine earlier named Windows FAILs (path/i18n, 22:55:15–22:56:41) are unrelated. Pre-#528 run 33443297020 hung at 99% for ~19.5 min with no timeout plugin and no `[gw*] node down` — #528 changed the symptom (worker now dies ~4 min after 99%) but the job still burns the 30-min budget after replace.

**This PR does not claim to fix that hang.** We still do not know the nodeid or why the worker vanished.

**Opt-in harness** (`WRITERAGENT_CI_DEBUG=1`, off by default):

- Per-worker `start <nodeid>` / `end <nodeid>` trail, flushed every line (`tests/ci_debug.py`).
- `faulthandler.dump_traceback_later(240, repeat=True, exit=False)` — dump while still hung; the observed death is ~261s.
- `--max-worker-restart=0` so xdist aborts on the first worker death and the crashitem summary can print the nodeid (highest-value Windows knob).
- Test-step `timeout-minutes: 25` so a wedge cannot eat the whole job; debug jobs get `timeout-minutes: 40` so dump + upload still run.
- `if: always()` leftover process dump (`tasklist` / `ps -ef`, grep `harper-ls` and `soffice`) and `actions/upload-artifact`.
- `pytest_serial` → `PYTEST_WORKERS=0` (no xdist) if we need a serial traceback.

Default PR CI (flag unset) is unchanged aside from the macOS `LO_PYTHON` fix and the loud-failure message.

## How to trigger the instrumented Windows run

Actions → **PR CI** → **Run workflow**:

| Input | Set to |
|---|---|
| `os` | `windows-latest` (or `all` if you also want macOS confirmation) |
| `test_mock_sidebar` | **false** |
| `ci_debug` | **true** |
| `pytest_serial` | **false** first (reproduce the xdist hang). If you want a serial traceback on a second run, set **true**. |

After the run, download artifact **`ci-debug-windows-latest-<run_id>`**.

| File | What to look for |
|---|---|
| `gw3.log` (or whichever worker died) | Last `start <nodeid>` with no matching `end` — that is the hung test. Faulthandler stacks land in the same file at 240s. |
| `controller.log` | Controller-side trail (usually idle during the hang). |
| `processes.txt` | Leftover `harper-ls` / `soffice.bin` after the test step. |
| Job log session summary | With `--max-worker-restart=0`, xdist should print `worker 'gwN' crashed while running '<nodeid>'` instead of replacing and going silent. |

Do not treat a green Ubuntu PR check as evidence the Windows hang is gone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ed28d0d-a154-4c99-8a52-a0be3bda70de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ed28d0d-a154-4c99-8a52-a0be3bda70de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

