### PR TITLE
Add GitHub Pages CI status dashboard

### DIFF
--- a/.github/workflows/ci-status-pages.yml
+++ b/.github/workflows/ci-status-pages.yml
@@ -1,0 +1,52 @@
+# Static CI status table for https://keithcu.github.io/writeragent/
+# Pages Source must be GitHub Actions (Settings → Pages). First deploy
+# may need approval of the github-pages environment.
+name: CI Status Pages
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - PR CI
+      - CrossHair Verification (Deep / On-Demand)
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate CI status HTML
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/generate_ci_status.py --out _site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/scripts/generate_ci_status.py
+++ b/scripts/generate_ci_status.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Build a static CI status table from the GitHub Actions API.
+
+Used by ``.github/workflows/ci-status-pages.yml`` to publish
+https://keithcu.github.io/writeragent/ . Auth is ``GITHUB_TOKEN`` only
+(optional for this public repo). The token is never written into HTML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterator
+from urllib.parse import quote
+
+DEFAULT_REPO = "KeithCu/writeragent"
+API_ROOT = "https://api.github.com"
+USER_AGENT = "writeragent-ci-status"
+API_VERSION = "2022-11-28"
+RUNS_PER_PAGE = 50
+MAX_RUN_PAGES = 5
+OS_LABELS = ("ubuntu-latest", "macos-latest", "windows-latest")
+
+# Each row is the newest job whose name contains every needle. CrossHair
+# jobs are ``CrossHair (check-all, ubuntu-latest)`` / ``cover-all`` (see
+# crosshair-deep.yml). PR CI jobs are ``Test & Typecheck (os)`` or
+# ``Mock LLM Sidebar (os)`` (see pr-ci.yml). ``both`` CrossHair jobs do
+# not contain those needles and are ignored.
+SUITE_SPECS: tuple[tuple[str, str, str, tuple[str, ...]], ...] = (
+    ("CrossHair check-all", "", "crosshair-deep.yml", ("check-all",)),
+    ("CrossHair cover-all", "", "crosshair-deep.yml", ("cover-all",)),
+    ("Test & Typecheck", "ubuntu-latest", "pr-ci.yml", ("Test & Typecheck", "ubuntu-latest")),
+    ("Test & Typecheck", "macos-latest", "pr-ci.yml", ("Test & Typecheck", "macos-latest")),
+    ("Test & Typecheck", "windows-latest", "pr-ci.yml", ("Test & Typecheck", "windows-latest")),
+    ("Mock LLM Sidebar", "ubuntu-latest", "pr-ci.yml", ("Mock LLM Sidebar", "ubuntu-latest")),
+    ("Mock LLM Sidebar", "macos-latest", "pr-ci.yml", ("Mock LLM Sidebar", "macos-latest")),
+    ("Mock LLM Sidebar", "windows-latest", "pr-ci.yml", ("Mock LLM Sidebar", "windows-latest")),
+)
+
+
+JsonDict = dict[str, Any]
+Fetcher = Callable[[str], JsonDict]
+
+
+@dataclass(frozen=True)
+class SuiteSpec:
+    suite: str
+    os: str
+    workflow: str
+    name_contains: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StatusRow:
+    suite: str
+    os: str
+    conclusion: str
+    sha: str
+    when: str
+    run_url: str
+
+
+def suite_specs() -> tuple[SuiteSpec, ...]:
+    return tuple(SuiteSpec(*item) for item in SUITE_SPECS)
+
+
+def job_matches(job_name: str, spec: SuiteSpec) -> bool:
+    """True when the Actions job name is this dashboard row.
+
+    Needles are AND-matched so ``Test & Typecheck (ubuntu-latest)`` does
+    not fill the macos row or a Mock LLM Sidebar row.
+    """
+    return all(needle in job_name for needle in spec.name_contains)
+
+
+def extract_os(job_name: str, fallback: str = "") -> str:
+    for label in OS_LABELS:
+        if label in job_name:
+            return label
+    return fallback
+
+
+def short_sha(sha: str) -> str:
+    sha = sha.strip()
+    if len(sha) < 7:
+        return sha
+    return sha[:7]
+
+
+def job_when(job: JsonDict) -> str:
+    for key in ("completed_at", "started_at"):
+        value = job.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def job_conclusion(job: JsonDict) -> str:
+    conclusion = job.get("conclusion")
+    if isinstance(conclusion, str) and conclusion:
+        return conclusion
+    status = job.get("status")
+    if isinstance(status, str) and status:
+        return status
+    return "unknown"
+
+
+def github_get(url: str, token: str) -> JsonDict:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API {exc.code} for {url}: {body[:300]}") from exc
+    parsed: Any = json.loads(raw.decode("utf-8"))
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"GitHub API returned a non-object for {url}")
+    return parsed
+
+
+def make_fetcher(token: str) -> Fetcher:
+    def fetch(url: str) -> JsonDict:
+        return github_get(url, token)
+
+    return fetch
+
+
+def iter_workflow_runs(fetch: Fetcher, repo: str, workflow: str) -> Iterator[JsonDict]:
+    encoded = quote(workflow, safe="")
+    for page in range(1, MAX_RUN_PAGES + 1):
+        url = (
+            f"{API_ROOT}/repos/{repo}/actions/workflows/{encoded}/runs"
+            f"?per_page={RUNS_PER_PAGE}&page={page}"
+        )
+        payload = fetch(url)
+        runs = payload.get("workflow_runs")
+        if not isinstance(runs, list) or not runs:
+            return
+        for run in runs:
+            if isinstance(run, dict):
+                yield run
+        if len(runs) < RUNS_PER_PAGE:
+            return
+
+
+def list_run_jobs(fetch: Fetcher, repo: str, run_id: int) -> list[JsonDict]:
+    url = f"{API_ROOT}/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"
+    payload = fetch(url)
+    jobs = payload.get("jobs")
+    if not isinstance(jobs, list):
+        return []
+    return [job for job in jobs if isinstance(job, dict)]
+
+
+def _empty_row(spec: SuiteSpec) -> StatusRow:
+    return StatusRow(
+        suite=spec.suite,
+        os=spec.os,
+        conclusion="no run",
+        sha="",
+        when="",
+        run_url="",
+    )
+
+
+def collect_status(fetch: Fetcher, repo: str) -> list[StatusRow]:
+    """Newest matching job per suite row (workflow runs are newest-first)."""
+    specs = suite_specs()
+    found: dict[int, StatusRow] = {}
+    pending_by_workflow: dict[str, list[int]] = {}
+    for index, spec in enumerate(specs):
+        pending_by_workflow.setdefault(spec.workflow, []).append(index)
+
+    for workflow, indexes in pending_by_workflow.items():
+        pending = set(indexes)
+        for run in iter_workflow_runs(fetch, repo, workflow):
+            if not pending:
+                break
+            run_id = run.get("id")
+            if not isinstance(run_id, int):
+                continue
+            run_url = run.get("html_url") if isinstance(run.get("html_url"), str) else ""
+            sha = short_sha(run.get("head_sha") if isinstance(run.get("head_sha"), str) else "")
+            jobs = list_run_jobs(fetch, repo, run_id)
+            for job in jobs:
+                name = job.get("name") if isinstance(job.get("name"), str) else ""
+                still_pending = list(pending)
+                for index in still_pending:
+                    spec = specs[index]
+                    if not job_matches(name, spec):
+                        continue
+                    found[index] = StatusRow(
+                        suite=spec.suite,
+                        os=spec.os or extract_os(name),
+                        conclusion=job_conclusion(job),
+                        sha=sha,
+                        when=job_when(job),
+                        run_url=run_url or "",
+                    )
+                    pending.discard(index)
+
+    return [found.get(index, _empty_row(spec)) for index, spec in enumerate(specs)]
+
+
+def _cell(value: str) -> str:
+    return html.escape(value, quote=True)
+
+
+def render_html(
+    rows: list[StatusRow],
+    *,
+    repo: str,
+    generated_at: str,
+) -> str:
+    """Ugly-simple table. No JS, no secrets, no placeholder SHAs."""
+    body_rows: list[str] = []
+    for row in rows:
+        link = ""
+        if row.run_url:
+            href = _cell(row.run_url)
+            link = f'<a href="{href}">{href}</a>'
+        css = row.conclusion.replace(" ", "-")
+        body_rows.append(
+            "<tr>"
+            f"<td>{_cell(row.suite)}</td>"
+            f"<td>{_cell(row.os)}</td>"
+            f'<td class="{_cell(css)}">{_cell(row.conclusion)}</td>'
+            f"<td><code>{_cell(row.sha)}</code></td>"
+            f"<td>{_cell(row.when)}</td>"
+            f"<td>{link}</td>"
+            "</tr>"
+        )
+    table_body = "\n".join(body_rows)
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        "<title>WriterAgent CI status</title>\n"
+        "<style>\n"
+        "body { font-family: sans-serif; margin: 1em; }\n"
+        "table { border-collapse: collapse; }\n"
+        "th, td { border: 1px solid #333; padding: 4px 8px; text-align: left; }\n"
+        "td.success { background: #cfc; }\n"
+        "td.failure { background: #fcc; }\n"
+        "td.cancelled { background: #eee; }\n"
+        "td.in_progress { background: #ffc; }\n"
+        "</style>\n"
+        "</head>\n"
+        "<body>\n"
+        "<h1>WriterAgent CI status</h1>\n"
+        f"<p>Latest Actions jobs for {_cell(repo)}. Generated { _cell(generated_at) }.</p>\n"
+        "<table>\n"
+        "<thead><tr>"
+        "<th>Suite</th><th>OS</th><th>Conclusion</th><th>SHA</th><th>When</th><th>Run</th>"
+        "</tr></thead>\n"
+        f"<tbody>\n{table_body}\n</tbody>\n"
+        "</table>\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_site(out_dir: Path, html_text: str) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    index = out_dir / "index.html"
+    index.write_text(html_text, encoding="utf-8")
+    return index
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        default="_site",
+        help="Directory to write index.html into (default: _site)",
+    )
+    parser.add_argument(
+        "--repo",
+        default="",
+        help="owner/name (default: GITHUB_REPOSITORY or KeithCu/writeragent)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo = (args.repo or os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO).strip()
+    token = os.environ.get("GITHUB_TOKEN", "")
+    rows = collect_status(make_fetcher(token), repo)
+    page = render_html(rows, repo=repo, generated_at=utc_now())
+    if token and token in page:
+        raise RuntimeError("refusing to write HTML that contains GITHUB_TOKEN")
+    path = write_site(Path(args.out), page)
+    print(f"Wrote {path} ({len(rows)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_generate_ci_status.py
+++ b/tests/scripts/test_generate_ci_status.py
@@ -1,0 +1,244 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""CI status page is generated from Actions API data, not placeholders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.generate_ci_status import (
+    StatusRow,
+    SuiteSpec,
+    collect_status,
+    job_matches,
+    main,
+    render_html,
+    short_sha,
+    suite_specs,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci-status-pages.yml"
+_GENERATOR = _REPO_ROOT / "scripts" / "generate_ci_status.py"
+
+
+def _spec(*needles: str, suite: str = "x", os: str = "", workflow: str = "pr-ci.yml") -> SuiteSpec:
+    return SuiteSpec(suite=suite, os=os, workflow=workflow, name_contains=needles)
+
+
+def test_job_matches_crosshair_needles() -> None:
+    check = _spec("check-all", workflow="crosshair-deep.yml")
+    cover = _spec("cover-all", workflow="crosshair-deep.yml")
+    assert job_matches("CrossHair (check-all, ubuntu-latest)", check)
+    assert not job_matches("CrossHair (cover-all, ubuntu-latest)", check)
+    assert job_matches("CrossHair (cover-all, ubuntu-latest)", cover)
+    assert not job_matches("CrossHair (check-all, ubuntu-latest)", cover)
+    assert not job_matches("CrossHair (both, ubuntu-latest)", check)
+    assert not job_matches("CrossHair (both, ubuntu-latest)", cover)
+
+
+def test_job_matches_pr_ci_suite_and_os() -> None:
+    ubuntu_typecheck = _spec("Test & Typecheck", "ubuntu-latest")
+    mac_sidebar = _spec("Mock LLM Sidebar", "macos-latest")
+    assert job_matches("Test & Typecheck (ubuntu-latest)", ubuntu_typecheck)
+    assert not job_matches("Test & Typecheck (windows-latest)", ubuntu_typecheck)
+    assert not job_matches("Mock LLM Sidebar (ubuntu-latest)", ubuntu_typecheck)
+    assert job_matches("Mock LLM Sidebar (macos-latest)", mac_sidebar)
+    assert not job_matches("Test & Typecheck (macos-latest)", mac_sidebar)
+
+
+def test_short_sha_is_seven_chars_from_real_oid() -> None:
+    assert short_sha("96912c4abf1c2d3e4f567890abcdef1234567890") == "96912c4"
+    assert short_sha("") == ""
+    assert short_sha("abc") == "abc"
+
+
+def _run(run_id: int, sha: str, html_url: str) -> dict[str, Any]:
+    return {"id": run_id, "head_sha": sha, "html_url": html_url}
+
+
+def _job(name: str, conclusion: str, when: str) -> dict[str, Any]:
+    return {"name": name, "conclusion": conclusion, "completed_at": when, "status": "completed"}
+
+
+def test_collect_status_picks_newest_matching_jobs() -> None:
+    """Fixtures use real KeithCu/writeragent run ids / SHAs / URLs."""
+    runs = {
+        "crosshair-deep.yml": [
+            _run(
+                33689813185,
+                "6045c1b0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "https://github.com/KeithCu/writeragent/actions/runs/33689813185",
+            ),
+            _run(
+                33677574062,
+                "ce0da960bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "https://github.com/KeithCu/writeragent/actions/runs/33677574062",
+            ),
+        ],
+        "pr-ci.yml": [
+            _run(
+                33789965142,
+                "a5957240cccccccccccccccccccccccccccccccc",
+                "https://github.com/KeithCu/writeragent/actions/runs/33789965142",
+            ),
+            _run(
+                33788378302,
+                "96912c40dddddddddddddddddddddddddddddddd",
+                "https://github.com/KeithCu/writeragent/actions/runs/33788378302",
+            ),
+            _run(
+                33780513241,
+                "589df340eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "https://github.com/KeithCu/writeragent/actions/runs/33780513241",
+            ),
+            _run(
+                33772067046,
+                "85f7a76fffffffffffffffffffffffffffffffff",
+                "https://github.com/KeithCu/writeragent/actions/runs/33772067046",
+            ),
+        ],
+    }
+    jobs = {
+        33689813185: [_job("CrossHair (cover-all, ubuntu-latest)", "cancelled", "2026-09-03T04:19:58Z")],
+        33677574062: [_job("CrossHair (check-all, ubuntu-latest)", "failure", "2026-09-02T21:21:27Z")],
+        33789965142: [
+            {"name": "Test & Typecheck (ubuntu-latest)", "conclusion": None, "status": "in_progress", "started_at": "2026-09-03T18:21:10Z"}
+        ],
+        33788378302: [_job("Test & Typecheck (windows-latest)", "success", "2026-09-03T18:15:33Z")],
+        33780513241: [_job("Test & Typecheck (macos-latest)", "success", "2026-09-03T16:54:58Z")],
+        33772067046: [
+            _job("Mock LLM Sidebar (ubuntu-latest)", "success", "2026-09-03T15:28:00Z"),
+            _job("Mock LLM Sidebar (macos-latest)", "success", "2026-09-03T15:29:00Z"),
+            _job("Mock LLM Sidebar (windows-latest)", "success", "2026-09-03T15:30:00Z"),
+        ],
+    }
+
+    def fetch(url: str) -> dict[str, Any]:
+        if "/workflows/crosshair-deep.yml/runs" in url:
+            return {"workflow_runs": runs["crosshair-deep.yml"]}
+        if "/workflows/pr-ci.yml/runs" in url:
+            return {"workflow_runs": runs["pr-ci.yml"]}
+        for run_id, job_list in jobs.items():
+            if f"/runs/{run_id}/jobs" in url:
+                return {"jobs": job_list}
+        raise AssertionError(f"unexpected URL {url}")
+
+    rows = collect_status(fetch, "KeithCu/writeragent")
+    by_key = {(row.suite, row.os): row for row in rows}
+    assert by_key[("CrossHair check-all", "ubuntu-latest")].conclusion == "failure"
+    assert by_key[("CrossHair check-all", "ubuntu-latest")].sha == "ce0da96"
+    assert by_key[("CrossHair cover-all", "ubuntu-latest")].conclusion == "cancelled"
+    assert by_key[("CrossHair cover-all", "ubuntu-latest")].sha == "6045c1b"
+    assert by_key[("Test & Typecheck", "ubuntu-latest")].conclusion == "in_progress"
+    assert by_key[("Test & Typecheck", "ubuntu-latest")].sha == "a595724"
+    assert by_key[("Test & Typecheck", "windows-latest")].sha == "96912c4"
+    assert by_key[("Test & Typecheck", "macos-latest")].sha == "589df34"
+    assert by_key[("Mock LLM Sidebar", "ubuntu-latest")].sha == "85f7a76"
+    assert by_key[("Mock LLM Sidebar", "windows-latest")].run_url.endswith("/33772067046")
+    assert all(row.sha != "deadbee" and row.sha != "0000000" for row in rows)
+
+
+def test_collect_status_empty_is_no_run_not_fake_sha() -> None:
+    def fetch(url: str) -> dict[str, Any]:
+        if "/runs?" in url or "/runs?per_page" in url:
+            return {"workflow_runs": []}
+        if url.endswith("/runs"):
+            return {"workflow_runs": []}
+        if "/workflows/" in url:
+            return {"workflow_runs": []}
+        raise AssertionError(f"unexpected URL {url}")
+
+    rows = collect_status(fetch, "KeithCu/writeragent")
+    assert len(rows) == len(suite_specs())
+    assert all(row.conclusion == "no run" for row in rows)
+    assert all(row.sha == "" for row in rows)
+
+
+def test_render_html_escapes_and_omits_token() -> None:
+    rows = [
+        StatusRow(
+            suite="<script>alert(1)</script>",
+            os="ubuntu-latest",
+            conclusion="success",
+            sha="96912c4",
+            when="2026-09-03T18:15:33Z",
+            run_url="https://github.com/KeithCu/writeragent/actions/runs/33788378302",
+        )
+    ]
+    page = render_html(rows, repo="KeithCu/writeragent", generated_at="2026-09-03T18:30:00Z")
+    assert "<script>alert(1)</script>" not in page
+    assert "&lt;script&gt;" in page
+    assert "96912c4" in page
+    assert "33788378302" in page
+    assert "ghs_" not in page
+    assert "GITHUB_TOKEN" not in page
+
+
+def test_main_writes_index_and_never_embeds_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_this_must_not_appear_in_html")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "KeithCu/writeragent")
+
+    def fetch(url: str) -> dict[str, Any]:
+        if "crosshair-deep.yml" in url:
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 33677574062,
+                        "head_sha": "ce0da960bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "html_url": "https://github.com/KeithCu/writeragent/actions/runs/33677574062",
+                    }
+                ]
+            }
+        if "pr-ci.yml" in url and "/jobs" not in url:
+            return {"workflow_runs": []}
+        if "/33677574062/jobs" in url:
+            return {
+                "jobs": [
+                    _job("CrossHair (check-all, ubuntu-latest)", "failure", "2026-09-02T21:21:27Z"),
+                ]
+            }
+        return {"workflow_runs": []}
+
+    monkeypatch.setattr("scripts.generate_ci_status.make_fetcher", lambda token: fetch)
+    out = tmp_path / "site"
+    assert main(["--out", str(out)]) == 0
+    text = (out / "index.html").read_text(encoding="utf-8")
+    assert "ghs_this_must_not_appear_in_html" not in text
+    assert "ce0da96" in text
+    assert "CrossHair check-all" in text
+    assert "no run" in text
+
+
+def test_workflow_deploys_pages_from_actions_api() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in text
+    assert "workflow_run:" in text
+    assert "PR CI" in text
+    assert "CrossHair Verification (Deep / On-Demand)" in text
+    assert "pages: write" in text
+    assert "id-token: write" in text
+    assert "actions: read" in text
+    assert "name: github-pages" in text
+    assert "actions/upload-pages-artifact" in text
+    assert "actions/deploy-pages" in text
+    assert "secrets.GITHUB_TOKEN" in text
+    assert "scripts/generate_ci_status.py" in text
+    assert "docs/" not in text
+
+
+def test_generator_and_workflow_live_outside_docs() -> None:
+    from scripts.generate_ci_status import SUITE_SPECS
+
+    assert "docs" not in _GENERATOR.parts
+    assert "docs" not in _WORKFLOW.parts
+    suites = [item[0] for item in SUITE_SPECS]
+    assert suites.count("CrossHair check-all") == 1
+    assert suites.count("CrossHair cover-all") == 1
+    assert suites.count("Test & Typecheck") == 3
+    assert suites.count("Mock LLM Sidebar") == 3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a static CI status page generated from this repo’s GitHub Actions API (real run data, not placeholders).

**Expected URL:** https://keithcu.github.io/writeragent/

**Keith needs to enable Pages before the first deploy works:**
1. Repo **Settings → Pages → Source = GitHub Actions** (`https://github.com/KeithCu/writeragent/settings/pages`). Pages is currently off (`has_pages: false`).
2. First deploy may require approving the **github-pages** environment (Settings → Environments).

The page lists the latest:
- CrossHair check-all / cover-all (`.github/workflows/crosshair-deep.yml`)
- Test & Typecheck and Mock LLM Sidebar on ubuntu-latest, macos-latest, windows-latest (`.github/workflows/pr-ci.yml`)

Each row: suite, OS if any, conclusion, short SHA, when, link to the Actions run.

HTML is built in CI (`scripts/generate_ci_status.py`, `GITHUB_TOKEN` only) and deployed with `actions/upload-pages-artifact` + `actions/deploy-pages`. Triggers: `workflow_dispatch`, plus `workflow_run` when **PR CI** or **CrossHair Verification (Deep / On-Demand)** completes.

The site is not under `docs/` (that tree stays the product manual). Please review; do not merge until you are ready.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1675ef2-81ea-4d62-b732-18ad10cbc570?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1675ef2-81ea-4d62-b732-18ad10cbc570&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

