### PR TITLE
Fix Geometric Recalc Order cap-hit spam and row-insert orphan map

### DIFF
--- a/docs/calc/geometric-recalc-order.md
+++ b/docs/calc/geometric-recalc-order.md
@@ -1,6 +1,8 @@
-# Geometric Recalc Order — implementation plan
+# Geometric Recalc Order (Experimental) — implementation plan
 
-**Status:** Implementation in progress. **Phases 1–4 landed on master** (Settings flag default off, attach on save / flag-on, UDProp load/save, Isolated `record_active_calc_session`, eval strip before the index heuristic, sheet modify-listener / insert-delete deferred repair, discovery `truncated` flag). When the flag is on, insert/delete/clear of `=PY()` cells retargets geometric predecessor fields without waiting for save; a data-edit that changes the PY list rebuilds the strip-safe eval index the same way. Closed calls in [§9](#9-decisions) stand (no IDL, no 1×1 value-shape strip, no `locate_formula_cell_in_doc` for eval identity, precedent-only, cap skip-sheet, no strip-on-disable, Isolated checkbox visible / no-op). **Eval identity** is **unanimous-ours** on `(workbook_key, resolved_code, n_args)` only ([§9.5](#95-marker-is-the-udprop--in-memory-map)). **Cap-hit UI:** skip the sheet, log, **and** show one message box per skipped sheet (`notify_geometric_cap_hit`) — do not only `log.error`.
+**Status:** **(Experimental).** Phases 1–4 landed on master (Settings flag default off, attach on save / flag-on, UDProp load/save, Isolated `record_active_calc_session`, eval strip before the index heuristic, sheet modify-listener / insert-delete deferred repair, discovery `truncated` flag). This revision repairs Gemini **B** (cap-hit modal persists across reconcile so debounce / save / open cannot storm) and **C** (row-insert rehomes the attach-map key onto the current address). Gemini **A** (two open workbooks → no strip) is **by design**, not a blackout bug: eval-time strip runs only when `off_main_calc_session_is_unambiguous()` is true (`len(_RECORDED_CALC_SESSION_IDS)==1`). Flag-off leftover `;predecessor` fields are also **by design** ([§9.4](#94-flag-turned-off-leave-refs)). Closed calls in [§9](#9-decisions) stand (no IDL, no 1×1 value-shape strip, no `locate_formula_cell_in_doc` for eval identity, precedent-only, cap skip-sheet, no strip-on-disable, Isolated checkbox visible / no-op). **Eval identity** is **unanimous-ours** on `(workbook_key, resolved_code, n_args)` only ([§9.5](#95-marker-is-the-udprop--in-memory-map)). **Cap-hit UI:** skip the sheet, log, **and** show one first message box per skipped sheet (`notify_geometric_cap_hit`, persisted across reconcile) — do not only `log.error`.
+
+**Parked (not this revision):** multi-workbook keyed strip (needs a real eval-time workbook id, not `len==1`); cycle / Err:522 detection before splice; workbook-global PY order and spatial clustering; Collabora extra-listen path ([§12](#12-collabora--libreoffice-core-living-sketch-not-final)).
 
 **Related:** [Enabling NumPy & Python](../enabling_numpy_in_libreoffice.md) (session modes, auto-spill), [Microsoft `=PY` design stance](../scripting/ms-py-compatibility.md) (why we refuse Excel co-volatility), [Calc `=PY()` data shapes](py-data-shapes.md) (`data` / `ranges` arity).
 
@@ -54,7 +56,7 @@ Do **not** add a dedicated IDL ordering argument. That rebuilds `.rdb`s for both
 
 ## 2. Product definition
 
-**Flag name (UI):** Geometric Recalc Order  
+**Flag name (UI):** Geometric Recalc Order (Experimental)  
 **Config key (proposed):** `scripting.python_geometric_recalc_order`  
 **Type:** bool, default **false**  
 **Surface:** Settings → Python, next to session mode / auto-spill (`plugin/scripting/module.yaml`). Same checkbox path as `python_auto_spill`. LibrePy **and** WriterAgent.
@@ -117,7 +119,7 @@ Example: list is A1, A3. A3 has `;A1`. User inserts a PY cell at A2.
 
 Delete A2: A3’s predecessor must become A1 again, or **remove-field** if A3 is now first.
 
-Row insert that only **moves** existing PY cells: Calc’s own reference adjust may already be correct. The deferred pass should be **idempotent**: recompute desired predecessor per cell, rewrite only when the geometric field differs.
+Row insert that only **moves** existing PY cells: Calc’s own reference adjust may already be correct. The deferred pass should be **idempotent**: recompute desired predecessor per cell, rewrite only when the geometric field differs. **Also rehome the attach-map key** onto the cell’s current discovery address and drop keys that are no longer on the sheet — formula-only idempotence left an orphan at the old address after Calc shifted the cell (Gemini C).
 
 ### 3.5 Writes must be outside recalc (same as auto-spill)
 
@@ -230,7 +232,7 @@ Compare to **full Excel co-volatility:** multiple engineer-months in `sc/`, high
 | Uniqueness / “fail-safe = no strip” | **Rejected** — kills fill-down of identical `=PY("np.mean(data)"; B1:B10)` |
 | ≥1-hit strip | **Rejected** — would strip a mixed matrix-index neighbor |
 | Mixed ours + user same triple | Do not mark strip-safe; residual is “chain loses strip,” not “user cell loses last arg” |
-| Two open workbooks | `off_main_calc_session_is_unambiguous()` false → no strip |
+| Two open workbooks | **By design (Gemini A):** `off_main_calc_session_is_unambiguous()` false → no strip. Eval cannot pick `workbook_key` when more than one Calc session is recorded. Not a blackout bug. |
 | Isolated still needs strip | Isolated never enters `workbook_session_id`. Init-non-empty already records via `build_python_eval_init_kwargs` → `calc_init_session_id`. Isolated + no init still never records. UI load/repair must `record_active_calc_session("calc:" + _workbook_session_key)` (same string, idempotent) so the no-init case can pass the unambiguous check |
 | Keying the token `$A$1` | Eval `code` is resolved source (`execute_python_addin`); repair must read the code cell |
 | Naive `;` arity | Repair `n_args` must match `split_python_addin_data_args`, not a semicolon count |
@@ -295,7 +297,7 @@ Precedent-only strip means Isolated `data` is unchanged. Isolated is a no-op for
 
 ### 9.4 Flag turned off — leave refs
 
-**Decision: A.** Stop attaching and stop repairing. The refs stay as valid DAG edges. After a precedent-only strip they do not change Python behavior.
+**Decision: A.** Stop attaching and stop repairing. The refs stay as valid DAG edges. After a precedent-only strip they do not change Python behavior. **By design**, not a missing strip-on-disable: leftover `;predecessor` fields remain when the flag is off.
 
 **Rejected for this feature: B — strip-on-disable.** The marker now exists ([§9.5](#95-marker-is-the-udprop--in-memory-map)), so B is implementable later with the same remove-field primitive. Do not build it here.
 
@@ -340,7 +342,7 @@ At **repair time** (UI thread, we have addresses), compute an eval-index bool pe
 
 `get_python_init_kwargs` does **not** carry `doc_url`. `build_python_eval_init_kwargs` (`document_scripts.py`) returns `{}` with **no** session record when the init script is empty. When init is non-empty it calls `calc_init_session_id(doc)` → `calc_workbook_base_session_id` → `record_active_calc_session("calc:" + _workbook_session_key)` (`session_manager.py`). `set_calc_init_script` and on-main `get_python_init_kwargs` both go through that builder. `record_active_calc_session(None, kwargs)` itself does **not** add to `_RECORDED_CALC_SESSION_IDS` (`None` is ignored); the add is the side effect of building kwargs. Isolated does **not** “never enter `record_active_calc_session`.” Isolated + no init still never records. `workbook_session_id` still returns `None` when mode ≠ `shared`. Isolated still needs strip off-main (else arity breaks). Do **not** write a unit test that asserts Isolated always leaves `_RECORDED_CALC_SESSION_IDS` empty.
 
-**Eval `workbook_key` = `get_cached_calc_session_id()` only when `off_main_calc_session_is_unambiguous()`** (`session_manager.py`: `len(_RECORDED_CALC_SESSION_IDS) == 1`). Else do not strip (two open workbooks, or Isolated that never recorded).
+**Eval `workbook_key` = `get_cached_calc_session_id()` only when `off_main_calc_session_is_unambiguous()`** (`session_manager.py`: `len(_RECORDED_CALC_SESSION_IDS) == 1`). Else do not strip (two open workbooks, or Isolated that never recorded). **By design (Gemini A):** eval cannot pick `workbook_key` when more than one session is recorded. Two open workbooks → no strip is not a blackout bug.
 
 On the **UI-thread** load / repair path, write that key into the geometric map **and** call `record_active_calc_session` with the **same string eval will read**: `calc:` + `_workbook_session_key` (never `""`). Do this **even in Isolated**. Same string as the init-kwargs path; idempotent; **required for the no-init case**. Do **not** invent a second Isolated key. Then one open file makes `len(_RECORDED_CALC_SESSION_IDS) == 1` and yellow Isolated can strip. Sibling of `load_spill_registry_for_doc`. Unsaved files must not use empty URL — same #402 hole as `session_key` / `_workbook_session_key` (URL, else a persisted unsaved id, never `""`).
 
@@ -394,7 +396,7 @@ Phase 4 — `data` strip (inject the in-memory map; no UNO):
 - **Fill-down:** two identical `=PY("np.mean(data)"; B1:B10)` after attach → **both** strip (unanimous-ours, same resolved code, `n_args=2`).
 - **Mixed:** matrix-index neighbor `=PY("f"; range; i)` next to a chain of `=PY("f"; range; pred)` → **neither** strips (mixed poisons the triple).
 - **Over-poison (fingerprint dropped):** same snippet + `n_args` on two ranges; mixed on A also poisons B. Residual is safe (no strip). Data-value edit after attach must still strip (3-field key). Flag-off leftover attached last arg must still strip.
-- **Two open workbooks / `off_main_calc_session_is_unambiguous()` false** → no strip.
+- **Two open workbooks / `off_main_calc_session_is_unambiguous()` false** → no strip (**by design**, Gemini A — eval cannot pick `workbook_key`).
 - **Isolated** UI load/repair calls `record_active_calc_session("calc:" + _workbook_session_key)` (same string eval reads) and strips when unambiguous. Do not assert Isolated always leaves `_RECORDED_CALC_SESSION_IDS` empty.
 - User 1×1 last arg **not** in the map, and no mixed poison of a chain: no strip of that user cell.
 - Never fall back to 1×1, uniqueness, or ≥1-hit.

--- a/docs/calc/geometric-recalc-order.md
+++ b/docs/calc/geometric-recalc-order.md
@@ -119,7 +119,7 @@ Example: list is A1, A3. A3 has `;A1`. User inserts a PY cell at A2.
 
 Delete A2: A3’s predecessor must become A1 again, or **remove-field** if A3 is now first.
 
-Row insert that only **moves** existing PY cells: Calc’s own reference adjust may already be correct. The deferred pass should be **idempotent**: recompute desired predecessor per cell, rewrite only when the geometric field differs. **Also rehome the attach-map key** onto the cell’s current discovery address and drop keys that are no longer on the sheet — formula-only idempotence left an orphan at the old address after Calc shifted the cell (Gemini C).
+Row insert that only **moves** existing PY cells: Calc’s own reference adjust may already be correct. The deferred pass should be **idempotent**: recompute desired predecessor per cell, rewrite only when the geometric field differs. **Also rehome the attach-map key** onto the cell’s current discovery address and drop keys that are no longer on the sheet — formula-only idempotence left an orphan at the old address after Calc shifted the cell (Gemini C). Rehome uses pred-match only for a **true orphan** (old key gone) or a row/col delta (`pred + (live − old)`); a live-key record stays unless the delta claims it. Undo after delete-middle often leaves `{A3: A1}` while formulas are again A2 `;A1` / A3 `;A2` — matching A3 onto A2 drops the successor from the map so the later successor-becomes-first remove-field is a noop.
 
 ### 3.5 Writes must be outside recalc (same as auto-spill)
 

--- a/plugin/calc/python/geometric_recalc.py
+++ b/plugin/calc/python/geometric_recalc.py
@@ -338,6 +338,27 @@ def _a1_shift(address: str, dcol: int, drow: int) -> str | None:
         return None
 
 
+def _rule2_candidate_score(
+    old: str,
+    rec: GeometricRecord,
+    live: str,
+    desired: str,
+) -> tuple[int, int] | None:
+    """``pred + (live − old)`` equals *desired* — the cell moved with its formula."""
+    try:
+        ocol, orow = parse_address(local_a1(old))
+        lcol, lrow = parse_address(local_a1(live))
+    except (TypeError, ValueError):
+        return None
+    dcol, drow = lcol - ocol, lrow - orow
+    if not (dcol or drow):
+        return None
+    shifted = _a1_shift(rec.predecessor, dcol, drow)
+    if shifted is not None and same_cell_ref(shifted, desired):
+        return (0, abs(dcol) + abs(drow))
+    return None
+
+
 def _rehome_candidate_score(
     old: str,
     rec: GeometricRecord,
@@ -354,36 +375,85 @@ def _rehome_candidate_score(
     it — otherwise undo's stale ``{A3: A1}`` is stolen onto A2 and
     successor-becomes-first cannot remove-field.
     """
-    rule1 = same_cell_ref(rec.predecessor, desired) and old not in live_keys
-    try:
-        ocol, orow = parse_address(local_a1(old))
-        lcol, lrow = parse_address(local_a1(live))
-    except (TypeError, ValueError):
-        return (1, 0) if rule1 else None
-    dcol, drow = lcol - ocol, lrow - orow
-    if dcol or drow:
-        shifted = _a1_shift(rec.predecessor, dcol, drow)
-        if shifted is not None and same_cell_ref(shifted, desired):
-            return (0, abs(dcol) + abs(drow))
-    if rule1:
+    rule2 = _rule2_candidate_score(old, rec, live, desired)
+    if rule2 is not None:
+        return rule2
+    if same_cell_ref(rec.predecessor, desired) and old not in live_keys:
         return (1, 0)
     return None
 
 
-def _record_is_homeless(
+def _incoming_is_displaced(
     old: str,
     rec: GeometricRecord,
     live_keys: set[str],
     desired_by_key: Mapping[str, str | None],
-    evicted: set[str],
 ) -> bool:
-    """Gone from the sheet, pred does not match that live cell, or overwritten."""
-    if old in evicted or old not in live_keys:
+    """True when *old* is gone, first in the list, or pred ≠ that cell's desired."""
+    if old not in live_keys:
         return True
     live_desired = desired_by_key.get(old)
     if live_desired is None:
         return True
     return not same_cell_ref(rec.predecessor, live_desired)
+
+
+def _collect_rule2_claimed(
+    cells: list[GeometricCell],
+    incoming: Mapping[str, GeometricRecord],
+    live_keys: set[str],
+    desired_by_key: Mapping[str, str | None],
+) -> set[str]:
+    """Incoming keys a row/col delta will move. Assigned in sheet order.
+
+    Only gone / pred-mismatched records are eligible. A live successor whose
+    pred already matches (mixed-poisons A3→A2) can satisfy ``pred+(A2-A3)==A1``
+    — that is not a move, and must not be pre-claimed.
+    """
+    claimed: set[str] = set()
+    for cell in cells:
+        key = cell_map_key(cell.address)
+        desired = desired_by_key.get(key)
+        if desired is None:
+            continue
+        data_args = formula_data_args(cell.formula)
+        if not data_args:
+            continue
+        last = data_args[-1]
+        if not is_single_cell_arg(last) or not same_cell_ref(last, desired):
+            continue
+        best: tuple[int, int] | None = None
+        chosen: str | None = None
+        for old, rec in incoming.items():
+            if old in claimed:
+                continue
+            if not _incoming_is_displaced(old, rec, live_keys, desired_by_key):
+                continue
+            score = _rule2_candidate_score(old, rec, key, desired)
+            if score is None:
+                continue
+            if best is None or score < best:
+                chosen, best = old, score
+        if chosen is not None:
+            claimed.add(chosen)
+    return claimed
+
+
+def _record_is_homeless(
+    old: str,
+    live_keys: set[str],
+    evicted: set[str],
+    rule2_claimed: set[str],
+) -> bool:
+    """Gone, rule-2 moved, or overwritten. Live unclaimed keys stay for in-place.
+
+    Stale incoming pred (undo ``A3→A1`` while the formula is already ``;A2``)
+    used to count as homeless because pred ≠ desired. Rule 1 then stole that
+    record onto A2 (same pred A1). Unclaimed live keys are not homeless.
+    """
+    if old in evicted or old not in live_keys:
+        return True
+    return old in rule2_claimed
 
 
 def _rehome_or_keep_record(
@@ -396,17 +466,19 @@ def _rehome_or_keep_record(
     *,
     consumed: set[str],
     evicted: set[str],
-    desired_by_key: Mapping[str, str | None],
+    rule2_claimed: set[str],
 ) -> None:
     """Keep a true live record, or rehome a homeless one after a row/col move.
 
     ``last == desired`` is a formula no-op. Do **not** bind ``working[key]``
     just because the key is live — after a 3+ chain shift that address is
     often the *moved* cell's old record (wrong occupant). Homeless: key not
-    in *live_keys*, live but incoming pred ≠ that cell's desired, or evicted
-    when another record was written onto its address. Match via pred==desired
-    or pred+delta. Never ``orphans[0]``. No matching homeless record → do
-    not invent one (§9.5 user-authored ``;prev``).
+    in *live_keys*, rule-2 claimed (row/col delta), or evicted when another
+    record was written onto its address. A live key that rule 2 did not
+    take is updated in place — do not leave it homeless for rule 1 (undo
+    ``{A3: A1}`` must not be stolen onto A2). Match via pred==desired
+    (true orphan only) or pred+delta. Never ``orphans[0]``. No matching
+    homeless record → do not invent one (§9.5 user-authored ``;prev``).
     """
     if desired is None:
         return
@@ -418,7 +490,7 @@ def _rehome_or_keep_record(
     for old, rec in incoming.items():
         if old in consumed:
             continue
-        if not _record_is_homeless(old, rec, live_keys, desired_by_key, evicted):
+        if not _record_is_homeless(old, live_keys, evicted, rule2_claimed):
             continue
         score = _rehome_candidate_score(old, rec, key, desired, live_keys)
         if score is None:
@@ -541,6 +613,11 @@ def compute_sheet_repair(
         )
     consumed: set[str] = set()
     evicted: set[str] = set()
+    # Rule-2 targets first so a live stale pred (undo A3→A1) is not left
+    # homeless for rule 1. 3+/4-cell row insert still moves claimed keys.
+    rule2_claimed = _collect_rule2_claimed(
+        cells, incoming, live_keys, desired_by_key
+    )
 
     for i, cell in enumerate(cells):
         data_args = formula_data_args(cell.formula)
@@ -558,8 +635,8 @@ def compute_sheet_repair(
             # formula (A2 with ;A1 became A3 with ;A1). last==desired so we
             # used to continue without writing working[new_key]; the record
             # stayed at A2 (orphan) and unanimous-ours / replace went wrong.
-            # Rehome when the old key is gone or displaced. Do not invent a
-            # record when the user authored the previous PY as real data (§9.5).
+            # Rehome when the old key is gone or rule-2 claimed. Do not invent
+            # a record when the user authored the previous PY as real data (§9.5).
             _rehome_or_keep_record(
                 working,
                 incoming,
@@ -569,7 +646,7 @@ def compute_sheet_repair(
                 data_args,
                 consumed=consumed,
                 evicted=evicted,
-                desired_by_key=desired_by_key,
+                rule2_claimed=rule2_claimed,
             )
             continue
         new_formula = rebuild_formula_with_data_args(cell.formula, new_args)

--- a/plugin/calc/python/geometric_recalc.py
+++ b/plugin/calc/python/geometric_recalc.py
@@ -260,16 +260,15 @@ def notify_geometric_cap_hit(
     ``(workbook_key, sheet_name)`` persists across reconcile / 0.1s debounce
     / save / open — a fresh local ``set()`` per call was the cap-hit spam.
     """
+    persist_key = (workbook_key, sheet_name)
     if already_notified is not None:
         if sheet_name in already_notified:
             return False
         already_notified.add(sheet_name)
     else:
-        persist_key = (workbook_key, sheet_name)
         with _GEOMETRIC_LOCK:
             if persist_key in _CAP_HIT_NOTIFIED:
                 return False
-            _CAP_HIT_NOTIFIED.add(persist_key)
 
     message = geometric_cap_hit_user_message(sheet_name)
     log.error("Geometric Recalc Order: %s", message)
@@ -277,12 +276,17 @@ def notify_geometric_cap_hit(
     from plugin.framework.thread_guard import on_main_thread
 
     if not on_main_thread():
+        # Off-main still logs. Do not persist — a later UI-thread call
+        # must still be able to show the first box.
         return False
 
     from plugin.chatbot.dialogs import msgbox
 
     # Msgid matches the Settings checkbox label in module.yaml.
     msgbox(ctx, _(FEATURE_TITLE), message, box_type=3)
+    if already_notified is None:
+        with _GEOMETRIC_LOCK:
+            _CAP_HIT_NOTIFIED.add(persist_key)
     return True
 
 
@@ -327,13 +331,14 @@ def _rehome_or_keep_record(
     desired: str | None,
     data_args: list[str],
 ) -> None:
-    """Keep/update a live record, or rehome an orphan after a row move.
+    """Keep/update a live record, or rehome a pred-matching orphan after a move.
 
     ``last == desired`` is a formula no-op. If we already have a record at
-    *key*, the predecessor must match the formula (Calc may have adjusted
-    it onto a key that still exists). If *key* is new and an incoming key
-    is gone from the sheet, that is a moved attach — rehome one orphan.
-    If we never attached, leave the map alone (§9.5: do not record).
+    *key*, keep it and align the predecessor with the formula. If *key* is
+    new, rehome only when a gone incoming key's predecessor equals *desired*
+    (Calc shifted a cell we attached). An unmatched orphan must not be
+    stolen onto a user-authored previous-PY last arg (§9.5: do not record).
+    Dead keys drop at the end of ``compute_sheet_repair``.
     """
     if desired is None:
         return
@@ -343,16 +348,22 @@ def _rehome_or_keep_record(
     if key in working:
         working[key] = GeometricRecord(predecessor=desired)
         return
-    orphans = [old for old in incoming if old not in live_keys and old in working]
-    if not orphans:
-        return
     chosen = None
-    for old in orphans:
-        if same_cell_ref(incoming[old].predecessor, desired):
+    for old, rec in incoming.items():
+        if old in live_keys or old not in working:
+            continue
+        if same_cell_ref(rec.predecessor, desired):
             chosen = old
             break
     if chosen is None:
-        chosen = orphans[0]
+        # Unmatched leftover (deleted cell, or a later cell after a multi-row
+        # shift whose incoming pred is stale). Do not invent a record — §9.5.
+        log.debug(
+            "geometric_recalc: no pred-matching orphan for %s (desired %s); not recording",
+            key,
+            desired,
+        )
+        return
     working.pop(chosen, None)
     working[key] = GeometricRecord(predecessor=desired)
     log.debug(

--- a/plugin/calc/python/geometric_recalc.py
+++ b/plugin/calc/python/geometric_recalc.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 KeithCu
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Geometric Recalc Order — list-diff, attach, UDProp map, eval-time strip.
+"""Geometric Recalc Order (Experimental) — list-diff, attach, UDProp map, eval-time strip.
 
 Phase 1 helpers stay pure (no UNO): given a row-major list of PY cells plus the
 in-memory attach map, compute formula patches and unanimous-ours strip-safe
@@ -11,13 +11,23 @@ save and flag-on, Isolated session record, and worker-ingress strip.
 Phase 3 shares the sheet modify trigger (0.1s debounce) and rebuilds the
 strip-safe index on insert/delete/clear and on a data-edit of the PY list.
 
+TODO (parked — not this revision):
+- Multi-workbook strip: today no-strip when more than one Calc session is
+  recorded; a future keyed strip would need a real eval-time workbook id,
+  not ``len==1``.
+- Cycle / Err:522: attaching the previous list entry can cycle if the user
+  already had a reverse ref; detect before splice.
+- Workbook-global PY order and spatial clustering (later options in the doc).
+- Collabora extra-listen path (doc §12) remains a living sketch.
+
 See ``docs/calc/geometric-recalc-order.md`` §8 and §9.5.
 Eval identity is unanimous-ours on ``(workbook_key, resolved_code, n_args)``
 only — a value fingerprint of ``args[:-1]`` was rejected. The strip-safe
 index is a frozenset snapshot rebound on the UI thread (§3.5); workers only
 read. Cap-hit skip uses the discovery ``truncated`` flag (exact 100 is not
 a skip). A skipped sheet must also show a user-visible error — callers use
-:func:`notify_geometric_cap_hit` on the UI thread (one box per sheet).
+:func:`notify_geometric_cap_hit` on the UI thread (one first box per sheet,
+persisted across reconcile so the 0.1s debounce cannot storm).
 """
 
 from __future__ import annotations
@@ -48,6 +58,7 @@ log = logging.getLogger(__name__)
 GEOMETRIC_DISCOVERY_CAP = _MAX_PYTHON_CELLS_FOUND
 GEOMETRIC_REGISTRY_PROP = "WriterAgentGeometricRegistry"
 CONFIG_KEY = "scripting.python_geometric_recalc_order"
+FEATURE_TITLE = "Geometric Recalc Order (Experimental)"
 
 GeometricAction = Literal["append", "replace", "remove"]
 
@@ -239,16 +250,26 @@ def notify_geometric_cap_hit(
     sheet_name: str,
     *,
     already_notified: set[str] | None = None,
+    workbook_key: str = "",
 ) -> bool:
     """Log the skip and show one message box per sheet. UI thread only.
 
     Returns True when a box was shown. A second call for the same sheet name
-    in *already_notified* is a no-op so repair cannot storm the user.
+    in *already_notified* is a no-op so one repair pass cannot storm the user.
+    When *already_notified* is omitted, a process-wide set keyed by
+    ``(workbook_key, sheet_name)`` persists across reconcile / 0.1s debounce
+    / save / open — a fresh local ``set()`` per call was the cap-hit spam.
     """
-    if already_notified is not None and sheet_name in already_notified:
-        return False
     if already_notified is not None:
+        if sheet_name in already_notified:
+            return False
         already_notified.add(sheet_name)
+    else:
+        persist_key = (workbook_key, sheet_name)
+        with _GEOMETRIC_LOCK:
+            if persist_key in _CAP_HIT_NOTIFIED:
+                return False
+            _CAP_HIT_NOTIFIED.add(persist_key)
 
     message = geometric_cap_hit_user_message(sheet_name)
     log.error("Geometric Recalc Order: %s", message)
@@ -260,7 +281,8 @@ def notify_geometric_cap_hit(
 
     from plugin.chatbot.dialogs import msgbox
 
-    msgbox(ctx, _("Geometric Recalc Order"), message, box_type=3)
+    # Msgid matches the Settings checkbox label in module.yaml.
+    msgbox(ctx, _(FEATURE_TITLE), message, box_type=3)
     return True
 
 
@@ -281,6 +303,9 @@ def _plan_action(
     if last_is_cell and last is not None and same_cell_ref(last, desired):
         # Already correct (ours) or user already passed the previous PY cell
         # as real data (not ours). Either way the formula is satisfied.
+        # Caller must still rehome / keep the map key — a row insert that
+        # only moves PY cells hits this branch with the record still at
+        # the old address.
         return "noop", data_args
 
     if (
@@ -292,6 +317,50 @@ def _plan_action(
         return "replace", data_args[:-1] + [desired]
 
     return "append", data_args + [desired]
+
+
+def _rehome_or_keep_record(
+    working: dict[str, GeometricRecord],
+    incoming: Mapping[str, GeometricRecord],
+    live_keys: set[str],
+    key: str,
+    desired: str | None,
+    data_args: list[str],
+) -> None:
+    """Keep/update a live record, or rehome an orphan after a row move.
+
+    ``last == desired`` is a formula no-op. If we already have a record at
+    *key*, the predecessor must match the formula (Calc may have adjusted
+    it onto a key that still exists). If *key* is new and an incoming key
+    is gone from the sheet, that is a moved attach — rehome one orphan.
+    If we never attached, leave the map alone (§9.5: do not record).
+    """
+    if desired is None:
+        return
+    last = data_args[-1] if data_args else None
+    if last is None or not is_single_cell_arg(last) or not same_cell_ref(last, desired):
+        return
+    if key in working:
+        working[key] = GeometricRecord(predecessor=desired)
+        return
+    orphans = [old for old in incoming if old not in live_keys and old in working]
+    if not orphans:
+        return
+    chosen = None
+    for old in orphans:
+        if same_cell_ref(incoming[old].predecessor, desired):
+            chosen = old
+            break
+    if chosen is None:
+        chosen = orphans[0]
+    working.pop(chosen, None)
+    working[key] = GeometricRecord(predecessor=desired)
+    log.debug(
+        "geometric_recalc: rehomed attach record %s -> %s (pred %s)",
+        chosen,
+        key,
+        desired,
+    )
 
 
 def compute_eval_index(
@@ -364,6 +433,7 @@ def compute_sheet_repair(
     working = dict(incoming)
     patches: list[GeometricPatch] = []
     new_formulas = {cell.address: cell.formula for cell in cells}
+    live_keys = {cell_map_key(cell.address) for cell in cells}
 
     for i, cell in enumerate(cells):
         data_args = formula_data_args(cell.formula)
@@ -377,6 +447,13 @@ def compute_sheet_repair(
             record=working.get(key),
         )
         if action == "noop":
+            # Row insert that only moves PY cells: Calc already rewrote the
+            # formula (A2 with ;A1 became A3 with ;A1). last==desired so we
+            # used to continue without writing working[new_key]; the record
+            # stayed at A2 (orphan) and unanimous-ours / replace went wrong.
+            # Rehome when the old key is gone. Do not invent a record when
+            # the user authored the previous PY as real data (§9.5).
+            _rehome_or_keep_record(working, incoming, live_keys, key, desired, data_args)
             continue
         new_formula = rebuild_formula_with_data_args(cell.formula, new_args)
         if new_formula is None or new_formula == cell.formula:
@@ -395,6 +472,9 @@ def compute_sheet_repair(
             working.pop(key, None)
         elif desired is not None:
             working[key] = GeometricRecord(predecessor=desired)
+
+    # Drop keys that are no longer on the sheet (moved or deleted).
+    working = {addr: rec for addr, rec in working.items() if addr in live_keys}
 
     strip_safe = compute_eval_index(cells, new_formulas, working, workbook_key)
     return SheetRepairResult(
@@ -420,6 +500,9 @@ _GEOMETRIC_LOCK = threading.Lock()
 _GEOMETRIC_REPAIRING = False
 _LAST_GEOMETRIC_FLAG: bool | None = None
 _CONFIG_SUBSCRIBED = False
+# One first cap-hit box per (workbook, sheet) until reset. A per-call set()
+# re-showed the modal on every 0.1s debounce / save / open reconcile.
+_CAP_HIT_NOTIFIED: set[tuple[str, str]] = set()
 
 
 def is_geometric_repairing() -> bool:
@@ -433,6 +516,7 @@ def reset_geometric_runtime_for_tests() -> None:
     with _GEOMETRIC_LOCK:
         GEOMETRIC_RECORDS.clear()
         GEOMETRIC_LOADED.clear()
+        _CAP_HIT_NOTIFIED.clear()
     _STRIP_SAFE = frozenset()
     _GEOMETRIC_REPAIRING = False
     try:
@@ -756,11 +840,12 @@ def _rebuild_strip_safe_from_doc(
     all_cells: list[GeometricCell] = []
     all_formulas: dict[str, str] = {}
     all_records: dict[str, GeometricRecord] = {}
-    notified = already_notified if already_notified is not None else set()
     for sheet in _iter_sheets(doc):
         cells, name, truncated = geometric_cells_on_sheet(doc, sheet)
         if discovery_cap_hit(len(cells), truncated=truncated):
-            notify_geometric_cap_hit(ctx, name, already_notified=notified)
+            notify_geometric_cap_hit(
+                ctx, name, already_notified=already_notified, workbook_key=workbook_key
+            )
             continue
         for cell in cells:
             scoped = f"{name}:{cell_map_key(cell.address)}"
@@ -794,7 +879,9 @@ def _repair_one_sheet(
         truncated=truncated,
     )
     if result.skipped:
-        notify_geometric_cap_hit(ctx, name, already_notified=already_notified)
+        notify_geometric_cap_hit(
+            ctx, name, already_notified=already_notified, workbook_key=workbook_key
+        )
         return result
     if apply_patches and result.patches:
         _apply_patches_to_sheet(sheet, result.patches)
@@ -815,8 +902,6 @@ def reconcile_geometric_document(ctx: Any, doc: Any, *, already_loaded: bool = F
     _GEOMETRIC_REPAIRING = True
     try:
         from plugin.calc.python.function import _undo_lock
-
-        notified: set[str] = set()
         from plugin.calc.python.sheet_modify import ensure_sheet_modify_listener
 
         with _undo_lock(doc):
@@ -828,12 +913,9 @@ def reconcile_geometric_document(ctx: Any, doc: Any, *, already_loaded: bool = F
                     sheet,
                     workbook_key,
                     apply_patches=True,
-                    already_notified=notified,
                 )
             save_geometric_registry_for_doc(doc, workbook_key)
-        _rebuild_strip_safe_from_doc(
-            ctx, doc, workbook_key, already_notified=notified
-        )
+        _rebuild_strip_safe_from_doc(ctx, doc, workbook_key)
     finally:
         _GEOMETRIC_REPAIRING = False
 
@@ -847,8 +929,6 @@ def reconcile_geometric_sheet(ctx: Any, doc: Any, sheet: Any) -> None:
     _GEOMETRIC_REPAIRING = True
     try:
         from plugin.calc.python.function import _undo_lock
-
-        notified: set[str] = set()
         from plugin.calc.python.sheet_modify import ensure_sheet_modify_listener
 
         ensure_sheet_modify_listener(ctx, doc, sheet)
@@ -859,12 +939,9 @@ def reconcile_geometric_sheet(ctx: Any, doc: Any, sheet: Any) -> None:
                 sheet,
                 workbook_key,
                 apply_patches=True,
-                already_notified=notified,
             )
             save_geometric_registry_for_doc(doc, workbook_key)
-        _rebuild_strip_safe_from_doc(
-            ctx, doc, workbook_key, already_notified=notified
-        )
+        _rebuild_strip_safe_from_doc(ctx, doc, workbook_key)
     finally:
         _GEOMETRIC_REPAIRING = False
 

--- a/plugin/calc/python/geometric_recalc.py
+++ b/plugin/calc/python/geometric_recalc.py
@@ -39,7 +39,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping
 
-from plugin.calc.address_utils import split_sheet_prefix
+from plugin.calc.address_utils import index_to_column, parse_address, split_sheet_prefix
 from plugin.calc.calc_addin_data import split_python_addin_data_args
 from plugin.calc.python.cell_discovery import _MAX_PYTHON_CELLS_FOUND
 from plugin.calc.python.formula_edit import (
@@ -323,6 +323,70 @@ def _plan_action(
     return "append", data_args + [desired]
 
 
+def _a1_shift(address: str, dcol: int, drow: int) -> str | None:
+    """Apply a col/row delta to a sheet-local A1 token. ``None`` if unusable."""
+    try:
+        col, row = parse_address(local_a1(address))
+    except (TypeError, ValueError):
+        return None
+    ncol, nrow = col + dcol, row + drow
+    if ncol < 0 or nrow < 0:
+        return None
+    try:
+        return f"{index_to_column(ncol)}{nrow + 1}"
+    except (TypeError, ValueError):
+        return None
+
+
+def _rehome_candidate_score(
+    old: str,
+    rec: GeometricRecord,
+    live: str,
+    desired: str,
+) -> tuple[int, int] | None:
+    """Match a homeless incoming record to a live noop cell. Lower is better.
+
+    Rule 2 (0, absdelta): ``pred + (live - old)`` equals *desired* — the cell
+    moved and Calc already shifted the formula pred. Rule 1 (1, 0): pred
+    already equals *desired* and *old* is a different address (first
+    successor; pred sat above the insert). Bind-in-place (2, 0) is last —
+    a live key whose stale pred happens to equal the new occupant's desired
+    is the 4-cell collision, not a keep.
+    """
+    rule1 = same_cell_ref(rec.predecessor, desired)
+    try:
+        ocol, orow = parse_address(local_a1(old))
+        lcol, lrow = parse_address(local_a1(live))
+    except (TypeError, ValueError):
+        if not rule1:
+            return None
+        return (2, 0) if local_a1(old) == local_a1(live) else (1, 0)
+    dcol, drow = lcol - ocol, lrow - orow
+    if dcol or drow:
+        shifted = _a1_shift(rec.predecessor, dcol, drow)
+        if shifted is not None and same_cell_ref(shifted, desired):
+            return (0, abs(dcol) + abs(drow))
+    if not rule1:
+        return None
+    return (2, 0) if local_a1(old) == local_a1(live) else (1, 0)
+
+
+def _record_is_homeless(
+    old: str,
+    rec: GeometricRecord,
+    live_keys: set[str],
+    desired_by_key: Mapping[str, str | None],
+    evicted: set[str],
+) -> bool:
+    """Gone from the sheet, pred does not match that live cell, or overwritten."""
+    if old in evicted or old not in live_keys:
+        return True
+    live_desired = desired_by_key.get(old)
+    if live_desired is None:
+        return True
+    return not same_cell_ref(rec.predecessor, live_desired)
+
+
 def _rehome_or_keep_record(
     working: dict[str, GeometricRecord],
     incoming: Mapping[str, GeometricRecord],
@@ -330,41 +394,65 @@ def _rehome_or_keep_record(
     key: str,
     desired: str | None,
     data_args: list[str],
+    *,
+    consumed: set[str],
+    evicted: set[str],
+    desired_by_key: Mapping[str, str | None],
 ) -> None:
-    """Keep/update a live record, or rehome a pred-matching orphan after a move.
+    """Keep a true live record, or rehome a homeless one after a row/col move.
 
-    ``last == desired`` is a formula no-op. If we already have a record at
-    *key*, keep it and align the predecessor with the formula. If *key* is
-    new, rehome only when a gone incoming key's predecessor equals *desired*
-    (Calc shifted a cell we attached). An unmatched orphan must not be
-    stolen onto a user-authored previous-PY last arg (§9.5: do not record).
-    Dead keys drop at the end of ``compute_sheet_repair``.
+    ``last == desired`` is a formula no-op. Do **not** bind ``working[key]``
+    just because the key is live — after a 3+ chain shift that address is
+    often the *moved* cell's old record (wrong occupant). Homeless: key not
+    in *live_keys*, live but incoming pred ≠ that cell's desired, or evicted
+    when another record was written onto its address. Match via pred==desired
+    or pred+delta. Never ``orphans[0]``. No matching homeless record → do
+    not invent one (§9.5 user-authored ``;prev``).
     """
     if desired is None:
         return
     last = data_args[-1] if data_args else None
     if last is None or not is_single_cell_arg(last) or not same_cell_ref(last, desired):
         return
-    if key in working:
-        working[key] = GeometricRecord(predecessor=desired)
-        return
-    chosen = None
+    chosen: str | None = None
+    best: tuple[int, int] | None = None
     for old, rec in incoming.items():
-        if old in live_keys or old not in working:
+        if old in consumed:
             continue
-        if same_cell_ref(rec.predecessor, desired):
-            chosen = old
-            break
+        if not _record_is_homeless(old, rec, live_keys, desired_by_key, evicted):
+            continue
+        score = _rehome_candidate_score(old, rec, key, desired)
+        if score is None:
+            continue
+        if best is None or score < best:
+            chosen, best = old, score
     if chosen is None:
-        # Unmatched leftover (deleted cell, or a later cell after a multi-row
-        # shift whose incoming pred is stale). Do not invent a record — §9.5.
-        log.debug(
-            "geometric_recalc: no pred-matching orphan for %s (desired %s); not recording",
-            key,
-            desired,
-        )
+        incoming_here = incoming.get(key)
+        if (
+            incoming_here is not None
+            and key not in consumed
+            and key not in evicted
+            and same_cell_ref(incoming_here.predecessor, desired)
+        ):
+            working[key] = GeometricRecord(predecessor=desired)
+        else:
+            log.debug(
+                "geometric_recalc: no homeless match for %s (desired %s); not recording",
+                key,
+                desired,
+            )
         return
-    working.pop(chosen, None)
+    consumed.add(chosen)
+    # Pop only while working[chosen] is still the incoming record. A prior
+    # rehome may already have written the correct occupant at a live *chosen*.
+    if chosen != key and working.get(chosen) is incoming.get(chosen):
+        working.pop(chosen, None)
+    elif chosen not in live_keys:
+        working.pop(chosen, None)
+    if key in incoming and key != chosen and key not in consumed:
+        # Overwriting this address evicts the incoming record that sat here
+        # (4-cell: A4→A3 is displaced onto A5 after A3 claims A4).
+        evicted.add(key)
     working[key] = GeometricRecord(predecessor=desired)
     log.debug(
         "geometric_recalc: rehomed attach record %s -> %s (pred %s)",
@@ -445,12 +533,19 @@ def compute_sheet_repair(
     patches: list[GeometricPatch] = []
     new_formulas = {cell.address: cell.formula for cell in cells}
     live_keys = {cell_map_key(cell.address) for cell in cells}
+    desired_by_key: dict[str, str | None] = {}
+    for i, cell in enumerate(cells):
+        desired_by_key[cell_map_key(cell.address)] = (
+            local_a1(cells[i - 1].address) if i > 0 else None
+        )
+    consumed: set[str] = set()
+    evicted: set[str] = set()
 
     for i, cell in enumerate(cells):
         data_args = formula_data_args(cell.formula)
         if data_args is None:
             continue
-        desired = local_a1(cells[i - 1].address) if i > 0 else None
+        desired = desired_by_key[cell_map_key(cell.address)]
         key = cell_map_key(cell.address)
         action, new_args = _plan_action(
             desired=desired,
@@ -462,9 +557,19 @@ def compute_sheet_repair(
             # formula (A2 with ;A1 became A3 with ;A1). last==desired so we
             # used to continue without writing working[new_key]; the record
             # stayed at A2 (orphan) and unanimous-ours / replace went wrong.
-            # Rehome when the old key is gone. Do not invent a record when
-            # the user authored the previous PY as real data (§9.5).
-            _rehome_or_keep_record(working, incoming, live_keys, key, desired, data_args)
+            # Rehome when the old key is gone or displaced. Do not invent a
+            # record when the user authored the previous PY as real data (§9.5).
+            _rehome_or_keep_record(
+                working,
+                incoming,
+                live_keys,
+                key,
+                desired,
+                data_args,
+                consumed=consumed,
+                evicted=evicted,
+                desired_by_key=desired_by_key,
+            )
             continue
         new_formula = rebuild_formula_with_data_args(cell.formula, new_args)
         if new_formula is None or new_formula == cell.formula:

--- a/plugin/calc/python/geometric_recalc.py
+++ b/plugin/calc/python/geometric_recalc.py
@@ -343,32 +343,31 @@ def _rehome_candidate_score(
     rec: GeometricRecord,
     live: str,
     desired: str,
+    live_keys: set[str],
 ) -> tuple[int, int] | None:
     """Match a homeless incoming record to a live noop cell. Lower is better.
 
     Rule 2 (0, absdelta): ``pred + (live - old)`` equals *desired* — the cell
     moved and Calc already shifted the formula pred. Rule 1 (1, 0): pred
-    already equals *desired* and *old* is a different address (first
-    successor; pred sat above the insert). Bind-in-place (2, 0) is last —
-    a live key whose stale pred happens to equal the new occupant's desired
-    is the 4-cell collision, not a keep.
+    already equals *desired*, but **only** when *old* is gone from the
+    sheet (true orphan). A live-key record stays put unless rule 2 claims
+    it — otherwise undo's stale ``{A3: A1}`` is stolen onto A2 and
+    successor-becomes-first cannot remove-field.
     """
-    rule1 = same_cell_ref(rec.predecessor, desired)
+    rule1 = same_cell_ref(rec.predecessor, desired) and old not in live_keys
     try:
         ocol, orow = parse_address(local_a1(old))
         lcol, lrow = parse_address(local_a1(live))
     except (TypeError, ValueError):
-        if not rule1:
-            return None
-        return (2, 0) if local_a1(old) == local_a1(live) else (1, 0)
+        return (1, 0) if rule1 else None
     dcol, drow = lcol - ocol, lrow - orow
     if dcol or drow:
         shifted = _a1_shift(rec.predecessor, dcol, drow)
         if shifted is not None and same_cell_ref(shifted, desired):
             return (0, abs(dcol) + abs(drow))
-    if not rule1:
-        return None
-    return (2, 0) if local_a1(old) == local_a1(live) else (1, 0)
+    if rule1:
+        return (1, 0)
+    return None
 
 
 def _record_is_homeless(
@@ -421,7 +420,7 @@ def _rehome_or_keep_record(
             continue
         if not _record_is_homeless(old, rec, live_keys, desired_by_key, evicted):
             continue
-        score = _rehome_candidate_score(old, rec, key, desired)
+        score = _rehome_candidate_score(old, rec, key, desired, live_keys)
         if score is None:
             continue
         if best is None or score < best:
@@ -432,8 +431,10 @@ def _rehome_or_keep_record(
             incoming_here is not None
             and key not in consumed
             and key not in evicted
-            and same_cell_ref(incoming_here.predecessor, desired)
         ):
+            # Live-key record stays (pred may be stale after undo). Align
+            # pred with the already-correct formula so later remove-field
+            # still sees an ours marker.
             working[key] = GeometricRecord(predecessor=desired)
         else:
             log.debug(

--- a/plugin/scripting/module.yaml
+++ b/plugin/scripting/module.yaml
@@ -87,6 +87,7 @@ config:
     label: Geometric Recalc Order (Experimental)
     helper: Ensures PY cells evaluate in sheet order. Most useful with Shared kernel.
     public: true
+    width: 250
 
   python_auto_spill:
     type: bool

--- a/plugin/scripting/module.yaml
+++ b/plugin/scripting/module.yaml
@@ -84,7 +84,7 @@ config:
     type: bool
     default: false
     widget: checkbox
-    label: Geometric Recalc Order
+    label: Geometric Recalc Order (Experimental)
     helper: Ensures PY cells evaluate in sheet order. Most useful with Shared kernel.
     public: true
 

--- a/tests/calc/python/test_geometric_recalc.py
+++ b/tests/calc/python/test_geometric_recalc.py
@@ -244,8 +244,52 @@ def test_user_authored_previous_py_is_not_recorded():
     assert "A3" not in result.records
 
 
+def test_unmatched_orphan_does_not_record_user_authored_cell():
+    """Orphan A2 whose pred is not desired must not be stolen onto user-authored A3.
+
+    A2 is gone; A3 already has ``;A1`` because the user typed it (§9.5), not
+    because we attached A2. ``orphans[0]`` used to record A3 anyway.
+    A matching pred (A2→A1) is the row-insert rehome case, not this one.
+    """
+    result = _repair(
+        [
+            _cell("A1", '=PY("a")'),
+            _cell("A3", '=PY("c";A1)'),
+        ],
+        {"A2": GeometricRecord(predecessor="Z9")},
+    )
+    assert result.patches == ()
+    assert "A3" not in result.records
+    assert "A2" not in result.records
+
+
+def test_only_matching_orphan_rehomes_unmatched_is_dropped():
+    """Two orphans: only the pred that equals desired may rehome; the other drops."""
+    result = _repair(
+        [
+            _cell("A1", '=PY("a")'),
+            _cell("A3", '=PY("b";A1)'),
+            _cell("C1", '=PY("user";A3)'),
+        ],
+        {
+            "A2": GeometricRecord(predecessor="A1"),
+            "B9": GeometricRecord(predecessor="Z9"),
+        },
+    )
+    assert result.patches == ()
+    assert result.records["A3"].predecessor == "A1"
+    assert "A2" not in result.records
+    assert "B9" not in result.records
+    assert "C1" not in result.records
+
+
 def test_row_insert_three_cell_chain_rehomes_all_keys():
-    """A1,A2,A3 shifted to A1,A3,A4; formulas already correct; map keys follow."""
+    """A1,A2,A3 shifted to A1,A3,A4; only a pred-matching orphan may rehome.
+
+    Incoming A3 is still a live key, so A3 is updated in place (pred A1).
+    Orphan A2 pred A1 matches A3's desired — not A4's (desired A3). Stealing
+    A2 onto A4 is the same ``orphans[0]`` bug as recording a user ``;prev``.
+    """
     result = _repair(
         [
             _cell("A1", '=PY("a")'),
@@ -259,8 +303,8 @@ def test_row_insert_three_cell_chain_rehomes_all_keys():
     )
     assert result.patches == ()
     assert result.records["A3"].predecessor == "A1"
-    assert result.records["A4"].predecessor == "A3"
     assert "A2" not in result.records
+    assert "A4" not in result.records
 
 
 def test_already_correct_dollar_ref_is_noop():
@@ -521,6 +565,23 @@ def test_notify_geometric_cap_hit_one_box_per_sheet_ui_thread_only():
         shown = notify_geometric_cap_hit("ctx", "Other", already_notified=set())
         assert shown is False
         mock_box.assert_not_called()
+
+
+def test_notify_geometric_cap_hit_off_main_does_not_persist():
+    """Off-main logs and returns False; it must not swallow the later UI box."""
+    reset_geometric_runtime_for_tests()
+    with (
+        patch("plugin.framework.thread_guard.on_main_thread", return_value=False),
+        patch("plugin.chatbot.dialogs.msgbox") as mock_box,
+    ):
+        assert notify_geometric_cap_hit("ctx", "Sheet1", workbook_key="wb1") is False
+        mock_box.assert_not_called()
+    with (
+        patch("plugin.framework.thread_guard.on_main_thread", return_value=True),
+        patch("plugin.chatbot.dialogs.msgbox") as mock_box,
+    ):
+        assert notify_geometric_cap_hit("ctx", "Sheet1", workbook_key="wb1")
+        assert mock_box.call_count == 1
 
 
 def test_cap_hit_user_message_names_the_sheet():

--- a/tests/calc/python/test_geometric_recalc.py
+++ b/tests/calc/python/test_geometric_recalc.py
@@ -303,21 +303,25 @@ def test_row_insert_three_cell_chain_rehomes_all_keys():
 
 
 def test_undo_stale_map_keeps_live_successor_record():
-    """Undo restores A2 and A3's ``;A2`` while the map still has A3→A1.
+    """Undo after delete-middle: stale ``{A3: A1}`` must not be stolen onto A2.
 
-    Rule 1 must not steal A3 onto A2 (A3 is live). A3 keeps its record so
-    successor-becomes-first can still remove-field.
+    Live sheet is A1/A2/A3 (formulas already correct). Incoming pred A1 ≠
+    A3's desired A2 used to mark A3 homeless; rule 1 then moved that record
+    onto A2 (pred A1 == A2's desired). A3 left unrecorded with ``;A2`` so
+    successor-becomes-first remove-field was a noop.
     """
     result = _repair(
         [
+            _cell("A1", '=PY("first")'),
             _cell("A2", '=PY("mid";A1)'),
             _cell("A3", '=PY("third";A2)'),
         ],
         {"A3": GeometricRecord(predecessor="A1")},
     )
     assert result.patches == ()
-    assert "A3" in result.records
     assert result.records["A3"].predecessor == "A2"
+    # Do not move A3's record onto A2. A2 has last==desired but no incoming
+    # key (delete dropped it); inventing one is §9.5 user-authored ``;A1``.
     assert "A2" not in result.records
 
     first_only = _repair(

--- a/tests/calc/python/test_geometric_recalc.py
+++ b/tests/calc/python/test_geometric_recalc.py
@@ -302,6 +302,32 @@ def test_row_insert_three_cell_chain_rehomes_all_keys():
     assert "A2" not in result.records
 
 
+def test_undo_stale_map_keeps_live_successor_record():
+    """Undo restores A2 and A3's ``;A2`` while the map still has A3→A1.
+
+    Rule 1 must not steal A3 onto A2 (A3 is live). A3 keeps its record so
+    successor-becomes-first can still remove-field.
+    """
+    result = _repair(
+        [
+            _cell("A2", '=PY("mid";A1)'),
+            _cell("A3", '=PY("third";A2)'),
+        ],
+        {"A3": GeometricRecord(predecessor="A1")},
+    )
+    assert result.patches == ()
+    assert "A3" in result.records
+    assert result.records["A3"].predecessor == "A2"
+    assert "A2" not in result.records
+
+    first_only = _repair(
+        [_cell("A3", '=PY("third";A2)')],
+        result.records,
+    )
+    assert _patch_map(first_only)["A3"].action == "remove"
+    assert "A3" not in first_only.records
+
+
 def test_row_insert_four_cell_chain_rehomes_all_keys():
     """A1–A4 shifted +1 row; all three successors rehome, no formula patches."""
     result = _repair(

--- a/tests/calc/python/test_geometric_recalc.py
+++ b/tests/calc/python/test_geometric_recalc.py
@@ -218,6 +218,51 @@ def test_already_correct_predecessor_is_noop():
     assert result.records["A2"].predecessor == "A1"
 
 
+def test_row_insert_move_rehomes_orphan_record():
+    """Calc already adjusted A2→A3; leftover map key A2 must move to A3."""
+    result = _repair(
+        [
+            _cell("A1", '=PY("a")'),
+            _cell("A3", '=PY("c";A1)'),
+        ],
+        {"A2": GeometricRecord(predecessor="A1")},
+    )
+    assert result.patches == ()
+    assert result.records["A3"].predecessor == "A1"
+    assert "A2" not in result.records
+
+
+def test_user_authored_previous_py_is_not_recorded():
+    """§9.5: last==desired with no incoming record must stay unrecorded."""
+    result = _repair(
+        [
+            _cell("A1", '=PY("a")'),
+            _cell("A3", '=PY("c";A1)'),
+        ]
+    )
+    assert result.patches == ()
+    assert "A3" not in result.records
+
+
+def test_row_insert_three_cell_chain_rehomes_all_keys():
+    """A1,A2,A3 shifted to A1,A3,A4; formulas already correct; map keys follow."""
+    result = _repair(
+        [
+            _cell("A1", '=PY("a")'),
+            _cell("A3", '=PY("b";A1)'),
+            _cell("A4", '=PY("c";A3)'),
+        ],
+        {
+            "A2": GeometricRecord(predecessor="A1"),
+            "A3": GeometricRecord(predecessor="A2"),
+        },
+    )
+    assert result.patches == ()
+    assert result.records["A3"].predecessor == "A1"
+    assert result.records["A4"].predecessor == "A3"
+    assert "A2" not in result.records
+
+
 def test_already_correct_dollar_ref_is_noop():
     result = _repair(
         [
@@ -466,7 +511,7 @@ def test_notify_geometric_cap_hit_one_box_per_sheet_ui_thread_only():
         assert notify_geometric_cap_hit("ctx", "Sheet2", already_notified=notified)
         assert mock_box.call_count == 2
         titles = [c.args[1] for c in mock_box.call_args_list]
-        assert all(t == "Geometric Recalc Order" or "Geometric" in t for t in titles)
+        assert all("Geometric Recalc Order" in t and "Experimental" in t for t in titles)
         assert mock_box.call_args_list[0].kwargs.get("box_type") == 3
 
     with (
@@ -696,6 +741,44 @@ def test_cap_hit_sheet_skipped_on_reconcile(monkeypatch):
     # First two cells stay unchained (whole sheet skipped).
     assert sheet.getCellByPosition(0, 1).getFormula() == '=PY("x1")'
     assert current_geometric_strip_safe() == frozenset()
+
+
+def test_cap_hit_msgbox_persists_across_reconcile_without_shared_set(monkeypatch):
+    """Two document reconciles on truncated sheets must not show a second box."""
+    from plugin.tests.testing_utils import CalcDocStub, CalcSheetStub
+
+    _reset_geo()
+    sheet1 = CalcSheetStub("Sheet1")
+    sheet2 = CalcSheetStub("Data")
+    for i in range(GEOMETRIC_DISCOVERY_CAP + 1):
+        sheet1.getCellByPosition(0, i).setFormula(f'=PY("x{i}")')
+        sheet2.getCellByPosition(0, i).setFormula(f'=PY("y{i}")')
+    doc = CalcDocStub(sheets=[sheet1, sheet2], url="file:///cap-persist.ods")
+    monkeypatch.setattr(
+        "plugin.calc.python.geometric_recalc.geometric_flag_enabled", lambda: True
+    )
+    monkeypatch.setattr("plugin.doc.udprops.get_document_property", lambda *_a, **_k: None)
+    monkeypatch.setattr("plugin.doc.udprops.set_document_property", lambda *_a, **_k: None)
+    with (
+        patch("plugin.framework.thread_guard.on_main_thread", return_value=True),
+        patch("plugin.chatbot.dialogs.msgbox") as mock_box,
+    ):
+        reconcile_geometric_document("ctx", doc)
+        reconcile_geometric_document("ctx", doc)
+        assert mock_box.call_count == 2
+        titles = [c.args[1] for c in mock_box.call_args_list]
+        assert all("Experimental" in t for t in titles)
+        bodies = " ".join(str(c.args[2]) for c in mock_box.call_args_list)
+        assert "Sheet1" in bodies
+        assert "Data" in bodies
+
+    _reset_geo()
+    with (
+        patch("plugin.framework.thread_guard.on_main_thread", return_value=True),
+        patch("plugin.chatbot.dialogs.msgbox") as mock_box,
+    ):
+        reconcile_geometric_document("ctx", doc)
+        assert mock_box.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/calc/python/test_geometric_recalc.py
+++ b/tests/calc/python/test_geometric_recalc.py
@@ -284,12 +284,7 @@ def test_only_matching_orphan_rehomes_unmatched_is_dropped():
 
 
 def test_row_insert_three_cell_chain_rehomes_all_keys():
-    """A1,A2,A3 shifted to A1,A3,A4; only a pred-matching orphan may rehome.
-
-    Incoming A3 is still a live key, so A3 is updated in place (pred A1).
-    Orphan A2 pred A1 matches A3's desired — not A4's (desired A3). Stealing
-    A2 onto A4 is the same ``orphans[0]`` bug as recording a user ``;prev``.
-    """
+    """A1,A2,A3 shifted to A1,A3,A4; every attach record follows the cell."""
     result = _repair(
         [
             _cell("A1", '=PY("a")'),
@@ -303,8 +298,30 @@ def test_row_insert_three_cell_chain_rehomes_all_keys():
     )
     assert result.patches == ()
     assert result.records["A3"].predecessor == "A1"
+    assert result.records["A4"].predecessor == "A3"
     assert "A2" not in result.records
-    assert "A4" not in result.records
+
+
+def test_row_insert_four_cell_chain_rehomes_all_keys():
+    """A1–A4 shifted +1 row; all three successors rehome, no formula patches."""
+    result = _repair(
+        [
+            _cell("A1", '=PY("a")'),
+            _cell("A3", '=PY("b";A1)'),
+            _cell("A4", '=PY("c";A3)'),
+            _cell("A5", '=PY("d";A4)'),
+        ],
+        {
+            "A2": GeometricRecord(predecessor="A1"),
+            "A3": GeometricRecord(predecessor="A2"),
+            "A4": GeometricRecord(predecessor="A3"),
+        },
+    )
+    assert result.patches == ()
+    assert result.records["A3"].predecessor == "A1"
+    assert result.records["A4"].predecessor == "A3"
+    assert result.records["A5"].predecessor == "A4"
+    assert "A2" not in result.records
 
 
 def test_already_correct_dollar_ref_is_noop():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Gemini **B** (cap-hit modal storm) and **C** (row-insert orphan attach map) for Geometric Recalc Order. Gemini **A** is documented as by design, not changed.

## B — cap-hit modal spam
Notifications persist in `_CAP_HIT_NOTIFIED`, keyed by `(workbook_key, sheet_name)`. Persist only after a box is shown; off-main still logs and returns False without swallowing the later UI-thread box.

## C — row-insert registry
Repair rehomes geometric records onto current discovery addresses after Calc has already adjusted formulas.

**3+ chain:** do not bind `working[key]` in place just because the key is live — that overwrites the moved cell’s record (old A3 sitting at A4). Homeless records are: key gone from the sheet, **rule-2 claimed** (`pred + (live − old) == desired` on a gone or pred-mismatched key), or evicted when another match claimed its address. A live key that rule 2 did not take is **updated in place** — do not leave a stale pred (`{A3: A1}` after undo) homeless for rule 1, or A3 is stolen onto A2 and successor-becomes-first remove-field is a noop. Rule 1 (`pred == desired`) is **true orphan only** (`old not in live_keys`). Never `orphans[0]`. A user-authored `;prev` with no matching homeless record stays unrecorded (§9.5).

`test_row_insert_three_cell_chain_rehomes_all_keys` expects `records["A4"].predecessor == "A3"`. Four-cell +1 row shift rehomes all three successors. `test_undo_stale_map_keeps_live_successor_record` is the Phase 3 insert/delete/undo map (A1/A2/A3 live, incoming `{A3: A1}`).

## Gemini A — no change
Two open workbooks / `off_main_calc_session_is_unambiguous()` false → **no strip**. Documented as by design.

## Experimental
Settings checkbox, docs title, and cap-hit msgbox title say **Geometric Recalc Order (Experimental)**. Flag stays default off.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60342b54-fae5-4384-8d1a-8ce1f25e571b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60342b54-fae5-4384-8d1a-8ce1f25e571b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

