### PR TITLE
Interleave notebook File → Open outputs; share page-style lookup

### DIFF
--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -17,13 +17,6 @@ Future work (do not forget — leave these until the matching phase, not drive-b
   Safe today because File → Open always targets a fresh doc. Phase 3
   append/merge must use notebook-owned styles so a user's styles keep
   spellcheck.
-- Code-cell outputs append all text then all images, so a cell whose outputs
-  are ``[display image, print(...)]`` renders out of order. Interleave per
-  output when rewriting ``_import_cells``.
-- ``stats["outputs"]`` calls ``format_output_text`` a second time; derive the
-  count from ``_format_outputs_for_body`` instead.
-- ``_text_area_width_units`` / ``_max_field_height_units`` duplicate page-style
-  lookup — extract a small ``_page_style(doc)`` helper.
 - ``notebook_controls._form_and_container`` uses ``forms.getByIndex(0)``. Fine
   while import owns the first form; iterate forms (or find ``nb_run_*``) if
   the document can already have other forms.
@@ -227,7 +220,21 @@ def format_all_outputs(outputs: list[Any]) -> str:
     return "\n\n".join(p for p in parts if p.strip())
 
 
-def _format_outputs_for_body(outputs: list[Any], cell_index: int, execution_count: Any | None = None) -> str:
+def _format_outputs_for_body(
+    outputs: list[Any], cell_index: int, execution_count: Any | None = None
+) -> tuple[list[tuple[str, Any]], int]:
+    """Interleave text and image outputs in notebook order.
+
+    Previously appended all text, then all images, so ``[display image,
+    print(...)]`` rendered print-then-image. Walk each output once: flush
+    consecutive text before an image, then the image. Caps at
+    ``_MAX_OUTPUTS_PER_CELL``.
+
+    Returns ``(segments, text_output_count)``. Each segment is
+    ``("text", joined_str)`` or ``("image", output)``. ``text_output_count`` is
+    the number of outputs that produced non-empty text (same meaning as the
+    old ``stats["outputs"]`` increment, without a second ``format_output_text``).
+    """
     out_list = outputs or []
     if len(out_list) > _MAX_OUTPUTS_PER_CELL:
         log.warning(
@@ -237,12 +244,25 @@ def _format_outputs_for_body(outputs: list[Any], cell_index: int, execution_coun
             _MAX_OUTPUTS_PER_CELL,
         )
         out_list = out_list[:_MAX_OUTPUTS_PER_CELL]
-    parts: list[str] = []
+    segments: list[tuple[str, Any]] = []
+    text_parts: list[str] = []
+    text_count = 0
+
+    def flush_text() -> None:
+        if text_parts:
+            segments.append(("text", "\n\n".join(text_parts)))
+            text_parts.clear()
+
     for output in out_list:
         text = format_output_text(output, execution_count)
         if text.strip():
-            parts.append(text)
-    return "\n\n".join(parts)
+            text_parts.append(text)
+            text_count += 1
+        if _outputs_contain_image([output]):
+            flush_text()
+            segments.append(("image", output))
+    flush_text()
+    return segments, text_count
 
 
 def _notebook_image_payload(data: dict[str, Any]) -> tuple[str, str] | None:
@@ -320,10 +340,10 @@ def _image_mime_from_bytes(raw: bytes, path: str) -> str:
     return "image/png"
 
 
-def _text_area_width_units(doc: Any | None) -> int:
-    """Page width minus left/right margins (1/100 mm), for code fields and images."""
+def _page_style(doc: Any | None) -> Any | None:
+    """Current page style, or Standard/Default fallback. None if unavailable."""
     if doc is None:
-        return _DEFAULT_WIDTH
+        return None
     try:
         families = doc.getStyleFamilies().getByName("PageStyles")
         name = ""
@@ -331,16 +351,22 @@ def _text_area_width_units(doc: Any | None) -> int:
             name = str(doc.getPropertyValue("PageDescName") or "")
         except Exception:
             name = ""
-        style = None
         if name and families.hasByName(name):
-            style = families.getByName(name)
-        else:
-            for candidate in ("Standard", "Default", "Default Page Style"):
-                if families.hasByName(candidate):
-                    style = families.getByName(candidate)
-                    break
-        if style is None:
-            return _DEFAULT_WIDTH
+            return families.getByName(name)
+        for candidate in ("Standard", "Default", "Default Page Style"):
+            if families.hasByName(candidate):
+                return families.getByName(candidate)
+    except Exception:
+        log.debug("notebook import could not read page style", exc_info=True)
+    return None
+
+
+def _text_area_width_units(doc: Any | None) -> int:
+    """Page width minus left/right margins (1/100 mm), for code fields and images."""
+    style = _page_style(doc)
+    if style is None:
+        return _DEFAULT_WIDTH
+    try:
         page_w = int(style.getPropertyValue("Width"))
         left = int(style.getPropertyValue("LeftMargin"))
         right = int(style.getPropertyValue("RightMargin"))
@@ -352,25 +378,10 @@ def _text_area_width_units(doc: Any | None) -> int:
 
 def _max_field_height_units(doc: Any | None) -> int:
     """Cap AS_CHARACTER code fields at roughly the page body height."""
-    if doc is None:
+    style = _page_style(doc)
+    if style is None:
         return _MAX_FIELD_HEIGHT
     try:
-        families = doc.getStyleFamilies().getByName("PageStyles")
-        name = ""
-        try:
-            name = str(doc.getPropertyValue("PageDescName") or "")
-        except Exception:
-            name = ""
-        style = None
-        if name and families.hasByName(name):
-            style = families.getByName(name)
-        else:
-            for candidate in ("Standard", "Default", "Default Page Style"):
-                if families.hasByName(candidate):
-                    style = families.getByName(candidate)
-                    break
-        if style is None:
-            return _MAX_FIELD_HEIGHT
         page_h = int(style.getPropertyValue("Height"))
         top = int(style.getPropertyValue("TopMargin"))
         bottom = int(style.getPropertyValue("BottomMargin"))
@@ -1775,18 +1786,20 @@ def _import_cells(
             if registry_state is not None and registry_state.code_cells:
                 bm_name = registry_state.code_cells[-1].output_start_bookmark
                 insert_output_start_bookmark(doc, bm_name)
-            out_text = _format_outputs_for_body(outputs, idx, execution_count=ec)
-            if out_text.strip():
-                stats["outputs"] += len(
-                    [o for o in outputs if format_output_text(o, ec).strip()]
-                )
-                _append_body_text_block(doc, out_text, _STYLE_OUTPUT, lead_break=True)
-            if _outputs_contain_image(outputs):
-                _append_paragraph_break_at_end(doc)
-                images_added = _import_image_outputs_in_flow(
-                    doc, outputs, idx, images_before=stats["images"], ctx=ctx
-                )
-                stats["images"] += images_added
+            # Interleave in notebook order. Used to dump all text, then all
+            # images, so [display image, print(...)] rendered print-then-image.
+            segments, n_text = _format_outputs_for_body(outputs, idx, execution_count=ec)
+            stats["outputs"] += n_text
+            for kind, payload in segments:
+                if kind == "text":
+                    if str(payload).strip():
+                        _append_body_text_block(doc, str(payload), _STYLE_OUTPUT, lead_break=True)
+                else:
+                    _append_paragraph_break_at_end(doc)
+                    images_added = _import_image_outputs_in_flow(
+                        doc, [payload], idx, images_before=stats["images"], ctx=ctx
+                    )
+                    stats["images"] += images_added
         else:
             stats["raw"] += 1
             _append_body_text_block(doc, source, _STYLE_BODY, lead_break=lead)

--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -30,12 +30,15 @@ from plugin.notebook.writer_importer import (
     _ensure_notebook_import_styles,
     _FIELD_HEIGHT_PAD,
     _format_in_prompt,
+    _format_outputs_for_body,
     _height_for_text,
     _inline_backticks_to_html,
     _iter_markdown_blocks,
     _LINE_HEIGHT,
     _looks_like_html,
+    _max_field_height_units,
     _notebook_image_payload,
+    _page_style,
     _png_pixel_size,
     _prepare_display_text,
     _resolve_para_style,
@@ -139,6 +142,27 @@ def test_format_all_outputs_joins():
     ]
     text = format_all_outputs(outputs)
     assert "a" in text and "b" in text
+
+
+def test_format_outputs_for_body_interleaves_image_then_stream():
+    """Mixed [display image, print] must stay image-then-text, not text-then-images."""
+    outputs = [
+        {"output_type": "display_data", "data": {"image/png": "abc"}},
+        {"output_type": "stream", "name": "stdout", "text": "hello printed\n"},
+    ]
+    segments, n_text = _format_outputs_for_body(outputs, 0)
+    assert n_text == 1
+    assert [kind for kind, _payload in segments] == ["image", "text"]
+    assert segments[1][1] == "hello printed\n"
+
+
+def test_import_cells_does_not_reformat_outputs_for_stats():
+    from plugin.notebook import writer_importer as wi
+
+    src = inspect.getsource(wi._import_cells)
+    assert "format_output_text" not in src
+    assert "_format_outputs_for_body" in src
+    assert 'stats["outputs"] += n_text' in src
 
 
 def test_trim_trailing_empty_paragraph_deletes_when_empty():
@@ -291,6 +315,35 @@ def test_code_field_uses_full_text_area_width():
     assert "_text_area_width_units(doc)" in src
     assert "_RUN_BUTTON_SIZE" not in src
     assert _text_area_width_units(None) == _DEFAULT_WIDTH
+
+
+def test_page_style_shared_by_width_and_height():
+    from plugin.notebook.writer_importer import _MAX_FIELD_HEIGHT, _MIN_FIELD_HEIGHT
+
+    assert _page_style(None) is None
+    assert "_page_style(doc)" in inspect.getsource(_text_area_width_units)
+    assert "_page_style(doc)" in inspect.getsource(_max_field_height_units)
+
+    style = MagicMock()
+    style.getPropertyValue.side_effect = lambda name: {
+        "Width": 21000,
+        "LeftMargin": 2000,
+        "RightMargin": 2000,
+        "Height": 29700,
+        "TopMargin": 2000,
+        "BottomMargin": 2000,
+    }[name]
+    families = MagicMock()
+    families.hasByName.side_effect = lambda name: name == "Standard"
+    families.getByName.return_value = style
+    doc = MagicMock()
+    doc.getStyleFamilies.return_value.getByName.return_value = families
+    doc.getPropertyValue.return_value = ""
+
+    assert _page_style(doc) is style
+    assert _text_area_width_units(doc) == 17000
+    assert _max_field_height_units(doc) == max(_MIN_FIELD_HEIGHT, 29700 - 2000 - 2000 - 1500)
+    assert _max_field_height_units(None) == _MAX_FIELD_HEIGHT
 
 
 def test_unglue_last_paragraph_clears_keep_with_next():
@@ -609,6 +662,49 @@ def test_import_ipynb_inserts_image_output(tmp_path, monkeypatch):
     assert stats["images"] == 1
     assert stats["shapes"] == 2
     assert len(insert_calls) == 2  # run button + code field; image via insert_image_at_locator
+
+
+def test_import_image_then_stream_keeps_notebook_order(tmp_path, monkeypatch):
+    png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    ipynb = tmp_path / "mixed.ipynb"
+    ipynb.write_text(
+        '{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":['
+        '{"cell_type":"code","metadata":{},"source":"plot(); print(1)","outputs":['
+        '{"output_type":"display_data","data":{"image/png":"' + png_b64 + '"}},'
+        '{"output_type":"stream","name":"stdout","text":"hello printed\\n"}'
+        "]}]}",
+        encoding="utf-8",
+    )
+
+    doc, body_text, _ = _writer_doc_mock()
+    order: list[str] = []
+
+    class FakeSize:
+        def __init__(self, w, h):
+            self.Width = w
+            self.Height = h
+
+    def tracking_insert_string(_cursor, content, _absorb=False):
+        if content == "hello printed\n":
+            order.append("text")
+
+    def tracking_insert_image(*_args, **_kwargs):
+        order.append("image")
+        return MagicMock()
+
+    body_text.insertString.side_effect = tracking_insert_string
+    doc.createInstance.side_effect = lambda service: MagicMock()
+    monkeypatch.setattr("plugin.notebook.writer_importer.Size", FakeSize)
+    monkeypatch.setattr(
+        "plugin.notebook.writer_importer.insert_image_at_locator",
+        tracking_insert_image,
+    )
+
+    stats = import_ipynb_to_writer(doc, str(ipynb), ctx=MagicMock())
+
+    assert order == ["image", "text"]
+    assert stats["outputs"] == 1
+    assert stats["images"] == 1
 
 
 def test_import_code_cell_without_outputs_has_no_output_heading(tmp_path, monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Focused File → Open import-quality fixes from the Future work block in `plugin/notebook/writer_importer.py`. No Phase 2–6 work (Settings, kill-switch, merge UX, Run All, form iteration).

## Changes

1. **Interleave outputs.** `_format_outputs_for_body` now walks each output once and returns `("text", …)` / `("image", …)` segments in notebook order. `_import_cells` appends those segments so `[display image, print(...)]` stays image-then-text. Caps unchanged (50k chars, 200 outputs, 8MB images).

2. **`stats["outputs"]` is one format pass.** Count comes from the interleaved formatter (`n_text`). The second `format_output_text` walk is gone. Key kept for dialog/tests.

3. **`_page_style(doc)`.** Shared helper for `_text_area_width_units` / `_max_field_height_units`. Same fallbacks (named page style, then Standard/Default), no layout change.

Phase 2/3/4 Future work comments are left in place.

## Tests

- `test_format_outputs_for_body_interleaves_image_then_stream`
- `test_import_image_then_stream_keeps_notebook_order`
- `test_import_cells_does_not_reformat_outputs_for_stats`
- `test_page_style_shared_by_width_and_height`

Docs: output order was not documented as a known gap, so `docs/writer/jupyter-notebook-import.md` is unchanged.

## Testing (local, green)

- `make typecheck` — ruff, basedpyright (0 errors), mypy (496 files), ty, bandit, pyspector, opengrep, thread-safety
- `.venv/bin/python -m pytest tests/notebook/test_writer_importer.py` — **64 passed**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b84cf58-0b0c-40f6-b45c-285b1c7a4db9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b84cf58-0b0c-40f6-b45c-285b1c7a4db9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

