### PR TITLE
Add GitHub Pages CI status dashboard

### DIFF
--- a/.github/workflows/ci-status.yml
+++ b/.github/workflows/ci-status.yml
@@ -1,0 +1,64 @@
+# Static CI status table for https://keithcu.github.io/writeragent/
+# (or the URL GitHub Pages assigns). Generated from the Actions API — do not
+# scrape keithcu.com. First deploy needs Pages source = GitHub Actions and
+# often a one-time github-pages environment approval.
+name: CI Status Pages
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Cheap weekly refresh if a trigger was missed (Monday 08:15 UTC).
+    - cron: "15 8 * * 1"
+  workflow_run:
+    workflows:
+      - "PR CI"
+      - "CrossHair Verification (Deep / On-Demand)"
+    types:
+      - completed
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/ci-status.yml"
+      - "scripts/generate_ci_status.py"
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate status HTML
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/generate_ci_status.py --out _site
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 localwriter.json
 
 # Build artifacts
+_site/
 build/
 bin/opengrep
 vendor/

--- a/scripts/generate_ci_status.py
+++ b/scripts/generate_ci_status.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+# WriterAgent — GitHub Pages CI status table (Actions API, no scraping)
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Build a one-table HTML dashboard of the Actions runs Keith actually looks up.
+
+Reads the GitHub Actions REST API (``GITHUB_TOKEN`` in CI; public unauthenticated
+reads work for this repo) and writes ``index.html``. Deployed by
+``.github/workflows/ci-status.yml`` — not the product manual under ``docs/``.
+
+CrossHair jobs are named ``CrossHair (<target>, <os>)``. A ``both`` target runs
+check-all and cover-all in one job, so it fills both rows when it is newer than
+the dedicated sweeps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+API_ROOT = "https://api.github.com"
+DEFAULT_REPO = "KeithCu/writeragent"
+USER_AGENT = "writeragent-ci-status"
+MAX_RUN_PAGES = 3
+RUNS_PER_PAGE = 100
+
+# Job names from .github/workflows/crosshair-deep.yml and pr-ci.yml.
+_CROSSHAIR_TARGET = re.compile(r"crosshair\s*\(\s*([^,)]+)", re.IGNORECASE)
+_JOB_OS = re.compile(r"\(([^)]+)\)\s*$")
+
+GetJson = Callable[[str], Any]
+
+
+@dataclass(frozen=True)
+class RowWanted:
+    """One dashboard row Keith wants, matched against Actions job names."""
+
+    suite: str
+    workflow_file: str
+    # Substring the job name must contain (e.g. "check-all", "Test & Typecheck").
+    job_contains: str
+    os_name: str | None = None
+    # CrossHair workflow_dispatch target "both" runs both sweeps in one job.
+    match_both: bool = False
+
+
+@dataclass(frozen=True)
+class StatusRow:
+    suite: str
+    os_name: str
+    conclusion: str
+    sha: str
+    when_utc: str
+    run_url: str
+    run_id: str
+
+
+WANTED_ROWS: tuple[RowWanted, ...] = (
+    RowWanted("CrossHair check-all", "crosshair-deep.yml", "check-all", match_both=True),
+    RowWanted("CrossHair cover-all", "crosshair-deep.yml", "cover-all", match_both=True),
+    RowWanted("Test & Typecheck (UNO+pytest+packaging)", "pr-ci.yml", "Test & Typecheck", "ubuntu-latest"),
+    RowWanted("Test & Typecheck (UNO+pytest+packaging)", "pr-ci.yml", "Test & Typecheck", "macos-latest"),
+    RowWanted("Test & Typecheck (UNO+pytest+packaging)", "pr-ci.yml", "Test & Typecheck", "windows-latest"),
+    RowWanted("Mock LLM Sidebar", "pr-ci.yml", "Mock LLM Sidebar", "ubuntu-latest"),
+    RowWanted("Mock LLM Sidebar", "pr-ci.yml", "Mock LLM Sidebar", "macos-latest"),
+    RowWanted("Mock LLM Sidebar", "pr-ci.yml", "Mock LLM Sidebar", "windows-latest"),
+)
+
+
+def short_sha(sha: str) -> str:
+    sha = (sha or "").strip()
+    if len(sha) <= 7:
+        return sha
+    return sha[:7]
+
+
+def format_utc(stamp: str | None) -> str:
+    """GitHub timestamps are ISO-8601 Zulu; label the column as UTC."""
+    if not stamp:
+        return ""
+    text = stamp.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return stamp
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%d %H:%M UTC")
+
+
+def classify_conclusion(status: str | None, conclusion: str | None) -> str:
+    """Map Actions status/conclusion onto the four colors Keith asked for."""
+    st = (status or "").lower()
+    if st in {"in_progress", "queued", "waiting", "pending", "requested"}:
+        return "in-progress"
+    con = (conclusion or "").lower()
+    if con == "success":
+        return "success"
+    if con in {"failure", "timed_out", "startup_failure"}:
+        return "failure"
+    if con == "cancelled":
+        return "cancelled"
+    if con == "skipped":
+        return "skipped"
+    if st and st != "completed":
+        return "in-progress"
+    return con or "unknown"
+
+
+def os_from_job_name(job_name: str) -> str:
+    """``Test & Typecheck (macos-latest)`` / ``CrossHair (check-all, ubuntu-latest)``."""
+    match = _JOB_OS.search(job_name or "")
+    if match is None:
+        return ""
+    inner = match.group(1)
+    if "," in inner:
+        return inner.split(",")[-1].strip()
+    return inner.strip()
+
+
+def job_matches(job_name: str, wanted: RowWanted) -> bool:
+    name = job_name or ""
+    if wanted.os_name and wanted.os_name.lower() not in name.lower():
+        return False
+    needle = wanted.job_contains.lower()
+    if needle in name.lower():
+        return True
+    if not wanted.match_both:
+        return False
+    target = _CROSSHAIR_TARGET.search(name)
+    return bool(target and target.group(1).strip().lower() == "both")
+
+
+def _run_sort_key(run: dict[str, Any]) -> str:
+    return str(run.get("created_at") or "")
+
+
+def collect_rows(
+    iter_runs: Callable[[str], Iterable[dict[str, Any]]],
+    list_jobs: Callable[[int], list[dict[str, Any]]],
+    wanted: tuple[RowWanted, ...] = WANTED_ROWS,
+) -> list[StatusRow]:
+    """Newest matching job per row. Skipped jobs are not a result (they never ran)."""
+    filled: list[StatusRow | None] = [None] * len(wanted)
+    workflows = {row.workflow_file for row in wanted}
+    for workflow_file in workflows:
+        indexes = [i for i, row in enumerate(wanted) if row.workflow_file == workflow_file]
+        if all(filled[i] is not None for i in indexes):
+            continue
+        runs = sorted(iter_runs(workflow_file), key=_run_sort_key, reverse=True)
+        for run in runs:
+            if all(filled[i] is not None for i in indexes):
+                break
+            run_id = run.get("id")
+            if not isinstance(run_id, int):
+                continue
+            for job in list_jobs(run_id):
+                if (job.get("conclusion") or "").lower() == "skipped":
+                    continue
+                job_name = str(job.get("name") or "")
+                for i in indexes:
+                    if filled[i] is not None:
+                        continue
+                    spec = wanted[i]
+                    if not job_matches(job_name, spec):
+                        continue
+                    when = job.get("completed_at") or job.get("started_at") or run.get("updated_at")
+                    filled[i] = StatusRow(
+                        suite=spec.suite,
+                        os_name=spec.os_name or os_from_job_name(job_name),
+                        conclusion=classify_conclusion(
+                            job.get("status") or run.get("status"),
+                            job.get("conclusion"),
+                        ),
+                        sha=short_sha(str(run.get("head_sha") or "")),
+                        when_utc=format_utc(when if isinstance(when, str) else None),
+                        run_url=str(run.get("html_url") or ""),
+                        run_id=str(run_id),
+                    )
+    rows: list[StatusRow] = []
+    for spec, found in zip(wanted, filled, strict=True):
+        if found is not None:
+            rows.append(found)
+            continue
+        rows.append(
+            StatusRow(
+                suite=spec.suite,
+                os_name=spec.os_name or "",
+                conclusion="no run found",
+                sha="",
+                when_utc="",
+                run_url="",
+                run_id="",
+            )
+        )
+    return rows
+
+
+def _assert_github_api_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "api.github.com":
+        raise ValueError(f"refusing non-GitHub API URL: {url}")
+
+
+def github_get_json(url: str, token: str | None) -> Any:
+    _assert_github_api_url(url)
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=45) as resp:  # noqa: S310 — host pinned to api.github.com
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API {exc.code} for {url}: {body[:400]}") from exc
+
+
+def iter_workflow_runs(repo: str, workflow_file: str, get_json: GetJson) -> Iterable[dict[str, Any]]:
+    for page in range(1, MAX_RUN_PAGES + 1):
+        url = (
+            f"{API_ROOT}/repos/{repo}/actions/workflows/{workflow_file}/runs"
+            f"?per_page={RUNS_PER_PAGE}&page={page}"
+        )
+        payload = get_json(url)
+        runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
+        if not isinstance(runs, list) or not runs:
+            return
+        yield from runs
+        if len(runs) < RUNS_PER_PAGE:
+            return
+
+
+def list_run_jobs(repo: str, run_id: int, get_json: GetJson) -> list[dict[str, Any]]:
+    jobs: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        url = f"{API_ROOT}/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100&page={page}"
+        payload = get_json(url)
+        batch = payload.get("jobs") if isinstance(payload, dict) else None
+        if not isinstance(batch, list) or not batch:
+            break
+        jobs.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return jobs
+
+
+def _conclusion_class(conclusion: str) -> str:
+    if conclusion == "success":
+        return "ok"
+    if conclusion in {"failure", "timed_out", "startup_failure"}:
+        return "bad"
+    if conclusion == "cancelled":
+        return "cancelled"
+    if conclusion == "in-progress":
+        return "progress"
+    return "other"
+
+
+def render_html(rows: list[StatusRow], *, repo: str, generated_at: str) -> str:
+    """Ugly-simple table. No JS, no keys, no third-party assets."""
+    cells: list[str] = []
+    for row in rows:
+        cls = _conclusion_class(row.conclusion)
+        if row.run_url:
+            link = f'<a href="{html.escape(row.run_url, quote=True)}">{html.escape(row.run_id or "run")}</a>'
+        else:
+            link = ""
+        cells.append(
+            "<tr>"
+            f"<td>{html.escape(row.suite)}</td>"
+            f"<td>{html.escape(row.os_name)}</td>"
+            f'<td class="{cls}">{html.escape(row.conclusion)}</td>'
+            f"<td><code>{html.escape(row.sha)}</code></td>"
+            f"<td>{html.escape(row.when_utc)}</td>"
+            f"<td>{link}</td>"
+            "</tr>"
+        )
+    body = "\n".join(cells)
+    title = f"{repo} CI status"
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{html.escape(title)}</title>
+<style>
+body {{ font-family: sans-serif; margin: 1.2rem; }}
+table {{ border-collapse: collapse; }}
+th, td {{ border: 1px solid #444; padding: 0.35rem 0.55rem; text-align: left; }}
+th {{ background: #eee; }}
+.ok {{ background: #c6f3c6; }}
+.bad {{ background: #f5c2c2; }}
+.cancelled {{ background: #ddd; }}
+.progress {{ background: #ffe08a; }}
+.other {{ background: #f3f3f3; }}
+code {{ font-size: 0.95em; }}
+p {{ max-width: 52rem; }}
+</style>
+</head>
+<body>
+<h1>{html.escape(title)}</h1>
+<p>Latest Actions jobs Keith cares about. Generated {html.escape(generated_at)} from the GitHub Actions API (not keithcu.com). Times are UTC.</p>
+<table>
+<thead>
+<tr><th>Suite</th><th>OS</th><th>Conclusion</th><th>SHA</th><th>When (UTC)</th><th>Run</th></tr>
+</thead>
+<tbody>
+{body}
+</tbody>
+</table>
+</body>
+</html>
+"""
+
+
+def write_site(out_dir: str, page: str) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    index = os.path.join(out_dir, "index.html")
+    with open(index, "w", encoding="utf-8") as handle:
+        handle.write(page)
+    # Pages will try Jekyll unless this exists; we ship raw HTML.
+    with open(os.path.join(out_dir, ".nojekyll"), "w", encoding="utf-8") as handle:
+        handle.write("")
+
+
+def build_page(repo: str, token: str | None) -> str:
+    def get_json(url: str) -> Any:
+        return github_get_json(url, token)
+
+    rows = collect_rows(
+        lambda workflow: iter_workflow_runs(repo, workflow, get_json),
+        lambda run_id: list_run_jobs(repo, run_id, get_json),
+    )
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    return render_html(rows, repo=repo, generated_at=generated)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate the Actions CI status HTML table.")
+    parser.add_argument("--out", default="_site", help="Directory for index.html (default: _site)")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO,
+        help="owner/repo (default: GITHUB_REPOSITORY or KeithCu/writeragent)",
+    )
+    args = parser.parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or None
+    page = build_page(args.repo, token)
+    write_site(args.out, page)
+    print(f"wrote {os.path.join(args.out, 'index.html')} for {args.repo} (token={'yes' if token else 'no'})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_ci_status_workflow.py
+++ b/tests/scripts/test_ci_status_workflow.py
@@ -1,0 +1,39 @@
+# WriterAgent tests — CI Status Pages workflow wiring
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci-status.yml"
+
+
+def _text() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_ci_status_workflow_triggers() -> None:
+    text = _text()
+    assert "workflow_dispatch:" in text
+    assert "workflow_run:" in text
+    assert "PR CI" in text
+    assert "CrossHair Verification (Deep / On-Demand)" in text
+    assert "cron:" in text
+    assert "generate_ci_status.py" in text
+
+
+def test_ci_status_workflow_pages_permissions_and_deploy() -> None:
+    text = _text()
+    assert "pages: write" in text
+    assert "id-token: write" in text
+    assert "actions: read" in text
+    assert "environment:" in text
+    assert "github-pages" in text
+    assert "actions/upload-pages-artifact" in text
+    assert "actions/deploy-pages" in text
+    assert "https://keithcu.com" not in text
+    assert "secrets.GITHUB_TOKEN" in text
+    assert "PAT" not in text

--- a/tests/scripts/test_generate_ci_status.py
+++ b/tests/scripts/test_generate_ci_status.py
@@ -1,0 +1,185 @@
+# WriterAgent tests — GitHub Pages CI status generator
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts.generate_ci_status import (
+    RowWanted,
+    StatusRow,
+    WANTED_ROWS,
+    classify_conclusion,
+    collect_rows,
+    format_utc,
+    github_get_json,
+    job_matches,
+    os_from_job_name,
+    render_html,
+    short_sha,
+    write_site,
+)
+
+
+def test_wanted_rows_cover_the_suites_keith_asks_for() -> None:
+    suites = [(row.suite, row.os_name, row.job_contains, row.workflow_file) for row in WANTED_ROWS]
+    assert suites == [
+        ("CrossHair check-all", None, "check-all", "crosshair-deep.yml"),
+        ("CrossHair cover-all", None, "cover-all", "crosshair-deep.yml"),
+        ("Test & Typecheck (UNO+pytest+packaging)", "ubuntu-latest", "Test & Typecheck", "pr-ci.yml"),
+        ("Test & Typecheck (UNO+pytest+packaging)", "macos-latest", "Test & Typecheck", "pr-ci.yml"),
+        ("Test & Typecheck (UNO+pytest+packaging)", "windows-latest", "Test & Typecheck", "pr-ci.yml"),
+        ("Mock LLM Sidebar", "ubuntu-latest", "Mock LLM Sidebar", "pr-ci.yml"),
+        ("Mock LLM Sidebar", "macos-latest", "Mock LLM Sidebar", "pr-ci.yml"),
+        ("Mock LLM Sidebar", "windows-latest", "Mock LLM Sidebar", "pr-ci.yml"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("job_name", "contains", "os_name", "match_both", "expected"),
+    [
+        ("CrossHair (check-all, ubuntu-latest)", "check-all", None, True, True),
+        ("CrossHair (cover-all, ubuntu-latest)", "cover-all", None, True, True),
+        ("CrossHair (check-all, ubuntu-latest)", "cover-all", None, True, False),
+        ("CrossHair (both, ubuntu-latest)", "check-all", None, True, True),
+        ("CrossHair (both, ubuntu-latest)", "cover-all", None, True, True),
+        ("CrossHair (both, ubuntu-latest)", "check-all", None, False, False),
+        ("Test & Typecheck (ubuntu-latest)", "Test & Typecheck", "ubuntu-latest", False, True),
+        ("Test & Typecheck (macos-latest)", "Test & Typecheck", "ubuntu-latest", False, False),
+        ("Mock LLM Sidebar (windows-latest)", "Mock LLM Sidebar", "windows-latest", False, True),
+        ("Test & Typecheck (windows-latest)", "Mock LLM Sidebar", "windows-latest", False, False),
+    ],
+)
+def test_job_matches(job_name: str, contains: str, os_name: str | None, match_both: bool, expected: bool) -> None:
+    wanted = RowWanted("suite", "wf.yml", contains, os_name, match_both)
+    assert job_matches(job_name, wanted) is expected
+
+
+def test_os_from_job_name() -> None:
+    assert os_from_job_name("Test & Typecheck (macos-latest)") == "macos-latest"
+    assert os_from_job_name("CrossHair (check-all, ubuntu-latest)") == "ubuntu-latest"
+    assert os_from_job_name("no parens") == ""
+
+
+def test_classify_and_sha_and_time() -> None:
+    assert classify_conclusion("in_progress", None) == "in-progress"
+    assert classify_conclusion("completed", "success") == "success"
+    assert classify_conclusion("completed", "failure") == "failure"
+    assert classify_conclusion("completed", "timed_out") == "failure"
+    assert classify_conclusion("completed", "cancelled") == "cancelled"
+    assert short_sha("abcdef1234567890") == "abcdef1"
+    assert format_utc("2026-09-03T15:41:00Z") == "2026-09-03 15:41 UTC"
+
+
+def _run(run_id: int, sha: str, created: str, url: str | None = None) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "head_sha": sha,
+        "created_at": created,
+        "updated_at": created,
+        "html_url": url or f"https://github.com/KeithCu/writeragent/actions/runs/{run_id}",
+        "status": "completed",
+    }
+
+
+def _job(name: str, conclusion: str, completed: str, status: str = "completed") -> dict[str, Any]:
+    return {"name": name, "conclusion": conclusion, "status": status, "completed_at": completed, "started_at": completed}
+
+
+def test_collect_rows_picks_newest_real_jobs_and_ignores_skipped() -> None:
+    runs = {
+        "crosshair-deep.yml": [
+            _run(2, "bbbbbbbcccccccc", "2026-09-02T20:00:00Z"),
+            _run(1, "aaaaaaacccccccc", "2026-09-03T04:00:00Z"),
+            _run(3, "bothbothbothxxx", "2026-08-01T00:00:00Z"),
+        ],
+        "pr-ci.yml": [
+            _run(10, "1111111aaaaaaaa", "2026-09-03T18:00:00Z"),
+            _run(11, "2222222aaaaaaaa", "2026-09-03T17:00:00Z"),
+            _run(12, "3333333aaaaaaaa", "2026-09-03T16:00:00Z"),
+            _run(13, "4444444aaaaaaaa", "2026-09-03T15:00:00Z"),
+        ],
+    }
+    jobs = {
+        1: [_job("CrossHair (cover-all, ubuntu-latest)", "cancelled", "2026-09-03T04:19:00Z")],
+        2: [_job("CrossHair (check-all, ubuntu-latest)", "failure", "2026-09-02T21:21:00Z")],
+        3: [_job("CrossHair (both, ubuntu-latest)", "success", "2026-08-01T01:00:00Z")],
+        10: [
+            _job("Test & Typecheck (ubuntu-latest)", None, "2026-09-03T18:21:00Z", status="in_progress"),
+            _job("Test & Typecheck (skipped-os)", "skipped", "2026-09-03T18:21:00Z"),
+        ],
+        11: [_job("Test & Typecheck (windows-latest)", "success", "2026-09-03T18:15:00Z")],
+        12: [_job("Test & Typecheck (macos-latest)", "success", "2026-09-03T16:54:00Z")],
+        13: [
+            _job("Mock LLM Sidebar (ubuntu-latest)", "success", "2026-09-03T15:32:00Z"),
+            _job("Mock LLM Sidebar (macos-latest)", "success", "2026-09-03T15:41:00Z"),
+            _job("Mock LLM Sidebar (windows-latest)", "success", "2026-09-03T15:25:00Z"),
+        ],
+    }
+
+    rows = collect_rows(lambda wf: runs[wf], lambda rid: jobs[rid])
+    by_key = {(row.suite, row.os_name): row for row in rows}
+
+    check = by_key[("CrossHair check-all", "ubuntu-latest")]
+    assert check.conclusion == "failure"
+    assert check.sha == "bbbbbbb"
+    assert check.run_id == "2"
+
+    cover = by_key[("CrossHair cover-all", "ubuntu-latest")]
+    assert cover.conclusion == "cancelled"
+    assert cover.sha == "aaaaaaa"
+    assert cover.run_id == "1"
+
+    assert by_key[("Test & Typecheck (UNO+pytest+packaging)", "ubuntu-latest")].conclusion == "in-progress"
+    assert by_key[("Test & Typecheck (UNO+pytest+packaging)", "ubuntu-latest")].sha == "1111111"
+    macos = by_key[("Test & Typecheck (UNO+pytest+packaging)", "macos-latest")]
+    assert macos.conclusion == "success"
+    assert macos.sha == "3333333"
+    windows = by_key[("Test & Typecheck (UNO+pytest+packaging)", "windows-latest")]
+    assert windows.conclusion == "success"
+    assert windows.sha == "2222222"
+    assert by_key[("Mock LLM Sidebar", "macos-latest")].run_id == "13"
+
+
+def test_collect_rows_both_fills_both_crosshair_suites_when_newest() -> None:
+    runs = {
+        "crosshair-deep.yml": [_run(9, "deadbeefdeadbee", "2026-09-03T12:00:00Z")],
+        "pr-ci.yml": [],
+    }
+    jobs = {9: [_job("CrossHair (both, windows-latest)", "success", "2026-09-03T12:30:00Z")]}
+    rows = collect_rows(lambda wf: runs[wf], lambda rid: jobs.get(rid, []))
+    cross = [row for row in rows if row.suite.startswith("CrossHair")]
+    assert {row.suite for row in cross} == {"CrossHair check-all", "CrossHair cover-all"}
+    assert all(row.conclusion == "success" and row.os_name == "windows-latest" for row in cross)
+    missing = [row for row in rows if row.conclusion == "no run found"]
+    assert len(missing) == 6
+
+
+def test_render_html_escapes_and_colors(tmp_path: Any) -> None:
+    rows = [
+        StatusRow("Suite <x>", "os&", "success", "abc1234", "2026-09-03 15:41 UTC", "https://example.test/1", "99"),
+        StatusRow("Fail", "ubuntu-latest", "failure", "def5678", "2026-09-01 00:00 UTC", "https://example.test/2", "88"),
+        StatusRow("Gone", "", "no run found", "", "", "", ""),
+    ]
+    page = render_html(rows, repo="KeithCu/writeragent", generated_at="2026-09-03 18:00 UTC")
+    assert "<script>" not in page
+    assert "Suite &lt;x&gt;" in page
+    assert "os&amp;" in page
+    assert 'class="ok">success</class>' not in page
+    assert 'class="ok">success</td>' in page
+    assert 'class="bad">failure</td>' in page
+    assert "https://example.test/1" in page
+    assert "keithcu.com" not in page.lower() or "not keithcu.com" in page
+    assert "When (UTC)" in page
+    write_site(str(tmp_path), page)
+    assert (tmp_path / "index.html").is_file()
+    assert (tmp_path / ".nojekyll").is_file()
+
+
+def test_github_get_json_rejects_non_api_hosts() -> None:
+    with pytest.raises(ValueError, match="refusing non-GitHub API URL"):
+        github_get_json("https://keithcu.com/status", token=None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A static CI status page so you can see the latest CrossHair and PR CI jobs without memorizing Actions run IDs.

**Expected URL:** https://keithcu.github.io/writeragent/

(If GitHub assigns a different Pages URL, it will show on the `CI Status Pages` workflow’s deploy job / `github-pages` environment.)

## What it shows

One HTML table generated in CI from the GitHub Actions API (`GITHUB_TOKEN` only — no PAT, no keithcu.com scrape):

- CrossHair check-all (`.github/workflows/crosshair-deep.yml`, job name contains `check-all`; a `both` target also counts, because that job runs both sweeps)
- CrossHair cover-all (same workflow, job name contains `cover-all`; `both` also counts)
- Test & Typecheck (UNO+pytest+packaging) for ubuntu / macos / windows (`.github/workflows/pr-ci.yml`)
- Mock LLM Sidebar for those three OSes (same workflow, `test_mock_sidebar=true`)

Each row: suite, OS if any, conclusion (green / red / cancelled / in-progress), short SHA, time (UTC), link to the Actions run.

Live generator output from this repo (not placeholders):

[Live CI status table generated from the GitHub Actions API](https://cursor.com/agents/bc-0202e615-3589-4a25-8e59-17a0c81075b3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_status_live.png)

## How it deploys

- Workflow: `.github/workflows/ci-status.yml` (`CI Status Pages`)
- Generator: `scripts/generate_ci_status.py` (stdlib only)
- Official `actions/upload-pages-artifact` + `actions/deploy-pages`
- Permissions: `pages: write`, `id-token: write`, `actions: read` (plus `contents: read` for checkout)
- Environment: `github-pages`
- Triggers: `workflow_dispatch`, `workflow_run` when **PR CI** or **CrossHair Verification (Deep / On-Demand)** completes, Monday 08:15 UTC cron, and push to `master` when the workflow/generator change

`workflow_run` always uses the default-branch copy of the workflow, so this page starts updating automatically only after merge.

This is **not** under `docs/` (product manual stays untouched).

## One-time enable (required — Pages is currently off)

First deploy usually needs a click:

1. **Settings → Pages → Build and deployment → Source:** **GitHub Actions** (not a branch).
2. Approve / allow the **`github-pages`** environment if GitHub asks (environment protection or first-time creation).
3. After merge, run **Actions → CI Status Pages → Run workflow**, or wait for the next PR CI / CrossHair completion (or the Monday cron).

Until that is enabled, the build job can still generate `index.html`; deploy will sit on the environment or fail with a Pages-not-configured error.

Please review; do not merge until you are happy with it.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0202e615-3589-4a25-8e59-17a0c81075b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0202e615-3589-4a25-8e59-17a0c81075b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

