### PR TITLE
Log stderr when compute worker spawn handshake times out

### DIFF
--- a/compute_service/worker_base.py
+++ b/compute_service/worker_base.py
@@ -131,7 +131,19 @@ class BaseProcessWorker:
                     )
             self.tasks_executed = 0
         except subprocess.TimeoutExpired:
-            log.error("%s #%d spawn handshake timed out", self.worker_name, self.worker_id)
+            # Handshake hang: child may still be importing, or stdout was not pickle.
+            # Execute-path timeouts already attach _stderr_snippet(); spawn must too.
+            snippet = self._stderr_snippet()
+            spawned = self.process
+            rc = spawned.poll() if spawned is not None else None
+            extra = f" stderr={snippet!r}" if snippet else " stderr=<empty>"
+            log.error(
+                "%s #%d spawn handshake timed out (returncode=%s)%s",
+                self.worker_name,
+                self.worker_id,
+                rc,
+                extra,
+            )
             self.kill()
         except Exception as exc:
             log.error("Failed to spawn %s #%d: %s", self.worker_name, self.worker_id, exc)

--- a/docs/scripting/worker-spawn-handshake-timeouts.md
+++ b/docs/scripting/worker-spawn-handshake-timeouts.md
@@ -263,6 +263,7 @@ Fill this in as you go. Do not delete failed experiments.
 | Date | SHA | Hypothesis | Command | Result |
 |------|-----|------------|---------|--------|
 | 2026-09-01 | tree at investigation | CPU / `-n 8` | `make pytest`; then isolated `-n 6` on compute/venv | Full suite 38 fail (handshake 15s). Isolated 138 pass. 12-way idle handshake OK. CPU headroom. |
-| | | | | |
+| 2026-09-01 | `2f96c06a` | Control A / C / D | isolated compute/venv `-n 6`; idle `formula_worker` ×3; 12-child contention + parent `load_cython_accelerator` | A: 138 passed in 22s, no handshake timeouts. C: ready in 0.25–0.30s. D: 12/12 ready, max 0.45s. Env had no `PYTHON_COMPUTE`/`PYTEST`/`COV_`/`WRITERAGENT_*` leak. Flake not reproduced outside full suite. |
+| 2026-09-01 | `2f96c06a` + local | H2 | log `_stderr_snippet()` + `returncode` on spawn `TimeoutExpired`; test `test_spawn_timeout_logs_stderr_snippet` | Diagnostic only (no root-cause fix). Did not raise 15s timeout or cap workers. |
 
 When the flake is gone, set **Status** at the top to Fixed, name the commit, and point at the tests that lock the behavior.

--- a/tests/compute_service/test_formula_pool.py
+++ b/tests/compute_service/test_formula_pool.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import socket
 import threading
@@ -137,6 +138,35 @@ class TestFormulaPoolSupervisor:
             res = worker.execute({"ping": True}, timeout_sec=10)
             assert res.get("status") == "ok"
             assert res.get("result") == 1
+        finally:
+            worker.kill()
+
+    def test_spawn_timeout_logs_stderr_snippet(self, tmp_path, caplog, monkeypatch) -> None:
+        """Handshake TimeoutExpired must log child stderr (H2), not a bare one-liner."""
+        from compute_service import worker_base
+        from compute_service.worker_base import BaseProcessWorker
+
+        monkeypatch.setattr(worker_base, "_SPAWN_READY_TIMEOUT_SEC", 0.5)
+        script = tmp_path / "hang_worker.py"
+        script.write_text(
+            "\n".join(
+                [
+                    "import sys, time",
+                    "sys.stderr.write('hang-before-ready\\n')",
+                    "sys.stderr.flush()",
+                    "time.sleep(30)",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        with caplog.at_level(logging.ERROR, logger="compute_service.worker"):
+            worker = BaseProcessWorker(1, str(script), worker_name="Hang worker")
+        try:
+            joined = "\n".join(r.getMessage() for r in caplog.records)
+            assert "spawn handshake timed out" in joined
+            assert "returncode=" in joined
+            assert "hang-before-ready" in joined
+            assert not worker.is_alive()
         finally:
             worker.kill()
 


### PR DESCRIPTION
## Summary
- On `_SPAWN_READY_TIMEOUT_SEC`, log `returncode` plus the child stderr snippet (or `stderr=<empty>`) instead of a one-line timeout.
- Test `test_spawn_timeout_logs_stderr_snippet` covers a hang-before-ready child.
- Diagnostic only: does not raise the 15s timeout or cap xdist workers.

## Test plan
- [x] `pytest tests/compute_service/test_formula_pool.py::TestFormulaPoolSupervisor::test_spawn_timeout_logs_stderr_snippet`
- [ ] Full `make pytest` on a machine that has seen the flake; look for `spawn handshake timed out (returncode=…)` and whether stderr is empty or an ImportError.