### PR TITLE
Don't crash _normalize_delta on non-plain dicts

### DIFF
--- a/plugin/framework/client/stream_normalizer.py
+++ b/plugin/framework/client/stream_normalizer.py
@@ -337,23 +337,27 @@ def _normalize_delta_tool_calls_ok(delta: dict[str, Any]) -> bool:
 
 
 @deal.pre(
-    lambda delta: type(delta) is dict
-    and len(delta) <= DEAL_MAX_SHAPE_DIM
-    and (
-        not isinstance(delta.get("tool_calls"), list)
-        or len(delta["tool_calls"]) <= DEAL_MAX_SHAPE_DIM
+    lambda delta: type(delta) is not dict
+    or (
+        len(delta) <= DEAL_MAX_SHAPE_DIM
+        and (
+            not isinstance(delta.get("tool_calls"), list)
+            or len(delta["tool_calls"]) <= DEAL_MAX_SHAPE_DIM
+        )
     )
 )
-@deal.ensure(lambda delta, result: "role" not in delta or delta.get("role") is not None)
-@deal.ensure(lambda delta, result: _normalize_delta_tool_calls_ok(delta))
-def _normalize_delta(delta: dict[str, Any]) -> None:  # pyright: ignore[reportUnusedFunction]  # used by llm_client / response_normalizers
+@deal.ensure(lambda delta, result: type(delta) is not dict or "role" not in delta or delta.get("role") is not None)
+@deal.ensure(lambda delta, result: type(delta) is not dict or _normalize_delta_tool_calls_ok(delta))
+def _normalize_delta(delta: object) -> None:  # pyright: ignore[reportUnusedFunction]  # used by llm_client / response_normalizers
     """Normalize delta for Mistral/Azure compat before accumulate_delta.
     LiteLLM: streaming_handler.py ~L847 (role), ~L853 (type), ~L820 (arguments).
     """
-    # Shim path (deal absent): keep the old non-dict no-op. With deal installed, pre rejects.
-    # Plain dict only — CrossHair AttrDict is isinstance(dict) but field access can crash.
+    # Plain dict only. Non-dicts and dict subclasses (OrderedDict, CrossHair AttrDict)
+    # no-op: pre used to require `type is dict` and crashed MiniMax/OpenRouter eval
+    # (`expected type(delta) is dict`). See docs/eval/stream-normalizer-delta-crash.md.
     if type(delta) is not dict:
         return
+    delta = cast("dict[str, Any]", delta)
     # LiteLLM: streaming_handler.py ~L847 "mistral's api returns role as None"
     if "role" in delta and delta["role"] is None:
         delta["role"] = "assistant"

--- a/tests/framework/test_stream_normalizer_verification.py
+++ b/tests/framework/test_stream_normalizer_verification.py
@@ -238,6 +238,22 @@ def test_normalize_delta_ignores_non_list_tool_calls() -> None:
     assert delta["tool_calls"] == 2
 
 
+def test_normalize_delta_no_crash_on_non_dict() -> None:
+    """deal.pre must not reject None/str/list; body no-ops (MiniMax eval crash)."""
+    for junk in (None, "x", [], 2):
+        _normalize_delta(junk)
+
+
+def test_normalize_delta_no_crash_on_ordered_dict() -> None:
+    """Dict subclasses are isinstance(dict) but type() is not dict; skip, don't raise."""
+    from collections import OrderedDict
+
+    delta: OrderedDict[str, object] = OrderedDict({"role": None, "content": "hi"})
+    _normalize_delta(delta)
+    assert delta["role"] is None
+    assert delta["content"] == "hi"
+
+
 def test_merge_reasoning_details_overflow_pre_fails_closed() -> None:
     if not deal_pre_present(_merge_reasoning_details):
         pytest.skip("@deal.pre stripped in release bundle")


### PR DESCRIPTION
MiniMax M3 eval aborted with `expected type(delta) is dict` before any tokens (`docs/eval/stream-normalizer-delta-crash.md`).

`_normalize_delta` already no-ops unless `type(delta) is dict` (plain dict only; CrossHair AttrDict). `@deal.pre` still required `type is dict`, so dict subclasses and non-dicts raised `PreContractError` in the sync `parse_sync_response` path.

Relax pre/ensure to match the body. Keep `DEAL_MAX_SHAPE_DIM` caps on the plain-dict path. Tests: `None`/`str`/`list`/`OrderedDict` must not raise.

Does not stack a cover-all run.
