### PR TITLE
Implement Geometric Recalc Order (Phase 1: list-diff + splice + eval-index)

### DIFF
--- a/docs/calc/geometric-recalc-order.md
+++ b/docs/calc/geometric-recalc-order.md
@@ -1,6 +1,6 @@
 # Geometric Recalc Order — implementation plan
 
-**Status:** Decided — ready to implement. **Not implemented.** Closed calls in [§9](#9-decisions) stand (no IDL, no 1×1 value-shape strip, no `locate_formula_cell_in_doc` for eval identity, precedent-only, cap skip-sheet, no strip-on-disable, Isolated checkbox visible / no-op). **Eval identity was not closed** in the previous draft — this revision specifies it as **unanimous-ours** plus an off-main `workbook_key` ([§9.5](#95-marker-is-the-udprop--in-memory-map)).
+**Status:** Decided — implementation in progress. **Phase 1 landed** (`plugin/calc/python/geometric_recalc.py`, unit tests only). Phases 2–4 are not implemented. Closed calls in [§9](#9-decisions) stand (no IDL, no 1×1 value-shape strip, no `locate_formula_cell_in_doc` for eval identity, precedent-only, cap skip-sheet, no strip-on-disable, Isolated checkbox visible / no-op). **Eval identity** is **unanimous-ours** plus an off-main `workbook_key` ([§9.5](#95-marker-is-the-udprop--in-memory-map)). **Cap-hit UI:** skip the sheet, log, **and** show one message box per skipped sheet (`notify_geometric_cap_hit`) — do not only `log.error`.
 
 **Related:** [Enabling NumPy & Python](../enabling_numpy_in_libreoffice.md) (session modes, auto-spill), [Microsoft `=PY` design stance](../scripting/ms-py-compatibility.md) (why we refuse Excel co-volatility), [Calc `=PY()` data shapes](py-data-shapes.md) (`data` / `ranges` arity).
 
@@ -82,7 +82,7 @@ Do **not** add a dedicated IDL ordering argument. That rebuilds `.rdb`s for both
 
 **Cross-cluster chaining (decided):** two independent PY clusters on one sheet (A1:A5 and D1:D5) become one chain — D1 waits on A5. That slightly over-dirties the D column when A3 changes. Correctness is fine; users who care can turn the flag off and write explicit `data` refs. Do not add spatial clustering.
 
-**Cap (decided):** `list_python_cells_on_sheet` stops at `_MAX_PYTHON_CELLS_FOUND = 100` (also `_MAX_CELLS_TO_SCAN = 50000`) and returns a list with **no truncated flag** (`cell_discovery.py`). **If a cap is hit, skip geometric chaining for that entire sheet and show a user-visible notice** (desktop message box; Online infobar — [§12](#12-collabora--libreoffice-core-living-sketch-not-final)). Do not chain the first 100 and leave #101 with no predecessor. Do not raise the cap. Do not mark any eval-index triple strip-safe for that sheet — you cannot prove unanimous-ours on a truncated list ([§9.5](#95-marker-is-the-udprop--in-memory-map)). Phase 1 treats `len(found) >= _MAX_PYTHON_CELLS_FOUND` as cap-hit (over-skips an exact 100). A real `truncated` flag is **Phase 3**, not Phase 1. If the 50k scan cap fires with fewer than 100 PY cells, that list is also incomplete — same skip.
+**Cap (decided):** `list_python_cells_on_sheet` stops at `_MAX_PYTHON_CELLS_FOUND = 100` (also `_MAX_CELLS_TO_SCAN = 50000`) and returns a list with **no truncated flag** (`cell_discovery.py`). **If a cap is hit, skip geometric chaining for that entire sheet, log it, and show one user-visible error** (`notify_geometric_cap_hit` → existing `msgbox`, UI thread only, one box per skipped sheet; Online infobar — [§12](#12-collabora--libreoffice-core-living-sketch-not-final)). Do not only `log.error`. Do not chain the first 100 and leave #101 with no predecessor. Do not raise the cap. Do not mark any eval-index triple strip-safe for that sheet — you cannot prove unanimous-ours on a truncated list ([§9.5](#95-marker-is-the-udprop--in-memory-map)). Phase 1 treats `len(found) >= _MAX_PYTHON_CELLS_FOUND` as cap-hit (over-skips an exact 100). A real `truncated` flag is **Phase 3**, not Phase 1. If the 50k scan cap fires with fewer than 100 PY cells, that list is also incomplete — same skip.
 
 A 100-cell chain is serial (venv IPC per dirty cell); that is the price of order, not a new cliff.
 
@@ -252,7 +252,7 @@ Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high
 
 **Phase 0 — Review (this doc).** Closed product calls stand. Eval identity is specified in [§9.5](#95-marker-is-the-udprop--in-memory-map) (unanimous-ours + `workbook_key`) — do not treat the previous uniqueness draft as closed. Do not reopen [§9.1](#91-precedent-only-not-value-in-data-not-idl) C (IDL) or a value-shape strip.
 
-**Phase 1 — Pure list + formula splice.** Unit tests only: given a list of addresses + current formulas + the in-memory record, compute the patch and the eval-index bools. No UNO. Encode the [§9.5](#95-marker-is-the-udprop--in-memory-map) table, including **remove-field**, code-in-cell splice from the raw formula (`rebuild_python_formula_with_code_ref`), fill-down unanimous-ours, mixed poison, and “`len >= 100` → skip sheet, do not mark strip-safe.” No truncated-flag API in this phase.
+**Phase 1 — Pure list + formula splice.** **Landed** in `plugin/calc/python/geometric_recalc.py` (`tests/calc/python/test_geometric_recalc.py`). Unit tests only: given a list of addresses + current formulas + the in-memory record, compute the patch and the eval-index bools. No UNO. Encodes the [§9.5](#95-marker-is-the-udprop--in-memory-map) table, including **remove-field**, code-in-cell splice from the raw formula (`rebuild_python_formula_with_code_ref`), fill-down unanimous-ours, mixed poison, and “`len >= 100` → skip sheet, do not mark strip-safe.” Cap-hit also returns a user-visible message; `notify_geometric_cap_hit` shows one `msgbox` per skipped sheet on the UI thread. No truncated-flag API in this phase.
 
 **Phase 2 — Flag + attach on save / flag-on.** Monaco and native cell save call the splicer; apply on the UI thread after save (save is already outside recalc). Settings default off. Flag-on walks **all sheets**. Persist / load the UDProp like spill. Isolated UI load/repair must `record_active_calc_session` with `calc:` + `_workbook_session_key` (same string eval reads; never `""`).
 
@@ -362,7 +362,7 @@ Parse → drop the last geometric data arg → rebuild → drop the map record. 
 | Mixed matrix-index neighbor `=PY("f"; range; i)` next to `=PY("f"; range; pred)` | 1×1 | one ours, one not | Do **not** mark strip-safe; **neither** strips |
 | Successor became first (delete) | geometric field | ours | **Remove-field**; drop record; recompute index |
 | First cell still has a leftover field | geometric field | ours | Remove-field (idempotent) |
-| Cap hit on this sheet | — | — | Skip the sheet; log; no partial chain; **do not** mark triples strip-safe |
+| Cap hit on this sheet | — | — | Skip the sheet; log **and** one message box; no partial chain; **do not** mark triples strip-safe |
 
 ### 9.6 Flag-on / document-open — all sheets
 

--- a/plugin/calc/python/geometric_recalc.py
+++ b/plugin/calc/python/geometric_recalc.py
@@ -1,0 +1,353 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Geometric Recalc Order — Phase 1: list-diff, formula splice, eval-index bools.
+
+Pure helpers. No UNO. Given a row-major list of PY cells plus the in-memory
+attach map, compute formula patches and unanimous-ours strip-safe triples.
+
+See ``docs/calc/geometric-recalc-order.md`` §8 Phase 1 and §9.5.
+Cap-hit skip uses ``len(cells) >= _MAX_PYTHON_CELLS_FOUND`` (no truncated flag
+in this phase). A skipped sheet must also show a user-visible error — callers
+use :func:`notify_geometric_cap_hit` on the UI thread (one box per sheet).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping
+
+from plugin.calc.address_utils import split_sheet_prefix
+from plugin.calc.calc_addin_data import split_python_addin_data_args
+from plugin.calc.python.cell_discovery import _MAX_PYTHON_CELLS_FOUND
+from plugin.calc.python.formula_edit import (
+    CALC_PYTHON_FN,
+    build_data_suffix,
+    format_data_binding_display,
+    parse_data_binding_text,
+    parse_python_formula,
+    py_code_arg_is_cell_ref,
+    py_formula_has_unquoted_code_ref,
+    rebuild_python_formula_with_code_ref,
+    rebuild_python_formula_with_data,
+)
+from plugin.framework.i18n import _
+
+log = logging.getLogger(__name__)
+
+GEOMETRIC_DISCOVERY_CAP = _MAX_PYTHON_CELLS_FOUND
+GEOMETRIC_REGISTRY_PROP = "WriterAgentGeometricRegistry"
+CONFIG_KEY = "scripting.python_geometric_recalc_order"
+
+GeometricAction = Literal["append", "replace", "remove"]
+
+
+@dataclass(frozen=True)
+class GeometricCell:
+    """One discovered PY cell, already in sheet row-major order."""
+
+    address: str
+    formula: str
+    resolved_code: str
+
+
+@dataclass(frozen=True)
+class GeometricRecord:
+    """Attach map entry: we wrote this predecessor onto the cell."""
+
+    predecessor: str
+
+
+@dataclass(frozen=True)
+class GeometricPatch:
+    """One formula rewrite for a successor (or remove-field on a new first)."""
+
+    address: str
+    old_formula: str
+    new_formula: str
+    action: GeometricAction
+    predecessor: str | None
+
+
+@dataclass(frozen=True)
+class EvalIndexKey:
+    """Eval-time strip key. ``code`` is resolved source, not a ``$A$1`` token."""
+
+    workbook_key: str
+    resolved_code: str
+    n_args: int
+
+
+@dataclass(frozen=True)
+class SheetRepairResult:
+    """Patch list + post-repair map + unanimous-ours bools for one sheet."""
+
+    skipped: bool
+    skip_reason: str | None
+    patches: tuple[GeometricPatch, ...]
+    records: dict[str, GeometricRecord]
+    strip_safe: frozenset[EvalIndexKey]
+    user_message: str | None = None
+    sheet_name: str = ""
+
+
+def local_a1(address: str) -> str:
+    """``Sheet1.A1`` / ``$A$1`` / ``A1`` → ``A1`` (no ``$``)."""
+    _sheet, rest = split_sheet_prefix(address or "")
+    return rest.replace("$", "").strip().upper()
+
+
+def cell_map_key(address: str) -> str:
+    """Per-sheet map key. Phase 1 lists are one sheet; callers scope the map."""
+    return local_a1(address)
+
+
+def same_cell_ref(left: str, right: str) -> bool:
+    """True when two formula tokens name the same cell (``$`` / sheet ignored)."""
+    return bool(left) and bool(right) and local_a1(left) == local_a1(right)
+
+
+def is_single_cell_arg(arg: str) -> bool:
+    """True for a single A1 token, not a range or Python snippet."""
+    return py_code_arg_is_cell_ref(arg)
+
+
+def formula_data_args(formula: str) -> list[str] | None:
+    """Trailing ``=PY`` data args, or None if the formula does not parse."""
+    parts = parse_python_formula(formula)
+    if parts is None:
+        return None
+    return parse_data_binding_text(format_data_binding_display(parts.data_suffix))
+
+
+def repair_n_args(formula: str) -> int:
+    """Arity that must match ``len(split_python_addin_data_args(data))``.
+
+    Counts parsed data args, not semicolons in the code string. After attach,
+    ``=PY("np.mean(data)"; B1:B10; A1)`` is ``n_args=2``.
+    """
+    args = formula_data_args(formula)
+    return 0 if args is None else len(args)
+
+
+def eval_n_args_from_data(data: Any) -> int:
+    """Eval-time arity: ``len(split_python_addin_data_args(data))``."""
+    return len(split_python_addin_data_args(data))
+
+
+def discovery_cap_hit(n_found: int) -> bool:
+    """Phase 1: treat ``len >= 100`` as cap-hit (over-skips an exact 100)."""
+    return n_found >= GEOMETRIC_DISCOVERY_CAP
+
+
+def resolved_code_for_formula(formula: str, *, code_cell_text: str | None = None) -> str:
+    """Source ``execute_python_addin`` receives.
+
+    For ``=PY($A$1; …)`` pass the contents of ``$A$1``. Do not key the token.
+    """
+    if py_formula_has_unquoted_code_ref(formula):
+        if code_cell_text is None:
+            raise ValueError("code-in-cell formula needs the referenced cell's text")
+        return code_cell_text
+    parts = parse_python_formula(formula)
+    return parts.code if parts is not None else ""
+
+
+def rebuild_formula_with_data_args(formula: str, data_args: list[str]) -> str | None:
+    """Spliced formula. Code-in-cell keeps the unquoted ref (``$A$1``), not a quoted token.
+
+    ``rebuild_python_formula_with_data`` would quote ``$A$1``.
+    ``rebuild_python_formula_with_code_ref`` is the code-ref builder, but it
+    runs the ref through ``format_py_data_range`` which strips ``$``. Emit the
+    parsed token + ``build_data_suffix`` so ``=PY($A$1; …)`` stays ``$A$1``.
+    """
+    parts = parse_python_formula(formula)
+    if parts is None:
+        return None
+    if py_formula_has_unquoted_code_ref(formula):
+        # rebuild_python_formula_with_code_ref strips $ via format_py_data_range.
+        # Keep the parsed token so =PY($A$1; …) stays $A$1, not A1 and not "$A$1".
+        ref = parts.code
+        if ref != ref.replace("$", ""):
+            return f"={CALC_PYTHON_FN}({ref}{build_data_suffix(data_args)}"
+        return rebuild_python_formula_with_code_ref(ref, data_args)
+    return rebuild_python_formula_with_data(parts.code, data_args)
+
+
+def geometric_cap_hit_user_message(sheet_name: str) -> str:
+    """User-facing text when a sheet is left unchained. Users do not read logfiles."""
+    return _(
+        "Geometric Recalc Order skipped sheet '%s': found %s or more Python "
+        "cells (discovery cap). The sheet was left unchained so a partial "
+        "list is not treated as complete."
+    ) % (sheet_name, GEOMETRIC_DISCOVERY_CAP)
+
+
+def notify_geometric_cap_hit(
+    ctx: Any,
+    sheet_name: str,
+    *,
+    already_notified: set[str] | None = None,
+) -> bool:
+    """Log the skip and show one message box per sheet. UI thread only.
+
+    Returns True when a box was shown. A second call for the same sheet name
+    in *already_notified* is a no-op so repair cannot storm the user.
+    """
+    if already_notified is not None and sheet_name in already_notified:
+        return False
+    if already_notified is not None:
+        already_notified.add(sheet_name)
+
+    message = geometric_cap_hit_user_message(sheet_name)
+    log.error("Geometric Recalc Order: %s", message)
+
+    from plugin.framework.thread_guard import on_main_thread
+
+    if not on_main_thread():
+        return False
+
+    from plugin.chatbot.dialogs import msgbox
+
+    msgbox(ctx, _("Geometric Recalc Order"), message, box_type=3)
+    return True
+
+
+def _plan_action(
+    *,
+    desired: str | None,
+    data_args: list[str],
+    record: GeometricRecord | None,
+) -> tuple[Literal["append", "replace", "remove", "noop"], list[str]]:
+    last = data_args[-1] if data_args else None
+    last_is_cell = last is not None and is_single_cell_arg(last)
+
+    if desired is None:
+        if record is not None and last_is_cell:
+            return "remove", data_args[:-1]
+        return "noop", data_args
+
+    if last_is_cell and last is not None and same_cell_ref(last, desired):
+        # Already correct (ours) or user already passed the previous PY cell
+        # as real data (not ours). Either way the formula is satisfied.
+        return "noop", data_args
+
+    if (
+        record is not None
+        and last_is_cell
+        and last is not None
+        and same_cell_ref(last, record.predecessor)
+    ):
+        return "replace", data_args[:-1] + [desired]
+
+    return "append", data_args + [desired]
+
+
+def compute_eval_index(
+    cells: list[GeometricCell],
+    formulas: Mapping[str, str],
+    records: Mapping[str, GeometricRecord],
+    workbook_key: str,
+) -> frozenset[EvalIndexKey]:
+    """Strip-safe iff every discovered cell with that triple is in the map."""
+    groups: dict[EvalIndexKey, list[str]] = {}
+    for cell in cells:
+        formula = formulas.get(cell.address, cell.formula)
+        key = EvalIndexKey(workbook_key, cell.resolved_code, repair_n_args(formula))
+        groups.setdefault(key, []).append(cell_map_key(cell.address))
+
+    safe: set[EvalIndexKey] = set()
+    for key, addrs in groups.items():
+        if addrs and all(addr in records for addr in addrs):
+            safe.add(key)
+    return frozenset(safe)
+
+
+def should_strip_eval_args(
+    *,
+    workbook_key: str | None,
+    resolved_code: str,
+    n_args: int,
+    strip_safe: Mapping[EvalIndexKey, bool] | frozenset[EvalIndexKey],
+    unambiguous: bool,
+) -> bool:
+    """Eval gate: strip only when the session is unambiguous and the triple is ours."""
+    if not unambiguous or not workbook_key:
+        return False
+    key = EvalIndexKey(workbook_key, resolved_code, n_args)
+    if isinstance(strip_safe, frozenset):
+        return key in strip_safe
+    return bool(strip_safe.get(key, False))
+
+
+def compute_sheet_repair(
+    cells: list[GeometricCell],
+    records: Mapping[str, GeometricRecord] | None = None,
+    *,
+    workbook_key: str,
+    sheet_name: str = "",
+) -> SheetRepairResult:
+    """List-diff + splice + eval-index for one sheet. No UNO.
+
+    *cells* must already be row-major. Cap-hit skips the whole sheet: no
+    patches, no strip-safe marks, and a user-visible message string.
+    """
+    incoming = {cell_map_key(k): v for k, v in dict(records or {}).items()}
+    if discovery_cap_hit(len(cells)):
+        message = geometric_cap_hit_user_message(sheet_name or "?")
+        return SheetRepairResult(
+            skipped=True,
+            skip_reason="discovery_cap",
+            patches=(),
+            records=dict(incoming),
+            strip_safe=frozenset(),
+            user_message=message,
+            sheet_name=sheet_name,
+        )
+
+    working = dict(incoming)
+    patches: list[GeometricPatch] = []
+    new_formulas = {cell.address: cell.formula for cell in cells}
+
+    for i, cell in enumerate(cells):
+        data_args = formula_data_args(cell.formula)
+        if data_args is None:
+            continue
+        desired = local_a1(cells[i - 1].address) if i > 0 else None
+        key = cell_map_key(cell.address)
+        action, new_args = _plan_action(
+            desired=desired,
+            data_args=data_args,
+            record=working.get(key),
+        )
+        if action == "noop":
+            continue
+        new_formula = rebuild_formula_with_data_args(cell.formula, new_args)
+        if new_formula is None or new_formula == cell.formula:
+            continue
+        patches.append(
+            GeometricPatch(
+                address=cell.address,
+                old_formula=cell.formula,
+                new_formula=new_formula,
+                action=action,
+                predecessor=desired,
+            )
+        )
+        new_formulas[cell.address] = new_formula
+        if action == "remove":
+            working.pop(key, None)
+        elif desired is not None:
+            working[key] = GeometricRecord(predecessor=desired)
+
+    strip_safe = compute_eval_index(cells, new_formulas, working, workbook_key)
+    return SheetRepairResult(
+        skipped=False,
+        skip_reason=None,
+        patches=tuple(patches),
+        records=working,
+        strip_safe=strip_safe,
+        sheet_name=sheet_name,
+    )

--- a/scripts/librepy_bundle_paths.py
+++ b/scripts/librepy_bundle_paths.py
@@ -82,6 +82,7 @@ LIBREPY_PLUGIN_FILES: tuple[str, ...] = (
     "plugin/calc/python/image_egress.py",
     "plugin/calc/python/formula_locator_cache.py",
     "plugin/calc/python/cell_discovery.py",
+    "plugin/calc/python/geometric_recalc.py",
     "plugin/calc/python/collabora_formula.py",
     "plugin/calc/python/diagnostics.py",
     "plugin/calc/python/init_script_editor.py",

--- a/tests/calc/python/test_geometric_recalc.py
+++ b/tests/calc/python/test_geometric_recalc.py
@@ -1,0 +1,413 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Phase 1 Geometric Recalc Order: list-diff, splice, unanimous-ours (no UNO)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from plugin.calc.calc_addin_data import split_python_addin_data_args
+from plugin.calc.python.cell_discovery import _MAX_PYTHON_CELLS_FOUND
+from plugin.calc.python.formula_edit import (
+    parse_python_formula,
+    py_formula_has_unquoted_code_ref,
+)
+from plugin.calc.python.geometric_recalc import (
+    CONFIG_KEY,
+    GEOMETRIC_DISCOVERY_CAP,
+    GEOMETRIC_REGISTRY_PROP,
+    EvalIndexKey,
+    GeometricCell,
+    GeometricRecord,
+    compute_sheet_repair,
+    discovery_cap_hit,
+    eval_n_args_from_data,
+    formula_data_args,
+    geometric_cap_hit_user_message,
+    local_a1,
+    notify_geometric_cap_hit,
+    rebuild_formula_with_data_args,
+    repair_n_args,
+    resolved_code_for_formula,
+    same_cell_ref,
+    should_strip_eval_args,
+)
+
+
+WB = "calc:file:///pipe.ods"
+
+
+def _cell(addr: str, formula: str, code: str | None = None) -> GeometricCell:
+    if code is None:
+        code = resolved_code_for_formula(formula)
+    return GeometricCell(address=addr, formula=formula, resolved_code=code)
+
+
+def _repair(
+    cells: list[GeometricCell],
+    records: dict[str, GeometricRecord] | None = None,
+    *,
+    workbook_key: str = WB,
+    sheet_name: str = "Sheet1",
+):
+    return compute_sheet_repair(
+        cells, records, workbook_key=workbook_key, sheet_name=sheet_name
+    )
+
+
+def _patch_map(result):
+    return {p.address: p for p in result.patches}
+
+
+def test_constants_match_discovery_and_spill_pattern():
+    assert GEOMETRIC_DISCOVERY_CAP == _MAX_PYTHON_CELLS_FOUND == 100
+    assert GEOMETRIC_REGISTRY_PROP == "WriterAgentGeometricRegistry"
+    assert CONFIG_KEY == "scripting.python_geometric_recalc_order"
+
+
+def test_local_a1_and_same_cell_ref():
+    assert local_a1("A1") == "A1"
+    assert local_a1("$A$1") == "A1"
+    assert local_a1("Sheet1.A1") == "A1"
+    assert local_a1("Sheet1.$B$2") == "B2"
+    assert same_cell_ref("$A$1", "A1")
+    assert same_cell_ref("Sheet1.A1", "A1")
+    assert not same_cell_ref("A1", "A2")
+
+
+def test_empty_list():
+    result = _repair([])
+    assert result.skipped is False
+    assert result.patches == ()
+    assert result.records == {}
+    assert result.strip_safe == frozenset()
+
+
+def test_one_cell_no_predecessor():
+    result = _repair([_cell("A1", '=PY("df = load()")')])
+    assert result.patches == ()
+    assert result.records == {}
+    assert not result.strip_safe
+
+
+def test_two_cells_append_predecessor():
+    result = _repair(
+        [
+            _cell("A1", '=PY("df = load()")'),
+            _cell("A2", '=PY("df = clean(df)")'),
+        ]
+    )
+    patches = _patch_map(result)
+    assert "A1" not in patches
+    assert patches["A2"].action == "append"
+    assert patches["A2"].new_formula == '=PY("df = clean(df)";A1)'
+    assert result.records["A2"].predecessor == "A1"
+
+
+def test_insert_in_middle_retargets_successor():
+    cells = [
+        _cell("A1", '=PY("a")'),
+        _cell("A2", '=PY("b")'),
+        _cell("A3", '=PY("c";A1)'),
+    ]
+    records = {"A3": GeometricRecord(predecessor="A1")}
+    result = _repair(cells, records)
+    patches = _patch_map(result)
+    assert patches["A2"].new_formula == '=PY("b";A1)'
+    assert patches["A3"].action == "replace"
+    assert patches["A3"].new_formula == '=PY("c";A2)'
+    assert result.records["A2"].predecessor == "A1"
+    assert result.records["A3"].predecessor == "A2"
+
+
+def test_delete_middle_retargets_successor():
+    cells = [
+        _cell("A1", '=PY("a")'),
+        _cell("A3", '=PY("c";A2)'),
+    ]
+    records = {"A3": GeometricRecord(predecessor="A2")}
+    result = _repair(cells, records)
+    patches = _patch_map(result)
+    assert patches["A3"].action == "replace"
+    assert patches["A3"].new_formula == '=PY("c";A1)'
+    assert result.records["A3"].predecessor == "A1"
+
+
+def test_delete_first_remove_field():
+    cells = [_cell("A2", '=PY("b";A1)')]
+    records = {"A2": GeometricRecord(predecessor="A1")}
+    result = _repair(cells, records)
+    patches = _patch_map(result)
+    assert patches["A2"].action == "remove"
+    assert patches["A2"].new_formula == '=PY("b")'
+    assert "A2" not in result.records
+
+
+def test_remove_field_is_idempotent():
+    first = _repair(
+        [_cell("A1", '=PY("x";Z9)')],
+        {"A1": GeometricRecord(predecessor="Z9")},
+    )
+    stripped = first.patches[0].new_formula
+    second = _repair([_cell("A1", stripped)])
+    assert first.patches[0].action == "remove"
+    assert second.patches == ()
+    assert second.records == {}
+
+
+def test_reorder_retargets_to_new_previous():
+    cells = [
+        _cell("B1", '=PY("first")'),
+        _cell("A2", '=PY("second";C9)'),
+    ]
+    records = {"A2": GeometricRecord(predecessor="C9")}
+    result = _repair(cells, records)
+    assert _patch_map(result)["A2"].new_formula == '=PY("second";B1)'
+
+
+def test_splice_no_args_appends():
+    result = _repair(
+        [_cell("A1", '=PY("x")'), _cell("A2", '=PY("y")')]
+    )
+    assert _patch_map(result)["A2"].new_formula == '=PY("y";A1)'
+
+
+def test_splice_preserves_user_range():
+    result = _repair(
+        [
+            _cell("A1", '=PY("x")'),
+            _cell("A2", '=PY("np.mean(data)";B1:B10)'),
+        ]
+    )
+    assert _patch_map(result)["A2"].new_formula == '=PY("np.mean(data)";B1:B10;A1)'
+    assert formula_data_args(result.patches[0].new_formula) == ["B1:B10", "A1"]
+
+
+def test_already_correct_predecessor_is_noop():
+    result = _repair(
+        [
+            _cell("A1", '=PY("x")'),
+            _cell("A2", '=PY("y";A1)'),
+        ],
+        {"A2": GeometricRecord(predecessor="A1")},
+    )
+    assert result.patches == ()
+    assert result.records["A2"].predecessor == "A1"
+
+
+def test_already_correct_dollar_ref_is_noop():
+    result = _repair(
+        [
+            _cell("A1", '=PY("x")'),
+            _cell("A2", '=PY("y";$A$1)'),
+        ],
+        {"A2": GeometricRecord(predecessor="A1")},
+    )
+    assert result.patches == ()
+
+
+def test_user_single_cell_data_is_appended_not_overwritten():
+    result = _repair(
+        [
+            _cell("A1", '=PY("x")'),
+            _cell("A2", '=PY("y";C5)'),
+        ]
+    )
+    assert _patch_map(result)["A2"].action == "append"
+    assert _patch_map(result)["A2"].new_formula == '=PY("y";C5;A1)'
+
+
+def test_user_already_passed_previous_py_not_recorded():
+    result = _repair(
+        [
+            _cell("A1", '=PY("x")'),
+            _cell("A2", '=PY("y";A1)'),
+        ]
+    )
+    assert result.patches == ()
+    assert "A2" not in result.records
+    assert not result.strip_safe
+
+
+def test_code_in_cell_splice_keeps_unquoted_ref():
+    raw = "=PY($A$1; B1:B10)"
+    assert py_formula_has_unquoted_code_ref(raw)
+    rebuilt = rebuild_formula_with_data_args(raw, ["B1:B10", "C1"])
+    assert rebuilt is not None
+    assert rebuilt.startswith("=PY($A$1")
+    assert '"$A$1"' not in rebuilt
+    assert "B1:B10" in rebuilt
+    assert rebuilt.endswith(";C1)")
+    parts = parse_python_formula(rebuilt)
+    assert parts is not None
+    assert parts.code == "$A$1"
+
+
+def test_code_in_cell_repair_and_resolved_source():
+    source = "df = clean(df)"
+    result = _repair(
+        [
+            _cell("B1", '=PY("df = load()")'),
+            _cell("B2", "=PY($A$1; C1:C10)", source),
+        ]
+    )
+    new = _patch_map(result)["B2"].new_formula
+    assert new.startswith("=PY($A$1")
+    assert '"$A$1"' not in new
+    assert formula_data_args(new) == ["C1:C10", "B1"]
+    assert resolved_code_for_formula("=PY($A$1; C1:C10)", code_cell_text=source) == source
+    assert resolved_code_for_formula('=PY("df = clean(df)")') == "df = clean(df)"
+    key = EvalIndexKey(WB, source, 2)
+    assert key in result.strip_safe
+
+
+def test_repair_n_args_is_not_semicolon_count():
+    assert repair_n_args('=PY("a; b; c")') == 0
+    assert repair_n_args('=PY("np.mean(data)"; B1:B10)') == 1
+    assert repair_n_args('=PY("np.mean(data)"; B1:B10; A1)') == 2
+    assert repair_n_args("=PY($A$1; B1:B10; C1)") == 2
+
+
+def test_n_args_matches_split_python_addin_data_args_for_range_plus_1x1():
+    """(range, 1×1 pred) stays two args — inner of the 1×1 is a sequence."""
+    col = ((1.0,), (2.0,), (3.0,))
+    pred = ((0.0,),)
+    split = split_python_addin_data_args((col, pred))
+    assert len(split) == 2
+    assert eval_n_args_from_data((col, pred)) == 2
+    assert repair_n_args('=PY("np.mean(data)"; B1:B10; A1)') == 2
+
+
+def test_fill_down_unanimous_ours_is_strip_safe():
+    code = "np.mean(data)"
+    result = _repair(
+        [
+            _cell("A1", f'=PY("{code}"; B1:B10)'),
+            _cell("A2", f'=PY("{code}"; B1:B10)'),
+            _cell("A3", f'=PY("{code}"; B1:B10)'),
+        ]
+    )
+    assert formula_data_args(_patch_map(result)["A2"].new_formula) == ["B1:B10", "A1"]
+    assert formula_data_args(_patch_map(result)["A3"].new_formula) == ["B1:B10", "A2"]
+    key = EvalIndexKey(WB, code, 2)
+    assert key in result.strip_safe
+    assert should_strip_eval_args(
+        workbook_key=WB,
+        resolved_code=code,
+        n_args=2,
+        strip_safe=result.strip_safe,
+        unambiguous=True,
+    )
+    first_key = EvalIndexKey(WB, code, 1)
+    assert first_key not in result.strip_safe
+
+
+def test_mixed_matrix_index_poisons_the_triple():
+    """Same (code, n_args=2), one ours and one not → neither is strip-safe."""
+    from plugin.calc.python.geometric_recalc import compute_eval_index
+
+    code = "f"
+    cells = [
+        GeometricCell("A2", f'=PY("{code}"; B1:B10; A1)', code),
+        GeometricCell("A3", f'=PY("{code}"; B1:B10; C5)', code),
+    ]
+    records = {"A2": GeometricRecord(predecessor="A1")}
+    formulas = {c.address: c.formula for c in cells}
+    safe = compute_eval_index(cells, formulas, records, WB)
+    assert EvalIndexKey(WB, code, 2) not in safe
+    assert not should_strip_eval_args(
+        workbook_key=WB,
+        resolved_code=code,
+        n_args=2,
+        strip_safe=safe,
+        unambiguous=True,
+    )
+
+
+def test_user_passed_previous_mixed_with_mapped_poisons():
+    code = "f"
+    cells = [
+        _cell("A1", f'=PY("{code}")'),
+        _cell("A2", f'=PY("{code}"; A1)', code),
+        _cell("A3", f'=PY("{code}"; A2)', code),
+    ]
+    result = _repair(cells, {"A3": GeometricRecord(predecessor="A2")})
+    # A2 last==desired, not ours → not recorded. A3 ours n_args=1. A2 n_args=1.
+    key = EvalIndexKey(WB, code, 1)
+    assert "A2" not in result.records
+    assert "A3" in result.records
+    assert key not in result.strip_safe
+
+
+def test_two_workbooks_unambiguous_false_no_strip():
+    result = _repair(
+        [
+            _cell("A1", '=PY("np.mean(data)"; B1:B10)'),
+            _cell("A2", '=PY("np.mean(data)"; B1:B10)'),
+        ]
+    )
+    assert EvalIndexKey(WB, "np.mean(data)", 2) in result.strip_safe
+    assert not should_strip_eval_args(
+        workbook_key=WB,
+        resolved_code="np.mean(data)",
+        n_args=2,
+        strip_safe=result.strip_safe,
+        unambiguous=False,
+    )
+    assert not should_strip_eval_args(
+        workbook_key="",
+        resolved_code="np.mean(data)",
+        n_args=2,
+        strip_safe=result.strip_safe,
+        unambiguous=True,
+    )
+
+
+def test_cap_hit_skips_sheet_no_patches_no_strip_safe():
+    cells = [_cell(f"A{i + 1}", '=PY("x")') for i in range(GEOMETRIC_DISCOVERY_CAP)]
+    result = _repair(cells, sheet_name="Data")
+    assert discovery_cap_hit(len(cells))
+    assert result.skipped is True
+    assert result.skip_reason == "discovery_cap"
+    assert result.patches == ()
+    assert result.strip_safe == frozenset()
+    assert result.user_message is not None
+    assert "Data" in result.user_message
+    assert str(GEOMETRIC_DISCOVERY_CAP) in result.user_message
+
+
+def test_cap_hit_over_skips_exact_100():
+    assert discovery_cap_hit(99) is False
+    assert discovery_cap_hit(100) is True
+    assert discovery_cap_hit(101) is True
+
+
+def test_notify_geometric_cap_hit_one_box_per_sheet_ui_thread_only():
+    notified: set[str] = set()
+    with (
+        patch("plugin.framework.thread_guard.on_main_thread", return_value=True),
+        patch("plugin.chatbot.dialogs.msgbox") as mock_box,
+    ):
+        assert notify_geometric_cap_hit("ctx", "Sheet1", already_notified=notified)
+        assert notify_geometric_cap_hit("ctx", "Sheet1", already_notified=notified) is False
+        assert notify_geometric_cap_hit("ctx", "Sheet2", already_notified=notified)
+        assert mock_box.call_count == 2
+        titles = [c.args[1] for c in mock_box.call_args_list]
+        assert all(t == "Geometric Recalc Order" or "Geometric" in t for t in titles)
+        assert mock_box.call_args_list[0].kwargs.get("box_type") == 3
+
+    with (
+        patch("plugin.framework.thread_guard.on_main_thread", return_value=False),
+        patch("plugin.chatbot.dialogs.msgbox") as mock_box,
+    ):
+        shown = notify_geometric_cap_hit("ctx", "Other", already_notified=set())
+        assert shown is False
+        mock_box.assert_not_called()
+
+
+def test_cap_hit_user_message_names_the_sheet():
+    text = geometric_cap_hit_user_message("Pivots")
+    assert "Pivots" in text
+    assert str(GEOMETRIC_DISCOVERY_CAP) in text

--- a/tests/scripts/test_librepy_writeragent_bundle.py
+++ b/tests/scripts/test_librepy_writeragent_bundle.py
@@ -94,6 +94,7 @@ def test_librepy_bundle_includes_xl_static_rewrite():
     assert "plugin/scripting/native_binaries.py" in paths
     assert "plugin/scripting/audio_recorder_service.py" not in paths
     assert "plugin/calc/python/workbook_lifecycle.py" in paths
+    assert "plugin/calc/python/geometric_recalc.py" in paths
 
 
 def test_librepy_bundle_includes_notebook_and_nbformat():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 1** of Geometric Recalc Order (`docs/calc/geometric-recalc-order.md` §8) on a new branch off master. Docs-only #547 is already on master; this is a separate implementation PR. **Phases 2–4 are not in this PR.**

Rebased onto current `origin/master` (`99339bac`, #551 + #549) so this PR is mergeable. Master's Collabora **§12** is kept in full. The only rebase conflict was the Cap paragraph in `docs/calc/geometric-recalc-order.md`: Phase 1's `notify_geometric_cap_hit` / `msgbox` wording is on top of #551's Online-infobar §12 pointer. Python/tests/bundle paths rebased cleanly.

Phase 1 is the whole algorithm, unit-tested, no UNO:

- List-diff / formula splice for the §9.5 rewrite table (append, replace stale pred, remove-field, user cell-ref append, user-already-passed-previous not recorded).
- Code-in-cell splice from the raw formula: `=PY($A$1; B1:B10)` stays an unquoted `$A$1`.
- Eval-index **unanimous-ours**: strip-safe iff every discovered cell with `(workbook_key, resolved_code, n_args)` is in the map. Mixed same-code/arity poisons the whole triple. Not uniqueness, not ≥1-hit.
- `n_args` is parsed data-arg count / `len(split_python_addin_data_args(...))`, not a semicolon count. `(range, 1×1 pred)` stays `n_args=2`.
- Cap-hit: `len >= 100` skips the sheet, no patches, no strip-safe marks. **Also** a user-visible error helper (`notify_geometric_cap_hit` → existing `msgbox`, UI thread only, one box per skipped sheet). Not log-only.

## Closed calls (not reopened)

Precedent-only. No IDL. No 1×1 / “last arg is a PY cell” strip. No `locate_formula_cell_in_doc` for eval identity. Flag / save / deferred repair / worker strip are later phases.

## Test plan

- [x] `pytest tests/calc/python/test_geometric_recalc.py` — 28 passed (after rebase)
- [x] LibrePy bundle includes `plugin/calc/python/geometric_recalc.py`
- [x] `make typecheck` — green after rebase
- [x] Rebased onto current master; §12 Collabora sketch still present
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b657dbf-7463-453e-8fc7-b064c1bf1710?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b657dbf-7463-453e-8fc7-b064c1bf1710&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

