### PR TITLE
README CI SVG Camo bust (`?v=2026-09-03`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![LibreOffice 7.0+](https://img.shields.io/badge/LibreOffice-7.0%2B-green.svg)](https://www.libreoffice.org/)
 [![Release](https://img.shields.io/github/v/release/KeithCu/writeragent)](https://github.com/KeithCu/writeragent/releases)
 
-![CI status](https://keithcu.github.io/writeragent/status.svg)
+![CI status](https://keithcu.github.io/writeragent/status.svg?v=2026-09-03)
 [CI status page](https://keithcu.github.io/writeragent/)
 
 **Python, NumPy, and Agentic AI for LibreOffice (Writer, Calc, and Draw)**

--- a/tests/scripts/test_generate_ci_status.py
+++ b/tests/scripts/test_generate_ci_status.py
@@ -226,7 +226,7 @@ def test_render_svg_escapes_xml() -> None:
 
 def test_readme_embeds_pages_svg() -> None:
     text = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
-    assert "![CI status](https://keithcu.github.io/writeragent/status.svg)" in text
+    assert "![CI status](https://keithcu.github.io/writeragent/status.svg?v=2026-09-03)" in text
     assert "[CI status page](https://keithcu.github.io/writeragent/)" in text
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub Camo caches the README CI status image; `?v=2026-09-03` is a fake query so Camo refreshes at least when that date is bumped. Pages still serves `status.svg` (the query is ignored). The HTML link is unchanged. No daily rewriter, cron, or README commit from Actions.

The existing README embed assertion in `tests/scripts/test_generate_ci_status.py` was updated to match.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f141b04-b0ae-4d92-8f6c-fb977108fb79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f141b04-b0ae-4d92-8f6c-fb977108fb79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

