### PR TITLE
Off cover-all 33689813185 leftovers (sandbox, cors, CalcRange, wire_types)

### DIFF
--- a/plugin/chatbot/tool_loop_state.py
+++ b/plugin/chatbot/tool_loop_state.py
@@ -36,6 +36,8 @@ _EMPTY_MODEL_DEBUG_CONTENT_PREVIEW_MAX = 120
 
 
 def _describe_empty_response_content(content: Any) -> str:
+    # crosshair: off
+    # cover-all 33689813185 leftover: Any content (~932 ex). Doable later: str-only preview domain.
     if content is None:
         return "None"
     if content == "":

--- a/plugin/framework/tool.py
+++ b/plugin/framework/tool.py
@@ -41,7 +41,7 @@ from plugin.framework.worker_pool import run_in_background
 from plugin.framework.thread_guard import assert_main_thread
 from plugin.framework.queue_executor import execute_on_main_thread
 
-from plugin.framework.deal_shim import deal
+from plugin.framework.deal_shim import DEAL_MAX_CMD_ARGS, DEAL_MAX_TOKEN, ascii_bounded, deal
 
 
 _SCALAR_TYPES = frozenset({"integer", "number", "boolean", "string"})
@@ -62,6 +62,15 @@ def _collapse_union_type(types: list) -> str | list:
     return non_null[0] if non_null else "string"
 
 
+@deal.pre(
+    lambda type_val: type_val is None
+    or isinstance(type_val, str)
+    or (
+        isinstance(type_val, list)
+        and len(type_val) <= DEAL_MAX_CMD_ARGS
+        and all(isinstance(x, str) and ascii_bounded(x, DEAL_MAX_TOKEN) for x in type_val)
+    )
+)
 def _type_allows_null(type_val: Any) -> bool:
     return isinstance(type_val, list) and "null" in type_val
 
@@ -273,6 +282,7 @@ _READ_NAME_TOKENS = frozenset(
 )
 
 
+@deal.pre(lambda name: isinstance(name, str) and ascii_bounded(name, DEAL_MAX_TOKEN))
 def _name_looks_readonly(name: str) -> bool:
     """True when the tool name implies a non-mutating read (prefix or domain_verb)."""
     if name.startswith(_READ_PREFIXES):

--- a/plugin/mcp/cors.py
+++ b/plugin/mcp/cors.py
@@ -94,6 +94,8 @@ def _deal_allow_headers_ok(value: object) -> bool:
     )
 )
 def normalize_cors_origin(value: str | None) -> str | None:
+    # crosshair: off
+    # cover-all 33689813185 leftover (~32m / 1289 ex) despite _deal_origin_ok. Doable later: closed origin enum.
     """Return a canonical origin URL or None if empty/invalid."""
     if value is None:
         return None

--- a/plugin/mcp/tunnel_state.py
+++ b/plugin/mcp/tunnel_state.py
@@ -140,6 +140,8 @@ def compute_backoff_delay(
 
 
 def _event_int(data: dict[str, Any], key: str, fallback: int) -> int:
+    # crosshair: off
+    # cover-all 33689813185 leftover: dict Any int parse (~1444 ex). Doable later: closed key/int domain.
     """Parse an optional int from event data; empty / invalid strings keep *fallback*.
 
     CrossHair can put ``''`` in ``port`` / ``max_retries``; ``int('')`` raises.

--- a/plugin/mcp/wire_types.py
+++ b/plugin/mcp/wire_types.py
@@ -212,6 +212,8 @@ class CallToolRequestParams:
 
     @classmethod
     def from_params(cls, params: dict[str, Any]) -> CallToolRequestParams:
+        # crosshair: off
+        # cover-all 33689813185 leftover: thin wrapper (~3186 ex) despite _deal_call_tool_params_ok. Doable later.
         return _call_tool_request_params_from_dict(params)
 
 
@@ -254,6 +256,8 @@ def _deal_call_tool_params_ok(params: object) -> bool:
 
 @deal.pre(lambda params: _deal_call_tool_params_ok(params))
 def _call_tool_request_params_from_dict(params: dict[str, Any]) -> CallToolRequestParams:
+    # crosshair: off
+    # cover-all 33689813185 leftover: dict Any (~3110 ex) despite dual-profile pre. Doable later: closed name/args enum.
     name = params.get("name")
     if not isinstance(name, str) or not name:
         raise ValueError("tools/call requires params.name")

--- a/plugin/scripting/calc_range.py
+++ b/plugin/scripting/calc_range.py
@@ -162,48 +162,70 @@ class CalcRange:
     __slots__ = ("_values", "_address")
 
     def __init__(self, values: Any, *, address: str | None = None) -> None:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         self._values = ensure_rectangular_2d(values)
         self._address = address
 
     @property
     def values(self) -> list[list[Any]]:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         return self._values
 
     @property
     def address(self) -> str | None:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         return self._address
 
     @property
     def shape(self) -> tuple[int, int]:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         nrows = len(self._values)
         ncols = len(self._values[0]) if self._values else 0
         return (nrows, ncols)
 
     @property
     def nrows(self) -> int:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         return self.shape[0]
 
     @property
     def ncols(self) -> int:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         return self.shape[1]
 
     def __repr__(self) -> str:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         r, c = self.shape
         addr = f" address={self._address!r}" if self._address else ""
         return f"CalcRange({r}x{c}{addr})"
 
     def __len__(self) -> int:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         return self.nrows
 
     def __iter__(self):
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         """Iterate rows (each a list). Does not flatten to cells."""
         return iter(self._values)
 
     def __getitem__(self, key: Any) -> Any:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         """Row access (``data[0]``) or slice of rows — not cell flattening."""
         return self._values[key]
 
     def __array__(self, dtype: Any = None) -> Any:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         """NumPy array protocol — enables ``np.mean(data)`` without flattening.
 
         ``None`` cells become ``nan`` when a numeric dtype is used so ``np.sum`` /
@@ -212,6 +234,8 @@ class CalcRange:
         return self.to_numpy(dtype=dtype)
 
     def to_numpy(self, *, dtype: Any = None) -> Any:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         """Explicit NumPy conversion (same as ``np.asarray(range)``)."""
         import numpy as np
 
@@ -268,6 +292,8 @@ class CalcRange:
     __hash__ = None  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType, reportGeneralTypeIssues]  # CalcRange is mutable / unhashable like ndarray
 
     def __bool__(self) -> bool:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         if self.shape == (1, 1):
             return bool(self._values[0][0])
         if self.shape == (0, 0) or not self._values:
@@ -278,17 +304,23 @@ class CalcRange:
         )
 
     def __str__(self) -> str:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         if self.shape == (1, 1):
             return str(self._values[0][0])
         return self.__repr__()
 
     def __format__(self, format_spec: str) -> str:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         if self.shape == (1, 1):
             return format(self._values[0][0], format_spec)
         return format(str(self), format_spec)
 
     # Scalar conversions
     def __float__(self) -> float:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         if self.shape == (1, 1):
             val = self._values[0][0]
             if val is None:
@@ -297,6 +329,8 @@ class CalcRange:
         raise TypeError(f"Only 1x1 CalcRange can be converted to float, got shape {self.shape}")
 
     def __int__(self) -> int:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         if self.shape == (1, 1):
             val = self._values[0][0]
             if val is None:
@@ -305,6 +339,8 @@ class CalcRange:
         raise TypeError(f"Only 1x1 CalcRange can be converted to int, got shape {self.shape}")
 
     def __round__(self, ndigits: int | None = None) -> Any:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         if self.shape == (1, 1):
             val = self._values[0][0]
             if val is None:
@@ -313,16 +349,24 @@ class CalcRange:
         raise TypeError(f"Only 1x1 CalcRange can be rounded, got shape {self.shape}")
 
     def __trunc__(self) -> int:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         return math.trunc(self.__float__())
 
     def __floor__(self) -> int:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         return math.floor(self.__float__())
 
     def __ceil__(self) -> int:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         return math.ceil(self.__float__())
 
     # Dispatchers
     def _binary_op(self, other: Any, op: Any, *, is_reverse: bool = False) -> Any:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         if self.shape == (1, 1):
             val = self._values[0][0]
             if isinstance(other, CalcRange):
@@ -345,6 +389,8 @@ class CalcRange:
         return op(other, self_arr) if is_reverse else op(self_arr, other)
 
     def _unary_op(self, op: Any) -> Any:
+        # crosshair: off
+        # cover-all 33689813185 leftover: combinatoric instance surface. Doable later: tiny 1x1 grid domain.
         if self.shape == (1, 1):
             return op(self._values[0][0])
         try:

--- a/plugin/scripting/sandbox.py
+++ b/plugin/scripting/sandbox.py
@@ -334,7 +334,8 @@ def _reset_cache() -> None:  # pyright: ignore[reportUnusedFunction]  # test hel
 @deal.pre(lambda path: str_bounded(path, DEAL_MAX_PATH))
 def _strip_surrounding_quotes(path: str) -> str:
     """Strip one layer of matching quotes (Windows Explorer \"Copy as path\")."""
-    # crosshair: off  # strip/quote SMT leftover (check-all 33668189572: Prev 8:33 despite DEAL_MAX_PATH). Doable later: tiny quoted-path alphabet.
+    # crosshair: off
+    # strip/quote SMT leftover (check-all 33668189572: Prev 8:33 despite DEAL_MAX_PATH). Doable later: tiny quoted-path alphabet.
     s = path.strip()
     if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
         return s[1:-1].strip()
@@ -343,7 +344,8 @@ def _strip_surrounding_quotes(path: str) -> str:
 
 def _path_from_file_url(raw: str) -> str | None:
     """Convert a ``file://`` / ``file:/`` URL to a filesystem path (stdlib only)."""
-    # crosshair: off  # urlparse/unquote/url2pathname combinatorics on free strings (cover-all 33293627157: ~2.0h, 190k lines / 108k examples). Doable later with a tiny file-URL alphabet.
+    # crosshair: off
+    # urlparse/unquote/url2pathname combinatorics on free strings (cover-all 33293627157: ~2.0h, 190k lines / 108k examples). Doable later with a tiny file-URL alphabet.
     from urllib.parse import unquote, urlparse
 
     text = raw.strip()
@@ -368,7 +370,8 @@ def _path_from_file_url(raw: str) -> str | None:
 
 def _normalize_venv_path_input(venv_dir: str) -> str:
     """Strip quotes, convert file URLs, then expand ``~`` and env vars."""
-    # crosshair: off  # expandvars/file-URL path still combinatoric as an entry (cover-all 33293627157: ~4.5m, 139k lines). Doable later with DEAL_MAX_PATH + opaque URL helper.
+    # crosshair: off
+    # expandvars/file-URL path still combinatoric as an entry (cover-all 33293627157: ~4.5m, 139k lines). Doable later with DEAL_MAX_PATH + opaque URL helper.
     cleaned = _strip_surrounding_quotes(venv_dir.strip())
     if cleaned.lower().startswith("file:"):
         from_url = _path_from_file_url(cleaned)
@@ -377,6 +380,7 @@ def _normalize_venv_path_input(venv_dir: str) -> str:
     return os.path.expanduser(os.path.expandvars(cleaned))
 
 
+@deal.pre(lambda base: str_bounded(base, DEAL_MAX_PATH))
 def _is_acceptable_python_basename(base: str) -> bool:
     """True for python / python3 / python.exe; false for pythonw (no console I/O)."""
     lower = base.lower()
@@ -386,6 +390,8 @@ def _is_acceptable_python_basename(base: str) -> bool:
 
 
 def _is_usable_python_file(path: str) -> bool:
+    # crosshair: off
+    # cover-all 33689813185 leftover: os.path.isfile/access combinatorics. Doable later: closed path alphabet.
     """True when *path* is a usable console Python interpreter file."""
     if not os.path.isfile(path):
         return False
@@ -398,6 +404,8 @@ def _is_usable_python_file(path: str) -> bool:
 
 
 def _python_beside_soffice(soffice_path: str) -> Optional[str]:
+    # crosshair: off
+    # cover-all 33689813185 leftover cluster: filesystem walk beside soffice. Doable later.
     """Office-bundled interpreter next to soffice (not checkout ``.venv``).
 
     Windows ``sys.executable`` is often ``soffice.exe``; Darwin is empty or
@@ -422,6 +430,8 @@ def _python_beside_soffice(soffice_path: str) -> Optional[str]:
 
 
 def _bundled_lo_python_candidates() -> list[str]:
+    # crosshair: off
+    # cover-all 33689813185 leftover cluster: os.listdir install-layout walk. Doable later.
     """Install-layout fallbacks when ``sys.executable`` is empty (Darwin soffice)."""
     out: list[str] = []
     if os.name == "nt":
@@ -486,6 +496,8 @@ def resolve_libreoffice_python() -> Optional[str]:
 
 
 def _python_candidates_in_bin_dir(bin_dir: str) -> list[str]:
+    # crosshair: off
+    # cover-all 33689813185 leftover: os.listdir python3.* combinatorics (~313 ex). Doable later: closed bin names.
     """Return candidate interpreter paths under a venv ``bin/`` or ``Scripts/`` directory."""
     candidates: list[str] = []
     if os.name == "nt":
@@ -507,6 +519,8 @@ def _python_candidates_in_bin_dir(bin_dir: str) -> list[str]:
 
 
 def _python_candidates_at_env_root(env_dir: str) -> list[str]:
+    # crosshair: off
+    # cover-all 33689813185 leftover: env-root path combinatorics. Doable later.
     """Return interpreter candidates at the env root (conda / pyenv-win layout)."""
     if os.name == "nt":
         return [
@@ -521,6 +535,8 @@ def _python_candidates_at_env_root(env_dir: str) -> list[str]:
 
 
 def _first_executable_python(candidates: list[str]) -> str | None:
+    # crosshair: off
+    # cover-all 33689813185 leftover: isfile walk (~473 ex). Doable later: closed candidate list.
     seen: set[str] = set()
     for candidate in candidates:
         if candidate in seen:

--- a/tests/mcp/test_cors_verification.py
+++ b/tests/mcp/test_cors_verification.py
@@ -126,7 +126,7 @@ def test_localhost_safe_origin() -> None:
 
 
 def test_normalize_origins_list_is_off_cover_all() -> None:
-    """cover-all 33569420452 leftover (~4h); # crosshair: off, doable later with a closed origin enum."""
+    """cover-all leftover offs (33569420452 ~4h plus 33689813185 normalize_cors_origin)."""
     from tests.strip_bundle import skip_if_release_build
 
     skip_if_release_build("scripts/ not in stripped release tree")
@@ -136,6 +136,7 @@ def test_normalize_origins_list_is_off_cover_all() -> None:
     # cover-all 33569420452 leftover offs (doable later with a closed origin enum).
     offed = (
         "normalize_origins_list",
+        "normalize_cors_origin",
         "is_safe_origin",
         "is_private_browser_origin",
         "merge_allow_headers",

--- a/tests/scripting/test_sandbox_path_verification.py
+++ b/tests/scripting/test_sandbox_path_verification.py
@@ -62,3 +62,25 @@ def test_safe_workspace_path_overflow_pre_fails_closed() -> None:
     with pytest.raises(deal.PreContractError):
         is_safe_workspace_path(too_long, "/home/user")
     assert is_safe_workspace_path("José.txt", "/home/user/workspace") is True
+
+
+def test_sandbox_filesystem_helpers_are_off_cover_all() -> None:
+    """cover-all 33689813185 leftover (~48m sandbox); filesystem walkers off, doable later."""
+    from pathlib import Path
+
+    from tests.strip_bundle import skip_if_release_build
+
+    skip_if_release_build("scripts/ not in stripped release tree")
+    from scripts.crosshair_stream import cover_fqns_for_module
+
+    fqns = cover_fqns_for_module(Path("plugin/scripting/sandbox.py"))
+    offed = (
+        "_is_usable_python_file",
+        "_python_beside_soffice",
+        "_bundled_lo_python_candidates",
+        "_python_candidates_in_bin_dir",
+        "_python_candidates_at_env_root",
+        "_first_executable_python",
+    )
+    for name in offed:
+        assert not any(f.endswith(f".{name}") for f in fqns), name


### PR DESCRIPTION
## Cover-all settle (run 33689813185)

- Run: https://github.com/KeithCu/writeragent/actions/runs/33689813185
- Workflow: CrossHair Verification (Deep / On-Demand), **cover-all only**, start-at **1**, SHA `6045c1b6` (master when kicked). This PR bases on current master.
- Wall: cancelled at the **360-minute** GitHub job limit (6h0m16s). Annotation: exceeded maximum execution time.
- **0 COVER FAIL / engine crash**
- Flushed **30/56** COVER TIMING modules (finish-order banners). Remaining 26 were still in the pool (unknowns done; `COVER_ALL_SCHEDULE_ORDER` starting at `formula_edit.py` in flight / queued). In-flight unflushed modules do not count as completed.

### Flushed COVER TIMING (slowest)

| Module | Seconds | Notes |
| --- | ---: | --- |
| `plugin/scripting/sandbox.py` | 2873.5 (~47.9m) | `_first_executable_python` 473 ex; `scrub_subprocess_env` 448; listdir walkers |
| `plugin/mcp/cors.py` | 1947.0 (~32.4m) | leftover `normalize_cors_origin` 1289 ex (540 left this on) |
| `plugin/chatbot/tool_loop_state.py` | 1165.4 (~19.4m) | `_describe_empty_response_content` 932 ex |
| `plugin/scripting/calc_range.py` | 860.3 (~14.3m) | remaining instance surface (`__init__` 1931, `_binary_op` 1913, conversions) |
| `plugin/framework/appearance.py` | 804.4 | left alone (closed `_darken` factors already) |
| `plugin/calc/excel_py_convert/to_dag.py` | 604.5 | already offed the 540 leftovers; left cheaper helpers |
| `plugin/framework/tool.py` | 487.4 | `_type_allows_null` 3846 ex; `_name_looks_readonly` 2887 ex |
| `plugin/mcp/wire_types.py` | 430.3 | `from_params` / `_call_tool_request_params_from_dict` ~3k ex |
| `plugin/mcp/tunnel_state.py` | 95.4 | `_event_int` 1444 ex |

## What changed

Same strategy as 512/517/529/535/540: combinatoric leftovers that already burned deep time get `# crosshair: off` with a doable-later comment on its **own** line. Easy tiny `deal.pre` when the hole is obvious.

### `plugin/scripting/sandbox.py` (~47.9m)
Offed filesystem walkers: `_is_usable_python_file`, `_python_candidates_in_bin_dir`, `_python_candidates_at_env_root`, `_first_executable_python`, plus the same-cluster `_python_beside_soffice` / `_bundled_lo_python_candidates` added on master after this run. Added `@deal.pre(str_bounded(..., DEAL_MAX_PATH))` on `_is_acceptable_python_basename`. Left `scrub_subprocess_env` on (dual-profile already; check FQN test stays). Split the remaining same-line `# crosshair: off  # …` comments to two-line form (InvalidDirective).

### `plugin/mcp/cors.py` (~32.4m)
Offed `normalize_cors_origin` (540 left it on as a building block; it is now the cors leftover). Updated `test_normalize_origins_list_is_off_cover_all` to assert the leftover set is skipped.

### `plugin/scripting/calc_range.py` (~14.3m)
Offed the remaining combinatoric instance surface (`__init__`, properties, conversions, `_binary_op` / `_unary_op`). Arithmetic dunders were already off as thin wrappers around `_binary_op`.

### `plugin/framework/tool.py`
Tiny `deal.pre` on `_type_allows_null` (list/str domain) and `_name_looks_readonly` (`ascii_bounded(..., DEAL_MAX_TOKEN)`).

### `plugin/mcp/wire_types.py`
Offed `CallToolRequestParams.from_params` and `_call_tool_request_params_from_dict` (dict Any leftover despite dual-profile pre).

### `plugin/chatbot/tool_loop_state.py` / `plugin/mcp/tunnel_state.py`
Offed `_describe_empty_response_content` and `_event_int`.

Did **not** module-off any file. Did **not** off `appearance._darken` or `scrub_subprocess_env`.

## Next

- **Next start-at = 31** (= 1 + 30 flushed COVER TIMING). First remaining schedule module is `plugin/calc/python/formula_edit.py`.
- Full 56 did **not** finish under 6h.
- After this PR merges, Keith kicks the next cover-all (from 31, or from-1 once these offs land). Hang-check stays paused. **Do not stack a run from this PR.**
