### PR TITLE
CI status SVG for README (GitHub Pages)

### DIFF
--- a/.github/workflows/ci-status-pages.yml
+++ b/.github/workflows/ci-status-pages.yml
@@ -1,4 +1,5 @@
-# Static CI status table for https://keithcu.github.io/writeragent/
+# Static CI status table (index.html + status.svg) for
+# https://keithcu.github.io/writeragent/
 # Pages Source must be GitHub Actions (Settings → Pages). First deploy
 # may need approval of the github-pages environment.
 name: CI Status Pages
@@ -29,7 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Generate CI status HTML
+      - name: Generate CI status HTML and SVG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 [![LibreOffice 7.0+](https://img.shields.io/badge/LibreOffice-7.0%2B-green.svg)](https://www.libreoffice.org/)
 [![Release](https://img.shields.io/github/v/release/KeithCu/writeragent)](https://github.com/KeithCu/writeragent/releases)
 
+![CI status](https://keithcu.github.io/writeragent/status.svg)
+[CI status page](https://keithcu.github.io/writeragent/)
+
 **Python, NumPy, and Agentic AI for LibreOffice (Writer, Calc, and Draw)**
 
 Run Python and scientific compute directly in spreadsheet formulas, edit documents with private local-first AI, conduct autonomous web research, generate diagrams, and automate office workflows — without cloud lock-in.

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -50,6 +50,7 @@ Start here by task.
 | Mock LLM (dev) | Fake OpenAI `/v1/chat/completions` for sidebar soak: HTML/scroll, research, Stop, empty replies, reasoning, delegate, parallel tools, HTTP fail/hang (`make mock-llm`, port 18766) | [`scripts/mock_llm_server.py`](../scripts/mock_llm_server.py) — [chat/rich-text-control-sidebar.md](chat/rich-text-control-sidebar.md#mock-llm-for-sidebar-soak) |
 | Extension packaging | OXT resources; register new components in manifest | [`extension/`](../extension/) (`Dialogs/`, `idl/`, `metadata/`), [`extension/META-INF/manifest.xml`](../extension/META-INF/manifest.xml) |
 | Build / tooling | Make targets, package metadata, Python pin, LibrePy file list | [`Makefile`](../Makefile), [`pyproject.toml`](../pyproject.toml), [`.python-version`](../.python-version), [`scripts/librepy_bundle_paths.py`](../scripts/librepy_bundle_paths.py) |
+| CI status (Pages) | Actions API → `index.html` + `status.svg` for the README | [`scripts/generate_ci_status.py`](../scripts/generate_ci_status.py), [`.github/workflows/ci-status-pages.yml`](../.github/workflows/ci-status-pages.yml) |
 
 ## Deep dives (link index)
 

--- a/scripts/generate_ci_status.py
+++ b/scripts/generate_ci_status.py
@@ -7,8 +7,10 @@
 """Build a static CI status table from the GitHub Actions API.
 
 Used by ``.github/workflows/ci-status-pages.yml`` to publish
-https://keithcu.github.io/writeragent/ . Auth is ``GITHUB_TOKEN`` only
-(optional for this public repo). The token is never written into HTML.
+https://keithcu.github.io/writeragent/ (``index.html`` + ``status.svg``).
+Auth is ``GITHUB_TOKEN`` only (optional for this public repo). The token
+is never written into HTML or SVG. The SVG is a drawn table (not a
+screenshot) so the repo README can embed it as an image.
 """
 
 from __future__ import annotations
@@ -227,6 +229,138 @@ def _cell(value: str) -> str:
     return html.escape(value, quote=True)
 
 
+# Drawn table for README ``<img>`` / Camo. No Run column: markdown images
+# are not clickable, and the HTML page already has the links.
+_SVG_COLS: tuple[tuple[str, int], ...] = (
+    ("Suite", 168),
+    ("OS", 118),
+    ("Conclusion", 100),
+    ("SHA", 72),
+    ("When", 172),
+)
+_SVG_PAD_X = 12
+_SVG_PAD_Y = 10
+_SVG_TITLE_H = 20
+_SVG_SUB_H = 16
+_SVG_GAP = 8
+_SVG_ROW_H = 22
+# class, light fill, light text — CSS overrides fills in dark mode.
+_CONCLUSION_STYLE: dict[str, tuple[str, str, str]] = {
+    "success": ("ok", "#cfc", "#1a7f37"),
+    "failure": ("fail", "#fcc", "#cf222e"),
+    "cancelled": ("cancel", "#eee", "#6e7781"),
+    "in_progress": ("prog", "#ffc", "#9a6700"),
+    "in-progress": ("prog", "#ffc", "#9a6700"),
+    "no run": ("norun", "#f6f8fa", "#6e7781"),
+}
+_DEFAULT_CONCLUSION_STYLE = ("unk", "#fff", "#111")
+
+
+def _svg_table_size(row_count: int) -> tuple[int, int, int]:
+    table_w = sum(width for _label, width in _SVG_COLS)
+    table_top = _SVG_PAD_Y + _SVG_TITLE_H + _SVG_SUB_H + _SVG_GAP
+    height = table_top + _SVG_ROW_H * (1 + row_count) + _SVG_PAD_Y
+    return table_w, table_top, height
+
+
+def _conclusion_style(conclusion: str) -> tuple[str, str, str]:
+    return _CONCLUSION_STYLE.get(conclusion, _DEFAULT_CONCLUSION_STYLE)
+
+
+def render_svg(
+    rows: list[StatusRow],
+    *,
+    repo: str,
+    generated_at: str,
+) -> str:
+    """Same suite/OS/conclusion/SHA/when table as HTML, as an SVG image."""
+    table_w, table_top, height = _svg_table_size(len(rows))
+    width = table_w + 2 * _SVG_PAD_X
+    parts: list[str] = [
+        '<?xml version="1.0" encoding="UTF-8"?>\n',
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" '
+        f'height="{height}" viewBox="0 0 {width} {height}" role="img">\n',
+        "<title>WriterAgent CI status</title>\n",
+        "<style>\n",
+        "text { font-family: sans-serif; font-size: 12px; }\n",
+        "text.mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }\n",
+        "@media (prefers-color-scheme: dark) {\n",
+        "  .bg { fill: #0d1117; }\n",
+        "  .grid { stroke: #8b949e; }\n",
+        "  .ink { fill: #e6edf3; }\n",
+        "  .hdr { fill: #161b22; }\n",
+        "  .ok { fill: #1a3d2a; } .okt { fill: #3fb950; }\n",
+        "  .fail { fill: #3d1a1a; } .failt { fill: #f85149; }\n",
+        "  .cancel { fill: #21262d; } .cancelt { fill: #8b949e; }\n",
+        "  .prog { fill: #3d2f0a; } .progt { fill: #d29922; }\n",
+        "  .norun { fill: #161b22; } .norunt { fill: #8b949e; }\n",
+        "  .unk { fill: #0d1117; } .unkt { fill: #e6edf3; }\n",
+        "}\n",
+        "</style>\n",
+        f'<rect class="bg" width="{width}" height="{height}" fill="#fff"/>\n',
+        f'<text class="ink" x="{_SVG_PAD_X}" y="{_SVG_PAD_Y + 14}" '
+        f'fill="#111" font-weight="bold">WriterAgent CI status</text>\n',
+        f'<text class="ink" x="{_SVG_PAD_X}" y="{_SVG_PAD_Y + _SVG_TITLE_H + 12}" '
+        f'fill="#333" font-size="11">{_cell(repo)} · {_cell(generated_at)}</text>\n',
+    ]
+
+    def _x_at(col: int) -> int:
+        return _SVG_PAD_X + sum(width for _label, width in _SVG_COLS[:col])
+
+    def _row_rect(y: int, fill: str, css: str) -> str:
+        return (
+            f'<rect class="{css}" x="{_SVG_PAD_X}" y="{y}" '
+            f'width="{table_w}" height="{_SVG_ROW_H}" fill="{fill}"/>\n'
+        )
+
+    def _grid(y: int) -> str:
+        lines = [
+            f'<rect class="grid" x="{_SVG_PAD_X}" y="{y}" width="{table_w}" '
+            f'height="{_SVG_ROW_H}" fill="none" stroke="#333"/>\n'
+        ]
+        for col in range(1, len(_SVG_COLS)):
+            x = _x_at(col)
+            lines.append(
+                f'<line class="grid" x1="{x}" y1="{y}" x2="{x}" '
+                f'y2="{y + _SVG_ROW_H}" stroke="#333"/>\n'
+            )
+        return "".join(lines)
+
+    def _cell_text(col: int, y: int, value: str, *, css: str = "ink", fill: str = "#111",
+                   mono: bool = False) -> str:
+        text_y = y + _SVG_ROW_H - 6
+        extra = ' class="mono ink"' if mono else f' class="{css}"'
+        return (
+            f"<text{extra} x=\"{_x_at(col) + 6}\" y=\"{text_y}\" "
+            f'fill="{fill}">{_cell(value)}</text>\n'
+        )
+
+    header_y = table_top
+    parts.append(_row_rect(header_y, "#f6f8fa", "hdr"))
+    parts.append(_grid(header_y))
+    for col, (label, _width) in enumerate(_SVG_COLS):
+        parts.append(_cell_text(col, header_y, label, fill="#111"))
+
+    for index, row in enumerate(rows):
+        y = table_top + _SVG_ROW_H * (index + 1)
+        css, bg, ink = _conclusion_style(row.conclusion)
+        parts.append(_row_rect(y, "#fff", "bg"))
+        # Conclusion tint only on that cell so the row stays readable.
+        parts.append(
+            f'<rect class="{css}" x="{_x_at(2)}" y="{y}" '
+            f'width="{_SVG_COLS[2][1]}" height="{_SVG_ROW_H}" fill="{bg}"/>\n'
+        )
+        parts.append(_grid(y))
+        parts.append(_cell_text(0, y, row.suite))
+        parts.append(_cell_text(1, y, row.os))
+        parts.append(_cell_text(2, y, row.conclusion, css=f"{css}t", fill=ink))
+        parts.append(_cell_text(3, y, row.sha, mono=True))
+        parts.append(_cell_text(4, y, row.when))
+
+    parts.append("</svg>\n")
+    return "".join(parts)
+
+
 def render_html(
     rows: list[StatusRow],
     *,
@@ -286,11 +420,13 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def write_site(out_dir: Path, html_text: str) -> Path:
+def write_site(out_dir: Path, html_text: str, svg_text: str) -> tuple[Path, Path]:
     out_dir.mkdir(parents=True, exist_ok=True)
     index = out_dir / "index.html"
+    svg = out_dir / "status.svg"
     index.write_text(html_text, encoding="utf-8")
-    return index
+    svg.write_text(svg_text, encoding="utf-8")
+    return index, svg
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -298,7 +434,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--out",
         default="_site",
-        help="Directory to write index.html into (default: _site)",
+        help="Directory to write index.html and status.svg into (default: _site)",
     )
     parser.add_argument(
         "--repo",
@@ -313,11 +449,13 @@ def main(argv: list[str] | None = None) -> int:
     repo = (args.repo or os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO).strip()
     token = os.environ.get("GITHUB_TOKEN", "")
     rows = collect_status(make_fetcher(token), repo)
-    page = render_html(rows, repo=repo, generated_at=utc_now())
-    if token and token in page:
-        raise RuntimeError("refusing to write HTML that contains GITHUB_TOKEN")
-    path = write_site(Path(args.out), page)
-    print(f"Wrote {path} ({len(rows)} rows)")
+    generated_at = utc_now()
+    page = render_html(rows, repo=repo, generated_at=generated_at)
+    svg = render_svg(rows, repo=repo, generated_at=generated_at)
+    if token and (token in page or token in svg):
+        raise RuntimeError("refusing to write output that contains GITHUB_TOKEN")
+    index, svg_path = write_site(Path(args.out), page, svg)
+    print(f"Wrote {index} and {svg_path} ({len(rows)} rows)")
     return 0
 
 

--- a/tests/scripts/test_generate_ci_status.py
+++ b/tests/scripts/test_generate_ci_status.py
@@ -18,6 +18,7 @@ from scripts.generate_ci_status import (
     job_matches,
     main,
     render_html,
+    render_svg,
     short_sha,
     suite_specs,
 )
@@ -160,6 +161,75 @@ def test_collect_status_empty_is_no_run_not_fake_sha() -> None:
     assert all(row.sha == "" for row in rows)
 
 
+def _sample_rows() -> list[StatusRow]:
+    return [
+        StatusRow("CrossHair check-all", "ubuntu-latest", "failure", "ce0da96", "2026-09-02T21:21:27Z", ""),
+        StatusRow("CrossHair cover-all", "ubuntu-latest", "cancelled", "6045c1b", "2026-09-03T04:19:58Z", ""),
+        StatusRow("Test & Typecheck", "ubuntu-latest", "success", "12a7676", "2026-09-03T19:01:28Z", ""),
+        StatusRow("Test & Typecheck", "macos-latest", "success", "589df34", "2026-09-03T16:54:58Z", ""),
+        StatusRow("Test & Typecheck", "windows-latest", "success", "96912c4", "2026-09-03T18:15:33Z", ""),
+        StatusRow("Mock LLM Sidebar", "ubuntu-latest", "success", "85f7a76", "2026-09-03T15:32:33Z", ""),
+        StatusRow("Mock LLM Sidebar", "macos-latest", "success", "85f7a76", "2026-09-03T15:41:00Z", ""),
+        StatusRow("Mock LLM Sidebar", "windows-latest", "success", "85f7a76", "2026-09-03T15:25:02Z", ""),
+    ]
+
+
+def test_render_svg_contains_suite_names() -> None:
+    svg = render_svg(_sample_rows(), repo="KeithCu/writeragent", generated_at="2026-09-03T19:01:48Z")
+    assert svg.startswith("<?xml")
+    assert "<svg" in svg
+    assert "CrossHair check-all" in svg
+    assert "CrossHair cover-all" in svg
+    assert "Test &amp; Typecheck" in svg
+    assert "Mock LLM Sidebar" in svg
+    assert "ubuntu-latest" in svg
+    assert "macos-latest" in svg
+    assert "windows-latest" in svg
+    assert "success" in svg
+    assert "failure" in svg
+    assert "cancelled" in svg
+    assert "ce0da96" in svg
+    assert "2026-09-03T19:01:48Z" in svg
+    assert "ghs_" not in svg
+
+
+def test_render_svg_empty_runs_does_not_crash() -> None:
+    empty_rows = [
+        StatusRow(spec.suite, spec.os, "no run", "", "", "") for spec in suite_specs()
+    ]
+    svg = render_svg(empty_rows, repo="KeithCu/writeragent", generated_at="2026-09-03T00:00:00Z")
+    assert "<svg" in svg
+    assert "CrossHair check-all" in svg
+    assert "Test &amp; Typecheck" in svg
+    assert "Mock LLM Sidebar" in svg
+    assert "no run" in svg
+    header_only = render_svg([], repo="KeithCu/writeragent", generated_at="2026-09-03T00:00:00Z")
+    assert "<svg" in header_only
+    assert "</svg>" in header_only
+
+
+def test_render_svg_escapes_xml() -> None:
+    rows = [
+        StatusRow(
+            suite="<script>alert(1)</script>",
+            os="ubuntu-latest",
+            conclusion="success",
+            sha="96912c4",
+            when="2026-09-03T18:15:33Z",
+            run_url="",
+        )
+    ]
+    svg = render_svg(rows, repo="KeithCu/writeragent", generated_at="2026-09-03T18:30:00Z")
+    assert "<script>alert(1)</script>" not in svg
+    assert "&lt;script&gt;" in svg
+
+
+def test_readme_embeds_pages_svg() -> None:
+    text = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "![CI status](https://keithcu.github.io/writeragent/status.svg)" in text
+    assert "[CI status page](https://keithcu.github.io/writeragent/)" in text
+
+
 def test_render_html_escapes_and_omits_token() -> None:
     rows = [
         StatusRow(
@@ -209,10 +279,15 @@ def test_main_writes_index_and_never_embeds_token(tmp_path: Path, monkeypatch: p
     out = tmp_path / "site"
     assert main(["--out", str(out)]) == 0
     text = (out / "index.html").read_text(encoding="utf-8")
+    svg = (out / "status.svg").read_text(encoding="utf-8")
     assert "ghs_this_must_not_appear_in_html" not in text
+    assert "ghs_this_must_not_appear_in_html" not in svg
     assert "ce0da96" in text
+    assert "ce0da96" in svg
     assert "CrossHair check-all" in text
+    assert "CrossHair check-all" in svg
     assert "no run" in text
+    assert "no run" in svg
 
 
 def test_workflow_deploys_pages_from_actions_api() -> None:
@@ -229,6 +304,7 @@ def test_workflow_deploys_pages_from_actions_api() -> None:
     assert "actions/deploy-pages" in text
     assert "secrets.GITHUB_TOKEN" in text
     assert "scripts/generate_ci_status.py" in text
+    assert "status.svg" in text
     assert "docs/" not in text
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Pages generator now writes `status.svg` next to `index.html`. README embeds the SVG and links to the HTML table.

Same data as the live page: CrossHair check-all/cover-all, Test & Typecheck and Mock LLM Sidebar × ubuntu/macOS/windows, conclusion, short SHA, when. Drawn table (not a screenshot). No Playwright, no keithcu.com, no extra bot.

After merge, the next CI Status Pages deploy publishes `https://keithcu.github.io/writeragent/status.svg`. GitHub Camo may cache the README image for a while; Pages itself is the source of truth. A cache-bust query is omitted so README does not need a rewrite every run.

Generated from the live Actions API (and the empty-run path):

[Live CI status SVG table](https://cursor.com/agents/bc-bbb5a930-efb9-4c03-8ce4-342bb2df0bf4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_status_svg_live.png)
[Empty-run CI status SVG table](https://cursor.com/agents/bc-bbb5a930-efb9-4c03-8ce4-342bb2df0bf4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_status_svg_empty.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbb5a930-efb9-4c03-8ce4-342bb2df0bf4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbb5a930-efb9-4c03-8ce4-342bb2df0bf4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

