### PR TITLE
Cap compute spawn handshake frames and show stdout header ASCII

### DIFF
--- a/compute_service/worker_base.py
+++ b/compute_service/worker_base.py
@@ -120,6 +120,8 @@ class BaseProcessWorker:
                     proc.stdout,
                     _SPAWN_READY_TIMEOUT_SEC,
                     is_alive=self.is_alive,
+                    max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES,
+                    require_dict=True,
                 )
                 if isinstance(ready_data, dict):
                     log.info(
@@ -146,7 +148,15 @@ class BaseProcessWorker:
             )
             self.kill()
         except Exception as exc:
-            log.error("Failed to spawn %s #%d: %s", self.worker_name, self.worker_id, exc)
+            snippet = self._stderr_snippet()
+            extra = f" stderr={snippet!r}" if snippet else " stderr=<empty>"
+            log.error(
+                "Failed to spawn %s #%d: %s%s",
+                self.worker_name,
+                self.worker_id,
+                exc,
+                extra,
+            )
             self.kill()
 
     def is_alive(self) -> bool:

--- a/docs/scripting/worker-spawn-handshake-timeouts.md
+++ b/docs/scripting/worker-spawn-handshake-timeouts.md
@@ -265,5 +265,6 @@ Fill this in as you go. Do not delete failed experiments.
 | 2026-09-01 | tree at investigation | CPU / `-n 8` | `make pytest`; then isolated `-n 6` on compute/venv | Full suite 38 fail (handshake 15s). Isolated 138 pass. 12-way idle handshake OK. CPU headroom. |
 | 2026-09-01 | `2f96c06a` | Control A / C / D | isolated compute/venv `-n 6`; idle `formula_worker` ×3; 12-child contention + parent `load_cython_accelerator` | A: 138 passed in 22s, no handshake timeouts. C: ready in 0.25–0.30s. D: 12/12 ready, max 0.45s. Env had no `PYTHON_COMPUTE`/`PYTEST`/`COV_`/`WRITERAGENT_*` leak. Flake not reproduced outside full suite. |
 | 2026-09-01 | `2f96c06a` + local | H2 | log `_stderr_snippet()` + `returncode` on spawn `TimeoutExpired`; test `test_spawn_timeout_logs_stderr_snippet` | Diagnostic only (no root-cause fix). Did not raise 15s timeout or cap workers. |
+| 2026-09-02 | Keith laptop full `make test` | H1 / H2 | PR 538 logging on full xdist | 38 failed, 6407 passed. Every compute timeout: `returncode=None stderr=<empty>`. Venv: `Invalid venv worker frame size: 1165128303` (= `b'Erro'`). Flood worker timed out too (not Cython). Same stdout-text bug; compute handshake had no `max_payload_bytes` so it waited 15s. |
 
 When the flake is gone, set **Status** at the top to Fixed, name the commit, and point at the tests that lock the behavior.

--- a/plugin/scripting/ipc.py
+++ b/plugin/scripting/ipc.py
@@ -64,7 +64,10 @@ class IpcFrameError(ValueError):
 
 def _validate_frame_size(size: int, *, max_payload_bytes: int | None, frame_label: str) -> None:
     if size <= 0 or (max_payload_bytes is not None and size > max_payload_bytes):
-        raise IpcFrameError(f"Invalid {frame_label} size: {size}")
+        header = struct.pack("!I", size & 0xFFFFFFFF)
+        raise IpcFrameError(
+            f"Invalid {frame_label} size: {size} (header={header!r})"
+        )
 
 
 def pack_pickle_frame(message: Any, *, max_payload_bytes: int | None = None) -> bytes:

--- a/tests/compute_service/test_formula_pool.py
+++ b/tests/compute_service/test_formula_pool.py
@@ -170,6 +170,35 @@ class TestFormulaPoolSupervisor:
         finally:
             worker.kill()
 
+    def test_spawn_stdout_garbage_fails_fast(self, tmp_path, caplog) -> None:
+        """Text on stdout (Keith 2026-09-02: frame size 1165128303 == b'Erro') must not wait 15s."""
+        from compute_service.worker_base import BaseProcessWorker
+
+        script = tmp_path / "garbage_worker.py"
+        script.write_text(
+            "\n".join(
+                [
+                    "import sys, time",
+                    "sys.stdout.write('Error: boom\\n')",
+                    "sys.stdout.flush()",
+                    "time.sleep(30)",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        t0 = time.monotonic()
+        with caplog.at_level(logging.ERROR, logger="compute_service.worker"):
+            worker = BaseProcessWorker(1, str(script), worker_name="Garbage worker")
+        elapsed = time.monotonic() - t0
+        try:
+            joined = "\n".join(r.getMessage() for r in caplog.records)
+            assert elapsed < 3.0, elapsed
+            assert "header=b'Erro'" in joined or "Invalid IPC frame size" in joined
+            assert "spawn handshake timed out" not in joined
+            assert not worker.is_alive()
+        finally:
+            worker.kill()
+
     def test_shared_and_isolated_exclusive_occupancy(self) -> None:
         pool = FormulaProcessPool(num_workers=1, default_timeout_sec=15)
         try:

--- a/tests/scripting/test_ipc.py
+++ b/tests/scripting/test_ipc.py
@@ -83,6 +83,15 @@ def test_pickle_frame_default_cap_rejects_oversized_header():
         read_pickle_frame(io.BytesIO(oversized), max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES)
 
 
+def test_text_error_prefix_is_invalid_frame_with_header_repr():
+    """1165128303 == b'Erro' from Keith's 2026-09-02 full-suite venv failures."""
+    with pytest.raises(IpcFrameError, match=r"header=b'Erro'"):
+        read_pickle_frame(
+            io.BytesIO(b"Error: boom\n"),
+            max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES,
+        )
+
+
 def test_json_line_roundtrip():
     buf = io.StringIO()
     write_json_line(buf, {"status": "ready"})


### PR DESCRIPTION
## Summary
Keith's full-suite log (`38 failed, 6407 passed`) showed:
- every compute timeout: `returncode=None stderr=<empty>`
- venv: `Invalid venv worker frame size: 1165128303` which is `b'Erro'`
- flood worker timed out too (not Cython)

Compute handshake had no `max_payload_bytes`, so those four bytes looked like a 1.1GB pickle and sat idle for 15s. This caps the handshake, logs `header=b'Erro'`, and fails fast.

Does not raise the 15s timeout or cap xdist workers. Does not yet stop whatever prints `Error...` onto child stdout.

## Test plan
- [x] `test_text_error_prefix_is_invalid_frame_with_header_repr`
- [x] `test_spawn_stdout_garbage_fails_fast` (fails in <3s, no 15s timeout)
- [ ] Full `make pytest` on the laptop that reproduced: expect fast `header=b'Erro'` (or the rest of the Error line) instead of 15s handshake timeouts.