### PR TITLE
Ask-box slash-command popup (UI stubs, not the full command set)

### DIFF
--- a/docs/chat/sidebar-implementation.md
+++ b/docs/chat/sidebar-implementation.md
@@ -6,7 +6,7 @@
 
 **Current state:** The sidebar panel is **working**. "Chat with Document" appears in the WriterAgent deck in Writer's sidebar with Response area, Ask field, and Send button. The menu item can remain as fallback.
 
-In-chat `/` commands are **not implemented**. A research candidate list (Aider-based, including new WriterAgent features) lives in [slash-commands.md](slash-commands.md).
+In-chat `/` **popup** is wired on the Ask field (prefix filter, LRU, Esc/arrows/Tab/Enter). Commands are still mostly stubs. The consider-list (Aider-based, including new WriterAgent features) lives in [slash-commands.md](slash-commands.md).
 
 ### Main chat: sidebar reply vs document edit
 

--- a/docs/chat/slash-commands.md
+++ b/docs/chat/slash-commands.md
@@ -1,6 +1,8 @@
 # Sidebar slash commands (research)
 
-**Status:** not implemented. Candidate list only. WriterAgent has no `/` parser today.
+**UI status:** The Ask-box `/` completion popup is wired. Typing `/` opens a ListBox just above (or below) the field; further typing filters; Esc dismisses; Up/Down moves the selection; Tab completes the selected name; Enter accepts it without sending a chat turn. Ranking uses LRU persisted as `slash_command_lru` in `writeragent.json`. **Commands are still mostly stubs** — mocks echo `slash: /name` in the response pane. `/help` prints the static list; `/clear` wipes the active transcript; `/stop` cancels an in-flight send. Keith will pick the real set later. Do not treat the consider-list below as shipped behavior.
+
+**Status:** product command implementations are not done. Candidate list only.
 
 Typed in the **chat sidebar** Ask box (Aider/Cursor style). Not a LibreOffice menu, not LibrePy, not a skills system.
 

--- a/docs/chat/slash-commands.md
+++ b/docs/chat/slash-commands.md
@@ -1,6 +1,6 @@
 # Sidebar slash commands (research)
 
-**UI status:** The Ask-box `/` completion popup is wired. Typing `/` opens a ListBox just above (or below) the field; further typing filters; Esc dismisses; Up/Down moves the selection; Tab completes the selected name; Enter accepts it without sending a chat turn. Ranking uses LRU persisted as `slash_command_lru` in `writeragent.json`. **Commands are still mostly stubs** — mocks echo `slash: /name` in the response pane. `/help` prints the static list; `/clear` wipes the active transcript; `/stop` cancels an in-flight send. Keith will pick the real set later. Do not treat the consider-list below as shipped behavior.
+**UI status:** The Ask-box `/` completion popup is wired. Typing `/` opens a ListBox just above (or below) the field; further typing filters; Esc dismisses; Up/Down moves the selection; Tab completes the selected name; Enter accepts it without sending a chat turn. Ranking uses LRU persisted as `slash_command_lru` in `writeragent.json`. The XDL placeholder is `dlg:menulist` (dialog.dtd has no `listbox`); that control is a ComboBox, so the visible menu is a runtime `UnoControlListBox`. **Commands are still mostly stubs** — mocks echo `slash: /name` in the response pane. `/help` prints the static list; `/clear` wipes the active transcript; `/stop` cancels an in-flight send. Keith will pick the real set later. Do not treat the consider-list below as shipped behavior.
 
 **Status:** product command implementations are not done. Candidate list only.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,7 +20,7 @@ Product overview lives in the root [README](../README.md). This page maps each a
 | Styles / LLM HTML | [writer/llm-styles.md](writer/llm-styles.md) · [LLM_STYLES.md](../LLM_STYLES.md) |
 | Reviewable edits | [writer/reviewable-agent-edits.md](writer/reviewable-agent-edits.md) |
 | Rich-text sidebar | [chat/rich-text-control-sidebar.md](chat/rich-text-control-sidebar.md) |
-| Chat sidebar | [chat/sidebar-implementation.md](chat/sidebar-implementation.md) · slash `/` candidates (not implemented): [chat/slash-commands.md](chat/slash-commands.md) |
+| Chat sidebar | [chat/sidebar-implementation.md](chat/sidebar-implementation.md) · slash `/` popup (commands mostly stubs): [chat/slash-commands.md](chat/slash-commands.md) |
 
 ## Calc
 

--- a/extension/Dialogs/ChatPanelDialog.xdl
+++ b/extension/Dialogs/ChatPanelDialog.xdl
@@ -14,6 +14,7 @@
   <dlg:textfield dlg:id="status" dlg:left="4" dlg:top="128" dlg:width="142" dlg:height="10" dlg:value="" dlg:readonly="true" dlg:border="none" dlg:tabstop="false"/>
   
   <dlg:text dlg:id="query_label" dlg:left="4" dlg:top="140" dlg:width="142" dlg:height="10" dlg:value="Ask / instruct:" dlg:align="left"/>
+  <dlg:menulist dlg:id="slash_popup" dlg:left="4" dlg:top="80" dlg:width="142" dlg:height="60" dlg:tabstop="false"/>
   <dlg:textfield dlg:id="query" dlg:left="4" dlg:top="152" dlg:width="142" dlg:height="30" dlg:tabstop="true" dlg:value="" dlg:multiline="true" dlg:vscroll="true"/>
   
   <dlg:button dlg:id="send" dlg:left="4" dlg:top="186" dlg:width="50" dlg:height="15" dlg:value="Send" dlg:tabstop="true"/>

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -200,7 +200,8 @@ class QueryTextListener(BaseTextListener):
         model = getattr(rEvent.Source, "Model", None)
         if not model:
             model = rEvent.Source.getModel()
-        text = model.Text.strip()
+        raw = model.Text or ""
+        text = raw.strip()
         try:
             src = rEvent.Source
             ps = src.getPosSize() if hasattr(src, "getPosSize") else None
@@ -214,6 +215,10 @@ class QueryTextListener(BaseTextListener):
 
         # Dispatch event to the state machine
         self.send_listener.dispatch(SendEvent(SendEventKind.TEXT_UPDATED, {"has_text": bool(text)}))
+        popup = getattr(self.send_listener, "slash_popup", None)
+        on_text = getattr(popup, "on_query_text", None) if popup is not None else None
+        if callable(on_text):
+            on_text(raw)
 
 
 # UNO Key.RETURN / KeyModifier.SHIFT (test-friendly integer codes)
@@ -236,6 +241,15 @@ class QueryKeyListener(BaseKeyListener):
         self.send_listener = send_listener
 
     def on_key_pressed(self, e):
+        # Popup Enter must not also Send. Consume only when handle_key is True
+        # (MagicMock hosts in unit tests return a mock, which is not True).
+        popup = getattr(self.send_listener, "slash_popup", None)
+        handle = getattr(popup, "handle_key", None) if popup is not None else None
+        if callable(handle) and handle(e.KeyCode, e.Modifiers) is True:
+            with suppress_disposed("QueryKeyListener slash Consume", logger=log):
+                if hasattr(e, "Consume"):
+                    setattr(e, "Consume", True)
+            return
         if not query_enter_triggers_primary_send(e.KeyCode, e.Modifiers):
             return
         try:
@@ -328,6 +342,8 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
         self._approval_ui_backup = None
         self._approval_query_for_engine = None
         self._dispatch_reenter: list[Any] | None = None
+        self.slash_popup = None
+        self.clear_listener = None
         self.rich_text_widget = None
         self._rich_plain_fallback_warned = False
         self.queue_executor = QueueExecutor(ctx=ctx)

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -283,6 +283,8 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
     cached_doc_type: str | None
     cached_uno_services: frozenset[str] | None
     _record_assistant_start: bool
+    slash_popup: Any
+    clear_listener: Any
 
     def __init__(
         self, ctx, frame, send_control, stop_control, query_control, response_control, image_model_selector, model_selector, status_control, session, chat_mode_selector=None, aspect_ratio_selector=None, base_size_input=None, sidebar_include_brainstorming=True, ensure_path_fn=None, clear_control=None

--- a/plugin/chatbot/panel_factory.py
+++ b/plugin/chatbot/panel_factory.py
@@ -70,12 +70,20 @@ _LIVE_CHAT_PANELS: WeakSet[Any] | None = None
 
 
 def _debug_live_panels_on() -> bool:
+    """True in dev thread-guard builds and mock-sidebar (``WRITERAGENT_TESTING=1``).
+
+    ``make test-mock-sidebar`` sets ``WRITERAGENT_UNO_THREAD_GUARD=0``, so the
+    thread_guard stub has no ``_designated_main_thread``. Still track the live
+    panel so URP slash/Packet G hooks can find ``SendButtonListener``.
+    """
     try:
         from plugin.framework import thread_guard as tg
 
-        return hasattr(tg, "_designated_main_thread")
+        if hasattr(tg, "_designated_main_thread"):
+            return True
     except Exception:
-        return False
+        pass
+    return os.environ.get("WRITERAGENT_TESTING") == "1"
 
 
 def _live_chat_panels() -> WeakSet[Any] | None:

--- a/plugin/chatbot/panel_factory.py
+++ b/plugin/chatbot/panel_factory.py
@@ -975,6 +975,8 @@ class ChatPanelElement(unohelper.Base, XUIElement):
             try:
                 clear_listener = ClearButtonListener(self.session, controls["response"], controls["status"], greeting=active_greeting, send_listener=send_listener)
                 controls["clear"].addActionListener(clear_listener)
+                if send_listener is not None:
+                    send_listener.clear_listener = clear_listener
             except Exception:
                 log.exception("Clear button wiring failed")
 

--- a/plugin/chatbot/panel_resize.py
+++ b/plugin/chatbot/panel_resize.py
@@ -26,6 +26,9 @@ _STRETCH_CONTROLS = frozenset({
     "aspect_ratio_selector",
 })
 
+# Completion menu overlays the transcript; do not park it in the bottom band.
+_OVERLAY_CONTROLS = frozenset({"slash_popup"})
+
 # ChatPanelDialog.xdl: response top=16 height=110, status top=128 -> gap=2.
 _XDL_GAP_BELOW_RESPONSE = 2
 _BOTTOM_MARGIN = 10
@@ -96,6 +99,9 @@ def compute_chat_panel_layout(
     layouts: dict[str, ControlRect] = {}
     for name, (ox, oy, ow, oh) in snapshot.items():
         if name == "response":
+            continue
+
+        if name in _OVERLAY_CONTROLS:
             continue
 
         if name in _STRETCH_CONTROLS:

--- a/plugin/chatbot/panel_wiring.py
+++ b/plugin/chatbot/panel_wiring.py
@@ -157,6 +157,7 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):  
                         self.send_listener.slash_popup = SlashPopupController(
                             slash_ctrl, self.send_listener, query_ctrl
                         )
+                        log.info("slash popup attached to Ask field")
 
                     # The label update logic is now handled correctly by the state machine
                     # so we can just trigger a fake text update event to sync the state

--- a/plugin/chatbot/panel_wiring.py
+++ b/plugin/chatbot/panel_wiring.py
@@ -1,6 +1,6 @@
 import logging
 
-from plugin.chatbot.dialogs import get_optional as get_optional_control, get_control_text, set_control_text, translate_dialog
+from plugin.chatbot.dialogs import get_optional as get_optional_control, get_control_text, set_control_text, set_control_visible, translate_dialog
 from plugin.chatbot.panel_resize import _PanelResizeListener
 from plugin.framework.config import get_config
 from plugin.framework.errors import suppress_disposed
@@ -79,7 +79,12 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):  
         "response_label": get_optional("response_label"),
         "query_label": get_optional("query_label"),
         "backend_indicator": get_optional("backend_indicator"),
+        "slash_popup": get_optional("slash_popup"),
     }
+
+    # Overlay completion menu — hide until `/` is typed (not a permanent widget).
+    if controls.get("slash_popup"):
+        set_control_visible(controls["slash_popup"], False)
 
     # Helper to show errors visibly in the response area
     def _show_init_error(msg):
@@ -144,6 +149,14 @@ def _wireControls(self, root_window, has_recording, ensure_extension_on_path):  
                     from plugin.chatbot.panel import QueryKeyListener
 
                     query_ctrl.addKeyListener(QueryKeyListener(self.send_listener))
+
+                    slash_ctrl = controls.get("slash_popup")
+                    if slash_ctrl is not None:
+                        from plugin.chatbot.slash_popup import SlashPopupController
+
+                        self.send_listener.slash_popup = SlashPopupController(
+                            slash_ctrl, self.send_listener, query_ctrl
+                        )
 
                     # The label update logic is now handled correctly by the state machine
                     # so we can just trigger a fake text update event to sync the state

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -934,7 +934,7 @@ class _UrpSlashHost:
     def __init__(self, query: Any, response: Any, clear: Any, stop: Any) -> None:
         self.query_control = query
         self.response_control = response
-        self.slash_popup = None
+        self.slash_popup: Any = None
         self.clear_listener = type(
             "ClearProxy",
             (),

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -159,8 +159,23 @@ def handle_debug_sidebar_command(command: str) -> None:
     adopt_runtime_send_listeners()
     rest = command[len(_DEBUG_SIDEBAR_PREFIX) :].lstrip(".")
     op = (rest or "SNAPSHOT").upper().replace("-", "_")
-    sl = send_listener()
+    sl = _listener_with_slash_popup(send_listener())
     if op == "SNAPSHOT":
+        _write_debug_snapshot(sl)
+        return
+    # Slash ops only touch the Ask ListBox. Run inline like SNAPSHOT —
+    # queue_executor.post is not drained on this URP path (no AsyncCallback).
+    if op in ("SLASH_REFRESH", "SLASH_ENTER", "SLASH_ESC"):
+        if sl is None:
+            log.warning("debug_sidebar %s: no SendButtonListener", op)
+            _write_debug_snapshot(None)
+            return
+        if op == "SLASH_REFRESH":
+            _slash_refresh_in_soffice(sl)
+        elif op == "SLASH_ENTER":
+            _slash_key_in_soffice(sl, 1280, 0)
+        else:
+            _slash_key_in_soffice(sl, 1281, 0)
         _write_debug_snapshot(sl)
         return
     if sl is None:
@@ -201,12 +216,6 @@ def handle_debug_sidebar_command(command: str) -> None:
                 from plugin.chatbot.chat_sidebar_mode import CHAT_MODE_CHAT
 
                 apply_fn(CHAT_MODE_CHAT)
-        elif op == "SLASH_REFRESH":
-            _slash_refresh_in_soffice(sl)
-        elif op == "SLASH_ENTER":
-            _slash_key_in_soffice(sl, 1280, 0)
-        elif op == "SLASH_ESC":
-            _slash_key_in_soffice(sl, 1281, 0)
         else:
             log.warning("debug_sidebar unknown op %s", op)
         _write_debug_snapshot(sl)
@@ -500,7 +509,12 @@ def send_listener(frame: Any = None) -> Any:
     panel = sidebar_panel(frame)
     if panel is not None:
         sl = getattr(panel, "send_listener", None)
+        if sl is not None and getattr(sl, "slash_popup", None) is not None:
+            return sl
         if sl is not None:
+            found = _listener_with_slash_popup(sl)
+            if found is not None:
+                return found
             return sl
     with_popup = [obj for obj in _LIVE_SEND_LISTENERS if getattr(obj, "slash_popup", None) is not None]
     if with_popup:
@@ -508,6 +522,24 @@ def send_listener(frame: Any = None) -> Any:
     if _LIVE_SEND_LISTENERS:
         return _LIVE_SEND_LISTENERS[-1]
     return None
+
+
+def _listener_with_slash_popup(sl: Any) -> Any:
+    """Prefer a SendButtonListener that already has the Ask-box controller."""
+    if sl is not None and getattr(sl, "slash_popup", None) is not None:
+        return sl
+    for obj in list(_LIVE_SEND_LISTENERS):
+        if getattr(obj, "slash_popup", None) is not None:
+            return obj
+    try:
+        panels = iter_live_chat_panels()
+    except Exception:
+        panels = []
+    for panel in panels:
+        cand = getattr(panel, "send_listener", None)
+        if cand is not None and getattr(cand, "slash_popup", None) is not None:
+            return cand
+    return sl
 
 
 def adopt_runtime_send_listeners() -> int:

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -127,6 +127,8 @@ def _write_debug_snapshot(sl: Any) -> dict[str, Any]:
         "stub_start_count": int(getattr(rec, "_stub_start_count", 0) or 0),
         "history_user_tail": _history_user_tail(sl) if sl is not None else "",
         "approval_active": bool(getattr(sl, "_approval_event", None)) if sl is not None else False,
+        **_slash_snapshot_fields(sl),
+        "slash_lru": _slash_lru_names(),
     }
     with open(debug_sidebar_snapshot_path(), "w", encoding="utf-8") as handle:
         json.dump(data, handle)
@@ -199,6 +201,12 @@ def handle_debug_sidebar_command(command: str) -> None:
                 from plugin.chatbot.chat_sidebar_mode import CHAT_MODE_CHAT
 
                 apply_fn(CHAT_MODE_CHAT)
+        elif op == "SLASH_REFRESH":
+            _slash_refresh_in_soffice(sl)
+        elif op == "SLASH_ENTER":
+            _slash_key_in_soffice(sl, 1280, 0)
+        elif op == "SLASH_ESC":
+            _slash_key_in_soffice(sl, 1281, 0)
         else:
             log.warning("debug_sidebar unknown op %s", op)
         _write_debug_snapshot(sl)
@@ -776,6 +784,9 @@ def set_query_text(text: str, *, listener: Any = None) -> None:
     if ctx is not None:
         controls = chat_dialog_controls(ctx, current_component(ctx)) or {}
         set_query_text_via_controls(controls, text)
+        # QueryTextListener may not fire over URP setText; refresh inside soffice.
+        if (text or "").lstrip().startswith("/") or not (text or "").strip():
+            execute_debug_sidebar_op("SLASH_REFRESH")
 
 
 def query_text(*, listener: Any = None) -> str:
@@ -786,6 +797,96 @@ def query_text(*, listener: Any = None) -> str:
     from plugin.chatbot.dialogs import get_control_text
 
     return get_control_text(getattr(sl, "query_control", None), default="") or ""
+
+
+def _slash_control_near_query(query: Any) -> Any:
+    if query is None:
+        return None
+    for getter_name in ("getContext", "getPeer"):
+        getter = getattr(query, getter_name, None)
+        if not callable(getter):
+            continue
+        try:
+            cur = getter()
+        except Exception:
+            continue
+        for unused in range(6):
+            if cur is None:
+                break
+            if hasattr(cur, "getControl"):
+                try:
+                    ctrl = cur.getControl("slash_popup")
+                except Exception:
+                    ctrl = None
+                if ctrl is not None:
+                    return ctrl
+            parent = getattr(cur, "getParent", None)
+            cur = parent() if callable(parent) else None
+    return None
+
+
+def _attach_slash_popup_on_listener(sl: Any) -> Any:
+    if sl is None:
+        return None
+    popup = getattr(sl, "slash_popup", None)
+    if popup is not None:
+        return popup
+    query = getattr(sl, "query_control", None)
+    ctrl = _slash_control_near_query(query)
+    if ctrl is None:
+        return None
+    from plugin.chatbot.slash_popup import SlashPopupController
+
+    popup = SlashPopupController(ctrl, sl, query)
+    sl.slash_popup = popup
+    return popup
+
+
+def _slash_lru_names() -> list[str]:
+    try:
+        from plugin.chatbot.slash_commands import load_slash_lru
+
+        return list(load_slash_lru())
+    except Exception:
+        return []
+
+
+def _slash_state_from_snapshot(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "visible": bool(data.get("slash_visible")),
+        "items": list(data.get("slash_items") or []),
+        "selected": data.get("slash_selected"),
+        "available": bool(data.get("slash_available")),
+        "lru": list(data.get("slash_lru") or []),
+    }
+
+
+def _slash_snapshot_fields(sl: Any) -> dict[str, Any]:
+    popup = _attach_slash_popup_on_listener(sl) if sl is not None else None
+    if popup is None:
+        return {"slash_available": False, "slash_visible": False, "slash_items": [], "slash_selected": None}
+    return {
+        "slash_available": True,
+        "slash_visible": bool(getattr(popup, "is_open", False)),
+        "slash_items": list(getattr(popup, "visible_names", None) or []),
+        "slash_selected": getattr(popup, "selected_name", None),
+    }
+
+
+def _slash_refresh_in_soffice(sl: Any) -> None:
+    from plugin.chatbot.dialogs import get_control_text
+
+    popup = _attach_slash_popup_on_listener(sl)
+    if popup is None:
+        return
+    popup.on_query_text(get_control_text(getattr(sl, "query_control", None), default="") or "")
+
+
+def _slash_key_in_soffice(sl: Any, key_code: int, modifiers: int) -> None:
+    popup = _attach_slash_popup_on_listener(sl)
+    if popup is None:
+        return
+    popup.handle_key(int(key_code), int(modifiers))
 
 
 def ensure_slash_popup(*, listener: Any = None) -> Any:
@@ -822,7 +923,8 @@ def slash_popup_state(*, listener: Any = None) -> dict[str, Any]:
     sl = listener if listener is not None else send_listener()
     popup = getattr(sl, "slash_popup", None) if sl is not None else None
     if popup is None:
-        return {"visible": False, "items": [], "selected": None}
+        # Out-of-process mock-sidebar: checkout gc cannot see soffice's listener.
+        return _slash_state_from_snapshot(execute_debug_sidebar_op("SNAPSHOT"))
     visible = bool(getattr(popup, "is_open", False))
     items = list(getattr(popup, "visible_names", None) or [])
     selected = getattr(popup, "selected_name", None)
@@ -834,7 +936,13 @@ def slash_popup_state(*, listener: Any = None) -> dict[str, Any]:
                 items = [str(ctrl.getItem(i)) for i in range(count)]
             except Exception:
                 items = []
-    return {"visible": visible, "items": items, "selected": selected}
+    return {
+        "visible": visible,
+        "items": items,
+        "selected": selected,
+        "available": True,
+        "lru": _slash_lru_names(),
+    }
 
 
 def press_query_key(key_code: int, modifiers: int = 0, *, listener: Any = None) -> None:
@@ -842,6 +950,13 @@ def press_query_key(key_code: int, modifiers: int = 0, *, listener: Any = None) 
     _require_debug()
     sl = listener if listener is not None else send_listener()
     if sl is None:
+        # URP mock-sidebar: Enter/Esc on the slash popup run inside soffice.
+        if int(key_code) == 1280 and int(modifiers) == 0:
+            execute_debug_sidebar_op("SLASH_ENTER")
+            return
+        if int(key_code) == 1281:
+            execute_debug_sidebar_op("SLASH_ESC")
+            return
         raise RuntimeError("no live SendButtonListener")
     from plugin.chatbot.panel import QueryKeyListener
 

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -38,6 +38,8 @@ _LIVE_CHAT_PANELS: WeakSet[Any] = WeakSet()
 _LIVE_SEND_LISTENERS: list[Any] = []
 # Last native-test ctx so URP fallbacks can executeDispatch without get_ctx().
 _HOOK_CTX: Any = None
+# Out-of-process mock-sidebar: controller bound to the live XDL ListBox over URP.
+_URP_SLASH_POPUP: Any = None
 
 
 def register_live_panel(element: Any) -> None:
@@ -817,7 +819,11 @@ def set_query_text(text: str, *, listener: Any = None) -> None:
         controls = chat_dialog_controls(ctx, current_component(ctx)) or {}
         set_query_text_via_controls(controls, text)
         # QueryTextListener may not fire over URP setText; refresh inside soffice.
-        if (text or "").lstrip().startswith("/") or not (text or "").strip():
+        popup = ensure_slash_popup()
+        on_text = getattr(popup, "on_query_text", None) if popup is not None else None
+        if callable(on_text):
+            on_text(text or "")
+        elif (text or "").lstrip().startswith("/") or not (text or "").strip():
             execute_debug_sidebar_op("SLASH_REFRESH")
 
 
@@ -922,32 +928,84 @@ def _slash_key_in_soffice(sl: Any, key_code: int, modifiers: int) -> None:
     popup.handle_key(int(key_code), int(modifiers))
 
 
+class _UrpSlashHost:
+    """Stand-in SendButtonListener so the popup can run over URP without gc."""
+
+    def __init__(self, query: Any, response: Any, clear: Any, stop: Any) -> None:
+        self.query_control = query
+        self.response_control = response
+        self.slash_popup = None
+        self.clear_listener = type(
+            "ClearProxy",
+            (),
+            {"on_action_performed": staticmethod(lambda _ev: uno_click(clear) if clear is not None else None)},
+        )()
+        self._stop = stop
+
+    def dispatch(self, event: Any) -> None:
+        kind = getattr(event, "kind", None)
+        if kind == SendEventKind.STOP_CLICKED and self._stop is not None:
+            uno_click(self._stop)
+
+    def _append_response(self, text: str, role: str = "assistant") -> None:
+        from plugin.chatbot.dialogs import get_control_text, set_control_text
+
+        # ``role`` matches SendButtonListener._append_response (run_slash_command).
+        current = get_control_text(self.response_control, default="") or ""
+        set_control_text(self.response_control, current + ("" if role is None else text))
+
+
+def _urp_slash_controller() -> Any:
+    """Bind ``SlashPopupController`` to the live sidebar ListBox over URP."""
+    global _URP_SLASH_POPUP
+    ctx = _HOOK_CTX
+    if ctx is None:
+        return None
+    controls = chat_dialog_controls(ctx, current_component(ctx)) or {}
+    ctrl = controls.get("slash_popup")
+    query = controls.get("query")
+    if ctrl is None or query is None:
+        return None
+    existing = _URP_SLASH_POPUP
+    if existing is not None and getattr(existing, "control", None) is ctrl:
+        return existing
+    from plugin.chatbot.slash_popup import SlashPopupController
+
+    response = controls.get("response_rich") or controls.get("response")
+    host = _UrpSlashHost(query, response, controls.get("clear"), controls.get("stop"))
+    popup = SlashPopupController(ctrl, host, query)
+    host.slash_popup = popup
+    _URP_SLASH_POPUP = popup
+    return popup
+
+
 def ensure_slash_popup(*, listener: Any = None) -> Any:
     """Return the Ask-box slash controller, attaching it if the XDL ListBox exists.
 
     OXT factory and checkout tests can see different ``SendButtonListener``
     objects. Re-bind from the live ``slash_popup`` control so hooks can drive
     the menu even when the listener we found was not the one wiring attached.
+    Out-of-process mock-sidebar has no in-process listener; bind over URP.
     """
     _require_debug()
     sl = listener if listener is not None else send_listener()
-    if sl is None:
-        return None
-    popup = getattr(sl, "slash_popup", None)
-    if popup is not None:
-        return popup
-    ctrl = None
-    ctx = _HOOK_CTX
-    if ctx is not None:
-        controls = chat_dialog_controls(ctx, current_component(ctx)) or {}
-        ctrl = controls.get("slash_popup")
-    if ctrl is None:
-        return None
-    from plugin.chatbot.slash_popup import SlashPopupController
+    if sl is not None:
+        popup = getattr(sl, "slash_popup", None)
+        if popup is not None:
+            return popup
+        ctrl = None
+        ctx = _HOOK_CTX
+        if ctx is not None:
+            controls = chat_dialog_controls(ctx, current_component(ctx)) or {}
+            ctrl = controls.get("slash_popup")
+        if ctrl is None:
+            return _urp_slash_controller()
+        from plugin.chatbot.slash_popup import SlashPopupController
 
-    popup = SlashPopupController(ctrl, sl, getattr(sl, "query_control", None))
-    sl.slash_popup = popup
-    return popup
+        popup = SlashPopupController(ctrl, sl, getattr(sl, "query_control", None) or ctrl)
+        sl.slash_popup = popup
+        return popup
+    return _urp_slash_controller()
 
 
 def slash_popup_state(*, listener: Any = None) -> dict[str, Any]:
@@ -956,7 +1014,9 @@ def slash_popup_state(*, listener: Any = None) -> dict[str, Any]:
     sl = listener if listener is not None else send_listener()
     popup = getattr(sl, "slash_popup", None) if sl is not None else None
     if popup is None:
-        # Out-of-process mock-sidebar: checkout gc cannot see soffice's listener.
+        popup = ensure_slash_popup(listener=sl)
+    if popup is None:
+        # Last resort: in-soffice snapshot (listener lives only in soffice).
         return _slash_state_from_snapshot(execute_debug_sidebar_op("SNAPSHOT"))
     visible = bool(getattr(popup, "is_open", False))
     items = list(getattr(popup, "visible_names", None) or [])
@@ -983,7 +1043,10 @@ def press_query_key(key_code: int, modifiers: int = 0, *, listener: Any = None) 
     _require_debug()
     sl = listener if listener is not None else send_listener()
     if sl is None:
-        # URP mock-sidebar: Enter/Esc on the slash popup run inside soffice.
+        popup = ensure_slash_popup()
+        handle = getattr(popup, "handle_key", None) if popup is not None else None
+        if callable(handle) and handle(int(key_code), int(modifiers)) is True:
+            return
         if int(key_code) == 1280 and int(modifiers) == 0:
             execute_debug_sidebar_op("SLASH_ENTER")
             return

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -494,6 +494,9 @@ def send_listener(frame: Any = None) -> Any:
         sl = getattr(panel, "send_listener", None)
         if sl is not None:
             return sl
+    with_popup = [obj for obj in _LIVE_SEND_LISTENERS if getattr(obj, "slash_popup", None) is not None]
+    if with_popup:
+        return with_popup[-1]
     if _LIVE_SEND_LISTENERS:
         return _LIVE_SEND_LISTENERS[-1]
     return None
@@ -783,6 +786,34 @@ def query_text(*, listener: Any = None) -> str:
     from plugin.chatbot.dialogs import get_control_text
 
     return get_control_text(getattr(sl, "query_control", None), default="") or ""
+
+
+def ensure_slash_popup(*, listener: Any = None) -> Any:
+    """Return the Ask-box slash controller, attaching it if the XDL ListBox exists.
+
+    OXT factory and checkout tests can see different ``SendButtonListener``
+    objects. Re-bind from the live ``slash_popup`` control so hooks can drive
+    the menu even when the listener we found was not the one wiring attached.
+    """
+    _require_debug()
+    sl = listener if listener is not None else send_listener()
+    if sl is None:
+        return None
+    popup = getattr(sl, "slash_popup", None)
+    if popup is not None:
+        return popup
+    ctrl = None
+    ctx = _HOOK_CTX
+    if ctx is not None:
+        controls = chat_dialog_controls(ctx, current_component(ctx)) or {}
+        ctrl = controls.get("slash_popup")
+    if ctrl is None:
+        return None
+    from plugin.chatbot.slash_popup import SlashPopupController
+
+    popup = SlashPopupController(ctrl, sl, getattr(sl, "query_control", None))
+    sl.slash_popup = popup
+    return popup
 
 
 def slash_popup_state(*, listener: Any = None) -> dict[str, Any]:

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -810,12 +810,13 @@ def _slash_control_near_query(query: Any) -> Any:
             cur = getter()
         except Exception:
             continue
-        for unused in range(6):
-            if cur is None:
-                break
-            if hasattr(cur, "getControl"):
+        hops = 0
+        while cur is not None and hops < 6:
+            hops += 1
+            get_control = getattr(cur, "getControl", None)
+            if callable(get_control):
                 try:
-                    ctrl = cur.getControl("slash_popup")
+                    ctrl = get_control("slash_popup")
                 except Exception:
                     ctrl = None
                 if ctrl is not None:

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -966,9 +966,9 @@ def _urp_slash_controller() -> Any:
     query = controls.get("query")
     if ctrl is None or query is None:
         return None
-    existing = _URP_SLASH_POPUP
-    if existing is not None and getattr(existing, "control", None) is ctrl:
-        return existing
+    # URP getControl returns a new proxy each time; do not compare with ``is``.
+    if _URP_SLASH_POPUP is not None:
+        return _URP_SLASH_POPUP
     from plugin.chatbot.slash_popup import SlashPopupController
 
     response = controls.get("response_rich") or controls.get("response")

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -438,6 +438,7 @@ _CHAT_CONTROL_NAMES = (
     "status",
     "model_selector",
     "chat_mode_selector",
+    "slash_popup",
 )
 
 
@@ -763,6 +764,10 @@ def set_query_text(text: str, *, listener: Any = None) -> None:
         set_control_text(query, text)
         stripped = (text or "").strip()
         sl.dispatch(SendEvent(SendEventKind.TEXT_UPDATED, {"has_text": bool(stripped)}))
+        popup = getattr(sl, "slash_popup", None)
+        on_text = getattr(popup, "on_query_text", None) if popup is not None else None
+        if callable(on_text):
+            on_text(text or "")
         return
     ctx = _HOOK_CTX
     if ctx is not None:
@@ -778,6 +783,39 @@ def query_text(*, listener: Any = None) -> str:
     from plugin.chatbot.dialogs import get_control_text
 
     return get_control_text(getattr(sl, "query_control", None), default="") or ""
+
+
+def slash_popup_state(*, listener: Any = None) -> dict[str, Any]:
+    """Visible names and selection for the Ask-box slash completion menu."""
+    _require_debug()
+    sl = listener if listener is not None else send_listener()
+    popup = getattr(sl, "slash_popup", None) if sl is not None else None
+    if popup is None:
+        return {"visible": False, "items": [], "selected": None}
+    visible = bool(getattr(popup, "is_open", False))
+    items = list(getattr(popup, "visible_names", None) or [])
+    selected = getattr(popup, "selected_name", None)
+    if not items:
+        ctrl = getattr(popup, "control", None)
+        if ctrl is not None and hasattr(ctrl, "getItemCount"):
+            try:
+                count = int(ctrl.getItemCount() or 0)
+                items = [str(ctrl.getItem(i)) for i in range(count)]
+            except Exception:
+                items = []
+    return {"visible": visible, "items": items, "selected": selected}
+
+
+def press_query_key(key_code: int, modifiers: int = 0, *, listener: Any = None) -> None:
+    """Drive ``QueryKeyListener`` (Enter / Esc / arrows / Tab) on the Ask field."""
+    _require_debug()
+    sl = listener if listener is not None else send_listener()
+    if sl is None:
+        raise RuntimeError("no live SendButtonListener")
+    from plugin.chatbot.panel import QueryKeyListener
+
+    event = type("KeyEvent", (), {"KeyCode": int(key_code), "Modifiers": int(modifiers), "Consume": False})()
+    QueryKeyListener(sl).on_key_pressed(event)
 
 
 def transcript_text(*, listener: Any = None) -> str:

--- a/plugin/chatbot/slash_commands.py
+++ b/plugin/chatbot/slash_commands.py
@@ -1,0 +1,213 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Ask-box slash-command registry, prefix filter, and LRU ranking.
+
+The sidebar popup is UI-first: most names are stubs so Keith can pick the
+real set later. Ranking is prefix match, then ``slash_command_lru`` in
+``writeragent.json`` (empty filter and as a tie-break). Do not implement
+the consider-list in ``docs/chat/slash-commands.md`` here.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from plugin.framework.i18n import _
+
+log = logging.getLogger("writeragent.slash_commands")
+
+# Persist via the same LRU helper as model/prompt history (not a sidecar file).
+SLASH_LRU_KEY = "slash_command_lru"
+
+# com.sun.star.awt.Key — integers so unit tests need no soffice.
+KEY_DOWN = 1024
+KEY_UP = 1025
+KEY_RETURN = 1280
+KEY_ESCAPE = 1281
+KEY_TAB = 1282
+KEY_MODIFIER_SHIFT = 1
+
+
+@dataclass(frozen=True)
+class SlashCommand:
+    """One popup row. ``name`` is without the leading slash."""
+
+    name: str
+    description: str
+    kind: str  # "wired" | "mock"
+
+
+# Wired: /help /clear /stop. The rest exist so prefix + LRU tests do not
+# depend on future product commands. Consider-list names are tagged mock.
+SLASH_COMMANDS: tuple[SlashCommand, ...] = (
+    SlashCommand("help", _("Print the command list"), "wired"),
+    SlashCommand("clear", _("Start a new chat"), "wired"),
+    SlashCommand("stop", _("Cancel the in-flight send"), "wired"),
+    SlashCommand("mock-alpha", _("Mock command (echo only)"), "mock"),
+    SlashCommand("mock-bravo", _("Mock command (echo only)"), "mock"),
+    SlashCommand("mock-charlie", _("Mock command (echo only)"), "mock"),
+    SlashCommand("apply", _("Apply last draft (mock)"), "mock"),
+    SlashCommand("web", _("Web research (mock)"), "mock"),
+    SlashCommand("model", _("Switch model (mock)"), "mock"),
+)
+
+
+def slash_typed_prefix(text: str) -> str | None:
+    """Prefix after ``/`` for the first Ask-box token, or None if not a slash draft.
+
+    ``/`` → ``""`` (full list). ``/he`` → ``"he"``. ``hello`` → None.
+    """
+    stripped = (text or "").lstrip()
+    if not stripped.startswith("/"):
+        return None
+    first = stripped.split()[0]
+    return first[1:].lower()
+
+
+def filter_slash_commands(
+    typed: str,
+    lru: Sequence[str] | None = None,
+    commands: Sequence[SlashCommand] | None = None,
+) -> list[SlashCommand]:
+    """Prefix-filter ``commands`` and rank by LRU then registry order.
+
+    ``typed`` is raw Ask-box text (``/he``) or a bare prefix. Recently used
+    names float to the top when the filter is empty and as a tie-break
+    among equal prefix matches.
+    """
+    registry = tuple(commands) if commands is not None else SLASH_COMMANDS
+    prefix = slash_typed_prefix(typed)
+    if prefix is None:
+        if (typed or "").startswith("/"):
+            prefix = ""
+        elif typed:
+            # Allow unit tests to pass ``"he"`` without a leading slash.
+            prefix = typed.lower().lstrip("/")
+        else:
+            return []
+    matches = [cmd for cmd in registry if cmd.name.startswith(prefix)]
+    lru_names = [str(n).lstrip("/").lower() for n in (lru or ()) if str(n).strip()]
+    lru_index = {name: idx for idx, name in enumerate(lru_names)}
+    registry_index = {cmd.name: idx for idx, cmd in enumerate(registry)}
+    sentinel = len(lru_names) + 1
+
+    def _key(cmd: SlashCommand) -> tuple[int, int]:
+        return (lru_index.get(cmd.name, sentinel), registry_index.get(cmd.name, sentinel))
+
+    return sorted(matches, key=_key)
+
+
+def classify_slash_key(key_code: int, modifiers: int = 0) -> str | None:
+    """Map a UNO key event to a popup action, or None if the Ask box should keep it."""
+    if key_code == KEY_ESCAPE:
+        return "escape"
+    if key_code == KEY_UP:
+        return "up"
+    if key_code == KEY_DOWN:
+        return "down"
+    if key_code == KEY_TAB:
+        return "tab"
+    if key_code == KEY_RETURN and (modifiers & KEY_MODIFIER_SHIFT) == 0:
+        return "enter"
+    return None
+
+
+def format_slash_item(cmd: SlashCommand) -> str:
+    tag = " [mock]" if cmd.kind == "mock" else ""
+    return "/%s%s — %s" % (cmd.name, tag, cmd.description)
+
+
+def format_help_text(commands: Sequence[SlashCommand] | None = None) -> str:
+    rows = commands if commands is not None else SLASH_COMMANDS
+    lines = [_("Slash commands:")]
+    for cmd in rows:
+        lines.append("  " + format_slash_item(cmd))
+    return "\n".join(lines)
+
+
+def load_slash_lru() -> list[str]:
+    from plugin.framework.config import get_config
+
+    raw = get_config(SLASH_LRU_KEY)
+    if not isinstance(raw, list):
+        return []
+    return [str(item).lstrip("/").lower() for item in raw if str(item).strip()]
+
+
+def record_slash_lru(name: str) -> None:
+    from plugin.chatbot.config_ui_helpers import update_lru_history
+
+    clean = (name or "").lstrip("/").strip().lower()
+    if not clean:
+        return
+    update_lru_history(clean, SLASH_LRU_KEY, "")
+
+
+def _append_sidebar_line(host: Any, text: str) -> None:
+    append = getattr(host, "_append_response", None)
+    if callable(append):
+        append(text, role="assistant")
+        return
+    response = getattr(host, "response_control", None)
+    if response is None:
+        return
+    from plugin.chatbot.dialogs import get_control_text, set_control_text
+
+    current = get_control_text(response) or ""
+    set_control_text(response, current + text)
+
+
+def _clear_ask_box(host: Any) -> None:
+    from plugin.chatbot.dialogs import set_control_text
+    from plugin.chatbot.send_state import SendEvent, SendEventKind
+
+    query = getattr(host, "query_control", None)
+    set_control_text(query, "")
+    dispatch = getattr(host, "dispatch", None)
+    if callable(dispatch):
+        dispatch(SendEvent(SendEventKind.TEXT_UPDATED, {"has_text": False}))
+
+
+def run_slash_command(name: str, host: Any) -> bool:
+    """Run a registry command on the live send listener. Not a chat turn.
+
+    Mocks echo ``slash: /name`` so the popup can be exercised. ``/help``
+    prints the static list. ``/clear`` uses ClearButtonListener. ``/stop``
+    is the same one-liner as the Stop button (``STOP_CLICKED``).
+    """
+    clean = (name or "").lstrip("/").strip().lower()
+    cmd = next((item for item in SLASH_COMMANDS if item.name == clean), None)
+    if cmd is None:
+        return False
+    record_slash_lru(cmd.name)
+    popup = getattr(host, "slash_popup", None)
+    hide = getattr(popup, "hide", None)
+    if callable(hide):
+        hide()
+    _clear_ask_box(host)
+    if cmd.name == "help":
+        _append_sidebar_line(host, "\n" + format_help_text() + "\n")
+        return True
+    if cmd.name == "clear":
+        clear_listener = getattr(host, "clear_listener", None)
+        action = getattr(clear_listener, "on_action_performed", None)
+        if callable(action):
+            action(None)
+        else:
+            session = getattr(host, "session", None)
+            if session is not None and hasattr(session, "clear"):
+                session.clear()
+        return True
+    if cmd.name == "stop":
+        from plugin.chatbot.send_state import SendEvent, SendEventKind
+
+        dispatch = getattr(host, "dispatch", None)
+        if callable(dispatch):
+            dispatch(SendEvent(SendEventKind.STOP_CLICKED))
+        return True
+    _append_sidebar_line(host, "\nslash: /%s\n" % cmd.name)
+    return True

--- a/plugin/chatbot/slash_popup.py
+++ b/plugin/chatbot/slash_popup.py
@@ -1,0 +1,210 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Steerable slash-command completion menu attached to the sidebar Ask field.
+
+A native ``PopupMenu`` is modal — the user could not keep typing. This is a
+hidden XDL ``menulist`` shown just above (or below) the query field, updated
+from ``QueryTextListener`` as they type.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from plugin.chatbot.dialogs import set_control_text, set_control_visible
+from plugin.chatbot.slash_commands import (
+    SLASH_COMMANDS,
+    SlashCommand,
+    classify_slash_key,
+    filter_slash_commands,
+    format_slash_item,
+    load_slash_lru,
+    run_slash_command,
+    slash_typed_prefix,
+)
+from plugin.framework.errors import suppress_disposed
+
+log = logging.getLogger("writeragent.slash_popup")
+
+_POPUP_MAX_ROWS = 6
+_POPUP_ROW_PX = 12
+_POS_SIZE_FLAGS = 15  # X + Y + WIDTH + HEIGHT
+
+
+class SlashPopupController:
+    """Show, filter, and accept slash commands on the Ask-field ListBox."""
+
+    def __init__(self, control: Any, send_listener: Any, query_control: Any) -> None:
+        self.control = control
+        self.send_listener = send_listener
+        self.query_control = query_control
+        self._open = False
+        self._matches: list[SlashCommand] = []
+        self._selected = 0
+        self.hide()
+        self._attach_click()
+
+    @property
+    def is_open(self) -> bool:
+        return self._open
+
+    @property
+    def visible_names(self) -> list[str]:
+        return [cmd.name for cmd in self._matches]
+
+    @property
+    def selected_name(self) -> str | None:
+        if not self._matches or not (0 <= self._selected < len(self._matches)):
+            return None
+        return self._matches[self._selected].name
+
+    def hide(self) -> None:
+        self._open = False
+        self._matches = []
+        self._selected = 0
+        set_control_visible(self.control, False)
+
+    def on_query_text(self, text: str) -> None:
+        """Open or narrow the popup from the current Ask-box contents."""
+        if slash_typed_prefix(text) is None:
+            self.hide()
+            return
+        matches = filter_slash_commands(text, load_slash_lru(), SLASH_COMMANDS)
+        if not matches:
+            self.hide()
+            return
+        self._matches = matches
+        self._selected = 0
+        self._refresh_list()
+        self._open = True
+        self.reposition()
+        set_control_visible(self.control, True)
+
+    def handle_key(self, key_code: int, modifiers: int = 0) -> bool:
+        """True when the popup consumed the key (do not Send / insert newline)."""
+        if not self._open:
+            return False
+        action = classify_slash_key(key_code, modifiers)
+        if action is None:
+            return False
+        if action == "escape":
+            self.hide()
+            return True
+        if action == "up":
+            self.move_selection(-1)
+            return True
+        if action == "down":
+            self.move_selection(1)
+            return True
+        if action == "tab":
+            self.complete_selected()
+            return True
+        if action == "enter":
+            self.accept_selected()
+            return True
+        return False
+
+    def move_selection(self, delta: int) -> None:
+        if not self._matches:
+            return
+        self._selected = (self._selected + delta) % len(self._matches)
+        self._select_row(self._selected)
+
+    def complete_selected(self) -> None:
+        name = self.selected_name
+        if not name:
+            return
+        set_control_text(self.query_control, "/" + name)
+        self.on_query_text("/" + name)
+
+    def accept_selected(self) -> None:
+        name = self._selected_name_from_control()
+        if not name:
+            return
+        run_slash_command(name, self.send_listener)
+
+    def reposition(self) -> None:
+        """Park the list just above the Ask field; fall back below if no room."""
+        query = self.query_control
+        ctrl = self.control
+        if query is None or ctrl is None or not hasattr(query, "getPosSize"):
+            return
+        with suppress_disposed("slash popup reposition", logger=log):
+            qr = query.getPosSize()
+            rows = min(len(self._matches) or 1, _POPUP_MAX_ROWS)
+            height = max(24, rows * _POPUP_ROW_PX + 6)
+            above_y = int(qr.Y) - height - 2
+            y = above_y if above_y >= 16 else int(qr.Y) + int(qr.Height) + 2
+            ctrl.setPosSize(int(qr.X), y, int(qr.Width), height, _POS_SIZE_FLAGS)
+
+    def _selected_name_from_control(self) -> str | None:
+        ctrl = self.control
+        if ctrl is not None and hasattr(ctrl, "getSelectedItemPos"):
+            try:
+                pos = int(ctrl.getSelectedItemPos())
+                if 0 <= pos < len(self._matches):
+                    self._selected = pos
+            except Exception:
+                pass
+        return self.selected_name
+
+    def _refresh_list(self) -> None:
+        ctrl = self.control
+        if ctrl is None:
+            return
+        labels = tuple(format_slash_item(cmd) for cmd in self._matches)
+        with suppress_disposed("slash popup refresh", logger=log):
+            if hasattr(ctrl, "getItemCount") and hasattr(ctrl, "removeItems"):
+                count = int(ctrl.getItemCount() or 0)
+                if count:
+                    ctrl.removeItems(0, count)
+            if labels and hasattr(ctrl, "addItems"):
+                ctrl.addItems(labels, 0)
+            self._select_row(0)
+
+    def _select_row(self, idx: int) -> None:
+        ctrl = self.control
+        if ctrl is None or not self._matches:
+            return
+        idx = max(0, min(idx, len(self._matches) - 1))
+        self._selected = idx
+        if hasattr(ctrl, "selectItemPos"):
+            with suppress_disposed("slash popup select", logger=log):
+                ctrl.selectItemPos(idx, True)
+
+    def _attach_click(self) -> None:
+        ctrl = self.control
+        if ctrl is None or not hasattr(ctrl, "addMouseListener"):
+            return
+        try:
+            import unohelper
+            from com.sun.star.awt import XMouseListener
+        except ImportError:
+            return
+
+        host = self
+
+        class _Click(unohelper.Base, XMouseListener):  # type: ignore[misc]
+            def disposing(self, Source):  # noqa: N802, N803 -- UNO signature
+                return
+
+            def mousePressed(self, e):  # noqa: N802 -- UNO signature
+                return
+
+            def mouseReleased(self, e):  # noqa: N802 -- UNO signature
+                if host.is_open:
+                    host.accept_selected()
+
+            def mouseEntered(self, e):  # noqa: N802 -- UNO signature
+                return
+
+            def mouseExited(self, e):  # noqa: N802 -- UNO signature
+                return
+
+        try:
+            ctrl.addMouseListener(_Click())
+        except Exception:
+            log.debug("slash popup mouse listener attach failed", exc_info=True)

--- a/plugin/chatbot/slash_popup.py
+++ b/plugin/chatbot/slash_popup.py
@@ -4,9 +4,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Steerable slash-command completion menu attached to the sidebar Ask field.
 
-A native ``PopupMenu`` is modal — the user could not keep typing. This is a
-hidden XDL ``menulist`` shown just above (or below) the query field, updated
-from ``QueryTextListener`` as they type.
+A native ``PopupMenu`` is modal — the user could not keep typing. The XDL
+placeholder is ``dlg:menulist`` (LibreOffice dialog.dtd has no ``listbox``;
+a ``listbox`` tag can crash the sidebar). That control is a ComboBox — one
+line plus a dropdown — so it does not look like a completion menu. This
+controller inserts a real ``UnoControlListBox`` on the dialog and parks it
+just above (or below) the Ask field while the user types.
 """
 
 from __future__ import annotations
@@ -30,17 +33,102 @@ from plugin.framework.errors import suppress_disposed
 log = logging.getLogger("writeragent.slash_popup")
 
 _POPUP_MAX_ROWS = 6
-_POPUP_ROW_PX = 12
+_POPUP_ROW_PX = 14
 _POS_SIZE_FLAGS = 15  # X + Y + WIDTH + HEIGHT
+_RUNTIME_LIST_NAME = "slash_popup_list"
+
+
+def _supported_services(ctrl: Any) -> str:
+    try:
+        model = ctrl.getModel() if ctrl is not None else None
+        if model is not None and hasattr(model, "getSupportedServiceNames"):
+            return " ".join(str(s) for s in model.getSupportedServiceNames())
+    except Exception:
+        return ""
+    return ""
+
+
+def _is_combo_box(ctrl: Any) -> bool:
+    """True for the XDL ``menulist`` placeholder (ComboBox), not a ListBox."""
+    names = _supported_services(ctrl)
+    return "ComboBox" in names or "UnoControlComboBox" in names
+
+
+def _dialog_for(ctrl: Any) -> Any:
+    cur = ctrl
+    hops = 0
+    while cur is not None and hops < 8:
+        hops += 1
+        if hasattr(cur, "getModel") and hasattr(cur, "getControl"):
+            model = None
+            try:
+                model = cur.getModel()
+            except Exception:
+                model = None
+            if model is not None and hasattr(model, "insertByName"):
+                return cur
+        getter = getattr(cur, "getContext", None) or getattr(cur, "getPeer", None)
+        try:
+            cur = getter() if callable(getter) else None
+        except Exception:
+            return None
+    return None
+
+
+def _ensure_listbox(control: Any, query_control: Any) -> Any:
+    """Replace the XDL ComboBox placeholder with a multi-row ListBox."""
+    if control is not None and not _is_combo_box(control):
+        return control
+    dlg = _dialog_for(query_control) or _dialog_for(control)
+    if dlg is None:
+        log.warning("slash popup: no dialog to insert ListBox; using XDL control")
+        return control
+    try:
+        if hasattr(dlg, "getControl"):
+            existing = dlg.getControl(_RUNTIME_LIST_NAME)
+            if existing is not None:
+                set_control_visible(control, False)
+                return existing
+    except Exception:
+        existing = None
+    model = dlg.getModel()
+    list_model = model.createInstance("com.sun.star.awt.UnoControlListBoxModel")
+    list_model.Name = _RUNTIME_LIST_NAME
+    list_model.Dropdown = False
+    list_model.Tabstop = False
+    list_model.Border = 1
+    try:
+        list_model.MultiSelection = False
+    except Exception:
+        pass
+    qr = query_control.getPosSize() if query_control is not None and hasattr(query_control, "getPosSize") else None
+    if qr is not None:
+        list_model.PositionX = int(qr.X)
+        list_model.PositionY = max(16, int(qr.Y) - 90)
+        list_model.Width = int(qr.Width)
+        list_model.Height = 80
+    else:
+        list_model.PositionX = 4
+        list_model.PositionY = 80
+        list_model.Width = 142
+        list_model.Height = 60
+    model.insertByName(_RUNTIME_LIST_NAME, list_model)
+    created = dlg.getControl(_RUNTIME_LIST_NAME)
+    if created is None:
+        log.warning("slash popup: ListBox insertByName succeeded but getControl is None")
+        return control
+    set_control_visible(control, False)
+    log.info("slash popup: runtime ListBox attached (XDL menulist is ComboBox)")
+    return created
 
 
 class SlashPopupController:
     """Show, filter, and accept slash commands on the Ask-field ListBox."""
 
     def __init__(self, control: Any, send_listener: Any, query_control: Any) -> None:
-        self.control = control
-        self.send_listener = send_listener
         self.query_control = query_control
+        self.send_listener = send_listener
+        self.control = _ensure_listbox(control, query_control)
         self._open = False
         self._matches: list[SlashCommand] = []
         self._selected = 0

--- a/plugin/chatbot/slash_popup.py
+++ b/plugin/chatbot/slash_popup.py
@@ -135,6 +135,7 @@ class SlashPopupController:
         self._selected = 0
         self.hide()
         self._attach_click()
+        self._attach_keys()
 
     @property
     def is_open(self) -> bool:
@@ -171,6 +172,11 @@ class SlashPopupController:
         self._open = True
         self.reposition()
         set_control_visible(self.control, True)
+        # ListBox can steal focus; Esc/arrows must stay on the Ask field.
+        set_focus = getattr(self.query_control, "setFocus", None)
+        if callable(set_focus):
+            with suppress_disposed("slash popup return focus", logger=log):
+                set_focus()
 
     def handle_key(self, key_code: int, modifiers: int = 0) -> bool:
         """True when the popup consumed the key (do not Send / insert newline)."""
@@ -297,3 +303,35 @@ class SlashPopupController:
             ctrl.addMouseListener(_Click())
         except Exception:
             log.debug("slash popup mouse listener attach failed", exc_info=True)
+
+    def _attach_keys(self) -> None:
+        """Forward Esc/Enter/arrows when the ListBox stole focus from Ask."""
+        ctrl = self.control
+        if ctrl is None or not hasattr(ctrl, "addKeyListener"):
+            return
+        try:
+            import unohelper
+            from com.sun.star.awt import XKeyListener
+        except ImportError:
+            return
+
+        host = self
+
+        class _Keys(unohelper.Base, XKeyListener):  # type: ignore[misc]
+            def disposing(self, Source):  # noqa: N802, N803 -- UNO signature
+                return
+
+            def keyPressed(self, e):  # noqa: N802 -- UNO signature
+                if host.handle_key(int(getattr(e, "KeyCode", 0) or 0), int(getattr(e, "Modifiers", 0) or 0)):
+                    with suppress_disposed("slash list Consume", logger=log):
+                        if hasattr(e, "Consume"):
+                            setattr(e, "Consume", True)
+                return
+
+            def keyReleased(self, e):  # noqa: N802 -- UNO signature
+                return
+
+        try:
+            ctrl.addKeyListener(_Keys())
+        except Exception:
+            log.debug("slash popup key listener attach failed", exc_info=True)

--- a/plugin/chatbot/slash_popup.py
+++ b/plugin/chatbot/slash_popup.py
@@ -59,10 +59,11 @@ def _dialog_for(ctrl: Any) -> Any:
     hops = 0
     while cur is not None and hops < 8:
         hops += 1
-        if hasattr(cur, "getModel") and hasattr(cur, "getControl"):
+        get_model = getattr(cur, "getModel", None)
+        if callable(get_model) and hasattr(cur, "getControl"):
             model = None
             try:
-                model = cur.getModel()
+                model = get_model()
             except Exception:
                 model = None
             if model is not None and hasattr(model, "insertByName"):

--- a/plugin/framework/config_schema.py
+++ b/plugin/framework/config_schema.py
@@ -101,7 +101,7 @@ set_manifest_modules(_DEFAULT_MODULES)
 
 
 # Keys used by populate_combobox_with_lru / update_lru_history (including endpoint-scoped "name@url").
-_LRU_LIST_CONFIG_KEY_PREFIXES: frozenset[str] = frozenset({"model_lru", "prompt_lru", "image_model_lru", "audio_model_lru", "endpoint_lru", "image_base_size_lru"})
+_LRU_LIST_CONFIG_KEY_PREFIXES: frozenset[str] = frozenset({"model_lru", "prompt_lru", "image_model_lru", "audio_model_lru", "endpoint_lru", "image_base_size_lru", "slash_command_lru"})
 
 
 @deal.post(lambda result: isinstance(result, bool))

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -2281,15 +2281,21 @@ def test_g29_native_400_then_stt_same_drain(ctx):
 
 def _slash_prep():
     """Clear Ask + LRU. Skip if this soffice still has a pre-popup OXT."""
-    from plugin.chatbot.sidebar_test_hooks import send_listener, set_query_text
+    from plugin.chatbot.sidebar_test_hooks import (
+        adopt_runtime_send_listeners,
+        ensure_slash_popup,
+        send_listener,
+        set_query_text,
+    )
     from plugin.framework.config import set_config
 
+    adopt_runtime_send_listeners()
     sl = getattr(_session, "listener", None) or send_listener()
-    popup = getattr(sl, "slash_popup", None) if sl is not None else None
+    popup = ensure_slash_popup(listener=sl)
     if sl is None or popup is None:
         raise unittest.SkipTest(
-            "slash popup not on live SendButtonListener — deploy the Ask-field "
-            "ListBox OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run."
+            "slash popup ListBox not on the live chat dialog — deploy the "
+            "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run."
         )
     set_config("slash_command_lru", [])
     set_query_text("", listener=sl)

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -2279,99 +2279,123 @@ def test_g29_native_400_then_stt_same_drain(ctx):
 # --- Slash-command Ask-box popup (UI-first; isolates from Packet G audio) ---
 
 
+def _slash_state(listener=None):
+    """Popup rows from the in-process controller or the URP debug snapshot."""
+    from plugin.chatbot.sidebar_test_hooks import slash_popup_state
+
+    return slash_popup_state(listener=listener)
+
+
+def _slash_type(text, listener=None):
+    """Set Ask text and refresh the slash popup (URP-safe)."""
+    from plugin.chatbot.sidebar_test_hooks import (
+        execute_debug_sidebar_op,
+        set_query_text,
+        set_query_text_via_controls,
+    )
+
+    if listener is not None:
+        set_query_text(text, listener=listener)
+        return _slash_state(listener)
+    controls = getattr(_session, "controls", None) or {}
+    set_query_text_via_controls(controls, text)
+    execute_debug_sidebar_op("SLASH_REFRESH")
+    return _slash_state()
+
+
+def _slash_key(key_code, listener=None):
+    from plugin.chatbot.sidebar_test_hooks import press_query_key
+
+    press_query_key(key_code, listener=listener)
+    return _slash_state(listener)
+
+
 def _slash_prep():
-    """Clear Ask + LRU. Skip if this soffice still has a pre-popup OXT."""
+    """Clear Ask + LRU. Isolated from Packet G. Works in-process or over URP."""
     from plugin.chatbot.sidebar_test_hooks import (
         adopt_runtime_send_listeners,
         ensure_slash_popup,
         send_listener,
-        set_query_text,
+        uno_click,
     )
     from plugin.framework.config import set_config
 
     adopt_runtime_send_listeners()
     sl = getattr(_session, "listener", None) or send_listener()
-    popup = ensure_slash_popup(listener=sl)
-    if sl is None or popup is None:
+    set_config("slash_command_lru", [])
+    controls = getattr(_session, "controls", None) or {}
+    clear = controls.get("clear")
+    if clear is not None:
+        uno_click(clear)
+    if sl is not None:
+        popup = ensure_slash_popup(listener=sl)
+        if popup is None:
+            raise unittest.SkipTest(
+                "slash popup ListBox not on the live chat dialog — deploy the "
+                "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run."
+            )
+        _slash_type("", sl)
+        if popup.is_open:
+            popup.hide()
+        return sl
+    state = _slash_type("")
+    if not state.get("available"):
         raise unittest.SkipTest(
             "slash popup ListBox not on the live chat dialog — deploy the "
             "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run."
         )
-    set_config("slash_command_lru", [])
-    set_query_text("", listener=sl)
-    if popup.is_open:
-        popup.hide()
-    return sl
+    return None
 
 
 @native_test
 def test_slash_popup_opens_on_slash(ctx):
-    from plugin.chatbot.sidebar_test_hooks import set_query_text, slash_popup_state
-
     sl = _slash_prep()
-    set_query_text("/", listener=sl)
-    state = slash_popup_state(listener=sl)
+    state = _slash_type("/", sl)
     assert state["visible"], "typing / should show the slash popup: %r" % state
     assert "help" in state["items"], state
     assert "mock-alpha" in state["items"], state
-    set_query_text("", listener=sl)
+    _slash_type("", sl)
 
 
 @native_test
 def test_slash_popup_he_selects_help_and_enter_accepts(ctx):
-    from plugin.chatbot.sidebar_test_hooks import (
-        press_query_key,
-        query_text,
-        set_query_text,
-        slash_popup_state,
-        transcript_text,
-    )
     from plugin.chatbot.slash_commands import KEY_RETURN
 
     sl = _slash_prep()
-    before = transcript_text(listener=sl)
-    set_query_text("/he", listener=sl)
-    state = slash_popup_state(listener=sl)
+    before = _transcript()
+    state = _slash_type("/he", sl)
     assert state["visible"], state
     assert state["selected"] == "help", state
-    press_query_key(KEY_RETURN, listener=sl)
-    after = slash_popup_state(listener=sl)
+    after = _slash_key(KEY_RETURN, sl)
     assert after["visible"] is False, after
-    assert query_text(listener=sl).strip() == "", query_text(listener=sl)
-    body = transcript_text(listener=sl)
+    assert _query_box_text().strip() == "", _query_box_text()
+    body = _transcript()
     suffix = body[len(before) :] if body.startswith(before) else body
     assert "Slash commands:" in suffix or "/help" in suffix, body[-500:]
 
 
 @native_test
 def test_slash_popup_esc_dismisses(ctx):
-    from plugin.chatbot.sidebar_test_hooks import press_query_key, set_query_text, slash_popup_state
     from plugin.chatbot.slash_commands import KEY_ESCAPE
 
     sl = _slash_prep()
-    set_query_text("/", listener=sl)
-    assert slash_popup_state(listener=sl)["visible"]
-    press_query_key(KEY_ESCAPE, listener=sl)
-    assert slash_popup_state(listener=sl)["visible"] is False
-    set_query_text("", listener=sl)
+    assert _slash_type("/", sl)["visible"]
+    assert _slash_key(KEY_ESCAPE, sl)["visible"] is False
+    _slash_type("", sl)
 
 
 @native_test
 def test_slash_popup_mock_records_lru(ctx):
-    from plugin.chatbot.sidebar_test_hooks import press_query_key, set_query_text, slash_popup_state
     from plugin.chatbot.slash_commands import KEY_RETURN
-    from plugin.framework.config import get_config
 
     sl = _slash_prep()
-    set_query_text("/mock-bravo", listener=sl)
-    state = slash_popup_state(listener=sl)
+    state = _slash_type("/mock-bravo", sl)
     assert state["selected"] == "mock-bravo", state
-    press_query_key(KEY_RETURN, listener=sl)
-    lru = get_config("slash_command_lru")
-    assert isinstance(lru, list) and lru and lru[0] == "mock-bravo", lru
-    set_query_text("/", listener=sl)
-    ranked = slash_popup_state(listener=sl)
+    after = _slash_key(KEY_RETURN, sl)
+    lru = list(after.get("lru") or [])
+    assert lru and lru[0] == "mock-bravo", after
+    ranked = _slash_type("/", sl)
     assert ranked["visible"], ranked
     assert ranked["items"][0] == "mock-bravo", ranked
-    set_query_text("", listener=sl)
+    _slash_type("", sl)
 

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -2275,3 +2275,97 @@ def test_g29_native_400_then_stt_same_drain(ctx):
         time.sleep(2.1)
     _hello_ok()
 
+
+# --- Slash-command Ask-box popup (UI-first; isolates from Packet G audio) ---
+
+
+def _slash_prep():
+    """Clear Ask + LRU. Skip if this soffice still has a pre-popup OXT."""
+    from plugin.chatbot.sidebar_test_hooks import send_listener, set_query_text
+    from plugin.framework.config import set_config
+
+    sl = getattr(_session, "listener", None) or send_listener()
+    popup = getattr(sl, "slash_popup", None) if sl is not None else None
+    if sl is None or popup is None:
+        raise unittest.SkipTest(
+            "slash popup not on live SendButtonListener — deploy the Ask-field "
+            "ListBox OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run."
+        )
+    set_config("slash_command_lru", [])
+    set_query_text("", listener=sl)
+    if popup.is_open:
+        popup.hide()
+    return sl
+
+
+@native_test
+def test_slash_popup_opens_on_slash(ctx):
+    from plugin.chatbot.sidebar_test_hooks import set_query_text, slash_popup_state
+
+    sl = _slash_prep()
+    set_query_text("/", listener=sl)
+    state = slash_popup_state(listener=sl)
+    assert state["visible"], "typing / should show the slash popup: %r" % state
+    assert "help" in state["items"], state
+    assert "mock-alpha" in state["items"], state
+    set_query_text("", listener=sl)
+
+
+@native_test
+def test_slash_popup_he_selects_help_and_enter_accepts(ctx):
+    from plugin.chatbot.sidebar_test_hooks import (
+        press_query_key,
+        query_text,
+        set_query_text,
+        slash_popup_state,
+        transcript_text,
+    )
+    from plugin.chatbot.slash_commands import KEY_RETURN
+
+    sl = _slash_prep()
+    before = transcript_text(listener=sl)
+    set_query_text("/he", listener=sl)
+    state = slash_popup_state(listener=sl)
+    assert state["visible"], state
+    assert state["selected"] == "help", state
+    press_query_key(KEY_RETURN, listener=sl)
+    after = slash_popup_state(listener=sl)
+    assert after["visible"] is False, after
+    assert query_text(listener=sl).strip() == "", query_text(listener=sl)
+    body = transcript_text(listener=sl)
+    suffix = body[len(before) :] if body.startswith(before) else body
+    assert "Slash commands:" in suffix or "/help" in suffix, body[-500:]
+
+
+@native_test
+def test_slash_popup_esc_dismisses(ctx):
+    from plugin.chatbot.sidebar_test_hooks import press_query_key, set_query_text, slash_popup_state
+    from plugin.chatbot.slash_commands import KEY_ESCAPE
+
+    sl = _slash_prep()
+    set_query_text("/", listener=sl)
+    assert slash_popup_state(listener=sl)["visible"]
+    press_query_key(KEY_ESCAPE, listener=sl)
+    assert slash_popup_state(listener=sl)["visible"] is False
+    set_query_text("", listener=sl)
+
+
+@native_test
+def test_slash_popup_mock_records_lru(ctx):
+    from plugin.chatbot.sidebar_test_hooks import press_query_key, set_query_text, slash_popup_state
+    from plugin.chatbot.slash_commands import KEY_RETURN
+    from plugin.framework.config import get_config
+
+    sl = _slash_prep()
+    set_query_text("/mock-bravo", listener=sl)
+    state = slash_popup_state(listener=sl)
+    assert state["selected"] == "mock-bravo", state
+    press_query_key(KEY_RETURN, listener=sl)
+    lru = get_config("slash_command_lru")
+    assert isinstance(lru, list) and lru and lru[0] == "mock-bravo", lru
+    set_query_text("/", listener=sl)
+    ranked = slash_popup_state(listener=sl)
+    assert ranked["visible"], ranked
+    assert ranked["items"][0] == "mock-bravo", ranked
+    set_query_text("", listener=sl)
+

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -2342,7 +2342,9 @@ def _slash_prep():
     if not state.get("available"):
         raise unittest.SkipTest(
             "slash popup ListBox not on the live chat dialog — deploy the "
-            "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run."
+            "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run. "
+            "snapshot=%r controls=%s"
+            % (state, sorted((getattr(_session, "controls", None) or {}).keys()))
         )
     return None
 

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -2339,14 +2339,22 @@ def _slash_prep():
             popup.hide()
         return sl
     state = _slash_type("")
-    if not state.get("available"):
-        raise unittest.SkipTest(
-            "slash popup ListBox not on the live chat dialog — deploy the "
-            "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run. "
-            "snapshot=%r controls=%s"
-            % (state, sorted((getattr(_session, "controls", None) or {}).keys()))
+    if state.get("available"):
+        return None
+    # The ListBox is on the live dialog (URP can see it). Do not skip — the
+    # in-soffice listener should have been attached during panel wiring.
+    if "slash_popup" in controls:
+        raise AssertionError(
+            "slash_popup control is on the chat dialog but the in-soffice "
+            "snapshot has no controller. snapshot=%r"
+            % (state,)
         )
-    return None
+    raise unittest.SkipTest(
+        "slash popup ListBox not on the live chat dialog — deploy the "
+        "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run. "
+        "snapshot=%r controls=%s"
+        % (state, sorted(controls.keys()))
+    )
 
 
 @native_test

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -2288,19 +2288,10 @@ def _slash_state(listener=None):
 
 def _slash_type(text, listener=None):
     """Set Ask text and refresh the slash popup (URP-safe)."""
-    from plugin.chatbot.sidebar_test_hooks import (
-        execute_debug_sidebar_op,
-        set_query_text,
-        set_query_text_via_controls,
-    )
+    from plugin.chatbot.sidebar_test_hooks import set_query_text
 
-    if listener is not None:
-        set_query_text(text, listener=listener)
-        return _slash_state(listener)
-    controls = getattr(_session, "controls", None) or {}
-    set_query_text_via_controls(controls, text)
-    execute_debug_sidebar_op("SLASH_REFRESH")
-    return _slash_state()
+    set_query_text(text, listener=listener)
+    return _slash_state(listener)
 
 
 def _slash_key(key_code, listener=None):
@@ -2327,34 +2318,17 @@ def _slash_prep():
     clear = controls.get("clear")
     if clear is not None:
         uno_click(clear)
-    if sl is not None:
-        popup = ensure_slash_popup(listener=sl)
-        if popup is None:
-            raise unittest.SkipTest(
-                "slash popup ListBox not on the live chat dialog — deploy the "
-                "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run."
-            )
-        _slash_type("", sl)
-        if popup.is_open:
-            popup.hide()
-        return sl
-    state = _slash_type("")
-    if state.get("available"):
-        return None
-    # The ListBox is on the live dialog (URP can see it). Do not skip — the
-    # in-soffice listener should have been attached during panel wiring.
-    if "slash_popup" in controls:
-        raise AssertionError(
-            "slash_popup control is on the chat dialog but the in-soffice "
-            "snapshot has no controller. snapshot=%r"
-            % (state,)
+    popup = ensure_slash_popup(listener=sl)
+    if popup is None:
+        raise unittest.SkipTest(
+            "slash popup ListBox not on the live chat dialog — deploy the "
+            "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run. "
+            "controls=%s" % (sorted(controls.keys()),)
         )
-    raise unittest.SkipTest(
-        "slash popup ListBox not on the live chat dialog — deploy the "
-        "Ask-field OXT (ChatPanelDialog slash_popup). Pure filter/LRU tests still run. "
-        "snapshot=%r controls=%s"
-        % (state, sorted(controls.keys()))
-    )
+    _slash_type("", sl)
+    if popup.is_open:
+        popup.hide()
+    return sl
 
 
 @native_test

--- a/tests/chatbot/test_panel.py
+++ b/tests/chatbot/test_panel.py
@@ -231,6 +231,15 @@ class QueryKeyListenerDisposeTests(unittest.TestCase):
             listener.on_key_pressed(event)
         send_listener.on_action_performed.assert_called_once_with(event)
 
+    def test_open_slash_popup_enter_does_not_send(self) -> None:
+        send_listener = MagicMock()
+        send_listener.slash_popup.handle_key.return_value = True
+        listener = QueryKeyListener(send_listener)
+        event = type("KeyEvent", (), {"KeyCode": 1280, "Modifiers": 0, "Consume": False})()
+        listener.on_key_pressed(event)
+        send_listener.on_action_performed.assert_not_called()
+        self.assertTrue(event.Consume)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/chatbot/test_panel_resize.py
+++ b/tests/chatbot/test_panel_resize.py
@@ -169,6 +169,13 @@ class TestPanelResizeListenerIntegration:
         assert rh == expected["response"].height
         assert rich.getPosSize().Height == rh - 16
 
+    def test_slash_popup_overlay_is_not_laid_out(self):
+        snapshot = _xdl_snapshot()
+        snapshot["slash_popup"] = (4, 80, 142, 60)
+        layouts = compute_chat_panel_layout(900, 500, snapshot)
+        assert "slash_popup" not in layouts
+        assert "query" in layouts
+
     def test_narrow_panel_stretches_response_to_margin(self):
         layouts = compute_chat_panel_layout(180, 500, _xdl_snapshot())
         response = layouts["response"]

--- a/tests/chatbot/test_sidebar_test_hooks.py
+++ b/tests/chatbot/test_sidebar_test_hooks.py
@@ -28,6 +28,7 @@ from plugin.chatbot.sidebar_test_hooks import (
     chat_dialog_controls,
     control_enabled,
     debug_hooks_available,
+    ensure_slash_popup,
     fire_audio_auto_stop,
     inject_wav,
     iter_live_chat_panels,
@@ -226,6 +227,13 @@ def test_slash_popup_hooks_read_state_and_consume_enter(fake_listener: _FakeList
     assert state["available"] is True
     press_query_key(1280, listener=fake_listener)
     assert not any(isinstance(e, tuple) and e and e[0] == "action" for e in fake_listener.events)
+
+
+def test_ensure_slash_popup_none_without_ctx_or_listener(monkeypatch) -> None:
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks._HOOK_CTX", None)
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.send_listener", lambda frame=None: None)
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks._URP_SLASH_POPUP", None)
+    assert ensure_slash_popup() is None
 
 
 def test_press_send_uses_on_action_performed(fake_listener: _FakeListener) -> None:

--- a/tests/chatbot/test_sidebar_test_hooks.py
+++ b/tests/chatbot/test_sidebar_test_hooks.py
@@ -34,6 +34,7 @@ from plugin.chatbot.sidebar_test_hooks import (
     unregister_live_panel,
     press_accept,
     press_change,
+    press_query_key,
     press_record,
     press_reject,
     press_send,
@@ -49,6 +50,7 @@ from plugin.chatbot.sidebar_test_hooks import (
     sidebar_deck_names,
     sidebar_panel,
     sidebar_provider,
+    slash_popup_state,
     stub_recorder_child,
     transcript_contains,
     transcript_text,
@@ -207,6 +209,19 @@ def test_set_query_text_dispatches_text_updated(fake_listener: _FakeListener) ->
     kinds = [e.kind for e in fake_listener.events if hasattr(e, "kind")]
     assert SendEventKind.TEXT_UPDATED in kinds
     assert fake_listener.sidebar_state.send.has_text is True
+
+
+def test_slash_popup_hooks_read_state_and_consume_enter(fake_listener: _FakeListener) -> None:
+    fake_listener.slash_popup = SimpleNamespace(
+        is_open=True,
+        visible_names=["help", "clear"],
+        selected_name="help",
+        handle_key=lambda *a, **k: True,
+    )
+    state = slash_popup_state(listener=fake_listener)
+    assert state == {"visible": True, "items": ["help", "clear"], "selected": "help"}
+    press_query_key(1280, listener=fake_listener)
+    assert not any(isinstance(e, tuple) and e and e[0] == "action" for e in fake_listener.events)
 
 
 def test_press_send_uses_on_action_performed(fake_listener: _FakeListener) -> None:

--- a/tests/chatbot/test_sidebar_test_hooks.py
+++ b/tests/chatbot/test_sidebar_test_hooks.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import os
 import sys
 from types import SimpleNamespace
@@ -219,7 +220,10 @@ def test_slash_popup_hooks_read_state_and_consume_enter(fake_listener: _FakeList
         handle_key=lambda *a, **k: True,
     )
     state = slash_popup_state(listener=fake_listener)
-    assert state == {"visible": True, "items": ["help", "clear"], "selected": "help"}
+    assert state["visible"] is True
+    assert state["items"] == ["help", "clear"]
+    assert state["selected"] == "help"
+    assert state["available"] is True
     press_query_key(1280, listener=fake_listener)
     assert not any(isinstance(e, tuple) and e and e[0] == "action" for e in fake_listener.events)
 
@@ -302,6 +306,42 @@ def test_handle_debug_sidebar_record_and_snapshot(fake_listener: _FakeListener, 
     handle_debug_sidebar_command("chatbot.debug_sidebar.SNAPSHOT")
     path = debug_sidebar_snapshot_path()
     assert os.path.isfile(path)
+    os.remove(path)
+
+
+def test_handle_debug_sidebar_slash_ops(fake_listener: _FakeListener, monkeypatch) -> None:
+    popup = SimpleNamespace(
+        is_open=True,
+        visible_names=["help", "clear"],
+        selected_name="help",
+        on_query_text=lambda text: setattr(popup, "last_text", text),
+        handle_key=lambda key, mods: setattr(popup, "last_key", (key, mods)),
+        last_text="",
+        last_key=None,
+    )
+    fake_listener.slash_popup = popup
+    fake_listener.query_control.setText("/he")
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.adopt_runtime_send_listeners", lambda: 0)
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.send_listener", lambda frame=None: fake_listener)
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks._slash_lru_names", lambda: ["help"])
+
+    handle_debug_sidebar_command("chatbot.debug_sidebar.SLASH_REFRESH")
+    assert popup.last_text == "/he"
+    handle_debug_sidebar_command("chatbot.debug_sidebar.SLASH_ENTER")
+    assert popup.last_key == (1280, 0)
+    handle_debug_sidebar_command("chatbot.debug_sidebar.SLASH_ESC")
+    assert popup.last_key == (1281, 0)
+    handle_debug_sidebar_command("chatbot.debug_sidebar.SNAPSHOT")
+    from plugin.chatbot.sidebar_test_hooks import debug_sidebar_snapshot_path
+
+    path = debug_sidebar_snapshot_path()
+    assert os.path.isfile(path)
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    assert data["slash_available"] is True
+    assert data["slash_visible"] is True
+    assert data["slash_items"] == ["help", "clear"]
+    assert data["slash_selected"] == "help"
     os.remove(path)
 
 

--- a/tests/chatbot/test_slash_commands.py
+++ b/tests/chatbot/test_slash_commands.py
@@ -1,0 +1,154 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Pure unit tests for Ask-box slash filter, LRU rank, and key classification."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from plugin.chatbot.slash_commands import (
+    KEY_DOWN,
+    KEY_ESCAPE,
+    KEY_MODIFIER_SHIFT,
+    KEY_RETURN,
+    KEY_TAB,
+    KEY_UP,
+    SLASH_COMMANDS,
+    SLASH_LRU_KEY,
+    classify_slash_key,
+    filter_slash_commands,
+    format_help_text,
+    record_slash_lru,
+    run_slash_command,
+    slash_typed_prefix,
+)
+from plugin.chatbot.send_state import SendEventKind
+
+
+def _names(typed: str, lru: list[str] | None = None) -> list[str]:
+    return [cmd.name for cmd in filter_slash_commands(typed, lru)]
+
+
+def test_slash_typed_prefix_full_list_and_narrow():
+    assert slash_typed_prefix("/") == ""
+    assert slash_typed_prefix("/he") == "he"
+    assert slash_typed_prefix("  /Help") == "help"
+    assert slash_typed_prefix("hello") is None
+    assert slash_typed_prefix("") is None
+
+
+def test_slash_opens_full_registry_order_without_lru():
+    names = _names("/")
+    assert names[0] == "help"
+    assert "clear" in names
+    assert "mock-alpha" in names
+    assert "mock-bravo" in names
+    assert "mock-charlie" in names
+    assert names == [cmd.name for cmd in SLASH_COMMANDS]
+
+
+def test_he_prefix_selects_help_as_top_match():
+    matches = filter_slash_commands("/he")
+    assert [cmd.name for cmd in matches] == ["help"]
+
+
+def test_further_typing_narrows_mocks():
+    assert _names("/mock-") == ["mock-alpha", "mock-bravo", "mock-charlie"]
+    assert _names("/mock-a") == ["mock-alpha"]
+    assert _names("/zzz") == []
+
+
+def test_lru_floats_to_top_on_empty_filter():
+    names = _names("/", lru=["mock-bravo", "clear"])
+    assert names[:2] == ["mock-bravo", "clear"]
+    assert "help" in names
+
+
+def test_lru_is_tie_break_among_prefix_matches():
+    names = _names("/m", lru=["model"])
+    assert names[0] == "model"
+    assert "mock-alpha" in names
+
+
+def test_classify_slash_keys():
+    assert classify_slash_key(KEY_RETURN, 0) == "enter"
+    assert classify_slash_key(KEY_RETURN, KEY_MODIFIER_SHIFT) is None
+    assert classify_slash_key(KEY_ESCAPE) == "escape"
+    assert classify_slash_key(KEY_UP) == "up"
+    assert classify_slash_key(KEY_DOWN) == "down"
+    assert classify_slash_key(KEY_TAB) == "tab"
+    assert classify_slash_key(65) is None
+
+
+def test_help_text_lists_wired_and_mocks():
+    text = format_help_text()
+    assert "/help" in text
+    assert "/mock-alpha [mock]" in text
+    assert "/clear" in text
+
+
+def test_record_slash_lru_uses_existing_config_helper():
+    with patch("plugin.chatbot.config_ui_helpers.update_lru_history") as update:
+        record_slash_lru("/Help")
+        update.assert_called_once_with("help", SLASH_LRU_KEY, "")
+
+
+def test_run_mock_echoes_and_records_lru():
+    host = SimpleNamespace(
+        slash_popup=SimpleNamespace(hide=MagicMock()),
+        query_control=MagicMock(),
+        dispatch=MagicMock(),
+        _append_response=MagicMock(),
+    )
+    with patch("plugin.chatbot.slash_commands.record_slash_lru") as record:
+        with patch("plugin.chatbot.dialogs.set_control_text"):
+            assert run_slash_command("mock-alpha", host) is True
+    record.assert_called_once_with("mock-alpha")
+    host.slash_popup.hide.assert_called_once()
+    host._append_response.assert_called_once()
+    assert "slash: /mock-alpha" in host._append_response.call_args[0][0]
+    event = host.dispatch.call_args[0][0]
+    assert event.kind is SendEventKind.TEXT_UPDATED
+    assert event.data == {"has_text": False}
+
+
+def test_run_help_prints_static_list():
+    host = SimpleNamespace(
+        slash_popup=None,
+        query_control=None,
+        dispatch=MagicMock(),
+        _append_response=MagicMock(),
+    )
+    with patch("plugin.chatbot.slash_commands.record_slash_lru"):
+        run_slash_command("help", host)
+    body = host._append_response.call_args[0][0]
+    assert "Slash commands:" in body
+    assert "/help" in body
+
+
+def test_run_clear_calls_existing_clear_listener():
+    clear = SimpleNamespace(on_action_performed=MagicMock())
+    host = SimpleNamespace(
+        slash_popup=None,
+        query_control=None,
+        dispatch=MagicMock(),
+        clear_listener=clear,
+    )
+    with patch("plugin.chatbot.slash_commands.record_slash_lru"):
+        run_slash_command("clear", host)
+    clear.on_action_performed.assert_called_once_with(None)
+
+
+def test_run_stop_dispatches_stop_clicked():
+    host = SimpleNamespace(
+        slash_popup=None,
+        query_control=None,
+        dispatch=MagicMock(),
+    )
+    with patch("plugin.chatbot.slash_commands.record_slash_lru"):
+        run_slash_command("stop", host)
+    event = host.dispatch.call_args[0][0]
+    assert event.kind is SendEventKind.STOP_CLICKED

--- a/tests/chatbot/test_slash_popup.py
+++ b/tests/chatbot/test_slash_popup.py
@@ -1,0 +1,162 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for the Ask-box slash ListBox controller (no soffice)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from plugin.chatbot.slash_commands import KEY_ESCAPE, KEY_RETURN, KEY_TAB, KEY_UP
+from plugin.chatbot.slash_popup import SlashPopupController
+
+
+class _ListBox:
+    def __init__(self) -> None:
+        self.items: list[str] = []
+        self.selected = 0
+        self.visible = True
+        self.pos = SimpleNamespace(X=4, Y=80, Width=142, Height=60)
+
+    def getItemCount(self) -> int:
+        return len(self.items)
+
+    def removeItems(self, start: int, count: int) -> None:
+        del self.items[start : start + count]
+
+    def addItems(self, labels, _pos: int) -> None:
+        self.items.extend(list(labels))
+
+    def selectItemPos(self, idx: int, _select: bool) -> None:
+        self.selected = idx
+
+    def getSelectedItemPos(self) -> int:
+        return self.selected
+
+    def getPosSize(self):
+        return self.pos
+
+    def setPosSize(self, x, y, w, h, _flags) -> None:
+        self.pos = SimpleNamespace(X=x, Y=y, Width=w, Height=h)
+
+    def setVisible(self, visible: bool) -> None:
+        self.visible = visible
+
+
+class _Query:
+    def __init__(self) -> None:
+        self.text = ""
+        self.pos = SimpleNamespace(X=4, Y=152, Width=142, Height=30)
+
+    def getPosSize(self):
+        return self.pos
+
+    def setText(self, text: str) -> None:
+        self.text = text
+
+    def getText(self) -> str:
+        return self.text
+
+    def getModel(self):
+        return SimpleNamespace(Text=self.text)
+
+
+def _controller(lru: list[str] | None = None) -> tuple[SlashPopupController, _ListBox]:
+    box = _ListBox()
+    query = _Query()
+    send = SimpleNamespace(query_control=query, slash_popup=None)
+    with patch("plugin.chatbot.slash_popup.load_slash_lru", return_value=lru or []):
+        popup = SlashPopupController(box, send, query)
+    send.slash_popup = popup
+    return popup, box
+
+
+def test_slash_opens_popup_with_full_list():
+    popup, box = _controller()
+    with patch("plugin.chatbot.slash_popup.load_slash_lru", return_value=[]):
+        popup.on_query_text("/")
+    assert popup.is_open is True
+    assert box.visible is True
+    assert popup.visible_names[0] == "help"
+    assert "mock-alpha" in popup.visible_names
+    assert popup.selected_name == "help"
+
+
+def test_he_leaves_help_selected():
+    popup, _box = _controller()
+    with patch("plugin.chatbot.slash_popup.load_slash_lru", return_value=[]):
+        popup.on_query_text("/he")
+    assert popup.visible_names == ["help"]
+    assert popup.selected_name == "help"
+
+
+def test_enter_accepts_help_without_send():
+    popup, _box = _controller()
+    send = popup.send_listener
+    send.dispatch = MagicMock()
+    send._append_response = MagicMock()
+    with patch("plugin.chatbot.slash_popup.load_slash_lru", return_value=[]):
+        popup.on_query_text("/he")
+    with patch("plugin.chatbot.slash_commands.record_slash_lru"):
+        with patch("plugin.chatbot.dialogs.set_control_text"):
+            assert popup.handle_key(KEY_RETURN, 0) is True
+    send._append_response.assert_called_once()
+    assert "Slash commands:" in send._append_response.call_args[0][0]
+    send.on_action_performed = MagicMock()
+    # Controller consumed Enter; send path is not invoked from handle_key.
+    send.on_action_performed.assert_not_called()
+
+
+def test_esc_dismisses():
+    popup, box = _controller()
+    with patch("plugin.chatbot.slash_popup.load_slash_lru", return_value=[]):
+        popup.on_query_text("/")
+    assert popup.handle_key(KEY_ESCAPE) is True
+    assert popup.is_open is False
+    assert box.visible is False
+
+
+def test_tab_completes_selected_name():
+    popup, _box = _controller()
+    query = popup.query_control
+    with patch("plugin.chatbot.slash_popup.load_slash_lru", return_value=[]):
+        popup.on_query_text("/he")
+        assert popup.handle_key(KEY_TAB) is True
+    assert query.text == "/help"
+
+
+def test_up_down_move_selection():
+    popup, box = _controller()
+    with patch("plugin.chatbot.slash_popup.load_slash_lru", return_value=[]):
+        popup.on_query_text("/")
+    first = popup.selected_name
+    popup.handle_key(KEY_UP)  # wrap to last
+    assert popup.selected_name != first
+    assert box.selected == len(popup.visible_names) - 1
+
+
+def test_lru_ranks_mock_higher_next_time():
+    popup, _box = _controller(lru=["mock-bravo"])
+    with patch("plugin.chatbot.slash_popup.load_slash_lru", return_value=["mock-bravo"]):
+        popup.on_query_text("/")
+    assert popup.selected_name == "mock-bravo"
+    assert popup.visible_names[0] == "mock-bravo"
+
+
+def test_closed_popup_does_not_steal_enter():
+    popup, _box = _controller()
+    assert popup.is_open is False
+    assert popup.handle_key(KEY_RETURN, 0) is False
+
+
+def test_chat_panel_xdl_uses_menulist_for_slash_popup():
+    """LibreOffice dialog.dtd has dlg:menulist only; dlg:listbox breaks the sidebar."""
+    from pathlib import Path
+
+    xdl = Path(__file__).resolve().parents[2] / "extension" / "Dialogs" / "ChatPanelDialog.xdl"
+    text = xdl.read_text(encoding="utf-8")
+    assert "dlg:listbox" not in text
+    assert 'dlg:id="slash_popup"' in text
+    assert "dlg:menulist" in text

--- a/tests/chatbot/test_slash_popup.py
+++ b/tests/chatbot/test_slash_popup.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from plugin.chatbot.slash_commands import KEY_ESCAPE, KEY_RETURN, KEY_TAB, KEY_UP
-from plugin.chatbot.slash_popup import SlashPopupController
+from plugin.chatbot.slash_popup import SlashPopupController, _ensure_listbox, _is_combo_box
 
 
 class _ListBox:
@@ -149,6 +149,14 @@ def test_closed_popup_does_not_steal_enter():
     popup, _box = _controller()
     assert popup.is_open is False
     assert popup.handle_key(KEY_RETURN, 0) is False
+
+
+def test_xdl_menulist_is_treated_as_combo_not_listbox():
+    combo = SimpleNamespace(getModel=lambda: SimpleNamespace(getSupportedServiceNames=lambda: ("com.sun.star.awt.UnoControlComboBoxModel",)))
+    box = SimpleNamespace(getModel=lambda: SimpleNamespace(getSupportedServiceNames=lambda: ("com.sun.star.awt.UnoControlListBoxModel",)))
+    assert _is_combo_box(combo) is True
+    assert _is_combo_box(box) is False
+    assert _ensure_listbox(box, None) is box
 
 
 def test_chat_panel_xdl_uses_menulist_for_slash_popup():

--- a/tests/chatbot/test_slash_popup_uno.py
+++ b/tests/chatbot/test_slash_popup_uno.py
@@ -1,0 +1,73 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Native UNO coverage for the Ask-box slash ListBox (no Packet G audio)."""
+
+from __future__ import annotations
+
+from plugin.testing_runner import native_test
+
+
+@native_test
+def test_slash_popup_listbox_filter_and_keys(ctx):
+    """Drive SlashPopupController on a live UnoControlListBox (throwaway dialog)."""
+    from plugin.chatbot.slash_commands import KEY_ESCAPE, KEY_RETURN
+    from plugin.chatbot.slash_popup import SlashPopupController
+
+    smgr = ctx.getServiceManager()
+    dlg_model = smgr.createInstanceWithContext("com.sun.star.awt.UnoControlDialogModel", ctx)
+    dlg_model.PositionX = 20
+    dlg_model.PositionY = 20
+    dlg_model.Width = 160
+    dlg_model.Height = 80
+    dlg_model.Title = "slash-popup-test"
+
+    query_model = dlg_model.createInstance("com.sun.star.awt.UnoControlEditModel")
+    query_model.Name = "query"
+    query_model.PositionX = 4
+    query_model.PositionY = 50
+    query_model.Width = 150
+    query_model.Height = 24
+    dlg_model.insertByName("query", query_model)
+
+    list_model = dlg_model.createInstance("com.sun.star.awt.UnoControlListBoxModel")
+    list_model.Name = "slash_popup"
+    list_model.PositionX = 4
+    list_model.PositionY = 4
+    list_model.Width = 150
+    list_model.Height = 40
+    list_model.Dropdown = False
+    dlg_model.insertByName("slash_popup", list_model)
+
+    dlg = smgr.createInstanceWithContext("com.sun.star.awt.UnoControlDialog", ctx)
+    dlg.setModel(dlg_model)
+    toolkit = smgr.createInstanceWithContext("com.sun.star.awt.Toolkit", ctx)
+    dlg.createPeer(toolkit, None)
+    dlg.setVisible(True)
+    try:
+        query = dlg.getControl("query")
+        box = dlg.getControl("slash_popup")
+        assert query is not None and box is not None
+        send = type("Host", (), {"query_control": query, "slash_popup": None, "dispatch": lambda *a, **k: None})()
+        popup = SlashPopupController(box, send, query)
+        send.slash_popup = popup
+
+        popup.on_query_text("/")
+        assert popup.is_open is True
+        assert popup.selected_name == "help"
+        assert "mock-alpha" in popup.visible_names
+        assert int(box.getItemCount()) >= 5
+
+        popup.on_query_text("/he")
+        assert popup.visible_names == ["help"]
+        assert popup.selected_name == "help"
+
+        assert popup.handle_key(KEY_ESCAPE) is True
+        assert popup.is_open is False
+
+        popup.on_query_text("/")
+        assert popup.handle_key(KEY_RETURN, 0) is True
+        assert popup.is_open is False
+    finally:
+        dlg.dispose()

--- a/tests/framework/test_config.py
+++ b/tests/framework/test_config.py
@@ -350,6 +350,7 @@ class TestConfigSyncFileIO(unittest.TestCase):
         from plugin.framework.errors import ConfigError
         self.assertEqual(get_config('calc_prompt_max_tokens'), 4096)
         self.assertEqual(get_config('prompt_lru'), [])
+        self.assertEqual(get_config('slash_command_lru'), [])
         self.assertEqual(get_config('endpoint'), 'http://localhost:11434')
         self.assertEqual(get_config('model_lru@http://localhost:11434'), [])
         self.assertEqual(get_config_int('extension_update_check_epoch'), 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
UI-first `/` completion menu on the WriterAgent chat sidebar Ask field. This is the Cursor/Aider in-chat feel, not a LibreOffice menu and not the hamburger.

## What landed
- Typing `/` in the Ask box shows a multi-row ListBox just above (or below) the field.
- Further typing filters (`/he` → `/help` selected). Esc dismisses, Up/Down moves, Tab completes, Enter accepts **without** sending a chat turn.
- LRU ranking persisted as `slash_command_lru` in existing `writeragent.json` (not a sidecar).
- Registry is mostly mocks (`/mock-alpha`, `/mock-bravo`, `/mock-charlie`, plus tagged consider-list names). Selecting a mock echoes `slash: /name` in the response pane.
- Test wiring only: `/help` prints the static list, `/clear` uses `ClearButtonListener`, `/stop` dispatches the existing `STOP_CLICKED` one-liner.

The XDL placeholder is `dlg:menulist` (dialog.dtd has no `listbox`). That control is a ComboBox, so the visible menu is a runtime `UnoControlListBox`.

## Not in this PR
- Real `/apply`, `/web`, `/model`, `/ask`, `/attach`, `/voice`, notebooks, skills, hamburger changes.
- Packet G audio (PR 563). New slash tests isolate themselves (clear Ask + reset LRU).

## Tests
- Pure unit: filter + LRU + `/he` → `/help` (no soffice).
- Controller + QueryKeyListener: Enter is consumed only while the popup is open.
- `make typecheck` clean on this revision.
- UNO: live ListBox on a throwaway dialog (`test_slash_popup_uno.py`) — passed.
- Mock-sidebar (`make test-mock-sidebar FILTER=test_slash`): all 4 passed. `--user-profile` is out-of-process URP, so checkout cannot see soffice's `SendButtonListener`. Hooks bind `SlashPopupController` to the live `slash_popup` control over URP.

## Manual UI (Linux)
Verified in Writer: `/` opens the list, `/he` selects `/help`, Enter prints the static command list (not an LLM turn), `/mock-bravo` echoes `slash: /mock-bravo`, and `/` then ranks `/mock-bravo` first (LRU).

Do not merge until you are happy with the UI.

[Slash popup open on slash](https://cursor.com/agents/bc-660753fa-bdcc-4c59-b96f-96211c037d04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslash_popup_open_on_slash.webp)
[he filters to help](https://cursor.com/agents/bc-660753fa-bdcc-4c59-b96f-96211c037d04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslash_popup_he_filters_help.webp)
[help accepted into response pane](https://cursor.com/agents/bc-660753fa-bdcc-4c59-b96f-96211c037d04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslash_popup_help_accepted.webp)
[slash mock-bravo echo](https://cursor.com/agents/bc-660753fa-bdcc-4c59-b96f-96211c037d04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslash_popup_mock_bravo_echo.webp)
[LRU ranks mock-bravo first](https://cursor.com/agents/bc-660753fa-bdcc-4c59-b96f-96211c037d04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslash_popup_lru_mock_bravo_top.webp)
[slash_popup_listbox_ask_box.mp4](https://cursor.com/agents/bc-660753fa-bdcc-4c59-b96f-96211c037d04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslash_popup_listbox_ask_box.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-660753fa-bdcc-4c59-b96f-96211c037d04?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-660753fa-bdcc-4c59-b96f-96211c037d04&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

