### PR TITLE
Guard os.set_blocking in leftover IPC stdout peek

### DIFF
--- a/docs/scripting/worker-spawn-handshake-timeouts.md
+++ b/docs/scripting/worker-spawn-handshake-timeouts.md
@@ -267,6 +267,7 @@ Fill this in as you go. Do not delete failed experiments.
 | 2026-09-01 | `2f96c06a` + local | H2 | log `_stderr_snippet()` + `returncode` on spawn `TimeoutExpired`; test `test_spawn_timeout_logs_stderr_snippet` | Diagnostic only (no root-cause fix). Did not raise 15s timeout or cap workers. |
 | 2026-09-02 | Keith laptop full `make test` | H1 / H2 | PR 538 logging on full xdist | 38 failed, 6407 passed in 385s. Every compute timeout: `returncode=None stderr=<empty>`. Venv: size `1165128303` (= `b'Erro'`). Flood worker too (not Cython). |
 | 2026-09-02 | after #543 | H1 | full `make test` with handshake cap | 37 failed, 6412 passed in **28s**. No 15s timeouts. Every spawn: `Invalid IPC frame size: 1165128303 (header=b'Erro') stderr=<empty>`. Still missing the rest of the stdout line. |
+| 2026-09-02 | after #545 | Windows ty | `ty check --python-platform win32 plugin/scripting/ipc.py` | `#545` leftover peek (`stdout_rest`) is useful on Linux, but `os.set_blocking` is POSIX-only. Guard the call; keep the BytesIO/mock fallback. Do not drop `stdout_rest`. |
 | 2026-09-02 | after #545 | H1 | leftover stdout on full `make test` | Same 37 fails. `stdout_rest` reconstructs: `Error importing huggingface_hub.hf_api: No module named 'envwrap' (or 'envwrap.envwrap' is unknown)`. Cause: `smolagents/__init__.py` star-imported `tools` → `huggingface_hub` on every `plugin.contrib.smolagents.*` import, including compute-worker `sandbox.py`. |
 
 When the flake is gone, set **Status** at the top to Fixed, name the commit, and point at the tests that lock the behavior.

--- a/plugin/scripting/ipc.py
+++ b/plugin/scripting/ipc.py
@@ -92,6 +92,12 @@ def _unread_pipe_bytes(stream: IO[bytes], n: int = 512) -> bytes:
     except (AttributeError, OSError, ValueError, io.UnsupportedOperation):
         fd = None
     if isinstance(fd, int):
+        # os.set_blocking is POSIX-only. PR 545 attached leftover stdout after a
+        # bad length prefix (header=Erro / envwrap). The unguarded call was the
+        # Windows ty hole; skip the non-blocking peek there. BytesIO/mocks still
+        # fall through to stream.read below (no real fileno).
+        if sys.platform == "win32" or not hasattr(os, "set_blocking"):
+            return b""
         try:
             os.set_blocking(fd, False)
             return os.read(fd, n)

--- a/tests/scripting/test_ipc.py
+++ b/tests/scripting/test_ipc.py
@@ -92,6 +92,41 @@ def test_text_error_prefix_is_invalid_frame_with_header_repr():
         )
 
 
+def test_unread_pipe_bytes_skips_set_blocking_on_win32(monkeypatch):
+    """Windows/ty: os.set_blocking is POSIX-only; skip the non-blocking peek."""
+    from plugin.scripting import ipc
+
+    monkeypatch.setattr(ipc.sys, "platform", "win32")
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("os.set_blocking must not run on win32")
+
+    monkeypatch.setattr(ipc.os, "set_blocking", boom)
+    stream = MagicMock()
+    stream.fileno.return_value = 3
+    assert ipc._unread_pipe_bytes(stream) == b""
+    stream.read.assert_not_called()
+
+
+def test_unread_pipe_bytes_posix_peek_uses_set_blocking(monkeypatch):
+    """Unix leftover peek still uses set_blocking; mock so Windows pytest can run it."""
+    from plugin.scripting import ipc
+
+    monkeypatch.setattr(ipc.sys, "platform", "linux")
+    seen: list[tuple[int, bool]] = []
+
+    def fake_set_blocking(fd: int, blocking: bool) -> None:
+        seen.append((fd, blocking))
+
+    monkeypatch.setattr(ipc.os, "set_blocking", fake_set_blocking)
+    monkeypatch.setattr(ipc.os, "read", lambda fd, n: b"rest")
+    stream = MagicMock()
+    stream.fileno.return_value = 7
+    assert ipc._unread_pipe_bytes(stream) == b"rest"
+    assert seen == [(7, False)]
+    stream.read.assert_not_called()
+
+
 def test_json_line_roundtrip():
     buf = io.StringIO()
     write_json_line(buf, {"status": "ready"})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Windows PR CI typecheck failed after #545. `ty` reports `os.set_blocking` as Unix-only in `plugin/scripting/ipc.py` (`_unread_pipe_bytes`, leftover-stdout peek after a bad pickle length prefix).

That peek is still useful on Linux (`header=Erro` / envwrap). The unguarded `os.set_blocking` call was the only Windows typecheck hole.

## Fix

In `_unread_pipe_bytes`, skip the non-blocking peek when `sys.platform == "win32"` or `os` has no `set_blocking`. BytesIO/mock streams still use `stream.read`, and `stdout_rest` stays on `IpcFrameError`.

## Tests

- Keep `test_text_error_prefix_is_invalid_frame_with_header_repr` (`stdout_rest` on BytesIO).
- Add `test_unread_pipe_bytes_skips_set_blocking_on_win32` so the Unix call cannot regress on Windows.
- Add `test_unread_pipe_bytes_posix_peek_uses_set_blocking` (mocked) so the Linux peek still runs.

## Out of scope

No CI timeout bumps. No Draw/UNO test changes. `stdout_rest` is not removed.

## Verification

- Reproduced on current `origin/master`: `ty check --python-platform win32 plugin/scripting/ipc.py` → `unresolved-attribute: Module os has no member set_blocking` at line 96.
- After the guard: same command → All checks passed.
- `make typecheck` green (ruff, ty, basedpyright, mypy, bandit, opengrep, pyspector, thread-safety).
- `pytest tests/scripting/test_ipc.py` → 18 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fa01f04-f080-4348-8ae8-5c3679ed9071?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fa01f04-f080-4348-8ae8-5c3679ed9071&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

