### PR TITLE
Fix PR CI startup_failure: runner.temp invalid in job env

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -56,11 +56,14 @@ jobs:
         shell: bash
 
     # Windows runners default Python stdio to cp1252; pyspector prints U+1F4A1.
+    # Do not set WRITERAGENT_CI_DEBUG_DIR here: runner is not available in
+    # jobs.<job_id>.env (startup_failure 33452656845). Run steps export
+    # $RUNNER_TEMP/pytest-ci-debug instead; upload-artifact path uses
+    # ${{ runner.temp }} at step level, which is valid.
     env:
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
       WRITERAGENT_CI_DEBUG: ${{ inputs.ci_debug == true && '1' || '' }}
-      WRITERAGENT_CI_DEBUG_DIR: ${{ runner.temp }}/pytest-ci-debug
 
     steps:
       - name: Checkout repository
@@ -142,6 +145,7 @@ jobs:
           if [ "${{ inputs.pytest_serial }}" = "true" ]; then
             export PYTEST_WORKERS=0
           fi
+          export WRITERAGENT_CI_DEBUG_DIR="$RUNNER_TEMP/pytest-ci-debug"
           if [ "$WRITERAGENT_CI_DEBUG" = "1" ]; then
             mkdir -p "$WRITERAGENT_CI_DEBUG_DIR"
           fi
@@ -150,6 +154,7 @@ jobs:
       - name: Dump leftover processes (CI debug)
         if: ${{ always() && inputs.ci_debug == true }}
         run: |
+          export WRITERAGENT_CI_DEBUG_DIR="$RUNNER_TEMP/pytest-ci-debug"
           mkdir -p "$WRITERAGENT_CI_DEBUG_DIR"
           dump="$WRITERAGENT_CI_DEBUG_DIR/processes.txt"
           if [ "${{ runner.os }}" = "Windows" ]; then

--- a/plugin/scripting/venv_probe_ui.py
+++ b/plugin/scripting/venv_probe_ui.py
@@ -19,6 +19,7 @@ from plugin.chatbot.dialogs import (
 from plugin.framework.uno_listeners import BaseActionListener
 from plugin.framework.i18n import _
 from plugin.framework.queue_executor import post_to_main_thread
+from plugin.framework.thread_guard import on_main_thread
 from plugin.framework.uno_context import process_events_to_idle
 from plugin.framework.worker_pool import run_in_background
 
@@ -85,11 +86,20 @@ class VenvProbeProgressDialog:
         if btn_close is not None:
             btn_close.addActionListener(_VenvProbeCloseListener(self))
 
+    def _pump_dialog(self) -> None:
+        # finish() is posted from the probe worker via post_to_main_thread.
+        # Opengrep intrafile taint still treats process_events_to_idle in
+        # finish() as a worker sink (uno-off-main-thread). A bare
+        # if on_main_thread() is the documented sanitizer; pumping VCL
+        # off-main is never correct.
+        if on_main_thread():
+            process_events_to_idle(self._ctx)
+
     def set_display(self, text: str) -> None:
         if self._dlg is None:
             return
         set_control_text(self._dlg.getControl("LogArea"), text)
-        process_events_to_idle(self._ctx)
+        self._pump_dialog()
 
     def set_status(self, text: str) -> None:
         if self._dlg is None:
@@ -98,7 +108,7 @@ class VenvProbeProgressDialog:
         if len(status) > 80:
             status = status[:77] + "..."
         set_control_text(self._dlg.getControl("StatusLbl"), status)
-        process_events_to_idle(self._ctx)
+        self._pump_dialog()
 
     def finish(self, title: str, ok: bool) -> None:
         if self._dlg is None:
@@ -109,7 +119,7 @@ class VenvProbeProgressDialog:
             log.debug("venv probe dialog title failed", exc_info=True)
         set_control_text(self._dlg.getControl("StatusLbl"), _("Done") if ok else _("Failed"))
         set_control_enabled(self._dlg.getControl("BtnClose"), True)
-        process_events_to_idle(self._ctx)
+        self._pump_dialog()
 
     def _dispose(self) -> None:
         dlg = self._dlg

--- a/tests/librepy/test_settings.py
+++ b/tests/librepy/test_settings.py
@@ -84,8 +84,36 @@ def test_venv_probe_progress_pumps_events():
     with (
         patch("plugin.scripting.venv_probe_ui.process_events_to_idle") as mock_pump,
         patch("plugin.scripting.venv_probe_ui.set_control_text"),
+        patch("plugin.scripting.venv_probe_ui.on_main_thread", return_value=True),
     ):
         progress.set_status("warming worker")
+
+    mock_pump.assert_called_once_with(ctx)
+
+
+def test_venv_probe_progress_finish_pumps_only_on_main_thread() -> None:
+    ctx = MagicMock()
+    progress = VenvProbeProgressDialog(ctx)
+    progress._dlg = MagicMock()
+    progress._dlg.getControl.return_value = MagicMock()
+
+    with (
+        patch("plugin.scripting.venv_probe_ui.process_events_to_idle") as mock_pump,
+        patch("plugin.scripting.venv_probe_ui.set_control_text"),
+        patch("plugin.scripting.venv_probe_ui.set_control_enabled"),
+        patch("plugin.scripting.venv_probe_ui.on_main_thread", return_value=False),
+    ):
+        progress.finish("Venv check failed", False)
+
+    mock_pump.assert_not_called()
+
+    with (
+        patch("plugin.scripting.venv_probe_ui.process_events_to_idle") as mock_pump,
+        patch("plugin.scripting.venv_probe_ui.set_control_text"),
+        patch("plugin.scripting.venv_probe_ui.set_control_enabled"),
+        patch("plugin.scripting.venv_probe_ui.on_main_thread", return_value=True),
+    ):
+        progress.finish("Venv OK", True)
 
     mock_pump.assert_called_once_with(ctx)
 

--- a/tests/scripts/test_pr_ci_debug.py
+++ b/tests/scripts/test_pr_ci_debug.py
@@ -31,8 +31,11 @@ def test_pr_ci_debug_env_only_when_input_true() -> None:
     text = _workflow()
     assert "WRITERAGENT_CI_DEBUG:" in text
     assert "inputs.ci_debug == true && '1' || ''" in text
-    assert "WRITERAGENT_CI_DEBUG_DIR:" in text
-    assert "pytest-ci-debug" in text
+    # runner is not available in jobs.<job_id>.env (startup_failure 33452656845).
+    job_env = text.split("    env:", 1)[1].split("    steps:", 1)[0]
+    assert "runner" not in job_env
+    assert "WRITERAGENT_CI_DEBUG_DIR" not in job_env
+    assert 'export WRITERAGENT_CI_DEBUG_DIR="$RUNNER_TEMP/pytest-ci-debug"' in text
 
 
 def test_pr_ci_debug_uploads_artifacts_and_process_dump() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub Actions run [33452656845](https://github.com/KeithCu/writeragent/actions/runs/33452656845) was a **startup_failure** with zero jobs:

```
Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.temp
```

`runner` is not available in `jobs.<job_id>.env` (evaluated before a runner is assigned). The job-level `WRITERAGENT_CI_DEBUG_DIR: ${{ runner.temp }}/pytest-ci-debug` line was the cause.

This PR removes that job-env line and exports `WRITERAGENT_CI_DEBUG_DIR="$RUNNER_TEMP/pytest-ci-debug"` in the run steps that write debug files. The upload-artifact `path: ${{ runner.temp }}/pytest-ci-debug/` stays as-is (step-level, valid). Debug-flag semantics and Mac `LO_PYTHON` are unchanged. This does not claim the Windows hang is fixed.

Also fixes the `uno-off-main-thread` opengrep hit in `plugin/scripting/venv_probe_ui.py`: `finish()` is posted from the probe worker, so intrafile taint treated `process_events_to_idle` as a worker sink. The VCL pump now runs only inside a bare `if on_main_thread()`.

After merge, re-dispatch **PR CI**:
- Windows: `ci_debug=true`, `pytest_serial=false`
- Mac: both flags off

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ed6c056-39b6-4b20-ba6e-fd27c9260386?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ed6c056-39b6-4b20-ba6e-fd27c9260386&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

