### PR TITLE
Put Writer apply-HTML and confirm-from-fields last for recency

### DIFF
--- a/docs/chat/sidebar-implementation.md
+++ b/docs/chat/sidebar-implementation.md
@@ -32,7 +32,7 @@ See [../framework/streaming-and-threading.md](../framework/streaming-and-threadi
 
 ## Chat prompt constants
 
-File layout in [`prompts.py`](../../plugin/framework/prompts.py) is Generic, then Writer, Calc, Draw, then Assembly. Writer main-chat blocks in the Writer section still follow runtime assembly in `get_chat_system_prompt_for_document` (persona → chat format → sidebar routing → core directives → tools → translation → usage patterns → review modes → `apply_document_content` HTML rules → specialized delegation → memory); shared format and memory live in Generic. The delivery is hybrid: the reference pieces (search, navigation, images) are NOT ambient — the sidebar pulls them on demand via the `get_guidance` tool (topics mapped in `plugin/chatbot/agent_manual.py`, the same single source the MCP serves).
+File layout in [`prompts.py`](../../plugin/framework/prompts.py) is Generic, then Writer, Calc, Draw, then Assembly. Writer main-chat blocks in the Writer section still follow runtime assembly in `get_chat_system_prompt_for_document` (persona → chat format → core directives → tools → translation → usage patterns → review modes → specialized delegation → memory → sidebar routing → `apply_document_content` HTML rules → confirm-from-fields). Apply-HTML and confirm-from-fields sit last on purpose (recency); do not copy the research tool-result trailer into this ambient prompt. Shared format and memory live in Generic. The delivery is hybrid: the reference pieces (search, navigation, images) are NOT ambient — the sidebar pulls them on demand via the `get_guidance` tool (topics mapped in `plugin/chatbot/agent_manual.py`, the same single source the MCP serves).
 
 Design notes for prompt authors live in this section so the source file stays scannable.
 

--- a/plugin/chatbot/agent_manual.py
+++ b/plugin/chatbot/agent_manual.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import logging
 
 from plugin.framework.prompts import (
+    CONFIRM_EDITS_FROM_STRUCTURED_FIELDS,
     GENERIC_EDIT_CONFIRMATION_RULES,
     TOOL_USAGE_PATTERNS,
     TRANSLATION_RULES,
@@ -80,6 +81,8 @@ MANUAL_SECTIONS: dict[str, str] = {
     # own subdivision (editing-html) so a model can pull just the part it needs.
     "editing": (
         "Change the document with tools, not chat.\n\n"
+        + CONFIRM_EDITS_FROM_STRUCTURED_FIELDS.strip()
+        + "\n\n"
         + TOOL_USAGE_PATTERNS.strip()
         + "\n\n"
         + TRANSLATION_RULES.strip()

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -241,11 +241,16 @@ Do not use old_content or target='search' for whole-document translation.
 Never refuse."""
 
 
+# Pulled out of TOOL_USAGE_PATTERNS so the Writer ambient prompt can put it last (recency)
+# without duplicating the bullet. MCP editing topic still includes this same object.
+CONFIRM_EDITS_FROM_STRUCTURED_FIELDS = """- Confirm edits from structured fields, not message wording: apply_document_content search replace → replaced_count > 0; inserts (target='beginning'/'end'/'selection', position='before'/'after') → status='ok' (also inserted=true); apply_style → applied is true; add_comment → comment_added is true.
+  No-op (text not found) is status="error"."""
+
+
 # Tool-usage workflow patterns (no repeat of apply_document_content targets; see WRITER_APPLY_DOCUMENT_HTML_RULES).
 # Shared piece: sidebar system prompt + MCP manual (agent_manual topic "editing").
+# Confirm-from-fields is CONFIRM_EDITS_FROM_STRUCTURED_FIELDS (appended last for recency).
 TOOL_USAGE_PATTERNS = """TOOL USAGE PATTERNS:
-- Confirm edits from structured fields, not message wording: apply_document_content search replace → replaced_count > 0; inserts (target='beginning'/'end'/'selection', position='before'/'after') → status='ok' (also inserted=true); apply_style → applied is true; add_comment → comment_added is true.
-  No-op (text not found) is status="error".
 - Earlier document text may be a partial/truncated snapshot — call get_document_content before a targeted edit that needs the exact current text.
 - Successful apply_document_content returns edited_context (touched paragraphs plus neighbors; in record/wait including the pending change).
   Use it to confirm placement instead of an immediate re-read; full_document rewrites have no echo.
@@ -270,7 +275,8 @@ WRITER_REVIEW_MODES_RULES = """TRACKED CHANGES / REVIEW MODES:
 # apply_document_content only — design notes in docs/chat/sidebar-implementation.md § Chat prompt constants and docs/writer/math-tex.md.
 WRITER_APPLY_DOCUMENT_HTML_RULES = f"""APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL):
 - Required: `content` and `target`.
-  Targets: 'beginning', 'end', 'selection', 'full_document' (preferred for rewrites/translations), 'search' (substring find/replace; also `old_content` as a **substring** — HTML in old_content is matched as plain text).
+  Targets: 'beginning', 'end', 'selection', 'full_document', 'search' (substring find/replace; also `old_content` as a **substring** — HTML in old_content is matched as plain text).
+- Local edits use target='search' + old_content as a substring; target='full_document' is rewrite/translation only.
 - **Never** pass the entire document as old_content — that is not supported and will fail search.
 - target='search': old_content may span paragraphs, but each interior line must match a WHOLE paragraph.
   position='before'/'after' INSERTS next to the match and leaves it untouched — add a paragraph without re-sending the clause.
@@ -340,19 +346,26 @@ def _build_writer_chat_system_prompt_template() -> str:
     (search, navigation, images) are pulled on demand through the get_guidance tool, so every
     turn stays lean. The MCP-only extras (e.g. the HTTP 429 concurrency contract) stay out of
     this ambient prompt — the sidebar runs in-process; if a sidebar model pulls the concurrency
-    topic anyway it just reads an inert rule."""
+    topic anyway it just reads an inert rule.
+
+    Apply-HTML and confirm-from-fields sit last on purpose (recency): last tokens in the
+    ambient prompt are what the model attends to. Same lesson as attaching
+    RESEARCH_COMPLETION_INSTRUCTION_WRITER to the web-research *tool result* instead of the
+    system prompt — do not paste that trailer into this ambient text. SIDEBAR_VS_DOCUMENT
+    sits with the apply block for the same reason (drafts go in the document)."""
     return "\n\n".join([
         WRITER_CHAT_PERSONA,
         CHAT_RESPONSE_FORMAT,
-        SIDEBAR_VS_DOCUMENT,
         "{core_directives}",
         WRITER_CHAT_TOOLS_SECTION,
         TRANSLATION_RULES,
         TOOL_USAGE_PATTERNS,
         WRITER_REVIEW_MODES_RULES,
-        WRITER_APPLY_DOCUMENT_HTML_RULES,
         "{specialized_delegation}",
         MEMORY_GUIDANCE,
+        SIDEBAR_VS_DOCUMENT,
+        WRITER_APPLY_DOCUMENT_HTML_RULES,
+        CONFIRM_EDITS_FROM_STRUCTURED_FIELDS,
     ])
 
 

--- a/tests/chatbot/test_agent_manual.py
+++ b/tests/chatbot/test_agent_manual.py
@@ -118,7 +118,7 @@ def test_shared_pieces_are_identical_in_both_channels():
     # subdivision, editing-html). The pointer to the subdivision is appended ONLY when the topic
     # is served alone (get_section) — in full_manual the editing-html section follows inline, so
     # a "go read that topic" sentence would dangle there.
-    for piece in (c.TOOL_USAGE_PATTERNS, c.TRANSLATION_RULES):
+    for piece in (c.CONFIRM_EDITS_FROM_STRUCTURED_FIELDS, c.TOOL_USAGE_PATTERNS, c.TRANSLATION_RULES):
         assert piece.strip() in MANUAL_SECTIONS["editing"]
     assert "editing-html" in get_section("editing", "writer")      # on-demand: pointer present
     assert "read the editing-html topic" not in full_manual("writer")  # concatenated: no dangler
@@ -144,6 +144,8 @@ def test_sidebar_hybrid_prompt_composition():
         c.WRITER_APPLY_DOCUMENT_HTML_RULES,
         c.TRANSLATION_RULES,
         c.WRITER_REVIEW_MODES_RULES,
+        c.CONFIRM_EDITS_FROM_STRUCTURED_FIELDS,
+        c.SIDEBAR_VS_DOCUMENT,
     ):
         assert template.count(piece) == 1
     for piece in (c.WRITER_SEARCH_RULES, c.WRITER_NAVIGATION_RULES, c.WRITER_IMAGES_RULES):

--- a/tests/framework/test_constants.py
+++ b/tests/framework/test_constants.py
@@ -122,15 +122,24 @@ def test_writer_chat_prompt_opens_with_persona_and_color_guidance():
 
 def test_writer_chat_prompt_section_order_matches_assembly():
     """Writer system prompt sections appear in model-facing order (persona → format → tools → HTML last)."""
+    from plugin.framework.prompts import (
+        CONFIRM_EDITS_FROM_STRUCTURED_FIELDS,
+        SIDEBAR_VS_DOCUMENT,
+        WRITER_APPLY_DOCUMENT_HTML_RULES,
+        WRITER_CHAT_TOOLS_SECTION,
+    )
+
     model = MagicMock()
     model.supportsService.return_value = False
     prompt = get_chat_system_prompt_for_document(model)
     chat_fmt = prompt.index("CHAT RESPONSE FORMAT")
-    tools = prompt.index("TOOLS:")
-    html_rules = prompt.index("APPLY_DOCUMENT_CONTENT AND HTML")
-    sidebar = prompt.index("SIDEBAR CHAT")
-    assert chat_fmt < tools < html_rules
-    assert tools < sidebar < html_rules
+    tools = prompt.index(WRITER_CHAT_TOOLS_SECTION)
+    # Use the full apply-HTML block — "APPLY_DOCUMENT_CONTENT AND HTML" also appears
+    # as a forward reference inside WRITER_CHAT_TOOLS_SECTION.
+    html_rules = prompt.index(WRITER_APPLY_DOCUMENT_HTML_RULES)
+    sidebar = prompt.index(SIDEBAR_VS_DOCUMENT)
+    confirm = prompt.index(CONFIRM_EDITS_FROM_STRUCTURED_FIELDS)
+    assert chat_fmt < tools < sidebar < html_rules < confirm
     assert prompt.index("LibreOffice Writer assistant") < chat_fmt
 
 

--- a/tests/framework/test_constants.py
+++ b/tests/framework/test_constants.py
@@ -121,7 +121,7 @@ def test_writer_chat_prompt_opens_with_persona_and_color_guidance():
 
 
 def test_writer_chat_prompt_section_order_matches_assembly():
-    """Writer system prompt sections appear in model-facing order (persona → format → tools → HTML rules)."""
+    """Writer system prompt sections appear in model-facing order (persona → format → tools → HTML last)."""
     model = MagicMock()
     model.supportsService.return_value = False
     prompt = get_chat_system_prompt_for_document(model)
@@ -130,8 +130,34 @@ def test_writer_chat_prompt_section_order_matches_assembly():
     html_rules = prompt.index("APPLY_DOCUMENT_CONTENT AND HTML")
     sidebar = prompt.index("SIDEBAR CHAT")
     assert chat_fmt < tools < html_rules
-    assert sidebar < tools
+    assert tools < sidebar < html_rules
     assert prompt.index("LibreOffice Writer assistant") < chat_fmt
+
+
+def test_writer_chat_template_ends_with_apply_html_then_confirm():
+    """Recency: apply-HTML then confirm-from-fields are the last two ambient pieces."""
+    from plugin.framework.prompts import (
+        CONFIRM_EDITS_FROM_STRUCTURED_FIELDS,
+        DEFAULT_CHAT_SYSTEM_PROMPT_TEMPLATE,
+        MEMORY_GUIDANCE,
+        RESEARCH_COMPLETION_INSTRUCTION_WRITER,
+        SIDEBAR_VS_DOCUMENT,
+        WRITER_APPLY_DOCUMENT_HTML_RULES,
+    )
+
+    template = DEFAULT_CHAT_SYSTEM_PROMPT_TEMPLATE
+    specialized = template.index("{specialized_delegation}")
+    memory = template.index(MEMORY_GUIDANCE)
+    sidebar = template.index(SIDEBAR_VS_DOCUMENT)
+    apply_html = template.index(WRITER_APPLY_DOCUMENT_HTML_RULES)
+    confirm = template.index(CONFIRM_EDITS_FROM_STRUCTURED_FIELDS)
+    assert specialized < memory < sidebar < apply_html < confirm
+    assert template.rstrip().endswith(CONFIRM_EDITS_FROM_STRUCTURED_FIELDS.rstrip())
+    after_apply = template[apply_html + len(WRITER_APPLY_DOCUMENT_HTML_RULES):].lstrip()
+    assert after_apply.startswith(CONFIRM_EDITS_FROM_STRUCTURED_FIELDS.lstrip())
+    # Confirm bullet is not also left inside TOOL_USAGE_PATTERNS (would bury recency).
+    assert template.count(CONFIRM_EDITS_FROM_STRUCTURED_FIELDS) == 1
+    assert RESEARCH_COMPLETION_INSTRUCTION_WRITER not in template
 
 
 def test_writer_chat_prompt_includes_sidebar_vs_document_routing():
@@ -173,6 +199,8 @@ def test_writer_apply_document_math_latex_rules_document_only():
     assert r"\[" in WRITER_APPLY_DOCUMENT_HTML_RULES
     assert "Math (display):" not in WRITER_APPLY_DOCUMENT_HTML_RULES
     assert "Math (CRITICAL)" not in HTML_FRAGMENT_RULES
+    assert "Local edits use target='search'" in WRITER_APPLY_DOCUMENT_HTML_RULES
+    assert "target='full_document' is rewrite/translation only" in WRITER_APPLY_DOCUMENT_HTML_RULES
 
     model = MagicMock()
     model.supportsService.return_value = False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Writer main-sidebar prompt only (`_build_writer_chat_system_prompt_template` / `DEFAULT_CHAT_SYSTEM_PROMPT_TEMPLATE`).

Aider-style recency: last tokens in the ambient prompt are what the model attends to. WriterAgent already proved this by attaching `RESEARCH_COMPLETION_INSTRUCTION_WRITER` to the web-research *tool result* instead of the top of the system prompt. This PR applies the same idea *inside* the ambient Writer prompt.

## Changes
- Reorder the Writer join list so apply-HTML + confirm-from-fields sit last (after specialized / memory).
- Move `SIDEBAR_VS_DOCUMENT` down with the apply block (wording unchanged). Drafts-go-in-the-doc is more useful late than next to `CHAT_RESPONSE_FORMAT`.
- Pull the “Confirm edits from structured fields…” bullet out of `TOOL_USAGE_PATTERNS` into `CONFIRM_EDITS_FROM_STRUCTURED_FIELDS` and append it after apply-HTML (no duplicate). MCP `editing` topic still includes the same object.
- One new apply-HTML rule: local edits use `target='search'` + `old_content` as a substring; `target='full_document'` is rewrite/translation only. All models stay on diffs — no weak-model wholefile off-ramp.
- Docstring + `docs/chat/sidebar-implementation.md` note the recency order. Research trailer is **not** copied into ambient text.

## Out of scope
Calc/Draw prompts, ReAct, skills, SEARCH/REPLACE, Aider’s loop, the research trailer itself, ok/go-ahead rules, lazy-vs-overeager knobs, few-shots.

## Tests
- Template join-order test: assembled Writer template ends with apply-HTML then confirm-from-fields.
- Section-order test pins the full apply-HTML block (not the tools-section forward reference).
- `tests/framework/test_constants.py`, `tests/chatbot/test_agent_manual.py`, `tests/scripts/test_eval_prompts.py`: 60 passed.
- `make typecheck` clean.

[Writer template join order](https://cursor.com/agents/bc-812dfa0d-eaaa-4e9a-b4ec-c3fce8901938/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwriter_prompt_join_order.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-812dfa0d-eaaa-4e9a-b4ec-c3fce8901938?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-812dfa0d-eaaa-4e9a-b4ec-c3fce8901938&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

