### PR TITLE
Handshake debug strip: leftover IPC hunt logs

### DIFF
--- a/docs/scripting/worker-spawn-handshake-timeouts.md
+++ b/docs/scripting/worker-spawn-handshake-timeouts.md
@@ -1,6 +1,6 @@
 # Investigate: worker spawn handshake timeouts in full pytest
 
-**Status:** Open — intermittent on `make pytest` / `make test-run` (2026-09-01)  
+**Status:** Leftover-stdout cause fixed in #546 (`smolagents` `__init__` no longer imports `huggingface_hub` on worker spawn). Hunt-only IPC breadcrumbs stripped after that. Do not reopen Hub/smolagents.  
 **Severity:** Unit-test flake that can fail ~30–40 tests at once; production spawn path is the same code  
 **Do not:** raise `_SPAWN_READY_TIMEOUT_SEC`, permanently cap `PYTEST_WORKERS`, or “fix” it by skipping tests
 
@@ -270,5 +270,6 @@ Fill this in as you go. Do not delete failed experiments.
 | 2026-09-02 | after #545 | Windows ty | `ty check --python-platform win32 plugin/scripting/ipc.py` | `#545` leftover peek (`stdout_rest`) is useful on Linux, but `os.set_blocking` is POSIX-only. Guard the call; keep the BytesIO/mock fallback. Do not drop `stdout_rest`. |
 | 2026-09-03 | after #548 | Windows pytest | CI 33697174793 `test_spawn_stdout_garbage_fails_fast` | `#548` skip returns `b""` on win32 pipes, so `if rest:` omitted `stdout_rest=` from `IpcFrameError`. Fail-fast still worked (`header=b'Erro'`, no 15s timeout). Always attach `stdout_rest=` (empty when peek skipped). Do not re-enable `set_blocking` on Windows. |
 | 2026-09-02 | after #545 | H1 | leftover stdout on full `make test` | Same 37 fails. `stdout_rest` reconstructs: `Error importing huggingface_hub.hf_api: No module named 'envwrap' (or 'envwrap.envwrap' is unknown)`. Cause: `smolagents/__init__.py` star-imported `tools` → `huggingface_hub` on every `plugin.contrib.smolagents.*` import, including compute-worker `sandbox.py`. |
+| 2026-09-03 | after #546 | hunt-log strip | leftover peek / `stdout_rest` stay; drop Windows `log.info` peek-skip and stderr hang breadcrumbs | Invalid frames keep `stdout_rest=` on `IpcFrameError` (empty when POSIX peek is skipped) and log at error. No `print(..., file=sys.stderr)` hunt line. Do not reopen Hub/smolagents. |
 
-When the flake is gone, set **Status** at the top to Fixed, name the commit, and point at the tests that lock the behavior.
+Invalid length prefix still raises `IpcFrameError` with `stdout_rest=` (empty `b''` when the POSIX leftover peek is skipped on win32). POSIX peek uses `os.set_blocking`; skip on win32. That is the error contract, not debug.

--- a/plugin/scripting/ipc.py
+++ b/plugin/scripting/ipc.py
@@ -95,16 +95,10 @@ def _unread_pipe_bytes(stream: IO[bytes], n: int = 512) -> bytes:
     except (AttributeError, OSError, ValueError, io.UnsupportedOperation):
         fd = None
     if isinstance(fd, int):
-        # os.set_blocking is POSIX-only. PR 545 attached leftover stdout after a
-        # bad length prefix (header=Erro / envwrap). The unguarded call was the
-        # Windows ty hole; skip the non-blocking peek there. BytesIO/mocks still
-        # fall through to stream.read below (no real fileno).
+        # os.set_blocking is POSIX-only; skip the non-blocking peek on win32.
+        # BytesIO/mocks still fall through to stream.read (no real fileno).
         if sys.platform == "win32" or not hasattr(os, "set_blocking"):
-            # Peek skipped (POSIX-only set_blocking). Do not stream.read()
-            # here — that can block. Return empty; caller always attaches
-            # stdout_rest= (PR 549). One breadcrumb so a later hang can
-            # show whether leftover peek ran on this process.
-            log.info("ipc leftover peek skipped platform=%s", sys.platform)
+            # Do not stream.read() here — that can block on a live pipe.
             return b""
         try:
             os.set_blocking(fd, False)
@@ -135,20 +129,10 @@ def read_frame_payload(
         _validate_frame_size(size, max_payload_bytes=max_payload_bytes, frame_label=frame_label)
     except IpcFrameError as exc:
         rest = _unread_pipe_bytes(stream)
-        # Always include stdout_rest= (b'' when the POSIX leftover peek is
-        # skipped on win32). Dropping the field broke the Windows log contract
-        # (CI 33697174793 / test_spawn_stdout_garbage_fails_fast).
-        # stderr so GHA names an invalid-frame fail if UNO hangs later
-        # (33699746211: three PY tests FAIL then insert_cell_html hung).
-        peek_skipped = sys.platform == "win32" or not hasattr(os, "set_blocking")
+        # stdout_rest= is leftover pipe bytes after a garbage length prefix
+        # (empty when the POSIX peek is skipped on win32).
         msg = f"{exc} stdout_rest={rest!r}"
-        print(
-            "ipc invalid frame platform=%s peek_skipped=%s %s"
-            % (sys.platform, peek_skipped, msg),
-            file=sys.stderr,
-            flush=True,
-        )
-        log.info("ipc invalid frame platform=%s peek_skipped=%s %s", sys.platform, peek_skipped, msg)
+        log.error("%s", msg)
         raise IpcFrameError(msg) from None
     payload = reader(size)
     if len(payload) < size:

--- a/tests/scripting/test_ipc.py
+++ b/tests/scripting/test_ipc.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import os
 import pickle
 import subprocess
@@ -92,7 +93,7 @@ def test_text_error_prefix_is_invalid_frame_with_header_repr():
         )
 
 
-def test_unread_pipe_bytes_skips_set_blocking_on_win32(monkeypatch):
+def test_unread_pipe_bytes_skips_set_blocking_on_win32(monkeypatch, caplog):
     """Windows/ty: os.set_blocking is POSIX-only; skip the non-blocking peek."""
     from plugin.scripting import ipc
 
@@ -104,12 +105,14 @@ def test_unread_pipe_bytes_skips_set_blocking_on_win32(monkeypatch):
     monkeypatch.setattr(ipc.os, "set_blocking", boom)
     stream = MagicMock()
     stream.fileno.return_value = 3
-    assert ipc._unread_pipe_bytes(stream) == b""
+    with caplog.at_level(logging.INFO, logger="writeragent.scripting.ipc"):
+        assert ipc._unread_pipe_bytes(stream) == b""
+    assert "leftover peek skipped" not in caplog.text
     stream.read.assert_not_called()
 
 
-def test_invalid_frame_includes_stdout_rest_when_win32_peek_skipped(monkeypatch):
-    """PR 548 skip still keeps stdout_rest= on the IpcFrameError (CI 33697174793)."""
+def test_invalid_frame_includes_stdout_rest_when_win32_peek_skipped(monkeypatch, caplog, capsys):
+    """Win32 skip still attaches stdout_rest= (empty) on IpcFrameError."""
     from plugin.scripting import ipc
 
     monkeypatch.setattr(ipc.sys, "platform", "win32")
@@ -121,25 +124,14 @@ def test_invalid_frame_includes_stdout_rest_when_win32_peek_skipped(monkeypatch)
     stream = MagicMock()
     stream.fileno.return_value = 3
     stream.read.return_value = b"Erro"
-    with pytest.raises(IpcFrameError, match=r"header=b'Erro'.*stdout_rest=b''"):
-        read_pickle_frame(stream, max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES)
-    stream.read.assert_called_once_with(4)
-
-
-def test_invalid_frame_prints_platform_and_peek_skipped(monkeypatch, capsys):
-    """GHA UNO hang: say whether leftover peek ran before a later insert_cell_html stall."""
-    from plugin.scripting import ipc
-
-    monkeypatch.setattr(ipc.sys, "platform", "win32")
-    monkeypatch.setattr(ipc.os, "set_blocking", lambda *_a, **_k: None)
-    stream = MagicMock()
-    stream.fileno.return_value = 3
-    stream.read.return_value = b"Erro"
-    with pytest.raises(IpcFrameError):
-        read_pickle_frame(stream, max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES)
+    with caplog.at_level(logging.ERROR, logger="writeragent.scripting.ipc"):
+        with pytest.raises(IpcFrameError, match=r"header=b'Erro'.*stdout_rest=b''"):
+            read_pickle_frame(stream, max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES)
+    assert "stdout_rest=b''" in caplog.text
     err = capsys.readouterr().err
-    assert "ipc invalid frame platform=win32 peek_skipped=True" in err
-    assert "stdout_rest=b''" in err
+    assert "ipc leftover peek" not in err
+    assert "peek_skipped" not in err
+    stream.read.assert_called_once_with(4)
 
 
 def test_unread_pipe_bytes_posix_peek_uses_set_blocking(monkeypatch):

--- a/tests/scripting/test_ipc.py
+++ b/tests/scripting/test_ipc.py
@@ -84,13 +84,18 @@ def test_pickle_frame_default_cap_rejects_oversized_header():
         read_pickle_frame(io.BytesIO(oversized), max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES)
 
 
-def test_text_error_prefix_is_invalid_frame_with_header_repr():
-    """1165128303 == b'Erro' from Keith's 2026-09-02 full-suite venv failures."""
-    with pytest.raises(IpcFrameError, match=r"header=b'Erro'.*stdout_rest=b'r: boom\\n'"):
-        read_pickle_frame(
-            io.BytesIO(b"Error: boom\n"),
-            max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES,
-        )
+def test_text_error_prefix_is_invalid_frame_with_header_repr(caplog, capsys):
+    """Garbage length prefix keeps stdout_rest= and logs at error, not stderr."""
+    with caplog.at_level(logging.ERROR, logger="writeragent.scripting.ipc"):
+        with pytest.raises(IpcFrameError, match=r"header=b'Erro'.*stdout_rest=b'r: boom\\n'"):
+            read_pickle_frame(
+                io.BytesIO(b"Error: boom\n"),
+                max_payload_bytes=DEFAULT_MAX_PAYLOAD_BYTES,
+            )
+    assert "stdout_rest=b'r: boom\\n'" in caplog.text
+    err = capsys.readouterr().err
+    assert "ipc leftover peek" not in err
+    assert "peek_skipped" not in err
 
 
 def test_unread_pipe_bytes_skips_set_blocking_on_win32(monkeypatch, caplog):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Strip hunt-only logging added while diagnosing pickle-pipe handshake failures. The leftover-stdout cause is already fixed in #546 (`smolagents` `__init__` no longer imports `huggingface_hub`). This change does not reopen Hub/smolagents and does not change pickle framing, worker protocol, or handshake timeouts.

## Keep
- `stdout_rest=` on `IpcFrameError` when the length prefix is garbage (empty `b''` when the POSIX peek is skipped on win32)
- POSIX leftover peek via `os.set_blocking` (skip on win32)
- Import-side-effect tests from #546 (sandbox / worker_base / formula-worker must not load `huggingface_hub` or `smolagents.tools`)

## Strip
- `log.info("ipc leftover peek skipped platform=%s", ...)` on the Windows skip path
- `print(..., file=sys.stderr)` hang breadcrumbs (GHA / `insert_cell_html` diary)
- CI-diary comments; invalid frames stay on the logger at error

## Tests
- Existing leftover-stdout / spawn-garbage IPC tests: 23 passed
- Existing smolagents import-side-effect tests
- `make typecheck` clean (Linux)

[Targeted leftover-stdout and import tests](https://cursor.com/agents/bc-4067a721-5285-42a3-ae36-9093e3380f6e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhandshake-debug-strip-tests.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4067a721-5285-42a3-ae36-9093e3380f6e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4067a721-5285-42a3-ae36-9093e3380f6e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

