### PR TITLE
CrossHair: fix check-all wire_types CHECK FAIL + leftover offs (33668189572)

### DIFF
--- a/plugin/mcp/wire_types.py
+++ b/plugin/mcp/wire_types.py
@@ -222,9 +222,17 @@ _DEAL_CALL_VAL_LEN = 4 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
 
 def _deal_call_tool_params_ok(params: object) -> bool:
     # cover-all 33180040863: unbounded params → 3400 examples on from_params.
+    # check-all 33668189572: missing/empty name → ValueError CHECK FAIL on {}.
     return (
         type(params) is dict
         and len(params) <= _DEAL_CALL_DICT_LEN
+        and isinstance(params.get("name"), str)
+        and ascii_bounded(params["name"], _DEAL_CALL_VAL_LEN, min_len=1)
+        and (
+            "arguments" not in params
+            or params["arguments"] is None
+            or type(params["arguments"]) is dict
+        )
         and all(type(k) is str and ascii_bounded(k, _DEAL_CALL_KEY_LEN) for k in params)
         and all(
             v is None

--- a/plugin/mcp/wire_types.py
+++ b/plugin/mcp/wire_types.py
@@ -223,28 +223,32 @@ _DEAL_CALL_VAL_LEN = 4 if UNDER_CROSSHAIR else DEAL_MAX_SOURCE
 def _deal_call_tool_params_ok(params: object) -> bool:
     # cover-all 33180040863: unbounded params → 3400 examples on from_params.
     # check-all 33668189572: missing/empty name → ValueError CHECK FAIL on {}.
-    return (
-        type(params) is dict
-        and len(params) <= _DEAL_CALL_DICT_LEN
-        and isinstance(params.get("name"), str)
-        and ascii_bounded(params["name"], _DEAL_CALL_VAL_LEN, min_len=1)
-        and (
-            "arguments" not in params
-            or params["arguments"] is None
-            or type(params["arguments"]) is dict
-        )
-        and all(type(k) is str and ascii_bounded(k, _DEAL_CALL_KEY_LEN) for k in params)
-        and all(
-            v is None
-            or (isinstance(v, str) and ascii_bounded(v, _DEAL_CALL_VAL_LEN))
-            or (
-                type(v) is dict
-                and len(v) <= _DEAL_CALL_DICT_LEN
-                and all(type(nk) is str and ascii_bounded(nk, _DEAL_CALL_KEY_LEN) for nk in v)
-            )
-            for v in params.values()
-        )
-    )
+    # ty: Top[dict] keys are Never, so __getitem__ with Literal name/arguments is invalid.
+    if type(params) is not dict:
+        return False
+    if len(params) > _DEAL_CALL_DICT_LEN:
+        return False
+    name = params.get("name")
+    if not isinstance(name, str) or not ascii_bounded(name, _DEAL_CALL_VAL_LEN, min_len=1):
+        return False
+    arguments = params.get("arguments")
+    if arguments is not None and type(arguments) is not dict:
+        return False
+    if not all(type(k) is str and ascii_bounded(k, _DEAL_CALL_KEY_LEN) for k in params):
+        return False
+    for v in params.values():
+        if v is None:
+            continue
+        if isinstance(v, str) and ascii_bounded(v, _DEAL_CALL_VAL_LEN):
+            continue
+        if (
+            type(v) is dict
+            and len(v) <= _DEAL_CALL_DICT_LEN
+            and all(type(nk) is str and ascii_bounded(nk, _DEAL_CALL_KEY_LEN) for nk in v)
+        ):
+            continue
+        return False
+    return True
 
 
 @deal.pre(lambda params: _deal_call_tool_params_ok(params))

--- a/plugin/scripting/import_policy.py
+++ b/plugin/scripting/import_policy.py
@@ -127,6 +127,7 @@ def _deal_auto_import_alias_ok(module_name: object, import_stmt: object) -> bool
 @deal.pre(lambda module_name, import_stmt: _deal_auto_import_alias_ok(module_name, import_stmt))
 @deal.post(lambda result: isinstance(result, str))
 def _auto_import_alias(module_name: str, import_stmt: str) -> str:
+    # crosshair: off  # rsplit/" as " walk still slow (check-all 33668189572: Prev 8:35 despite 32/48 ascii bounds). Doable later: closed AUTO_IMPORTS enum.
     marker = " as "
     if marker in import_stmt:
         return import_stmt.rsplit(marker, 1)[-1].strip()

--- a/plugin/scripting/sandbox.py
+++ b/plugin/scripting/sandbox.py
@@ -16,7 +16,16 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     import subprocess
 
-from plugin.framework.deal_shim import DEAL_MAX_ARGV, DEAL_MAX_CMD_ARGS, DEAL_MAX_PATH, DEAL_MAX_TOKEN, deal, inverse_ensure, str_bounded
+from plugin.framework.deal_shim import (
+    DEAL_MAX_ARGV,
+    DEAL_MAX_CMD_ARGS,
+    DEAL_MAX_PATH,
+    DEAL_MAX_TOKEN,
+    UNDER_CROSSHAIR,
+    deal,
+    inverse_ensure,
+    str_bounded,
+)
 
 # --- Import whitelist (shared by venv_sandbox and import_policy) ---
 
@@ -185,16 +194,22 @@ _cached_sandbox: str | None = _NOT_SET  # type: ignore[assignment]  # sentinel
 _PIPE_BUF_TARGET = 1024 * 1024
 
 
+# check-all 33668189572: scrub_subprocess_env ~6m under DEAL_MAX_ARGV=32; keep pytest wide.
+_DEAL_SCRUB_DICT = 2 if UNDER_CROSSHAIR else DEAL_MAX_ARGV
+_DEAL_SCRUB_KEY = 4 if UNDER_CROSSHAIR else DEAL_MAX_TOKEN
+_DEAL_SCRUB_VAL = 8 if UNDER_CROSSHAIR else DEAL_MAX_ARGV
+
+
 @deal.pre(
     lambda base: base is None
     or (
         isinstance(base, dict)
-        and len(base) <= DEAL_MAX_ARGV
+        and len(base) <= _DEAL_SCRUB_DICT
         and all(
             isinstance(k, str)
-            and str_bounded(k, DEAL_MAX_TOKEN)
+            and str_bounded(k, _DEAL_SCRUB_KEY)
             and isinstance(v, str)
-            and str_bounded(v, DEAL_MAX_ARGV)
+            and str_bounded(v, _DEAL_SCRUB_VAL)
             for k, v in base.items()
         )
     )
@@ -319,6 +334,7 @@ def _reset_cache() -> None:  # pyright: ignore[reportUnusedFunction]  # test hel
 @deal.pre(lambda path: str_bounded(path, DEAL_MAX_PATH))
 def _strip_surrounding_quotes(path: str) -> str:
     """Strip one layer of matching quotes (Windows Explorer \"Copy as path\")."""
+    # crosshair: off  # strip/quote SMT leftover (check-all 33668189572: Prev 8:33 despite DEAL_MAX_PATH). Doable later: tiny quoted-path alphabet.
     s = path.strip()
     if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
         return s[1:-1].strip()

--- a/tests/mcp/test_wire_types.py
+++ b/tests/mcp/test_wire_types.py
@@ -115,8 +115,20 @@ def test_call_tool_request_params_from_params():
 
 
 def test_call_tool_request_params_missing_name():
-    with pytest.raises(ValueError, match="params.name"):
-        wire_types.CallToolRequestParams.from_params({})
+    # check-all 33668189572: deal.pre now requires non-empty name (avoids ValueError CHECK FAIL).
+    # Release bundles strip @deal.pre; body still raises ValueError.
+    from tests.strip_bundle import deal_pre_present
+
+    if deal_pre_present(wire_types._call_tool_request_params_from_dict):
+        import deal
+
+        with pytest.raises(deal.PreContractError):
+            wire_types.CallToolRequestParams.from_params({})
+        with pytest.raises(deal.PreContractError):
+            wire_types.CallToolRequestParams.from_params({"name": ""})
+    else:
+        with pytest.raises(ValueError, match="params.name"):
+            wire_types.CallToolRequestParams.from_params({})
 
 
 def test_progress_notification_shape():


### PR DESCRIPTION
## Summary
Follow-up from check-all deep run [33668189572](https://github.com/KeithCu/writeragent/actions/runs/33668189572) on `2cc9c488` (start-at 30 → 56/56 in ~38m).

**CHECK FAIL (1):** `plugin.mcp.wire_types._call_tool_request_params_from_dict({})` raised `ValueError: tools/call requires params.name`. Tightened `_deal_call_tool_params_ok` to require a non-empty `name` str and `arguments` None|dict so CrossHair does not explore the raise path.

**Leftovers (combinatoric despite tiny bounds):**
- `# crosshair: off` `_auto_import_alias` (Prev 8:35)
- `# crosshair: off` `_strip_surrounding_quotes` (Prev 8:33)
- Dual-profile shrink `scrub_subprocess_env` under `UNDER_CROSSHAIR` (~6m → tiny dict/key/val)

## Next start-at
**1** (modules 30–56 flushed; wrap for a clean full pass after this lands). Do not stack a run on top of anything live.

## Test plan
- [ ] `tests/mcp/test_wire_types.py` missing-name now expects `deal.PreContractError` when deal.pre present
- [ ] PR CI green
- [ ] After merge, Keith kicks check-all deep from start-at 1