### PR TITLE
Off cover-all 33569420452 leftovers (cors, i18n, to_dag, embeddings)

### DIFF
--- a/plugin/calc/excel_py_convert/to_dag.py
+++ b/plugin/calc/excel_py_convert/to_dag.py
@@ -474,6 +474,7 @@ def _excel_execution_order(model: ExcelWorkbookModel) -> list[ExcelPyCell]:
     and ascii_bounded(candidate or "", _DEAL_BINDING_A1_LEN)
 )
 def _prefer_excel_dep_token(current: str, candidate: str) -> str:
+    # crosshair: off  # string branch leftover (cover-all 33569420452: ~977s est / 1812 ex despite ascii_bounded A1). Doable later.
     """When merging deps that snap to the same A1, keep the Excel-native token if any.
 
     See ``EXCEL_DEP_TOKEN_FIDELITY`` / models module doc — fidelity only, not Calc semantics.
@@ -575,6 +576,7 @@ def convert_cell_to_dag(
     prior_in_order: list[ExcelPyCell] | None = None,
     best_effort: bool = False,
 ) -> ConvertedCell:
+    # crosshair: off  # ExcelWorkbookModel + resolve_deps/rewrite stack (cover-all 33569420452: ~1195s est / 2217 ex despite tiny list deals). Doable later.
     """Convert one Excel PY cell: rewrite ``xl`` in code + attach ranges on ``=PY``."""
     base = ConvertedCell(
         sheet=cell.sheet,

--- a/plugin/chatbot/memory.py
+++ b/plugin/chatbot/memory.py
@@ -88,6 +88,7 @@ UPSERT_MEMORY_CHAT_VALUE_MAX = 400
 )
 @deal.post(lambda result: result is None or isinstance(result, dict))
 def upsert_memory_arguments_dict(arguments: object) -> dict[str, Any] | None:
+    # crosshair: off  # dict|JSON str Any still explodes (cover-all 33569420452: 4656 examples / ~503s est despite DEAL_MAX_SOURCE). Doable later: closed key set.
     """Normalize smolagents ToolCall.arguments (dict or JSON string) to a dict."""
     if isinstance(arguments, dict):
         return cast("dict[str, Any]", arguments)
@@ -113,6 +114,7 @@ def upsert_memory_arguments_dict(arguments: object) -> dict[str, Any] | None:
 )
 @deal.post(lambda result: result is None or isinstance(result, str))
 def memory_key_from_tool_arguments(arguments: object) -> str | None:
+    # crosshair: off  # wraps upsert_memory_arguments_dict (cover-all 33569420452: 4491 examples / ~485s est). Doable later.
     """Extract memory key from smolagents ToolCall.arguments (dict or JSON string)."""
     d = upsert_memory_arguments_dict(arguments)
     if not d:

--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -124,6 +124,7 @@ _deal_func_args_ok = _deal_func_args_ok_crosshair if UNDER_CROSSHAIR else _deal_
 
 @deal.pre(lambda func_args: _deal_func_args_ok(func_args))
 def domain_from_delegate_args(func_args: Mapping[str, Any]) -> str:
+    # crosshair: off  # Mapping Any domain extract (cover-all 33569420452: 4647 examples / ~634s est despite UNDER_CROSSHAIR dual-profile). Doable later.
     domain = func_args.get("domain")
     if isinstance(domain, str) and domain.strip():
         return domain.strip()
@@ -132,6 +133,7 @@ def domain_from_delegate_args(func_args: Mapping[str, Any]) -> str:
 
 @deal.pre(lambda func_args: _deal_func_args_ok(func_args))
 def delegate_status_label(func_args: Mapping[str, Any]) -> str:
+    # crosshair: off  # thin wrapper over domain_from_delegate_args (cover-all 33569420452: 2063 examples / ~282s est). Doable later.
     return f"delegate ({domain_from_delegate_args(func_args)})"
 
 
@@ -179,6 +181,7 @@ def format_delegate_running_chat_line(func_args: Mapping[str, Any]) -> str:
     and all(v is None or (isinstance(v, str) and ascii_bounded(v, _DEAL_FUNC_ARG_TOKEN_LEN)) for v in result_data.values())
 )
 def format_delegate_result_chat_line(func_args: Mapping[str, Any], result_data: Mapping[str, Any]) -> str:
+    # crosshair: off  # dual Mapping + web_research import (cover-all 33569420452: 2249 examples / ~307s est). Doable later.
     """Completion line for delegate gateway tools (domain shown; success is short)."""
     domain = domain_from_delegate_args(func_args)
     if result_data.get("status") == "error":

--- a/plugin/embeddings/embeddings_split.py
+++ b/plugin/embeddings/embeddings_split.py
@@ -231,6 +231,7 @@ def _split_passage_whitespace_to_sentences(passage: str) -> list[tuple[int, int,
     and (locale_bcp47 is None or ascii_bounded(locale_bcp47, DEAL_MAX_TOKEN))
 )
 def _split_prose_passage_to_spans(passage: str, locale_bcp47: str | None = None) -> list[tuple[int, int]]:
+    # crosshair: off  # ICU/locale sentence merge still combinatoric (cover-all 33569420452: ~738s est / 2036 ex despite str_bounded). Doable later.
     from plugin.writer.locale.grammar_proofread_locale import (
         bcp47_to_icu_sentence_breaker_locale,
         is_whitespace_sentence_locale,
@@ -337,6 +338,7 @@ def split_passage_to_chunk_meta(
     prose: bool = True,
     locale_bcp47: str | None = None,
 ) -> list[dict[str, Any]]:
+    # crosshair: off  # LocaleTextRun + prose/non-prose split (cover-all 33569420452: ~958s est / 2642 ex despite ascii_bounded meta). Doable later.
     """Split one passage into embed-sized chunks with char offsets relative to passage text."""
     from plugin.embeddings.embeddings_fs import LocaleTextRun
 

--- a/plugin/framework/i18n.py
+++ b/plugin/framework/i18n.py
@@ -91,6 +91,7 @@ def get_lo_locale(ctx=None):
 
 
 def _mo_candidates(localedir: str, lang: str, domain: str = "writeragent") -> list[str]:
+    # crosshair: off  # path join / locale stem combinatorics (cover-all 33569420452: 14810 examples / ~48m module with load_translation). Doable later: closed lang tag set.
     """Likely ``.mo`` paths for *lang* (exact tag, then language stem)."""
     tags = [lang]
     stem = lang.split(".")[0]
@@ -109,6 +110,7 @@ def load_translation(
     *,
     fallback: bool = True,
 ) -> gettext.NullTranslations:
+    # crosshair: off  # gettext.find + open(.mo) filesystem (cover-all 33569420452: 13456 examples). Engine-hostile; doable later with injected catalog.
     """Load domain ``writeragent`` for *languages*.
 
     ``gettext.find`` expands tags via ``locale.normalize``. On Windows that

--- a/plugin/mcp/cors.py
+++ b/plugin/mcp/cors.py
@@ -123,6 +123,7 @@ def normalize_cors_origin(value: str | None) -> str | None:
 @deal.post(lambda result: isinstance(result, list) and all(isinstance(x, str) for x in result))
 @inverse_ensure(lambda value, result: len(result) == len(set(result)))
 def normalize_origins_list(value) -> list[str]:
+    # crosshair: off  # list/str Any + unique-length post still combinatoric (cover-all 33569420452: ~4040s est / 5594 ex despite _deal_origin_ok). Doable later: closed origin enum.
     """Coerce config value to a deduped list of normalized origin strings."""
     if value is None:
         return []
@@ -144,6 +145,7 @@ def normalize_origins_list(value) -> list[str]:
 @deal.pre(lambda origin: _deal_origin_ok(origin))
 @deal.post(lambda result: isinstance(result, bool))
 def is_private_browser_origin(origin: str) -> bool:
+    # crosshair: off  # urlparse + ipaddress SMT wander (cover-all 33569420452: ~939s est / 1298 ex despite _deal_origin_ok). Doable later.
     """True when Origin is http(s) with a LAN-style hostname or private/link-local IP."""
     normalized = normalize_cors_origin(origin)
     if normalized is None:
@@ -179,6 +181,7 @@ def is_private_browser_origin(origin: str) -> bool:
     )
 )
 def set_extra_allowed_origins(origins) -> None:
+    # crosshair: off  # frozenset(normalize_origins_list) leftover (cover-all 33569420452: ~4419s est / 6120 ex). Doable later.
     """Update explicit-origin cache used by is_safe_origin (HTTP threads, no ctx)."""
     global _extra_allowed_origins
     _extra_allowed_origins = frozenset(normalize_origins_list(origins))
@@ -200,6 +203,7 @@ def set_allow_private_origins(allow: bool) -> None:
 @deal.pre(lambda origin: _deal_origin_ok(origin))
 @deal.post(lambda result: isinstance(result, bool))
 def is_extra_allowed_origin(origin: str) -> bool:
+    # crosshair: off  # frozenset membership under symbolic origin (cover-all 33569420452: ~966s est / 1335 ex). Doable later.
     if len(origin) == 0:
         return False
     normalized = normalize_cors_origin(origin)
@@ -207,6 +211,7 @@ def is_extra_allowed_origin(origin: str) -> bool:
 
 
 def _is_loopback_origin(origin: str) -> bool:
+    # crosshair: off  # urlparse hostname walk (cover-all 33569420452: ~939s est / 1298 ex). Doable later.
     """True for http(s) localhost / 127.0.0.1 / ::1 (optional port). No regex."""
     normalized = normalize_cors_origin(origin)
     if normalized is None:
@@ -245,6 +250,7 @@ def reload_cors_policy_from_config(services) -> None:
 @deal.pre(lambda origin: _deal_origin_ok(origin))
 @deal.post(lambda result: isinstance(result, bool))
 def is_safe_origin(origin: str) -> bool:
+    # crosshair: off  # composes loopback/extra/private (cover-all 33569420452: ~966s est / 1335 ex). Doable later.
     """True when Origin may receive Access-Control-Allow-Origin reflection."""
     if len(origin) == 0:
         return False
@@ -264,6 +270,7 @@ def is_safe_origin(origin: str) -> bool:
 @deal.post(lambda result: isinstance(result, str))
 @inverse_ensure(lambda access_control_request_headers, result: "Content-Type" in result)
 def merge_allow_headers(access_control_request_headers: str | None) -> str:
+    # crosshair: off  # split/merge header list still SMT-heavy (cover-all 33569420452: ~1393s est / 1927 ex despite _deal_allow_headers_ok). Doable later.
     """Build Access-Control-Allow-Headers: base list union preflight request list."""
     merged: dict[str, str] = {}
     for header in _BASE_ALLOW_HEADERS:

--- a/plugin/scripting/calc_range.py
+++ b/plugin/scripting/calc_range.py
@@ -612,6 +612,7 @@ def materialize_inputs(wire: Any) -> tuple[CalcRange, ...]:
 
 @deal.pre(lambda obj: _deal_json_list_of_grids_arg_ok(obj))
 def _is_json_list_of_grids(obj: Any) -> bool:
+    # crosshair: off  # nested list/tuple shape walk (cover-all 33569420452: 13580 examples / ~527s est despite dual-profile pre). Doable later: fixed small grid domain.
     """True when *obj* is a JSON array of 2D grids (Online =PY multi-range without multi_data).
 
     A normal 2D sheet block ``[[1, 2], [3, 4]]`` has scalar cells — not a list of grids.
@@ -654,6 +655,7 @@ def dataframe_to_labeled_grid(
     *,
     include_header: bool = True,
 ) -> list[list[Any]]:
+    # crosshair: off  # columns+data nested lists (cover-all 33569420452: 3337 examples / ~130s est despite _DEAL_GRID_DIM). Doable later.
     """Build a Calc-ready grid from a dataframe envelope (optional header row)."""
     body: list[list[Any]]
     if data is None:

--- a/tests/mcp/test_cors_verification.py
+++ b/tests/mcp/test_cors_verification.py
@@ -125,15 +125,15 @@ def test_localhost_safe_origin() -> None:
     assert is_private_browser_origin("http://192.168.1.50:3000") is True
 
 
-def test_normalize_origins_list_stays_on_check_all() -> None:
-    """Nested unique-length ensure is inverse_ensure; the FQN itself stays analyzed."""
+def test_normalize_origins_list_is_off_cover_all() -> None:
+    """cover-all 33569420452 leftover (~4h); # crosshair: off, doable later with a closed origin enum."""
     from tests.strip_bundle import skip_if_release_build
 
     skip_if_release_build("scripts/ not in stripped release tree")
     from scripts.crosshair_stream import cover_fqns_for_module
 
     fqns = cover_fqns_for_module(Path("plugin/mcp/cors.py"), require_deal=True)
-    assert any(f.endswith(".normalize_origins_list") for f in fqns)
+    assert not any(f.endswith(".normalize_origins_list") for f in fqns)
     assert any(f.endswith(".is_safe_origin") for f in fqns)
     assert any(f.endswith(".is_private_browser_origin") for f in fqns)
     assert any(f.endswith(".merge_allow_headers") for f in fqns)

--- a/tests/mcp/test_cors_verification.py
+++ b/tests/mcp/test_cors_verification.py
@@ -133,10 +133,18 @@ def test_normalize_origins_list_is_off_cover_all() -> None:
     from scripts.crosshair_stream import cover_fqns_for_module
 
     fqns = cover_fqns_for_module(Path("plugin/mcp/cors.py"), require_deal=True)
-    assert not any(f.endswith(".normalize_origins_list") for f in fqns)
-    assert any(f.endswith(".is_safe_origin") for f in fqns)
-    assert any(f.endswith(".is_private_browser_origin") for f in fqns)
-    assert any(f.endswith(".merge_allow_headers") for f in fqns)
+    # cover-all 33569420452 leftover offs (doable later with a closed origin enum).
+    offed = (
+        "normalize_origins_list",
+        "is_safe_origin",
+        "is_private_browser_origin",
+        "merge_allow_headers",
+        "set_extra_allowed_origins",
+        "is_extra_allowed_origin",
+        "_is_loopback_origin",
+    )
+    for name in offed:
+        assert not any(f.endswith(f".{name}") for f in fqns), name
 
 
 def test_cors_origin_overflow_pre_fails_closed() -> None:


### PR DESCRIPTION
## Cover-all settle (run 33569420452)

- Run: https://github.com/KeithCu/writeragent/actions/runs/33569420452
- Workflow: CrossHair Verification (Deep / On-Demand), **cover-all only** (check-all skipped), start-at **1**, SHA `3f948548` (master when kicked; this PR bases on current master `434f32a3`, ahead by merges including #536)
- Wall: cancelled (~21623000 ms / **~6.0h**, typical 360-minute wall-kill)
- **0 COVER FAIL / engine crash**
- Flushed **29/56** COVER TIMING modules. No in-flight unflushed module (cors completed fully; wall hit before module 30 started).

### Flushed COVER TIMING (completion order)

| # | Module | Seconds | Notes |
| ---: | --- | ---: | --- |
| 1 | `plugin/calc/calc_addin_data.py` | 0.0 | |
| 2 | `plugin/calc/cells.py` | 0.0 | |
| 3 | `plugin/calc/python/xl_static_rewrite.py` | 238.7 | |
| 4 | `plugin/chatbot/chat_sidebar_mode.py` | 84.9 | |
| 5 | `plugin/chatbot/memory.py` | 988.8 | `upsert_memory_arguments_dict` 4656 ex; `memory_key_from_tool_arguments` 4491 ex |
| 6 | `plugin/chatbot/state_machine.py` | 23.6 | |
| 7 | `plugin/chatbot/tool_loop_state.py` | 1444.0 | `domain_from_delegate_args` 4647 ex |
| 8 | `plugin/chatbot/web_research_cache.py` | 0.0 | |
| 9 | `plugin/calc/excel_py_convert/to_dag.py` | 3319.3 (~55.3m) | `convert_cell_to_dag` 2217 ex; `_prefer_excel_dep_token` 1812 ex |
| 10 | `plugin/framework/appearance.py` | 798.6 | left alone (closed `_darken` factors already) |
| 11 | `plugin/framework/async_stream.py` | 0.0 | |
| 12 | `plugin/framework/client/auth.py` | 281.3 | |
| 13 | `plugin/framework/config_schema.py` | 0.0 | |
| 14 | `plugin/framework/config_service.py` | 0.0 | |
| 15 | `plugin/framework/deal_shim.py` | 123.3 | |
| 16 | `plugin/framework/default_models.py` | 2.6 | |
| 17 | `plugin/framework/errors.py` | 0.0 | |
| 18 | `plugin/framework/event_bus.py` | 8.8 | |
| 19 | `plugin/embeddings/embeddings_split.py` | 2161.6 (~36.0m) | `split_passage_to_chunk_meta` 2642 ex; `_split_prose_passage_to_spans` 2036 ex |
| 20 | `plugin/framework/json_utils.py` | 0.3 | |
| 21 | `plugin/framework/tool.py` | 422.4 | |
| 22 | `plugin/framework/url_utils.py` | 0.0 | |
| 23 | `plugin/framework/i18n.py` | 2869.6 (~47.8m) | `_mo_candidates` 14810 ex; `load_translation` 13456 ex |
| 24 | `plugin/mcp/tunnel_state.py` | 97.9 | |
| 25 | `plugin/mcp/wire_types.py` | 319.6 | |
| 26 | `plugin/scripting/calc_range.py` | 1742.6 (~29.0m) | `_is_json_list_of_grids` 13580 ex; `dataframe_to_labeled_grid` 3337 ex |
| 27 | `plugin/scripting/duckdb_sql.py` | 52.7 | |
| 28 | `plugin/scripting/editor_ipc.py` | 117.8 | |
| 29 | `plugin/mcp/cors.py` | **14607.3 (~4.06h)** | W1 wall: `set_extra_allowed_origins` 6120 ex; `normalize_origins_list` 5594 ex; `merge_allow_headers` 1927 ex |

**Dominant wall:** `plugin/mcp/cors.py` (~4.06h) despite existing `_deal_origin_ok` / `_deal_allow_headers_ok` deal.pre domains.

## What changed

Same strategy as 512/514/516/517/523/529/535: combinatoric leftovers that already burned deep time get `# crosshair: off` with a doable-later comment citing this run. Kept existing deal.pre helpers.

### `plugin/mcp/cors.py` (~4.06h)
Offed: `normalize_origins_list`, `is_private_browser_origin`, `set_extra_allowed_origins`, `is_extra_allowed_origin`, `_is_loopback_origin`, `is_safe_origin`, `merge_allow_headers`. Left `normalize_cors_origin` on (simple string building block) plus getters / already-off `reload_cors_policy_from_config` / `send_cors_headers`.

### `plugin/framework/i18n.py` (~47.8m)
Offed `_mo_candidates` and `load_translation` (filesystem/gettext; no prior deal.pre). Left `get_active_locale` / already-off `get_lo_locale` / `init_i18n` / `_`.

### `plugin/calc/excel_py_convert/to_dag.py` (~55.3m)
Offed `convert_cell_to_dag` and `_prefer_excel_dep_token`. Left cheaper rewrite helpers and already-off `_normalize_bindings`.

### `plugin/embeddings/embeddings_split.py` (~36.0m)
Offed `split_passage_to_chunk_meta` and `_split_prose_passage_to_spans`. Left sentence splitters / already-off whitespace regex helper.

### `plugin/scripting/calc_range.py` (~29.0m)
Offed `_is_json_list_of_grids` and `dataframe_to_labeled_grid`. Arithmetic dunders already off from earlier PRs.

### `plugin/chatbot/tool_loop_state.py` (~24.1m)
Offed `domain_from_delegate_args`, `delegate_status_label`, `format_delegate_result_chat_line` (dual-profile deal.pre not enough).

### `plugin/chatbot/memory.py` (~16.5m)
Offed `upsert_memory_arguments_dict` and `memory_key_from_tool_arguments`.

Did **not** module-off any file. Did **not** off `appearance._darken` (already closed factor set).

## Next

- **Next start-at = 30** (= 1 + 29 flushed COVER TIMING). First remaining schedule module is `plugin/calc/python/formula_edit.py` (unknowns 1–29 done; schedule order begins).
- Full 56 did **not** finish under 6h.
- After this PR merges, **check-all deep** is the useful next kick (then cover-all from 30 or from-1). Keith kicks it himself. Hang-check stays paused. **Do not stack a run from this PR.**