### PR TITLE
Make geometric recalc plan implementable

### DIFF
--- a/docs/calc/geometric-recalc-order.md
+++ b/docs/calc/geometric-recalc-order.md
@@ -1,6 +1,6 @@
 # Geometric Recalc Order — implementation plan
 
-**Status:** Decided — ready to implement. **Not implemented.** Product calls in [§9](#9-decisions) are closed.
+**Status:** Decided — ready to implement. **Not implemented.** Closed calls in [§9](#9-decisions) stand (no IDL, no 1×1 value-shape strip, no `locate_formula_cell_in_doc` for eval identity, precedent-only, cap skip-sheet, no strip-on-disable, Isolated checkbox visible / no-op). **Eval identity was not closed** in the previous draft — this revision specifies it as **unanimous-ours** plus an off-main `workbook_key` ([§9.5](#95-marker-is-the-udprop--in-memory-map)).
 
 **Related:** [Enabling NumPy & Python](../enabling_numpy_in_libreoffice.md) (session modes, auto-spill), [Microsoft `=PY` design stance](../scripting/ms-py-compatibility.md) (why we refuse Excel co-volatility), [Calc `=PY()` data shapes](py-data-shapes.md) (`data` / `ranges` arity).
 
@@ -80,7 +80,7 @@ Do **not** add a dedicated IDL ordering argument. That rebuilds `.rdb`s for both
 
 **Cross-cluster chaining (decided):** two independent PY clusters on one sheet (A1:A5 and D1:D5) become one chain — D1 waits on A5. That slightly over-dirties the D column when A3 changes. Correctness is fine; users who care can turn the flag off and write explicit `data` refs. Do not add spatial clustering.
 
-**Cap (decided):** `list_python_cells_on_sheet` stops at `_MAX_PYTHON_CELLS_FOUND = 100` (also `_MAX_CELLS_TO_SCAN = 50000`). The function returns a truncated list and does **not** currently say whether a cap fired. **If a cap is hit, skip geometric chaining for that entire sheet and log it.** Do not chain the first 100 and leave #101 with no predecessor. Do not raise the cap in this feature. Treat `len(found) >= _MAX_PYTHON_CELLS_FOUND` as capped (cannot tell “exactly 100” from “101+”; skipping a full 100-cell sheet is the safe default). If the scan cap fires with fewer than 100 PY cells, that list is also incomplete — same skip. A small `(cells, truncated)` wrapper around discovery is fine; do not change the 100/50k constants.
+**Cap (decided):** `list_python_cells_on_sheet` stops at `_MAX_PYTHON_CELLS_FOUND = 100` (also `_MAX_CELLS_TO_SCAN = 50000`) and returns a list with **no truncated flag** (`cell_discovery.py`). **If a cap is hit, skip geometric chaining for that entire sheet and log it.** Do not chain the first 100 and leave #101 with no predecessor. Do not raise the cap. Do not mark any eval-index triple strip-safe for that sheet — you cannot prove unanimous-ours on a truncated list ([§9.5](#95-marker-is-the-udprop--in-memory-map)). Phase 1 treats `len(found) >= _MAX_PYTHON_CELLS_FOUND` as cap-hit (over-skips an exact 100). A real `truncated` flag is **Phase 3**, not Phase 1. If the 50k scan cap fires with fewer than 100 PY cells, that list is also incomplete — same skip.
 
 A 100-cell chain is serial (venv IPC per dirty cell); that is the price of order, not a new cliff.
 
@@ -93,7 +93,7 @@ A2:  =PY("df = clean(df)")          →  =PY("df = clean(df)"; A1)
 A3:  =PY("result = df.describe()")   →  =PY("result = df.describe()"; A2)
 ```
 
-Reuse [`parse_python_formula`](../../plugin/calc/python/formula_edit.py) / `parse_data_binding_text` / `build_data_suffix`. Quoted-code cells: `rebuild_python_formula_with_data`. Code-in-cell (`=PY($A$1; B1:B10)`): detect with `py_formula_has_unquoted_code_ref` / `py_code_arg_is_cell_ref` and rebuild with `rebuild_python_formula_with_code_ref` — **not** `rebuild_python_formula_with_data` (that quotes the code-ref as a string). Do not invent a second formula serializer.
+Reuse [`parse_python_formula`](../../plugin/calc/python/formula_edit.py) / `parse_data_binding_text` / `build_data_suffix`. Quoted-code cells: `rebuild_python_formula_with_data`. Code-in-cell (`=PY($A$1; B1:B10)`): detect with `py_formula_has_unquoted_code_ref` / `py_code_arg_is_cell_ref` and rebuild with `rebuild_python_formula_with_code_ref` — **not** `rebuild_python_formula_with_data` (that quotes the code-ref as a string). `PythonFormulaParts` has no quoted flag (`prefix` / `code` / `data_suffix` only) — splice code-in-cell from the **raw formula**, not `parts.code` alone. Eval-index `code` is the **resolved source** (contents of `$A$1`), not the token `$A$1` ([§9.5](#95-marker-is-the-udprop--in-memory-map)). Do not invent a second formula serializer.
 
 The first cell in the list gets **no** predecessor. Cycles cannot appear if we only ever attach the previous entry in a total order. If a first cell still has a trailing geometric field (successor became first after delete), run the **remove-field** primitive ([§9.5](#95-marker-is-the-udprop--in-memory-map)).
 
@@ -175,10 +175,10 @@ The last-row idea “user already passed the previous PY cell as real data → n
 In `_execute_python_addin_impl` ([`function.py`](../../plugin/calc/python/function.py)):
 
 1. `args = split_python_addin_data_args(data)`
-2. **Strip here** if the in-memory map says this evaluation has a geometric last field (see [§9.5](#95-marker-is-the-udprop--in-memory-map) eval index). Unconditional across **both** branches — including `_code_uses_indexed_multi_data` (`"data["` / `"ranges["` in the source). If the geometric field stays, it becomes `data[-1]` / `ranges[-1]`.
+2. **Strip here** if the eval index marks this `(workbook_key, resolved_code, n_args)` **strip-safe** (unanimous-ours — [§9.5](#95-marker-is-the-udprop--in-memory-map)). Unconditional across **both** branches — including `_code_uses_indexed_multi_data` (`"data["` / `"ranges["` in the source). If the geometric field stays, it becomes `data[-1]` / `ranges[-1]`.
 3. Then `py_data = calc_addin_args_from_split(...)` and the existing trailing-single-cell **matrix-index** heuristic (the `is_multi and not _code_uses_indexed_multi_data(code)` block that peels a last 1-cell arg as `index_arg`, after which `finalize_python_return` slices `flat[value]`).
 
-If strip runs after that heuristic, appending `;A1` to `=PY("np.mean(data)"; B1:B10)` would coincidentally fix arity and **corrupt** the result (A1’s value used as a matrix index). Phase 4 must test both `=PY("np.mean(data)"; B1:B10)` and `=PY("ranges[-1].shape"; B1:B10)`.
+If strip is skipped on a fill-down of identical `=PY("np.mean(data)"; B1:B10; pred)`, `calc_addin_args_from_split` flips `data` to a list, then the index heuristic peels the predecessor **value** as `index_arg` — silent wrong numbers. Strip must run first, and fill-down must be strip-safe when every cell with that triple is ours. Phase 4 must test both `=PY("np.mean(data)"; B1:B10)` and `=PY("ranges[-1].shape"; B1:B10)`, plus fill-down and mixed neighbors.
 
 Do not invent a reserved formula suffix. Do not add a third IDL argument.
 
@@ -201,9 +201,9 @@ Do not invent a reserved formula suffix. Do not add a third IDL argument.
 | Piece | New? | Reuse |
 |-------|------|--------|
 | Settings checkbox | Small | `module.yaml` + existing Settings dialog |
-| Discover PY cells in order | Tiny wrapper | `cell_discovery.list_python_cells_on_sheet` / `list_python_cells_in_doc` — add a truncation signal, do not raise the cap |
+| Discover PY cells in order | Phase 1: `len >= 100` | `list_python_cells_on_sheet` / `list_python_cells_in_doc` — no truncated flag today; a real flag is Phase 3, do not raise the cap |
 | Parse / rebuild `=PY(code; args)` | Small splice + remove-field | `formula_edit.py` — `rebuild_python_formula_with_data` **or** `rebuild_python_formula_with_code_ref` |
-| Marker | ~1 extra day | Copy `WriterAgentSpillRegistry` / `load_spill_registry_for_doc` / `SPILL_REGISTRY` / `save_spill_registry_for_doc` (`udprops.get_document_property` / `set_document_property`) |
+| Marker | ~1 extra day | Copy `WriterAgentSpillRegistry` / `load_spill_registry_for_doc` / `SPILL_REGISTRY` (`udprops`). Record `workbook_key` even in Isolated. Unanimous-ours eval index — not uniqueness, not ≥1-hit. |
 | Deferred UI-thread writes + undo | Small | `perform_deferred_spill`, `_undo_lock`, Timer 0.1s — share debounce; explicit re-entrancy flag |
 | Sheet modify | Small | **Shared trigger**, not a sibling listener; geometric job does its own PY discovery |
 | Strip geometric arg from worker `data` | Medium | `_execute_python_addin_impl` — map lookup **before** the index heuristic and **before** `calc_addin_args_from_split` |
@@ -224,7 +224,14 @@ Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high
 |------|------------|
 | Shadowing `data` (arity flip) | Precedent-only strip via the map, **before** the index heuristic ([§4](#4-data-binding--do-not-shadow-data)) |
 | 1×1 / “is a PY cell” strip | Forbidden — add-in sees values only ([§4.1](#41-why-a-value-shape-strip-cannot-work)) |
-| Index heuristic eats `;A1` | Strip first; Phase 4 tests `np.mean(data)` and `ranges[-1].shape` |
+| Index heuristic eats `;A1` | Strip first; Phase 4 tests `np.mean(data)`, `ranges[-1].shape`, fill-down |
+| Uniqueness / “fail-safe = no strip” | **Rejected** — kills fill-down of identical `=PY("np.mean(data)"; B1:B10)` |
+| ≥1-hit strip | **Rejected** — would strip a mixed matrix-index neighbor |
+| Mixed ours + user same triple | Do not mark strip-safe; residual is “chain loses strip,” not “user cell loses last arg” |
+| Two open workbooks | `off_main_calc_session_is_unambiguous()` false → no strip |
+| Isolated still needs strip | Record `workbook_key` on the UI-thread path even when `workbook_session_id` is `None` |
+| Keying the token `$A$1` | Eval `code` is resolved source (`execute_python_addin`); repair must read the code cell |
+| Naive `;` arity | Repair `n_args` must match `split_python_addin_data_args`, not a semicolon count |
 | Rewrite during recalc | Same ban as spill; deferred only |
 | Undo fragmentation | `_undo_lock`: hidden when `isUndoPossible()`, else `lock()`; flag-on reconcile is one locked unit |
 | Infinite rewrite loop | Idempotent desired-vs-actual; re-entrancy flag; skip if already correct |
@@ -241,15 +248,15 @@ Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high
 
 ## 8. Suggested phases
 
-**Phase 0 — Review (this doc).** Closed. Do not reopen [§9.1](#91-precedent-only-not-value-in-data-not-idl) C (IDL) or a value-shape strip.
+**Phase 0 — Review (this doc).** Closed product calls stand. Eval identity is specified in [§9.5](#95-marker-is-the-udprop--in-memory-map) (unanimous-ours + `workbook_key`) — do not treat the previous uniqueness draft as closed. Do not reopen [§9.1](#91-precedent-only-not-value-in-data-not-idl) C (IDL) or a value-shape strip.
 
-**Phase 1 — Pure list + formula splice.** Unit tests only: given a list of addresses + current formulas + the in-memory record, compute the patch. No UNO. This is the whole algorithm. Encode the [§9.5](#95-marker-is-the-udprop--in-memory-map) table, including **remove-field**, code-in-cell `=PY($A$1; B1:B10)`, and “cap-hit → skip sheet.”
+**Phase 1 — Pure list + formula splice.** Unit tests only: given a list of addresses + current formulas + the in-memory record, compute the patch and the eval-index bools. No UNO. Encode the [§9.5](#95-marker-is-the-udprop--in-memory-map) table, including **remove-field**, code-in-cell splice from the raw formula (`rebuild_python_formula_with_code_ref`), fill-down unanimous-ours, mixed poison, and “`len >= 100` → skip sheet, do not mark strip-safe.” No truncated-flag API in this phase.
 
-**Phase 2 — Flag + attach on save / flag-on.** Monaco and native cell save call the splicer; apply on the UI thread after save (save is already outside recalc). Settings default off. Flag-on walks **all sheets**. Persist / load the UDProp like spill.
+**Phase 2 — Flag + attach on save / flag-on.** Monaco and native cell save call the splicer; apply on the UI thread after save (save is already outside recalc). Settings default off. Flag-on walks **all sheets**. Persist / load the UDProp like spill. Record `workbook_key` even in Isolated (unsaved files must not use empty URL).
 
-**Phase 3 — Deferred repair on insert/delete.** Shared trigger + spill-like timer + re-entrancy flag. UNO tests: three-cell column, insert PY in the middle, successor’s field updates; delete (including successor-becomes-first → remove-field); undo. Cap-hit sheet is left unchained.
+**Phase 3 — Deferred repair on insert/delete.** Shared trigger + spill-like timer + re-entrancy flag. UNO tests: three-cell column, insert PY in the middle, successor’s field updates; delete (including successor-becomes-first → remove-field); undo. Cap-hit sheet is left unchained. A real discovery `truncated` flag belongs here if needed — not Phase 1.
 
-**Phase 4 — Strip geometric arg from worker ingress.** Map lookup after `split_python_addin_data_args`, **before** the index heuristic and `calc_addin_args_from_split`. Tests in [§10](#10-test-plan-when-implemented).
+**Phase 4 — Strip geometric arg from worker ingress.** After `split_python_addin_data_args`, if the triple is strip-safe, drop `args[-1]` **before** the index heuristic and `calc_addin_args_from_split`. Tests in [§10](#10-test-plan-when-implemented).
 
 **Non-goals until someone asks:** cross-sheet chains, workbook-global order, Isolated value-piping, sidebar annotations, Excel export special-case, raising the 100-cell cap, strip-on-disable, spatial clustering of independent PY groups, a dedicated IDL arg.
 
@@ -257,7 +264,7 @@ Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high
 
 ## 9. Decisions
 
-Closed. Rejected alternatives are listed so they are not reopened in the first PR.
+Closed product calls stand. Eval identity is specified in [§9.5](#95-marker-is-the-udprop--in-memory-map) (was not closed by the uniqueness draft). Rejected alternatives are listed so they are not reopened.
 
 ### 9.1 Precedent-only (not value-in-`data`, not IDL)
 
@@ -282,7 +289,7 @@ A trailing A1 field is enough **if** we strip it via the map, not a 1×1 heurist
 
 **Rejected:** hide the checkbox when Isolated is selected (couples two settings; looks like a bug when the box disappears).
 
-Precedent-only strip means Isolated `data` is unchanged.
+Precedent-only strip means Isolated `data` is unchanged. Isolated is a no-op for **Python globals**, not for the strip: `workbook_session_id` returns `None` when mode ≠ `shared`, but Isolated still needs strip (else arity breaks). Record `workbook_key` on the UI-thread path even in Isolated ([§9.5](#95-marker-is-the-udprop--in-memory-map)).
 
 ### 9.4 Flag turned off — leave refs
 
@@ -292,7 +299,7 @@ Precedent-only strip means Isolated `data` is unchanged.
 
 ### 9.5 Marker is the UDProp / in-memory map
 
-**Decision: C (required), used to implement A’s rewrite table.** Not a reserved suffix. Not IDL. Not a 1×1 / “last arg is a PY cell” heuristic.
+**Decision: C (required), used to implement A’s rewrite table.** Not a reserved suffix. Not IDL. Not a 1×1 / “last arg is a PY cell” heuristic. **Eval identity was not closed** by the uniqueness draft — it is **unanimous-ours** plus `workbook_key`, below.
 
 Copy the spill pattern — do not invent a second subsystem:
 
@@ -301,17 +308,43 @@ Copy the spill pattern — do not invent a second subsystem:
 | UDProp `WriterAgentSpillRegistry` | A sibling document property (e.g. `WriterAgentGeometricRegistry`) |
 | `SPILL_REGISTRY` in memory | In-memory map, loaded on the UI thread |
 | `load_spill_registry_for_doc` / `save_spill_registry_for_doc` | Same load/save shape via `udprops` |
-| Keyed by `(doc_url, sheet, row, col)` | Same: cells **we** attached, plus the predecessor we wrote |
+| Keyed by `(doc_url, sheet, row, col)` | Per-cell attach record (addresses on the UI thread) **plus** `workbook_key` even in Isolated |
 
 **Rewrite** (UI thread) always has addresses. The map is the ours-vs-user marker: append / replace / remove using the table below.
 
-**Eval-time strip** cannot look up `(sheet, row, col)` unless it already knows the origin. `execute_python_addin` does not receive the calling address. Do **not** call `locate_formula_cell_in_doc` to recover it (None on 0 or 2+ matches; cannot tell user-data-is-previous-PY from our field). Do **not** query the desktop / document from a recalc worker.
+**Eval-time strip** cannot look up `(sheet, row, col)`. `PythonFunction.python` / `execute_python_addin` never get a calling address (`addin_impl.py`). Do **not** call `locate_formula_cell_in_doc` (None on 0 or 2+ matches; cannot tell user-data-is-previous-PY from our field). Do **not** query the desktop / document from a recalc worker. Off-main, `doc` stays `None` (`_execute_python_addin_impl` fills `doc` only on main).
 
-**Eval index (least extra complexity):** when attaching or repairing on the UI thread, also maintain a uniqueness-filtered view of the same map, keyed by `(doc_url, code, n_args)` → “strip last.” `n_args` is `len(split_python_addin_data_args(...))` **including** the geometric field. At eval, if that triple hits a **unique** strip entry, drop `args[-1]`. If the triple is missing or not unique, **do not strip** (leave user data; log the collision). Never fall back to 1×1. `doc_url` at eval: use `doc` when already passed, or the same unambiguous cached session `get_python_init_kwargs` already uses off-main — no new UNO walk.
+#### Eval index — unanimous-ours (not uniqueness, not ≥1-hit)
 
-Typical pipelines have distinct `code` strings, so the triple is unique. Duplicate identical formulas are the leftover hole (same as locate); fail safe = no strip.
+At **repair time** (UI thread, we have addresses), compute an eval-index bool per `(workbook_key, resolved_code, n_args)`:
 
-**Remove-field primitive:** parse → drop the last geometric data arg → rebuild → drop the map record. Needed when a successor becomes first after delete. Same primitive strip-on-disable ([§9.4](#94-flag-turned-off-leave-refs) B) would use later. **Idempotent:** first cell with a trailing geometric field → strip that field.
+- **strip-safe** iff **every** discovered PY cell with that triple is in the map (ours-only / unanimous).
+- **Eval:** if that triple is marked strip-safe, drop `args[-1]` before the index heuristic and before `calc_addin_args_from_split`. Unconditional on both branches including `data[]` / `ranges[]`.
+- **Mixed** same-code/arity (a non-mapped user cell, e.g. matrix-index `=PY("f"; range; i)` next to a chain of `=PY("f"; range; pred)`) → do **not** mark strip-safe → **no-strip for the whole triple** (chain included) until the user cell is gone or attached. Residual to name: **mixed poisons the chain**, not “user cell also loses last arg.” Do **not** use a ≥1-hit rule; that would strip the matrix-index neighbor.
+- **Cap-hit** → skip the entire sheet, do **not** mark any triple strip-safe, do not write a partial chain. You cannot prove unanimous on a truncated list.
+- **Rejected:** uniqueness / “fail-safe = no strip” / “typical pipelines have distinct code strings.” That kills fill-down of identical `=PY("np.mean(data)"; B1:B10)`: after attach every successor has the same `resolved_code` and `n_args=2`, non-unique → no-strip → `calc_addin_args_from_split` flips `data` to a list, then the index heuristic peels the predecessor **value** as `index_arg` — silent wrong numbers.
+
+Optional (not instead of unanimous, not the primary key): a fingerprint of `args[:-1]` so two chains with the same snippet and **different ranges** do not share a triple. Does not save mixed same-range. Do **not** fingerprint the last-arg value (first recalc is empty/0).
+
+#### Three must-gets (easy to get wrong)
+
+**1. Key `code` is what `execute_python_addin` receives, not the formula token.** `PythonFunction.python` passes Calc’s first argument through as `code` (`addin_impl.py`). For `=PY($A$1; B1:B10; pred)` that is the **cell contents of `$A$1`** (resolved source), not the token `$A$1`. Repair must **read that cell** when building the eval index (`formula_edit.py` unquoted branch vs `addin_impl.py`). Keying the token `$A$1` misses every script-bank cell. Detect / splice with `py_formula_has_unquoted_code_ref` / `py_code_arg_is_cell_ref` / `rebuild_python_formula_with_code_ref` (exist on master). `PythonFormulaParts` has no quoted flag (`prefix` / `code` / `data_suffix` only) — splice code-in-cell from the **raw formula**, not `parts.code` alone, or `$A$1` gets quoted by `rebuild_python_formula_with_data`. Cells that share resolved source collide on this triple; same unanimous rule.
+
+**2. `n_args` at eval is `len(split_python_addin_data_args(data))`** (`calc_addin_data.py`). Repair arity **must** match that splitter, not a naive semicolon count. A pair `(range, 1×1 pred)` does **not** collapse under `_is_legacy_single_column_range`: the inner of the 1×1 is a sequence, so two varargs stay two args (`n_args=2` after attach).
+
+**3. Cap-hit:** `list_python_cells_on_sheet` returns 100 with **no** truncated flag (`cell_discovery.py`). You cannot prove unanimous. Already-decided skip-sheet is the fail-safe; do **not** mark those triples strip-safe. Phase 1 treats `len >= _MAX_PYTHON_CELLS_FOUND` as cap-hit (over-skips exact 100). A real truncated flag is Phase 3.
+
+#### `workbook_key` (blocking — do not cite `get_python_init_kwargs`)
+
+`get_python_init_kwargs` does **not** carry `doc_url`. `build_python_eval_init_kwargs` is init-script / hash only. `session_key` leaves `doc_url=""` off-main (fills `doc` only on main). Isolated: `workbook_session_id` returns `None` when mode ≠ `shared`, but Isolated still needs strip.
+
+**Eval `workbook_key` = `get_cached_calc_session_id()` only when `off_main_calc_session_is_unambiguous()`** (`session_manager.py`: `len(_RECORDED_CALC_SESSION_IDS) == 1`). Else do not strip (two open workbooks).
+
+On the **UI-thread** load / repair path, record that workbook key in the geometric map **even in Isolated** (sibling of `load_spill_registry_for_doc`). Unsaved files must not use empty URL — same #402 hole as `session_key` / `_workbook_session_key` (URL, else a persisted unsaved id, never `""`).
+
+#### Remove-field
+
+Parse → drop the last geometric data arg → rebuild → drop the map record. Needed when a successor becomes first after delete. Same primitive strip-on-disable ([§9.4](#94-flag-turned-off-leave-refs) B) would use later. **Idempotent:** first cell with a trailing geometric field → strip that field. After remove-field, recompute unanimous-ours for the affected triples.
 
 **Rewrite table** (desired predecessor A1 unless noted). “Ours” means the map has a record for this cell.
 
@@ -319,13 +352,15 @@ Typical pipelines have distinct `code` strings, so the triple is unique. Duplica
 |----------|----------|-----|--------|
 | No args | — | none | Append `;A1`; record |
 | User range `B1:B10` | range | none | Append (`;B1:B10;A1`); record |
+| Fill-down of identical `=PY("np.mean(data)"; B1:B10)` | range + pred | **all** successors ours | Append each; triple is strip-safe (unanimous) |
 | Already correct | single cell = desired | ours, pred A1 | No-op |
 | Stale predecessor after insert | single cell = old pred | ours, old pred A1, desired A2 | Replace `;A1` → `;A2`; update record |
 | User single-cell data `C5` | single cell ≠ desired | none | Append (`;C5;A1`); do not overwrite `C5` |
-| User already passed the previous PY cell as **real data** | single cell = desired | **none** (we did not attach) | **No-op. Do not record. Do not strip at eval.** |
-| Successor became first (delete) | geometric field | ours | **Remove-field**; drop record |
+| User already passed the previous PY cell as **real data** | single cell = desired | **none** (we did not attach) | **No-op. Do not record.** If this cell shares a triple with mapped cells, the triple is **not** strip-safe (mixed poisons the chain). |
+| Mixed matrix-index neighbor `=PY("f"; range; i)` next to `=PY("f"; range; pred)` | 1×1 | one ours, one not | Do **not** mark strip-safe; **neither** strips |
+| Successor became first (delete) | geometric field | ours | **Remove-field**; drop record; recompute index |
 | First cell still has a leftover field | geometric field | ours | Remove-field (idempotent) |
-| Cap hit on this sheet | — | — | Skip the sheet; log; do not write a partial chain |
+| Cap hit on this sheet | — | — | Skip the sheet; log; no partial chain; **do not** mark triples strip-safe |
 
 ### 9.6 Flag-on / document-open — all sheets
 
@@ -339,22 +374,26 @@ Typical pipelines have distinct `code` strings, so the triple is unique. Duplica
 
 **Unit (`tests/calc/python/`, match the new module name; splice cases can extend `test_formula_edit.py`):**
 
-Phase 1 — list-diff + splice (encode [§9.5](#95-marker-is-the-udprop--in-memory-map)):
+Phase 1 — list-diff + splice + eval-index bools (encode [§9.5](#95-marker-is-the-udprop--in-memory-map)):
 
 - Empty, one cell, two cells, insert in middle, delete middle, delete first (remove-field), reorder.
 - Formula splice: no args; existing range args preserved; already-correct predecessor; stale predecessor replaced; user extra cell-ref appended not overwritten when it is not ours.
-- **Code-in-cell:** `=PY($A$1; B1:B10)` → attach / replace / remove via `rebuild_python_formula_with_code_ref`; result stays an unquoted `$A$1` (or the original ref token), not `=PY("$A$1"; …)`.
+- **Code-in-cell:** splice `=PY($A$1; B1:B10)` from the **raw formula** via `rebuild_python_formula_with_code_ref`; result stays an unquoted `$A$1`, not `=PY("$A$1"; …)`. Eval-index `code` is the **resolved source** (cell contents of `$A$1`), not the token.
+- Repair `n_args` matches `len(split_python_addin_data_args(...))`, not a semicolon count. `(range, 1×1 pred)` stays `n_args=2`.
 - Remove-field: first cell with a trailing geometric field → field gone; second call is a no-op.
-- Cap: `len == _MAX_PYTHON_CELLS_FOUND` → skip sheet, no patch for that sheet.
+- Cap: `len >= _MAX_PYTHON_CELLS_FOUND` → skip sheet, no patch, **no strip-safe marks**. No truncated-flag helper in Phase 1.
 
 Phase 4 — `data` strip (inject the in-memory map; no UNO):
 
 - `=PY("np.mean(data)"; B1:B10)` after attach still packs a single `CalcRange` (not a list).
 - `=PY("ranges[-1].shape"; B1:B10)` after attach: `ranges[-1]` is `B1:B10`, not the predecessor (indexed multi-data branch).
 - Strip runs before the matrix-index peel: last geometric 1-cell must **not** become `index_arg`.
-- User 1×1 last arg **not** in the map: no strip (do not drop real data).
-- User already passed previous PY cell as data (not in the map): no strip.
-- Missing / non-unique `(doc_url, code, n_args)`: no strip, no 1×1 fallback.
+- **Fill-down:** two identical `=PY("np.mean(data)"; B1:B10)` after attach → **both** strip (unanimous-ours, same resolved code, `n_args=2`).
+- **Mixed:** matrix-index neighbor `=PY("f"; range; i)` next to a chain of `=PY("f"; range; pred)` → **neither** strips (mixed poisons the triple).
+- **Two open workbooks / `off_main_calc_session_is_unambiguous()` false** → no strip.
+- **Isolated** still records a `workbook_key` and strips when unambiguous.
+- User 1×1 last arg **not** in the map, and no mixed poison of a chain: no strip of that user cell.
+- Never fall back to 1×1, uniqueness, or ≥1-hit.
 
 **UNO (`test_*_uno.py`):**
 
@@ -362,11 +401,11 @@ Phase 4 — `data` strip (inject the in-memory map; no UNO):
 - Insert a PY row between two chained cells; after the deferred pass, successor formula names the new cell; values update on next recalc.
 - Delete middle cell: successor retargets or remove-field if it is now first.
 - Flag off: no new attaches; existing refs stay.
-- Isolated + flag on: no-op for Python semantics; no `data` breakage.
+- Isolated + flag on: no-op for Python **globals**; strip still runs when `workbook_key` is unambiguous (no `data` breakage).
 - Undo: user types a new PY cell, geometric rewrite does not add a second undo step when `isUndoPossible()` (hidden context). Flag-on reconcile with no prior edit is one locked unit (`test_calc_spill_undo_lock` is the spill analogue).
 - `#SPILL!` / auto-spill still works on a chained origin cell.
 - Re-entrancy: repair `setFormula` does not nest a second repair.
-- Cap-hit sheet: no chain, log emitted.
+- Cap-hit sheet: no chain, log emitted, no strip-safe marks.
 
 Do not run the full suite until this is implemented. Phase 1 is mockable without soffice.
 

--- a/docs/calc/geometric-recalc-order.md
+++ b/docs/calc/geometric-recalc-order.md
@@ -229,7 +229,7 @@ Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high
 | ≥1-hit strip | **Rejected** — would strip a mixed matrix-index neighbor |
 | Mixed ours + user same triple | Do not mark strip-safe; residual is “chain loses strip,” not “user cell loses last arg” |
 | Two open workbooks | `off_main_calc_session_is_unambiguous()` false → no strip |
-| Isolated still needs strip | Record `workbook_key` on the UI-thread path even when `workbook_session_id` is `None` |
+| Isolated still needs strip | Isolated never enters `workbook_session_id`; UI load/repair must `record_active_calc_session("calc:" + _workbook_session_key)` so the unambiguous check can pass |
 | Keying the token `$A$1` | Eval `code` is resolved source (`execute_python_addin`); repair must read the code cell |
 | Naive `;` arity | Repair `n_args` must match `split_python_addin_data_args`, not a semicolon count |
 | Rewrite during recalc | Same ban as spill; deferred only |
@@ -252,7 +252,7 @@ Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high
 
 **Phase 1 — Pure list + formula splice.** Unit tests only: given a list of addresses + current formulas + the in-memory record, compute the patch and the eval-index bools. No UNO. Encode the [§9.5](#95-marker-is-the-udprop--in-memory-map) table, including **remove-field**, code-in-cell splice from the raw formula (`rebuild_python_formula_with_code_ref`), fill-down unanimous-ours, mixed poison, and “`len >= 100` → skip sheet, do not mark strip-safe.” No truncated-flag API in this phase.
 
-**Phase 2 — Flag + attach on save / flag-on.** Monaco and native cell save call the splicer; apply on the UI thread after save (save is already outside recalc). Settings default off. Flag-on walks **all sheets**. Persist / load the UDProp like spill. Record `workbook_key` even in Isolated (unsaved files must not use empty URL).
+**Phase 2 — Flag + attach on save / flag-on.** Monaco and native cell save call the splicer; apply on the UI thread after save (save is already outside recalc). Settings default off. Flag-on walks **all sheets**. Persist / load the UDProp like spill. Isolated UI load/repair must `record_active_calc_session` with `calc:` + `_workbook_session_key` (same string eval reads; never `""`).
 
 **Phase 3 — Deferred repair on insert/delete.** Shared trigger + spill-like timer + re-entrancy flag. UNO tests: three-cell column, insert PY in the middle, successor’s field updates; delete (including successor-becomes-first → remove-field); undo. Cap-hit sheet is left unchained. A real discovery `truncated` flag belongs here if needed — not Phase 1.
 
@@ -289,7 +289,7 @@ A trailing A1 field is enough **if** we strip it via the map, not a 1×1 heurist
 
 **Rejected:** hide the checkbox when Isolated is selected (couples two settings; looks like a bug when the box disappears).
 
-Precedent-only strip means Isolated `data` is unchanged. Isolated is a no-op for **Python globals**, not for the strip: `workbook_session_id` returns `None` when mode ≠ `shared`, but Isolated still needs strip (else arity breaks). Record `workbook_key` on the UI-thread path even in Isolated ([§9.5](#95-marker-is-the-udprop--in-memory-map)).
+Precedent-only strip means Isolated `data` is unchanged. Isolated is a no-op for **Python globals**, not for the strip: `workbook_session_id` returns `None` when mode ≠ `shared`, but Isolated still needs strip (else arity breaks). Isolated UI load/repair must `record_active_calc_session` with `calc:` + `_workbook_session_key` so yellow eval can see one recorded id ([§9.5](#95-marker-is-the-udprop--in-memory-map)).
 
 ### 9.4 Flag turned off — leave refs
 
@@ -336,11 +336,11 @@ Optional (not instead of unanimous, not the primary key): a fingerprint of `args
 
 #### `workbook_key` (blocking — do not cite `get_python_init_kwargs`)
 
-`get_python_init_kwargs` does **not** carry `doc_url`. `build_python_eval_init_kwargs` is init-script / hash only. `session_key` leaves `doc_url=""` off-main (fills `doc` only on main). Isolated: `workbook_session_id` returns `None` when mode ≠ `shared`, but Isolated still needs strip.
+`get_python_init_kwargs` does **not** carry `doc_url`. `build_python_eval_init_kwargs` is init-script / hash only. `session_key` leaves `doc_url=""` off-main (fills `doc` only on main). Isolated: `workbook_session_id` returns `None` when mode ≠ `shared` (`session_manager.py`) and **never enters** that function’s `record_active_calc_session` path, so `_RECORDED_CALC_SESSION_IDS` can stay empty and `off_main_calc_session_is_unambiguous()` stays false. Isolated still needs strip off-main (else arity breaks).
 
-**Eval `workbook_key` = `get_cached_calc_session_id()` only when `off_main_calc_session_is_unambiguous()`** (`session_manager.py`: `len(_RECORDED_CALC_SESSION_IDS) == 1`). Else do not strip (two open workbooks).
+**Eval `workbook_key` = `get_cached_calc_session_id()` only when `off_main_calc_session_is_unambiguous()`** (`session_manager.py`: `len(_RECORDED_CALC_SESSION_IDS) == 1`). Else do not strip (two open workbooks, or Isolated that never recorded).
 
-On the **UI-thread** load / repair path, record that workbook key in the geometric map **even in Isolated** (sibling of `load_spill_registry_for_doc`). Unsaved files must not use empty URL — same #402 hole as `session_key` / `_workbook_session_key` (URL, else a persisted unsaved id, never `""`).
+On the **UI-thread** load / repair path, write that key into the geometric map **and** call `record_active_calc_session` with the **same string eval will read**: `calc:` + `_workbook_session_key` (never `""`). Do this **even in Isolated**. Do **not** invent a second Isolated key. Then one open file makes `len(_RECORDED_CALC_SESSION_IDS) == 1` and yellow Isolated can strip. Sibling of `load_spill_registry_for_doc`. Unsaved files must not use empty URL — same #402 hole as `session_key` / `_workbook_session_key` (URL, else a persisted unsaved id, never `""`).
 
 #### Remove-field
 
@@ -391,7 +391,7 @@ Phase 4 — `data` strip (inject the in-memory map; no UNO):
 - **Fill-down:** two identical `=PY("np.mean(data)"; B1:B10)` after attach → **both** strip (unanimous-ours, same resolved code, `n_args=2`).
 - **Mixed:** matrix-index neighbor `=PY("f"; range; i)` next to a chain of `=PY("f"; range; pred)` → **neither** strips (mixed poisons the triple).
 - **Two open workbooks / `off_main_calc_session_is_unambiguous()` false** → no strip.
-- **Isolated** still records a `workbook_key` and strips when unambiguous.
+- **Isolated** UI load/repair calls `record_active_calc_session("calc:" + _workbook_session_key)` (same string eval reads) and strips when unambiguous.
 - User 1×1 last arg **not** in the map, and no mixed poison of a chain: no strip of that user cell.
 - Never fall back to 1×1, uniqueness, or ≥1-hit.
 

--- a/docs/calc/geometric-recalc-order.md
+++ b/docs/calc/geometric-recalc-order.md
@@ -1,6 +1,6 @@
-# Geometric Recalc Order — PM / Senior Dev Review
+# Geometric Recalc Order — implementation plan
 
-**Status:** Proposal under review. Not implemented. Product calls in [§9](#9-open-questions) are **open** — each lists alternatives and a current opinion.
+**Status:** Decided — ready to implement. **Not implemented.** Product calls in [§9](#9-decisions) are closed.
 
 **Related:** [Enabling NumPy & Python](../enabling_numpy_in_libreoffice.md) (session modes, auto-spill), [Microsoft `=PY` design stance](../scripting/ms-py-compatibility.md) (why we refuse Excel co-volatility), [Calc `=PY()` data shapes](py-data-shapes.md) (`data` / `ranges` arity).
 
@@ -14,11 +14,11 @@ Shared-kernel `=PY()` already persists one Python namespace per workbook, but Ca
 
 This is **not** Excel co-volatility (re-run every Python cell when any one is dirty). It is the existing `data`-as-dependency-edge idea, applied automatically to one predecessor.
 
-**Hard part:** inserting a new `=PY()` cell in the middle of the list. The successor’s predecessor field must be rewritten to the new cell. Those writes **must happen outside recalc**, using the same deferred, undo-isolated pattern as auto-spill (`perform_deferred_spill` + short timer). Writing other cells from inside the add-in re-enters the formula engine.
+**Hard part:** inserting a new `=PY()` cell in the middle of the list. The successor’s predecessor field must be rewritten to the new cell. Those writes **must happen outside recalc**, using the same deferred, undo-isolated pattern as auto-spill (`perform_deferred_spill` + 0.1s timer). Writing other cells from inside the add-in re-enters the formula engine.
 
-**Difficulty:** medium for someone who already knows the spill / formula-edit path — on the order of **one careful week**, not a core-Calc project. The risk is semantic (`data` arity, insert/delete, undo), not “can we write cells after recalc.”
+**Marker (required):** a workbook UDProp plus an in-memory map, same pattern as `WriterAgentSpillRegistry` / `SPILL_REGISTRY` / `load_spill_registry_for_doc` in [`function.py`](../../plugin/calc/python/function.py). Eval-time strip consults that map. A 1×1 / “last arg is a PY cell” heuristic is **unimplementable** — `execute_python_addin` / `split_python_addin_data_args` / `calc_addin_args_from_split` see only values, never addresses.
 
-**Current opinion:** accept the flag as an **opt-in Shared-kernel companion**, default **off**. The two product calls that most affect implementation are still open in [§9](#9-open-questions): whether the geometric arg is **precedent-only** (stripped before packing worker `data`), and whether the list is **all PY cells on the sheet, row-major**. The rest of this doc describes the design under those current opinions.
+**Difficulty:** medium for someone who already knows the spill / formula-edit path — on the order of **one careful week plus about a day** for the UDProp / in-memory map (the original happy-path week did not budget a marker). The risk is semantic (`data` arity, insert/delete, undo), not “can we write cells after recalc.”
 
 ---
 
@@ -46,6 +46,8 @@ Without `data` edges, Calc may run A3 before A1. The current docs tell authors t
 
 Do **not** implement Excel co-volatility. That needs a workbook-global PY barrier in `sc/`, flip-flop with non-PY formulas, and N Python executions per keystroke. [ms-py-compatibility §5.2](../scripting/ms-py-compatibility.md#52-co-volatility-a-second-calculation-mode) already rejected it. Geometric order reuses Calc’s DAG: one extra precedent per cell, dirty subgraph only.
 
+Do **not** add a dedicated IDL ordering argument. That rebuilds `.rdb`s for both OXTs and adds a Collabora/Excel arity case. Collabora Gerrit is in review with Tomaž; do not pile another IDL change on that. Precedent-only strip of a trailing A1 field is enough ([§9.1](#91-precedent-only-not-value-in-data-not-idl)).
+
 ---
 
 ## 2. Product definition
@@ -58,13 +60,13 @@ Do **not** implement Excel co-volatility. That needs a workbook-global PY barrie
 **When on:**
 
 1. Discover `=PY()` / `=PYTHON()` cells (reuse [`cell_discovery.py`](../../plugin/calc/python/cell_discovery.py) — already sorted **row then column**).
-2. For each cell after the first in that list, ensure the formula’s trailing fields include **exactly one geometric predecessor**: the previous list entry’s address.
-3. Leave user-authored ranges alone (see [§4 Data binding](#4-data-binding--do-not-shadow-data)).
+2. For each cell after the first in that list, ensure the formula’s trailing fields include **exactly one geometric predecessor**: the previous list entry’s address. Record the attach in the UDProp / in-memory map ([§4](#4-data-binding--do-not-shadow-data)).
+3. Leave user-authored ranges alone (see [§4](#4-data-binding--do-not-shadow-data)).
 4. On insert / delete / move that changes who “previous” is, **rewrite** the affected successor formulas — **deferred**, not during add-in evaluation.
 
-**When off:** no attach, no rewrite. Existing user-written `data` args stay. Geometric refs already attached **stay** (they are valid DAG edges). No strip-on-disable under the current opinion ([§9.4](#94-flag-turned-off)).
+**When off:** no attach, no rewrite. Existing user-written `data` args stay. Geometric refs already attached **stay** (they are valid DAG edges). Do **not** implement strip-on-disable in this feature — the marker exists, but leaving refs is the cheaper correct default ([§9.4](#94-flag-turned-off-leave-refs)).
 
-**Most valuable with Shared kernel.** Isolated cells do not share names, so order-only precedents do nothing useful for Python globals. Isolated + this flag is a **no-op** for Python semantics (the checkbox stays visible; helper text says it is used with Shared kernel). Do not hide the checkbox when Isolated is selected — current opinion; see [§9.3](#93-isolated-mode--checkbox).
+**Most valuable with Shared kernel.** Isolated cells do not share names, so order-only precedents do nothing useful for Python globals. Isolated + this flag is a **no-op** for Python semantics (the checkbox stays visible; helper text says it is used with Shared kernel). Do not hide the checkbox when Isolated is selected.
 
 ---
 
@@ -74,11 +76,13 @@ Do **not** implement Excel co-volatility. That needs a workbook-global PY barrie
 
 `list_python_cells_on_sheet` already returns `PythonCellInfo` sorted by `(row, column)`. That **is** the geometric list.
 
-**Proposed list (current opinion, [§9.2](#92-what-is-the-list) / [§9.6](#96-flag-on--document-open-scope)):** all PY cells on **each sheet**, row-major, each sheet chained **independently**. Flag-on / document-open reconcile every sheet (`list_python_cells_in_doc(..., active_sheet_only=False)`). Insert/delete repair only the **modified** sheet. Cross-sheet predecessors are out of scope (sheet-qualified refs + sheet insert/rename). Workbook-global order (Sheet1 then Sheet2) is a later option, not required to prove the idea.
+**List (decided):** all PY cells on **each sheet**, row-major, each sheet chained **independently**. Flag-on / document-open reconcile every sheet (`list_python_cells_in_doc(..., active_sheet_only=False)`). Insert/delete repair only the **modified** sheet. Cross-sheet predecessors are out of scope (sheet-qualified refs + sheet insert/rename). Workbook-global order (Sheet1 then Sheet2) is a later option, not required to prove the idea.
 
-**Cross-cluster chaining (current opinion, [§9.2](#92-what-is-the-list)):** two independent PY clusters on one sheet (A1:A5 and D1:D5) become one chain — D1 waits on A5. That slightly over-dirties the D column when A3 changes. Correctness is fine; users who care can turn the flag off and write explicit `data` refs. Spatial clustering is an alternative, not the current lean.
+**Cross-cluster chaining (decided):** two independent PY clusters on one sheet (A1:A5 and D1:D5) become one chain — D1 waits on A5. That slightly over-dirties the D column when A3 changes. Correctness is fine; users who care can turn the flag off and write explicit `data` refs. Do not add spatial clustering.
 
-**Cap:** discovery stops at 100 PY cells / 50k scanned (`_MAX_PYTHON_CELLS_FOUND`). Geometric order must honor the same cap or raise it deliberately — do not silently chain a truncated list. A 100-cell chain is serial (venv IPC per dirty cell); that is the price of order, not a new cliff. Document the cap; do not raise it in this feature.
+**Cap (decided):** `list_python_cells_on_sheet` stops at `_MAX_PYTHON_CELLS_FOUND = 100` (also `_MAX_CELLS_TO_SCAN = 50000`). The function returns a truncated list and does **not** currently say whether a cap fired. **If a cap is hit, skip geometric chaining for that entire sheet and log it.** Do not chain the first 100 and leave #101 with no predecessor. Do not raise the cap in this feature. Treat `len(found) >= _MAX_PYTHON_CELLS_FOUND` as capped (cannot tell “exactly 100” from “101+”; skipping a full 100-cell sheet is the safe default). If the scan cap fires with fewer than 100 PY cells, that list is also incomplete — same skip. A small `(cells, truncated)` wrapper around discovery is fine; do not change the 100/50k constants.
+
+A 100-cell chain is serial (venv IPC per dirty cell); that is the price of order, not a new cliff.
 
 ### 3.2 Auto-attach is a formula field, not a Python parse
 
@@ -89,9 +93,9 @@ A2:  =PY("df = clean(df)")          →  =PY("df = clean(df)"; A1)
 A3:  =PY("result = df.describe()")   →  =PY("result = df.describe()"; A2)
 ```
 
-Reuse [`parse_python_formula`](../../plugin/calc/python/formula_edit.py) / `rebuild_python_formula_with_data` / `build_data_suffix`. Do not invent a second formula serializer.
+Reuse [`parse_python_formula`](../../plugin/calc/python/formula_edit.py) / `parse_data_binding_text` / `build_data_suffix`. Quoted-code cells: `rebuild_python_formula_with_data`. Code-in-cell (`=PY($A$1; B1:B10)`): detect with `py_formula_has_unquoted_code_ref` / `py_code_arg_is_cell_ref` and rebuild with `rebuild_python_formula_with_code_ref` — **not** `rebuild_python_formula_with_data` (that quotes the code-ref as a string). Do not invent a second formula serializer.
 
-The first cell in the list gets **no** predecessor. Cycles cannot appear if we only ever attach the previous entry in a total order.
+The first cell in the list gets **no** predecessor. Cycles cannot appear if we only ever attach the previous entry in a total order. If a first cell still has a trailing geometric field (successor became first after delete), run the **remove-field** primitive ([§9.5](#95-marker-is-the-udprop--in-memory-map)).
 
 ### 3.3 Why “just the previous” is enough
 
@@ -106,10 +110,10 @@ Example: list is A1, A3. A3 has `;A1`. User inserts a PY cell at A2.
 | Cell | Before | After repair |
 |------|--------|----------------|
 | A1 | `=PY("…")` | unchanged |
-| A2 | `=PY("…")` (new) | `=PY("…"; A1)` |
-| A3 | `=PY("…"; A1)` | `=PY("…"; A2)` |
+| A2 | `=PY("…")` (new) | `=PY("…"; A1)` + map record |
+| A3 | `=PY("…"; A1)` | `=PY("…"; A2)` + map record updated |
 
-Delete A2: A3’s predecessor must become A1 again (or empty if A3 is now first).
+Delete A2: A3’s predecessor must become A1 again, or **remove-field** if A3 is now first.
 
 Row insert that only **moves** existing PY cells: Calc’s own reference adjust may already be correct. The deferred pass should be **idempotent**: recompute desired predecessor per cell, rewrite only when the geometric field differs.
 
@@ -119,29 +123,27 @@ Row insert that only **moves** existing PY cells: Calc’s own reference adjust 
 
 - Do not mutate other cells from `execute_python_addin` / `finalize_python_return`.
 - Do not `processEventsToIdle` during recalc (re-enters the engine → `#VALUE!`).
-- Auto-spill already defers neighbor writes: collision check sync, then `threading.Timer(0.1)` → `perform_deferred_spill` on the **UI thread**, inside `_undo_lock` (`enterHiddenUndoContext` / `lock`).
+- Auto-spill already defers neighbor writes: collision check sync, then `threading.Timer(0.1)` → `perform_deferred_spill` on the **UI thread**, inside `_undo_lock`.
 
 Geometric rewrites use that same shape:
 
-1. **Detect** (modify listener, Monaco/formula save, flag toggle) that the geometric list changed.
+1. **Detect** (shared modify/save trigger, Monaco/formula save, flag toggle) that the geometric list changed.
 2. **Compute** a small patch: cells whose predecessor field is wrong.
 3. **Schedule** a deferred UI-thread job (reuse the 0.1s timer / drain pattern; do not start a raw thread — `run_in_background` + main-thread apply, or the existing Timer-on-main pattern in `function.py`).
-4. **Apply** `setFormula` under `_undo_lock` so Ctrl+Z still undoes the user’s edit, not a stray “rewrite A3” undo step.
-5. **Guard** like spill: same doc URL / lifecycle key; skip if the origin formula is no longer what we expected.
+4. **Apply** `setFormula` under `_undo_lock`. `_undo_lock` calls `enterHiddenUndoContext` only when `um.isUndoPossible()`; otherwise `um.lock()`. User edits hide under the existing undo action. Flag-on / document-open reconcile with no prior edit is **one locked unit**, not a hidden-under-nothing no-op.
+5. **Guard** like spill: same doc URL / lifecycle key; skip if the origin formula is no longer what we expected. **Re-entrancy:** an explicit flag so `setFormula` → `modified` cannot run repair inside repair. A rewrite pass that finds nothing to do is a no-op.
 
-`setFormula` on a successor will dirty that cell and start another recalc. That is intended. The deferred job must be **re-entrant-safe**: a rewrite pass that finds nothing to do is a no-op; do not loop “rewrite → recalc → rewrite.”
-
-Yellow recalc / off-main formula groups: same contract as spill and session lookup — **no UNO desktop/document queries from a recalc worker**. Discovery + rewrite only on the UI thread after the pass.
+Yellow recalc / off-main formula groups: same contract as spill and session lookup — **no UNO desktop/document queries from a recalc worker**. Discovery + rewrite only on the UI thread after the pass. Eval-time strip reads the already-loaded in-memory map only.
 
 ### 3.6 When to run the repair pass
 
 | Trigger | Why |
 |---------|-----|
 | Flag turned **on** | One-shot attach for **all sheets**, each chained independently |
-| Flag turned **off** | Stop maintaining refs; **leave** existing geometric fields |
-| Monaco / native **Save** of a PY cell | New or edited formula may need a predecessor; neighbors may need retarget |
-| `XModifyListener` on sheets that already have PY cells | Insert/delete/clear. Prefer a **sibling** `CalcGeometricModifyListener` (spill listener is tightly coupled to `SPILL_REGISTRY`). If a third `addModifyListener` is undesirable, factor a one-sheet dispatcher that fans out to spill cleanup and geometric repair — do not merge the two jobs into one class. |
-| Document open | Cheap: if flag on, reconcile once so files authored with the flag stay consistent |
+| Flag turned **off** | Stop maintaining refs; **leave** existing geometric fields; leave the map (do not strip-on-disable) |
+| Monaco / native **Save** of a PY cell | Primary attach path — save is already outside recalc (`editor.py` `_apply_formula_save` / native Save). New or edited formula may need a predecessor; neighbors may need retarget. Do **not** collapse everything onto modify-only. |
+| Sheet `XModifyListener` (shared trigger) | Insert/delete/clear. **Do not** add a sibling `CalcGeometricModifyListener`. `CalcSpillModifyListener.modified` walks `SPILL_REGISTRY` for that sheet only — it does **not** scan formula cells, so geometric repair cannot piggyback on that walk. Share the **trigger / debounce** (0.1s timer, drain, UI thread, `_undo_lock`) and the re-entrancy flag. Geometric repair then runs its own `list_python_cells_on_sheet`. Factor a one-sheet dispatcher if a second `addModifyListener` is undesirable; do not merge the two jobs into one class. |
+| Document open | If flag on, load the UDProp into the in-memory map (like `load_spill_registry_for_doc`) and reconcile once so files authored with the flag stay consistent |
 
 Do **not** rewrite from inside the add-in just because this cell is evaluating.
 
@@ -149,7 +151,7 @@ Do **not** rewrite from inside the add-in just because this cell is evaluating.
 
 ## 4. Data binding — do not shadow `data`
 
-**This is the highest-risk product call.** Current opinion is **precedent-only** ([§9.1](#91-does-the-geometric-arg-change-python-data)).
+**Highest-risk implementation detail.** Decided: **precedent-only**, strip via the UDProp / in-memory map ([§9.1](#91-precedent-only-not-value-in-data-not-idl), [§9.5](#95-marker-is-the-udprop--in-memory-map)).
 
 Today ([data shapes](py-data-shapes.md)):
 
@@ -158,15 +160,27 @@ Today ([data shapes](py-data-shapes.md)):
 
 `calc_addin_args_from_split` in [`calc_addin_data.py`](../../plugin/calc/calc_addin_data.py) is the flip: `len(args) == 1` returns one 2D grid; `len(args) >= 2` returns a **list** of grids. If A2 is `=PY("np.mean(data)"; B1:B10)` and we append `;A1`, then `data` suddenly becomes a list and `np.mean(data)` breaks. That is the common case, not a corner.
 
-**Proposed contract under opinion A:**
+**Contract:** the geometric predecessor is a **Calc-only ordering token**. The add-in **strips it** before packing worker `data` / `ranges`. User-authored args keep today’s arity. Isolated and Shared both see the same `data` they wrote.
 
-The geometric predecessor is a **Calc-only ordering token**. The add-in **strips it** before packing worker `data` / `ranges`. User-authored args keep today’s arity. Isolated and Shared both see the same `data` they wrote.
+### 4.1 Why a value-shape strip cannot work
 
-**Where to strip:** after `split_python_addin_data_args` and **before** `calc_addin_args_from_split` / `pack_calc_data_for_wire` in `_execute_python_addin_impl` ([`function.py`](../../plugin/calc/python/function.py)). The geometric token is the last trailing arg when it is a **single cell** that matches the computed previous PY address (or, at eval time, a 1×1 last arg that is itself a PY cell — see [§9.5](#95-how-do-we-recognize-our-field)). Do not invent a reserved formula suffix or a third IDL argument unless review picks those alternatives.
+`PythonFunction.python` / `execute_python_addin` receive `(code, data)` values only (`addin_impl.py`). `split_python_addin_data_args` and `calc_addin_args_from_split` never see addresses or “this arg is a PY cell.”
 
-**Alternatives (not the current lean):** injecting the previous cell’s *value* into `data` / `data[-1]` (changes Python semantics and fights existing scripts), or a third IDL parameter (rebuilds `.rdb`s for both OXTs; Collabora/Excel import get another arity case). A trailing A1 field is enough if we strip it.
+A rule like “if the last arg is a 1×1 PY cell, drop it” is therefore unimplementable. `locate_formula_cell_in_doc` (`function.py` `session_key`) is **not** a fix: it returns `None` on 0 or 2+ matches, and cannot disambiguate `=PY("f(data)"; A1)` when A1 is both predecessor and user data.
 
-Code-in-cell form (`=PY($A$1; B1:B10)`) must keep `$A$1` as the code arg and still accept a geometric trailing field.
+The last-row idea “user already passed the previous PY cell as real data → no-op, satisfied either way” is **wrong** under a shape-strip: it would drop real user data. Under the map, that row is: **do not record as ours, do not strip** ([§9.5](#95-marker-is-the-udprop--in-memory-map) table).
+
+### 4.2 Where to strip (must be before the index heuristic)
+
+In `_execute_python_addin_impl` ([`function.py`](../../plugin/calc/python/function.py)):
+
+1. `args = split_python_addin_data_args(data)`
+2. **Strip here** if the in-memory map says this evaluation has a geometric last field (see [§9.5](#95-marker-is-the-udprop--in-memory-map) eval index). Unconditional across **both** branches — including `_code_uses_indexed_multi_data` (`"data["` / `"ranges["` in the source). If the geometric field stays, it becomes `data[-1]` / `ranges[-1]`.
+3. Then `py_data = calc_addin_args_from_split(...)` and the existing trailing-single-cell **matrix-index** heuristic (the `is_multi and not _code_uses_indexed_multi_data(code)` block that peels a last 1-cell arg as `index_arg`, after which `finalize_python_return` slices `flat[value]`).
+
+If strip runs after that heuristic, appending `;A1` to `=PY("np.mean(data)"; B1:B10)` would coincidentally fix arity and **corrupt** the result (A1’s value used as a matrix index). Phase 4 must test both `=PY("np.mean(data)"; B1:B10)` and `=PY("ranges[-1].shape"; B1:B10)`.
+
+Do not invent a reserved formula suffix. Do not add a third IDL argument.
 
 ---
 
@@ -174,7 +188,7 @@ Code-in-cell form (`=PY($A$1; B1:B10)`) must keep `$A$1` as the code arg and sti
 
 **What the user sees:** formulas gain a trailing cell ref they did not type. That is the feature (Calc must see it). Document it in Settings helper text and the hub session-modes page when this ships.
 
-**What they should not see:** extra undo steps, `#REF!` storms after insert, `data` breaking on cells that already pass ranges, or a full-sheet PY re-run after one edit.
+**What they should not see:** extra undo steps **when an undo action already exists** (hidden under the user edit); `#REF!` storms after insert; `data` breaking on cells that already pass ranges; a full-sheet PY re-run after one edit. Flag-on / open reconcile with an empty undo stack may appear as **one locked unit** — that is accepted, not a second “rewrite A3” step on top of a user edit.
 
 **LibrePy sidebar:** the existing cell list is already geometric. A later UX nicety (not MVP) is a small “depends on A1” hint. Do not block the flag on sidebar chrome.
 
@@ -187,17 +201,18 @@ Code-in-cell form (`=PY($A$1; B1:B10)`) must keep `$A$1` as the code arg and sti
 | Piece | New? | Reuse |
 |-------|------|--------|
 | Settings checkbox | Small | `module.yaml` + existing Settings dialog |
-| Discover PY cells in order | None | `cell_discovery.list_python_cells_on_sheet` / `list_python_cells_in_doc` |
-| Parse / rebuild `=PY(code; args)` | Small helper to splice one address | `formula_edit.py` |
-| Deferred UI-thread writes + undo hide | Small | `perform_deferred_spill`, `_undo_lock`, Timer 0.1s |
-| Sheet modify | Small | Sibling `CalcGeometricModifyListener`; optional one-sheet dispatcher shared with spill |
-| Strip geometric arg from worker `data` | Medium | `function.py` / `calc_addin_data.py` — strip **before** `calc_addin_args_from_split` |
+| Discover PY cells in order | Tiny wrapper | `cell_discovery.list_python_cells_on_sheet` / `list_python_cells_in_doc` — add a truncation signal, do not raise the cap |
+| Parse / rebuild `=PY(code; args)` | Small splice + remove-field | `formula_edit.py` — `rebuild_python_formula_with_data` **or** `rebuild_python_formula_with_code_ref` |
+| Marker | ~1 extra day | Copy `WriterAgentSpillRegistry` / `load_spill_registry_for_doc` / `SPILL_REGISTRY` / `save_spill_registry_for_doc` (`udprops.get_document_property` / `set_document_property`) |
+| Deferred UI-thread writes + undo | Small | `perform_deferred_spill`, `_undo_lock`, Timer 0.1s — share debounce; explicit re-entrancy flag |
+| Sheet modify | Small | **Shared trigger**, not a sibling listener; geometric job does its own PY discovery |
+| Strip geometric arg from worker `data` | Medium | `_execute_python_addin_impl` — map lookup **before** the index heuristic and **before** `calc_addin_args_from_split` |
 | Insert-in-middle repair | Medium | Pure list-diff + `setFormula` |
-| Tests | Required | pytest on list-diff + formula splice; UNO for insert-row + deferred rewrite |
+| Tests | Required | pytest on list-diff + formula splice + map/strip; UNO for insert-row + deferred rewrite |
 
-**Not required:** LibreOffice core patches, co-volatility, IDL change, venv protocol change, chat tools.
+**Not required:** LibreOffice core patches, co-volatility, IDL change, venv protocol change, chat tools, strip-on-disable, raising the 100-cell cap.
 
-**Rough effort:** 3–5 days for the happy path (flag + attach + deferred repair on one sheet) once [§9.1](#91-does-the-geometric-arg-change-python-data) is settled; another 2–3 days for insert/delete/undo/flag-toggle edges and tests.
+**Rough effort:** 3–5 days for the happy path (flag + attach + deferred repair on one sheet) **plus about a day** for the UDProp / in-memory map; another 2–3 days for insert/delete/undo/flag-toggle edges and tests.
 
 Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high regression risk. This flag is the cheap 80%.
 
@@ -207,147 +222,151 @@ Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high
 
 | Risk | Mitigation |
 |------|------------|
-| Shadowing `data` (arity flip) | Precedent-only strip ([§4](#4-data-binding--do-not-shadow-data); [§9.1](#91-does-the-geometric-arg-change-python-data)) |
+| Shadowing `data` (arity flip) | Precedent-only strip via the map, **before** the index heuristic ([§4](#4-data-binding--do-not-shadow-data)) |
+| 1×1 / “is a PY cell” strip | Forbidden — add-in sees values only ([§4.1](#41-why-a-value-shape-strip-cannot-work)) |
+| Index heuristic eats `;A1` | Strip first; Phase 4 tests `np.mean(data)` and `ranges[-1].shape` |
 | Rewrite during recalc | Same ban as spill; deferred only |
-| Undo fragmentation | `_undo_lock` / hidden undo, same as spill (`test_calc_spill_undo_lock`) |
-| Infinite rewrite loop | Idempotent desired-vs-actual; skip if already correct |
+| Undo fragmentation | `_undo_lock`: hidden when `isUndoPossible()`, else `lock()`; flag-on reconcile is one locked unit |
+| Infinite rewrite loop | Idempotent desired-vs-actual; re-entrancy flag; skip if already correct |
 | Calc already adjusted refs on row insert | Repair pass compares desired predecessor, does not blindly rewrite |
-| User already passed the previous cell | No duplicate field ([§9.5](#95-how-do-we-recognize-our-field)) |
-| User passed a **different** single-cell last arg (real data) | Append, do not replace, unless that last arg is a **stale** geometric predecessor |
-| Two independent PY clusters on one sheet | Current opinion: one row-major chain; slightly over-dirties the later cluster ([§9.2](#92-what-is-the-list)) |
+| User already passed the previous cell as **data** | Do not record as ours; do not strip ([§9.5](#95-marker-is-the-udprop--in-memory-map)) |
+| User passed a **different** single-cell last arg (real data) | Append, do not replace, unless the map says that last arg is **our** stale predecessor |
+| Two independent PY clusters on one sheet | One row-major chain; slightly over-dirties the later cluster |
 | Circular refs from user forward-refs | Calc reports circular; we never attach a later cell |
-| 100-cell discovery cap | Honor it; never chain a partial list as if complete |
-| Shared + Isolated confusion | Checkbox always visible; helper: “Used with Shared kernel”; Isolated is a no-op ([§9.3](#93-isolated-mode--checkbox)) |
+| 100-cell discovery cap | Skip the **whole** sheet; never chain a partial list |
+| Shared + Isolated confusion | Checkbox always visible; helper: “Used with Shared kernel”; Isolated is a no-op |
 | Collabora Online | Desktop LibrePy first. Online has no deferred UNO spill-style writes in the same way; do not promise this flag in jail-safe compute until desktop is boring |
 
 ---
 
-## 8. Suggested phases (when scheduled)
+## 8. Suggested phases
 
-**Phase 0 — Review (this doc).** Product calls in [§9](#9-open-questions) are open. No code until review picks (or confirms) the current opinions.
+**Phase 0 — Review (this doc).** Closed. Do not reopen [§9.1](#91-precedent-only-not-value-in-data-not-idl) C (IDL) or a value-shape strip.
 
-**Phase 1 — Pure list + formula splice.** Unit tests only: given a list of addresses + current formulas, compute the patch. No UNO. This is the whole algorithm. Encode the [§9.5](#95-how-do-we-recognize-our-field) table.
+**Phase 1 — Pure list + formula splice.** Unit tests only: given a list of addresses + current formulas + the in-memory record, compute the patch. No UNO. This is the whole algorithm. Encode the [§9.5](#95-marker-is-the-udprop--in-memory-map) table, including **remove-field**, code-in-cell `=PY($A$1; B1:B10)`, and “cap-hit → skip sheet.”
 
-**Phase 2 — Flag + attach on save / flag-on.** Monaco and native cell save call the splicer; apply on the UI thread after save (save is already outside recalc). Settings default off. Flag-on walks **all sheets**.
+**Phase 2 — Flag + attach on save / flag-on.** Monaco and native cell save call the splicer; apply on the UI thread after save (save is already outside recalc). Settings default off. Flag-on walks **all sheets**. Persist / load the UDProp like spill.
 
-**Phase 3 — Deferred repair on insert/delete.** Sibling modify listener + spill-like timer. UNO tests: three-cell column, insert PY in the middle, successor’s field updates; delete; undo.
+**Phase 3 — Deferred repair on insert/delete.** Shared trigger + spill-like timer + re-entrancy flag. UNO tests: three-cell column, insert PY in the middle, successor’s field updates; delete (including successor-becomes-first → remove-field); undo. Cap-hit sheet is left unchained.
 
-**Phase 4 — Strip geometric arg from worker ingress.** Tests that `=PY("np.mean(data)"; B1:B10)` still sees a single `CalcRange` after attach.
+**Phase 4 — Strip geometric arg from worker ingress.** Map lookup after `split_python_addin_data_args`, **before** the index heuristic and `calc_addin_args_from_split`. Tests in [§10](#10-test-plan-when-implemented).
 
-**Non-goals until someone asks:** cross-sheet chains, workbook-global order, Isolated value-piping, sidebar annotations, Excel export special-case, raising the 100-cell cap, strip-on-disable, spatial clustering of independent PY groups.
+**Non-goals until someone asks:** cross-sheet chains, workbook-global order, Isolated value-piping, sidebar annotations, Excel export special-case, raising the 100-cell cap, strip-on-disable, spatial clustering of independent PY groups, a dedicated IDL arg.
 
 ---
 
-## 9. Open questions
+## 9. Decisions
 
-Please mark these up. Each item is a question, the real alternatives, and a current opinion — not a closed contract.
+Closed. Rejected alternatives are listed so they are not reopened in the first PR.
 
-### 9.1 Does the geometric arg change Python `data`?
+### 9.1 Precedent-only (not value-in-`data`, not IDL)
 
-**Question:** After we append a predecessor cell so Calc orders the DAG, what does the worker see in `data` / `ranges`?
+**Decision: A — Precedent-only.** The geometric arg is a Calc DAG token. Strip it before packing worker `data` / `ranges`. Do not inject the previous cell’s value.
 
-**Alternatives:**
+**Rejected:**
 
-- **A — Precedent-only.** The geometric arg is a Calc DAG token. Strip it before packing worker `data` / `ranges`. Do not inject the previous cell’s value.
-- **B — Value-in-`data`.** Inject the previous cell’s value into `data` / `data[-1]`.
-- **C — Third IDL parameter.** A dedicated ordering argument, not a trailing A1 field. Rebuilds `.rdb`s for both OXTs; Collabora/Excel import get another arity case.
+- **B — Value-in-`data`.** Inject the previous cell’s value into `data` / `data[-1]`. Breaks `np.mean(data)` on every cell that already passes one range.
+- **C — Third IDL parameter.** Rebuilds `.rdb`s for both OXTs; Collabora/Excel import get another arity case. Collabora Gerrit is in review; do not pile another IDL change. Do not reopen C in this feature.
 
-**Current opinion: A.** `calc_addin_args_from_split` flips arity at two args. Value-in-`data` would break `np.mean(data)` on every cell that already passes one range — the common case. A trailing A1 field is enough if we strip it.
+A trailing A1 field is enough **if** we strip it via the map, not a 1×1 heuristic.
 
-### 9.2 What is “the list”?
+### 9.2 The list is all PY cells on the sheet, row-major
 
-**Question:** Which `=PY()` cells are chained, and in what order?
+**Decision: A.** One chain per sheet. Independent clusters become one chain. Matches `list_python_cells_on_sheet` and the sidebar.
 
-**Alternatives:**
+**Rejected:** contiguous-column-only (surprises authors who put the next step in C1); spatial clustering; workbook-global order. Those can wait.
 
-- **A — All PY cells on the sheet, row-major.** One chain per sheet. Independent clusters (A1:A5 and D1:D5) become one chain — D1 waits on A5.
-- **B — Contiguous column only.** Only cells stacked in the same column (or a contiguous block) are chained.
-- **C — Spatial clustering.** Detect independent PY groups by proximity and chain within each group.
-- **D — Workbook-global.** Sheet1 then Sheet2 (and so on), one chain for the whole file.
+### 9.3 Isolated mode — checkbox visible, no-op
 
-**Current opinion: A.** Matches `list_python_cells_on_sheet` and the sidebar. Contiguous-column-only would surprise authors who put the next step in C1. Spatial clustering and workbook-global order can wait; they are not required to prove the idea. Over-dirtying the later cluster is acceptable; users who care can turn the flag off and write explicit `data` refs.
+**Decision: A.** Always visible; Isolated is a no-op. Helper: “Ensures PY cells evaluate in sheet order. Most useful with Shared kernel.”
 
-### 9.3 Isolated mode + checkbox?
+**Rejected:** hide the checkbox when Isolated is selected (couples two settings; looks like a bug when the box disappears).
 
-**Question:** What should Settings do when session mode is Isolated?
+Precedent-only strip means Isolated `data` is unchanged.
 
-**Alternatives:**
+### 9.4 Flag turned off — leave refs
 
-- **A — Always visible; Isolated is a no-op.** Helper text says the flag is used with Shared kernel.
-- **B — Hide the checkbox** when Isolated is selected.
+**Decision: A.** Stop attaching and stop repairing. The refs stay as valid DAG edges. After a precedent-only strip they do not change Python behavior.
 
-**Current opinion: A.** Hiding the box when Isolated is selected couples two settings and looks like a bug when the box disappears. Isolated cells have independent namespaces, so order-only precedents do nothing useful for Python globals. Precedent-only strip ([§9.1](#91-does-the-geometric-arg-change-python-data) A) means Isolated `data` is unchanged.
+**Rejected for this feature: B — strip-on-disable.** The marker now exists ([§9.5](#95-marker-is-the-udprop--in-memory-map)), so B is implementable later with the same remove-field primitive. Do not build it here.
 
-Helper: “Ensures PY cells evaluate in sheet order. Most useful with Shared kernel.”
+### 9.5 Marker is the UDProp / in-memory map
 
-### 9.4 Flag turned off?
+**Decision: C (required), used to implement A’s rewrite table.** Not a reserved suffix. Not IDL. Not a 1×1 / “last arg is a PY cell” heuristic.
 
-**Question:** What happens to geometric refs already attached when the user turns the flag off?
+Copy the spill pattern — do not invent a second subsystem:
 
-**Alternatives:**
+| Spill (exists) | Geometric (this feature) |
+|----------------|--------------------------|
+| UDProp `WriterAgentSpillRegistry` | A sibling document property (e.g. `WriterAgentGeometricRegistry`) |
+| `SPILL_REGISTRY` in memory | In-memory map, loaded on the UI thread |
+| `load_spill_registry_for_doc` / `save_spill_registry_for_doc` | Same load/save shape via `udprops` |
+| Keyed by `(doc_url, sheet, row, col)` | Same: cells **we** attached, plus the predecessor we wrote |
 
-- **A — Leave attached refs.** Stop attaching and stop repairing. The refs stay as valid DAG edges.
-- **B — Strip-on-disable.** Rewrite formulas to remove the geometric field.
+**Rewrite** (UI thread) always has addresses. The map is the ours-vs-user marker: append / replace / remove using the table below.
 
-**Current opinion: A.** After a precedent-only strip they do not change Python behavior. Strip-on-disable needs a reliable “ours vs user-typed” marker; do not build that unless review wants B.
+**Eval-time strip** cannot look up `(sheet, row, col)` unless it already knows the origin. `execute_python_addin` does not receive the calling address. Do **not** call `locate_formula_cell_in_doc` to recover it (None on 0 or 2+ matches; cannot tell user-data-is-previous-PY from our field). Do **not** query the desktop / document from a recalc worker.
 
-### 9.5 How do we recognize “our” field?
+**Eval index (least extra complexity):** when attaching or repairing on the UI thread, also maintain a uniqueness-filtered view of the same map, keyed by `(doc_url, code, n_args)` → “strip last.” `n_args` is `len(split_python_addin_data_args(...))` **including** the geometric field. At eval, if that triple hits a **unique** strip entry, drop `args[-1]`. If the triple is missing or not unique, **do not strip** (leave user data; log the collision). Never fall back to 1×1. `doc_url` at eval: use `doc` when already passed, or the same unambiguous cached session `get_python_init_kwargs` already uses off-main — no new UNO walk.
 
-**Question:** When rewriting or stripping, how do we tell a geometric predecessor from a user-typed last arg?
+Typical pipelines have distinct `code` strings, so the triple is unique. Duplicate identical formulas are the leftover hole (same as locate); fail safe = no strip.
 
-**Alternatives:**
+**Remove-field primitive:** parse → drop the last geometric data arg → rebuild → drop the map record. Needed when a successor becomes first after delete. Same primitive strip-on-disable ([§9.4](#94-flag-turned-off-leave-refs) B) would use later. **Idempotent:** first cell with a trailing geometric field → strip that field.
 
-- **A — Match the computed predecessor.** No reserved suffix and no document UDProp. Desired predecessor is the previous entry in the sheet’s row-major PY list (or none if first). Compare the last trailing arg using the table below.
-- **B — Reserved formula suffix.** A marker that is unambiguously ours (and visible in the formula bar).
-- **C — Workbook UDProp** listing cells we attached. Useful later if someone wants strip-on-disable ([§9.4](#94-flag-turned-off) B).
-- **D — Third IDL argument.** Same as [§9.1](#91-does-the-geometric-arg-change-python-data) C — the field is not a trailing `data` arg at all.
+**Rewrite table** (desired predecessor A1 unless noted). “Ours” means the map has a record for this cell.
 
-**Current opinion: A** for a first version. C only if someone later wants strip-on-disable.
+| Scenario | Last arg | Map | Action |
+|----------|----------|-----|--------|
+| No args | — | none | Append `;A1`; record |
+| User range `B1:B10` | range | none | Append (`;B1:B10;A1`); record |
+| Already correct | single cell = desired | ours, pred A1 | No-op |
+| Stale predecessor after insert | single cell = old pred | ours, old pred A1, desired A2 | Replace `;A1` → `;A2`; update record |
+| User single-cell data `C5` | single cell ≠ desired | none | Append (`;C5;A1`); do not overwrite `C5` |
+| User already passed the previous PY cell as **real data** | single cell = desired | **none** (we did not attach) | **No-op. Do not record. Do not strip at eval.** |
+| Successor became first (delete) | geometric field | ours | **Remove-field**; drop record |
+| First cell still has a leftover field | geometric field | ours | Remove-field (idempotent) |
+| Cap hit on this sheet | — | — | Skip the sheet; log; do not write a partial chain |
 
-**Proposed heuristic under A.** Compare the last trailing arg:
+### 9.6 Flag-on / document-open — all sheets
 
-| Scenario | Last arg | Desired predecessor | Action |
-|----------|----------|---------------------|--------|
-| No args | — | A1 | Append `;A1` |
-| User range `B1:B10` | range | A1 | Append (`;B1:B10;A1`) |
-| Already correct | single cell = desired | A1 | No-op |
-| Stale predecessor after insert | single cell ≠ desired, and last arg **was** the old geometric predecessor | A2 | Replace `;A1` → `;A2` |
-| User single-cell data `C5` (not a PY cell, not the old predecessor) | single cell ≠ desired | A1 | Append (`;C5;A1`) — do not overwrite user data |
-| User already passed the previous PY cell as real data | single cell = desired | A1 | No-op (satisfied either way) |
+**Decision: A.** All sheets, each chained independently. `list_python_cells_in_doc(..., active_sheet_only=False)` already walks `doc.getSheets()`. Modify-listener repair stays per-sheet.
 
-**Eval-time strip** can be slightly looser than the rewrite heuristic: if the last split arg is a 1×1 cell that is itself a PY cell, drop it before packing. False positive (user passed a PY cell as real `data`) is the same case as the last row above — accepted under A.
-
-Phase 1 tests would encode this table if A is confirmed.
-
-### 9.6 Flag-on / document-open scope?
-
-**Question:** When the flag is turned on, or a flagged workbook is opened, which sheets get a chain?
-
-**Alternatives:**
-
-- **A — All sheets, each chained independently.** Opening a workbook with the flag on orders every tab, not whichever sheet happens to be active. `list_python_cells_in_doc(..., active_sheet_only=False)` already walks `doc.getSheets()`. Modify-listener repair stays per-sheet.
-- **B — Active sheet only.** Cheaper first pass; other tabs wait until the user visits them or toggles the flag again.
-
-**Current opinion: A.** A flagged file should stay consistent on every tab.
+**Rejected:** active sheet only (other tabs stay inconsistent until visited).
 
 ---
 
 ## 10. Test plan (when implemented)
 
-**Unit (`tests/calc/python/`, match the new module name):**
+**Unit (`tests/calc/python/`, match the new module name; splice cases can extend `test_formula_edit.py`):**
 
-- List-diff: empty, one cell, two cells, insert in middle, delete middle, delete first, reorder.
-- Formula splice: no args; existing range args preserved; code-in-cell `$A$1`; already-correct predecessor; stale predecessor replaced; user extra cell-ref appended not overwritten when it is not the old predecessor. Encode the [§9.5](#95-how-do-we-recognize-our-field) table.
-- `data` strip: host payload arity unchanged when a geometric token is present.
+Phase 1 — list-diff + splice (encode [§9.5](#95-marker-is-the-udprop--in-memory-map)):
+
+- Empty, one cell, two cells, insert in middle, delete middle, delete first (remove-field), reorder.
+- Formula splice: no args; existing range args preserved; already-correct predecessor; stale predecessor replaced; user extra cell-ref appended not overwritten when it is not ours.
+- **Code-in-cell:** `=PY($A$1; B1:B10)` → attach / replace / remove via `rebuild_python_formula_with_code_ref`; result stays an unquoted `$A$1` (or the original ref token), not `=PY("$A$1"; …)`.
+- Remove-field: first cell with a trailing geometric field → field gone; second call is a no-op.
+- Cap: `len == _MAX_PYTHON_CELLS_FOUND` → skip sheet, no patch for that sheet.
+
+Phase 4 — `data` strip (inject the in-memory map; no UNO):
+
+- `=PY("np.mean(data)"; B1:B10)` after attach still packs a single `CalcRange` (not a list).
+- `=PY("ranges[-1].shape"; B1:B10)` after attach: `ranges[-1]` is `B1:B10`, not the predecessor (indexed multi-data branch).
+- Strip runs before the matrix-index peel: last geometric 1-cell must **not** become `index_arg`.
+- User 1×1 last arg **not** in the map: no strip (do not drop real data).
+- User already passed previous PY cell as data (not in the map): no strip.
+- Missing / non-unique `(doc_url, code, n_args)`: no strip, no 1×1 fallback.
 
 **UNO (`test_*_uno.py`):**
 
 - Shared kernel, flag on: A3 reads a name assigned in A1 without a user-typed `data` ref; result is stable across F9.
 - Insert a PY row between two chained cells; after the deferred pass, successor formula names the new cell; values update on next recalc.
+- Delete middle cell: successor retargets or remove-field if it is now first.
 - Flag off: no new attaches; existing refs stay.
 - Isolated + flag on: no-op for Python semantics; no `data` breakage.
-- Undo: user types a new PY cell, geometric rewrite does not add a second undo step (hidden context).
+- Undo: user types a new PY cell, geometric rewrite does not add a second undo step when `isUndoPossible()` (hidden context). Flag-on reconcile with no prior edit is one locked unit (`test_calc_spill_undo_lock` is the spill analogue).
 - `#SPILL!` / auto-spill still works on a chained origin cell.
+- Re-entrancy: repair `setFormula` does not nest a second repair.
+- Cap-hit sheet: no chain, log emitted.
 
 Do not run the full suite until this is implemented. Phase 1 is mockable without soffice.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Phase 0 of the geometric recalc plan is closed. Docs-only rewrite of `docs/calc/geometric-recalc-order.md`. No plugin/Python changes. `AGENTS.md` is untouched. Status remains decided-but-not-implemented. **Eval identity was not closed** in the first revision of this PR — this update specifies it.

## Closed product calls (unchanged)

No IDL. No 1×1 value-shape strip. No `locate_formula_cell_in_doc` for eval identity. Precedent-only. Cap skip-sheet. No strip-on-disable. Isolated checkbox visible / no-op for Python globals (Isolated still needs strip so arity does not break).

## Eval identity

**Unanimous-ours**, not uniqueness and not ≥1-hit.

- At repair time, compute strip-safe per `(workbook_key, resolved_code, n_args)` iff **every** discovered PY cell with that triple is in the map.
- Eval: if strip-safe, drop `args[-1]` before the index heuristic and before `calc_addin_args_from_split`, both branches including `data[]` / `ranges[]`.
- Fill-down of two identical `=PY("np.mean(data)"; B1:B10)` → both strip.
- Mixed matrix-index neighbor → **neither** strips (mixed poisons the chain).
- Cap-hit: `list_python_cells_on_sheet` returns 100 with no truncated flag; skip the sheet; do not mark triples strip-safe. A real truncated flag is Phase 3.

## Three must-gets

1. Key `code` is what `execute_python_addin` receives (resolved source). For `=PY($A$1; …)` that is the cell contents of `$A$1`, not the token.
2. `n_args` is `len(split_python_addin_data_args(data))`. `(range, 1×1 pred)` does not collapse under `_is_legacy_single_column_range`.
3. Cap-hit cannot prove unanimous — skip-sheet is the fail-safe.

## `workbook_key`

Eval key is `get_cached_calc_session_id()` **only** when `off_main_calc_session_is_unambiguous()`. Else no strip. Do **not** cite `get_python_init_kwargs` as a source of `doc_url`.

**Isolated yellow:** Isolated never enters `workbook_session_id` (returns `None` when mode ≠ shared), so `_RECORDED_CALC_SESSION_IDS` can stay empty and the unambiguous check stays false. Isolated UI load/repair must `record_active_calc_session` with the **same string eval will read**: `calc:` + `_workbook_session_key` (never `""`). Do not invent a second Isolated key. Then one open file makes the cache length 1 and yellow Isolated can strip.

Unsaved files must not use empty URL (#402). Optional (not the primary key): fingerprint of `args[:-1]`. Do not fingerprint last-arg value.

Phase 4 tests: fill-down both strip; mixed neither strips; two workbooks / unambiguous-false → no strip; Isolated records `calc:` + `_workbook_session_key` via `record_active_calc_session` and strips when unambiguous.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f039274-9abe-4164-8e5b-49529aca9a8b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f039274-9abe-4164-8e5b-49529aca9a8b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

