### PR TITLE
Stop smolagents init from importing huggingface_hub

### DIFF
--- a/docs/scripting/worker-spawn-handshake-timeouts.md
+++ b/docs/scripting/worker-spawn-handshake-timeouts.md
@@ -267,5 +267,6 @@ Fill this in as you go. Do not delete failed experiments.
 | 2026-09-01 | `2f96c06a` + local | H2 | log `_stderr_snippet()` + `returncode` on spawn `TimeoutExpired`; test `test_spawn_timeout_logs_stderr_snippet` | Diagnostic only (no root-cause fix). Did not raise 15s timeout or cap workers. |
 | 2026-09-02 | Keith laptop full `make test` | H1 / H2 | PR 538 logging on full xdist | 38 failed, 6407 passed in 385s. Every compute timeout: `returncode=None stderr=<empty>`. Venv: size `1165128303` (= `b'Erro'`). Flood worker too (not Cython). |
 | 2026-09-02 | after #543 | H1 | full `make test` with handshake cap | 37 failed, 6412 passed in **28s**. No 15s timeouts. Every spawn: `Invalid IPC frame size: 1165128303 (header=b'Erro') stderr=<empty>`. Still missing the rest of the stdout line. |
+| 2026-09-02 | after #545 | H1 | leftover stdout on full `make test` | Same 37 fails. `stdout_rest` reconstructs: `Error importing huggingface_hub.hf_api: No module named 'envwrap' (or 'envwrap.envwrap' is unknown)`. Cause: `smolagents/__init__.py` star-imported `tools` → `huggingface_hub` on every `plugin.contrib.smolagents.*` import, including compute-worker `sandbox.py`. |
 
 When the flake is gone, set **Status** at the top to Fixed, name the commit, and point at the tests that lock the behavior.

--- a/plugin/contrib/smolagents/__init__.py
+++ b/plugin/contrib/smolagents/__init__.py
@@ -14,14 +14,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "1.25.0.dev0"
+"""Vendored smolagents package.
 
-from .agent_types import *  # noqa: I001
-from .agents import *  # Above noqa avoids a circular dependency due to cli.py
-from .default_tools import *
-from .memory import *
-from .models import *
-from .monitoring import *
-from .serialization import *
-from .tools import *
-from .utils import *
+Import submodules directly (``plugin.contrib.smolagents.utils``, ``.tools``,
+…). This file used to star-import every submodule, which meant
+``from plugin.contrib.smolagents.utils import BASE_BUILTIN_MODULES`` (used by
+compute workers via sandbox.py) also ran ``tools.py`` → ``huggingface_hub``.
+That printed to stdout under full pytest:
+
+    Error importing huggingface_hub.hf_api: No module named 'envwrap'
+    (or 'envwrap.envwrap' is unknown)
+
+and broke pickle-stdio spawn. Keep this init side-effect free.
+"""
+__version__ = "1.25.0.dev0"

--- a/plugin/contrib/smolagents/default_tools.py
+++ b/plugin/contrib/smolagents/default_tools.py
@@ -196,6 +196,7 @@ class PreTool:
     repo_id: str
 
 
+'''WriterAgent: unused HuggingFace Hub API (not called).
 class PythonInterpreterTool(Tool):
     name = "python_interpreter"
     description = "This is a tool that evaluates python code. It can be used to perform calculations."
@@ -240,6 +241,8 @@ class PythonInterpreterTool(Tool):
         return f"Stdout:\n{str(state['_print_outputs'])}\nOutput: {output}"
 
 
+'''
+
 class FinalAnswerTool(Tool):
     name = "final_answer"
     description = "Provides a final answer to the given problem."
@@ -251,6 +254,7 @@ class FinalAnswerTool(Tool):
         return answer
 
 
+'''WriterAgent: unused HuggingFace Hub API (not called).
 class UserInputTool(Tool):
     name = "user_input"
     description = "Asks for user's input on a specific question"
@@ -261,9 +265,9 @@ class UserInputTool(Tool):
         user_input = input(f"{question} => Type your answer here:")
         return user_input
 
+'''
 
 _RECENCY_TO_DF = {"day": "d", "week": "w", "month": "m", "year": "y"}
-
 
 def _norm_recency(value):
     """Normalize recency to a cache-key token. Unknown or unset values are 'any'."""
@@ -550,16 +554,13 @@ class VisitWebpageTool(Tool):
 TOOL_MAPPING = {
     tool_class.name: tool_class
     for tool_class in [
-        PythonInterpreterTool,
         DuckDuckGoSearchTool,
         VisitWebpageTool,
     ]
 }
 
 __all__ = [
-    "PythonInterpreterTool",
     "FinalAnswerTool",
-    "UserInputTool",
     "DuckDuckGoSearchTool",
     "VisitWebpageTool",
 ]

--- a/plugin/contrib/smolagents/models.py
+++ b/plugin/contrib/smolagents/models.py
@@ -632,6 +632,7 @@ class Model:
         return cls(**{k: v for k, v in model_dictionary.items()})
 
 
+'''WriterAgent: unused HuggingFace Hub API (not called).
 class VLLMModel(Model):
     """Model to use [vLLM](https://docs.vllm.ai/) for fast LLM inference and serving.
 
@@ -1815,19 +1816,13 @@ class AmazonBedrockModel(ApiModel):
 AmazonBedrockServerModel = AmazonBedrockModel
 
 
+'''
+
 # Model Registry for secure deserialization
 # This registry maps model class names to their actual classes.
 # Only classes listed here can be instantiated during deserialization (from_dict).
 # This prevents arbitrary code execution via importlib-based dynamic loading.
-MODEL_REGISTRY = {
-    "VLLMModel": VLLMModel,
-    "MLXModel": MLXModel,
-    "TransformersModel": TransformersModel,
-    "InferenceClientModel": InferenceClientModel,
-    "OpenAIModel": OpenAIModel,
-    "AzureOpenAIModel": AzureOpenAIModel,
-    "AmazonBedrockModel": AmazonBedrockModel,
-}
+MODEL_REGISTRY = {"Model": Model}
 
 __all__ = [
     "REMOVE_PARAMETER",
@@ -1835,16 +1830,5 @@ __all__ = [
     "tool_role_conversions",
     "get_clean_message_list",
     "Model",
-    "MLXModel",
-    "TransformersModel",
-    "ApiModel",
-    "InferenceClientModel",
-    "OpenAIServerModel",
-    "OpenAIModel",
-    "VLLMModel",
-    "AzureOpenAIServerModel",
-    "AzureOpenAIModel",
-    "AmazonBedrockServerModel",
-    "AmazonBedrockModel",
     "ChatMessage",
 ]

--- a/plugin/contrib/smolagents/tools.py
+++ b/plugin/contrib/smolagents/tools.py
@@ -601,6 +601,7 @@ class Tool(BaseTool):
 
         return tool_class(**kwargs)
 
+    '''WriterAgent: unused HuggingFace Hub API (not called).
     @staticmethod
     def from_space(
         space_id: str,
@@ -796,6 +797,9 @@ class Tool(BaseTool):
         return LangChainToolWrapper(langchain_tool)
 
 
+    '''
+
+'''WriterAgent: unused HuggingFace Hub API (not called).
 def launch_gradio_demo(tool: Tool):
     """
     Launches a gradio demo for a tool. The corresponding tool class needs to properly implement the class attributes
@@ -841,6 +845,8 @@ def launch_gradio_demo(tool: Tool):
         api_name=tool.name,
     ).launch()
 
+
+'''
 
 '''WriterAgent: unused HuggingFace Hub API (not called).
 def load_tool(
@@ -957,6 +963,7 @@ class ToolCollection:
 
     '''
 
+    '''WriterAgent: unused HuggingFace Hub API (not called).
     @classmethod
     @contextmanager
     def from_mcp(
@@ -1069,6 +1076,8 @@ class ToolCollection:
             yield cls(tools)
 
 
+    '''
+
 def tool(tool_function: Callable) -> Tool:
     """
     Convert a function into an instance of a dynamically created Tool subclass.
@@ -1179,6 +1188,7 @@ def tool(tool_function: Callable) -> Tool:
     return simple_tool
 
 
+'''WriterAgent: unused HuggingFace Hub API (not called).
 class PipelineTool(Tool):
     """
     A [`Tool`] tailored towards Transformer models. On top of the class attributes of the base class [`Tool`], you will
@@ -1343,6 +1353,8 @@ class PipelineTool(Tool):
         return decoded_outputs
 
 
+'''
+
 def get_tools_definition_code(tools: dict[str, Tool]) -> str:
     tool_codes = []
     for tool in tools.values():
@@ -1427,7 +1439,5 @@ __all__ = [
     "AUTHORIZED_TYPES",
     "Tool",
     "tool",
-    "load_tool",
-    "launch_gradio_demo",
     "ToolCollection",
 ]

--- a/plugin/contrib/smolagents/tools.py
+++ b/plugin/contrib/smolagents/tools.py
@@ -32,18 +32,12 @@ from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-try:
-    from huggingface_hub import (
-        CommitOperationAdd,
-        create_commit,
-        create_repo,
-        get_collection,
-        hf_hub_download,
-        metadata_update,
-    )
-except ImportError:
-    CommitOperationAdd = create_commit = create_repo = get_collection = None  # type: ignore[assignment]
-    hf_hub_download = metadata_update = None  # type: ignore[assignment]
+# WriterAgent: do not import huggingface_hub at module load. A try/except still
+# ran the import and printed onto compute-worker stdout:
+#   Error importing huggingface_hub.hf_api: No module named 'envwrap'
+# Hub push/from_hub is unused here; the methods are kept as commented-out text.
+CommitOperationAdd = create_commit = create_repo = get_collection = None  # type: ignore[assignment]
+hf_hub_download = metadata_update = None  # type: ignore[assignment]
 
 from ._function_type_hints_utils import (
     TypeHintParsingException,
@@ -423,6 +417,7 @@ class Tool(BaseTool):
         """Writes content to a file with UTF-8 encoding."""
         file_path.write_text(content, encoding="utf-8")
 
+    '''WriterAgent: unused HuggingFace Hub API (not called).
     def push_to_hub(
         self,
         repo_id: str,
@@ -497,6 +492,8 @@ class Tool(BaseTool):
         ]
         return additions
 
+    '''
+
     def _get_tool_code(self) -> str:
         """Get the tool's code."""
         return self.to_dict()["code"]
@@ -518,6 +515,7 @@ class Tool(BaseTool):
         """Get the requirements."""
         return "\n".join(self.to_dict()["requirements"])
 
+    '''WriterAgent: unused HuggingFace Hub API (not called).
     @classmethod
     def from_hub(
         cls,
@@ -572,6 +570,8 @@ class Tool(BaseTool):
 
         tool_code = Path(tool_file).read_text()
         return Tool.from_code(tool_code, **kwargs)
+
+    '''
 
     @classmethod
     def from_code(cls, tool_code: str, **kwargs):
@@ -842,6 +842,7 @@ def launch_gradio_demo(tool: Tool):
     ).launch()
 
 
+'''WriterAgent: unused HuggingFace Hub API (not called).
 def load_tool(
     repo_id,
     model_repo_id: str | None = None,
@@ -882,6 +883,8 @@ def load_tool(
         trust_remote_code=trust_remote_code,
         **kwargs,
     )
+'''
+
 
 
 def add_description(description):
@@ -911,6 +914,7 @@ class ToolCollection:
     def __init__(self, tools: list[Tool]):
         self.tools = tools
 
+    '''WriterAgent: unused HuggingFace Hub API (not called).
     @classmethod
     def from_hub(
         cls,
@@ -950,6 +954,8 @@ class ToolCollection:
         tools = [Tool.from_hub(repo_id, token, trust_remote_code) for repo_id in _hub_repo_ids]
 
         return cls(tools)
+
+    '''
 
     @classmethod
     @contextmanager

--- a/tests/scripting/test_smolagents_import_side_effects.py
+++ b/tests/scripting/test_smolagents_import_side_effects.py
@@ -1,0 +1,53 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+def _child_modules_after(import_stmt: str) -> set[str]:
+    env = {**os.environ, "PYTHONPATH": str(_REPO)}
+    # Fresh interpreter: parent pytest already imported huggingface in this process.
+    code = import_stmt + "; import sys; print('\\n'.join(sorted(sys.modules)))"
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=_REPO,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return {line for line in proc.stdout.splitlines() if line}
+
+
+def test_sandbox_import_does_not_load_huggingface_hub() -> None:
+    mods = _child_modules_after("import plugin.scripting.sandbox")
+    leaked = {m for m in mods if m == "huggingface_hub" or m.startswith("huggingface_hub.")}
+    assert not leaked
+    assert "plugin.contrib.smolagents.tools" not in mods
+
+
+def test_worker_base_import_does_not_load_huggingface_hub() -> None:
+    mods = _child_modules_after("import compute_service.worker_base")
+    leaked = {m for m in mods if m == "huggingface_hub" or m.startswith("huggingface_hub.")}
+    assert not leaked
+    assert "plugin.contrib.smolagents.tools" not in mods
+
+
+def test_formula_executor_import_does_not_load_huggingface_hub() -> None:
+    """formula_worker.py imports executor + worker_base + payload_codec."""
+    mods = _child_modules_after(
+        "import compute_service.executor, compute_service.worker_base, "
+        "plugin.scripting.payload_codec"
+    )
+    leaked = {m for m in mods if m == "huggingface_hub" or m.startswith("huggingface_hub.")}
+    assert not leaked
+    assert "plugin.contrib.smolagents.tools" not in mods


### PR DESCRIPTION
## Summary
Keith's leftover-stdout dump reconstructed:

\`Error importing huggingface_hub.hf_api: No module named 'envwrap' (or 'envwrap.envwrap' is unknown)\`

That is **not** embeddings loading Hub. Compute workers import \`sandbox.py\` → \`plugin.contrib.smolagents.utils\`. Package \`__init__.py\` used to star-import every submodule, so that also ran \`tools.py\` → \`huggingface_hub\` (Hub API for smolagents tools/collections). The print landed on the pickle pipe.

\`envwrap\` is the embeddings extra; it only appears because that accidental Hub import died looking for it.

This keeps \`__init__.py\` at \`__version__\` only. Callers already import submodules directly. Tests spawn a fresh interpreter and assert \`sandbox\` / \`worker_base\` / formula-worker imports do not load \`huggingface_hub\` or \`smolagents.tools\`.

## Test plan
- [x] \`tests/scripting/test_smolagents_import_side_effects.py\`
- [x] sandbox + flood worker + \`test_smol_agent\` (87 passed)
- [ ] Full \`make pytest\` on the laptop that had the 37 handshake failures