### PR TITLE
Clear leftover list numbering after notebook HTML list insert

### DIFF
--- a/docs/writer/jupyter-notebook-import.md
+++ b/docs/writer/jupyter-notebook-import.md
@@ -214,7 +214,7 @@ Native test suite execution:
 - **Wire Timing:** Attach a single form-level `XActionListener` on the form controller container after import; do not query control views per button click.
 - **Paragraph Mutations:** Never use `setString()` on paragraph ranges containing `AS_CHARACTER` controls, as this deletes the form shapes. Rewrite text portions specifically.
 - **Spellcheck:** Set locale to `zxx` (no linguistic content) on imported notebook paragraphs to prevent spellcheck squiggles on code blocks.
-- **HTML list insert:** StarWriter `insertDocumentFromURL` leaves `NumberingRules` on the last list item; a following paragraph break inherits that leftover. Do **not** pre-clear numbering on the list insertion cursor — a 1-item `<ol start="N">` then imports as plain text. After list insert, clear leftover numbering only on an empty trailing paragraph (`exit_list=True`). Always clear on body/h2/blockquote insertion so those blocks are not leftover bullets.
+- **HTML list insert:** StarWriter `insertDocumentFromURL` leaves `NumberingRules` on the last list item; a following paragraph break inherits that leftover (often nested-ul `NumberingLevel=1`). Do **not** pre-clear numbering on the list insertion cursor — a 1-item `<ol start="N">` then imports as plain text. For that 1-item fragment, promote the merge para to outer-list `NumberingLevel=0` and restart at N (same style as the previous level-0 `<ol>`). After list insert, clear leftover numbering only on an empty trailing paragraph (`exit_list=True`). Always clear on body/h2/blockquote insertion so those blocks are not leftover bullets.
 
 ---
 

--- a/docs/writer/jupyter-notebook-import.md
+++ b/docs/writer/jupyter-notebook-import.md
@@ -56,7 +56,7 @@ Addons.xcu cannot gate on a user-defined document property, so there is no nativ
 |-------------------|----------|
 | **Vendored nbformat v4 read** — [`plugin/contrib/nbformat/`](../../plugin/contrib/nbformat/): `read_ipynb(path)`, `reads(json_string)` → `NotebookNode` with `rejoin_lines` | **nbformat v3** upgrade path |
 | **File → Open** — native `.ipynb` import filter ([`import_filter.py`](../../plugin/notebook/import_filter.py)); TypeDetection registry | Append-into-open-document menu (Phase 3) |
-| **Import engine** — [`writer_importer.py`](../../plugin/notebook/writer_importer.py): ATX `#`/`##` headings, `* `/`- ` lists (nested + `<ol start=N>`), `>` blockquotes, `**bold**` / `*italic*`, `[text](url)` hyperlinks, HTML `<img>`/`<a>`, in-flow code fields, output text + images; `zxx` spellcheck-off locale | GFM tables, hover-only play, collapsible cells |
+| **Import engine** — [`writer_importer.py`](../../plugin/notebook/writer_importer.py): ATX `#`/`##` headings, `* `/`- ` lists (nested + `<ol start=N>`), `>` blockquotes, `**bold**` / `*italic*`, `[text](url)` hyperlinks, HTML `<img>`/`<a>`, in-flow code fields, output text + images; `zxx` spellcheck-off locale; leftover list `NumberingRules` cleared after HTML list insert | GFM tables, hover-only play, collapsible cells |
 | **Notebook registry (Phase 0)** — [`cell_registry.py`](../../plugin/notebook/cell_registry.py): `WriterAgentNotebookJson`, stable `cell_id` (UUID), output bookmarks `nb_out_*`, `WriterAgentNotebookSourcePath` | Export back to `.ipynb` (Phase 5 roadmap) |
 | **Run code cell (Phase 1)** — in-flow ▶ **push** button + [`notebook_controls.py`](../../plugin/notebook/notebook_controls.py) + [`notebook_runner.py`](../../plugin/notebook/notebook_runner.py); shared `notebook:…` kernel; re-run **replaces** output (`setString("")`); no VCL pump during execute (LayoutIdle livelock) | Cell CRUD, sidebar (Phases 3–4 roadmap) |
 | **Run All / Run From Here / Stop (Phase 2)** — sidebar hamburger only, and only when `load_registry(doc)` is set (not ordinary Writer / Calc / Draw; not menubar or review toolbar); registry-order sequence; drain **between** cells only; Stop skips the remainder (busy guard does not block Stop) | — |
@@ -214,6 +214,7 @@ Native test suite execution:
 - **Wire Timing:** Attach a single form-level `XActionListener` on the form controller container after import; do not query control views per button click.
 - **Paragraph Mutations:** Never use `setString()` on paragraph ranges containing `AS_CHARACTER` controls, as this deletes the form shapes. Rewrite text portions specifically.
 - **Spellcheck:** Set locale to `zxx` (no linguistic content) on imported notebook paragraphs to prevent spellcheck squiggles on code blocks.
+- **HTML list insert:** StarWriter `insertDocumentFromURL` leaves `NumberingRules` on the trailing paragraph. Clear `NumberingStyleName` and `NumberingRules` after list HTML insert (`exit_list=True`) and on body/h2 paras so the next heading, blockquote, or resumed `<ol>` is not a leftover bullet.
 
 ---
 

--- a/docs/writer/jupyter-notebook-import.md
+++ b/docs/writer/jupyter-notebook-import.md
@@ -214,7 +214,7 @@ Native test suite execution:
 - **Wire Timing:** Attach a single form-level `XActionListener` on the form controller container after import; do not query control views per button click.
 - **Paragraph Mutations:** Never use `setString()` on paragraph ranges containing `AS_CHARACTER` controls, as this deletes the form shapes. Rewrite text portions specifically.
 - **Spellcheck:** Set locale to `zxx` (no linguistic content) on imported notebook paragraphs to prevent spellcheck squiggles on code blocks.
-- **HTML list insert:** StarWriter `insertDocumentFromURL` leaves `NumberingRules` on the trailing paragraph. Clear `NumberingStyleName` and `NumberingRules` after list HTML insert (`exit_list=True`) and on body/h2 paras so the next heading, blockquote, or resumed `<ol>` is not a leftover bullet.
+- **HTML list insert:** StarWriter `insertDocumentFromURL` leaves `NumberingRules` on the last list item; a following paragraph break inherits that leftover. Do **not** pre-clear numbering on the list insertion cursor — a 1-item `<ol start="N">` then imports as plain text. After list insert, clear leftover numbering only on an empty trailing paragraph (`exit_list=True`). Always clear on body/h2/blockquote insertion so those blocks are not leftover bullets.
 
 ---
 

--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -1280,11 +1280,127 @@ def _anchor_control_as_character(shape: Any) -> None:
         log.debug("notebook import TextWrap not applied", exc_info=True)
 
 
-def _clear_para_numbering(cursor: Any) -> None:
+def _dbg_safe(val: Any) -> Any:
+    if val is None or isinstance(val, (bool, int, float)):
+        return val
+    if isinstance(val, str):
+        return val[:160]
+    try:
+        text = str(val)
+    except Exception:
+        return type(val).__name__
+    if "MagicMock" in text:
+        return "MagicMock"
+    return text[:120]
+
+
+def _dbg_agent_log(hypothesis_id: str, location: str, message: str, data: dict[str, Any]) -> None:
+    # #region agent log
+    try:
+        import json as _json
+
+        with open("/opt/cursor/logs/debug.log", "a", encoding="utf-8") as fh:
+            fh.write(
+                _json.dumps(
+                    {
+                        "hypothesisId": hypothesis_id,
+                        "location": location,
+                        "message": message,
+                        "data": data,
+                        "timestamp": int(time.time() * 1000),
+                    },
+                    default=str,
+                )
+                + "\n"
+            )
+    except Exception:
+        pass
+    # #endregion
+
+
+def _dbg_cursor_num(obj: Any) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for name in (
+        "NumberingStyleName",
+        "NumberingIsNumber",
+        "NumberingLevel",
+        "NumberingStartValue",
+        "ParaIsNumberingRestart",
+        "ParaStyleName",
+    ):
+        try:
+            out[name] = _dbg_safe(obj.getPropertyValue(name))
+        except Exception as exc:
+            out[name] = "err:" + type(exc).__name__
+    try:
+        rules = obj.getPropertyValue("NumberingRules")
+        if rules is None:
+            out["NumberingRules"] = None
+        else:
+            rname = type(rules).__name__
+            out["NumberingRules"] = "MagicMock" if "MagicMock" in rname else rname
+    except Exception as exc:
+        out["NumberingRules"] = "err:" + type(exc).__name__
+    try:
+        text_obj = obj.getText() if hasattr(obj, "getText") else None
+        if text_obj is not None:
+            rng = text_obj.createTextCursorByRange(obj)
+            rng.gotoStartOfParagraph(False)
+            rng.gotoEndOfParagraph(True)
+            out["para_text"] = _dbg_safe(rng.getString() or "")
+        else:
+            out["para_text"] = _dbg_safe(obj.getString() or "")
+    except Exception as exc:
+        try:
+            out["para_text"] = _dbg_safe(obj.getString() or "")
+        except Exception:
+            out["para_text"] = "err:" + type(exc).__name__
+    return out
+
+
+def _dbg_doc_paras(doc: Any, *, limit: int = 30) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        enum = doc.getText().createEnumeration()
+    except Exception:
+        return rows
+    i = 0
+    steps = 0
+    while steps < 64 and i < limit:
+        steps += 1
+        try:
+            more = enum.hasMoreElements()
+            if more is not True and more != 1:
+                break
+            el = enum.nextElement()
+        except Exception:
+            break
+        try:
+            if hasattr(el, "supportsService") and not el.supportsService("com.sun.star.text.Paragraph"):
+                continue
+        except Exception:
+            continue
+        row = _dbg_cursor_num(el)
+        row["i"] = i
+        rows.append(row)
+        i += 1
+    return rows
+
+
+def _clear_para_numbering(cursor: Any, *, reason: str = "") -> None:
     """Drop inherited list numbering so the next block is not a leftover bullet."""
     # StarWriter insertDocumentFromURL leaves NumberingRules on the trailing
     # para. The next heading, body, blockquote, or resumed <ol> then inherits
     # leftover bullets. Clear both properties on the insertion cursor.
+    # #region agent log
+    before = _dbg_cursor_num(cursor)
+    _dbg_agent_log(
+        "A",
+        "writer_importer.py:_clear_para_numbering:before",
+        "clear numbering enter",
+        {"reason": reason, "before": before},
+    )
+    # #endregion
     try:
         cursor.setPropertyValue("NumberingStyleName", "")
     except Exception:
@@ -1293,6 +1409,15 @@ def _clear_para_numbering(cursor: Any) -> None:
         cursor.setPropertyValue("NumberingRules", None)
     except Exception:
         log.debug("notebook import NumberingRules clear failed", exc_info=True)
+    # #region agent log
+    after = _dbg_cursor_num(cursor)
+    _dbg_agent_log(
+        "A",
+        "writer_importer.py:_clear_para_numbering:after",
+        "clear numbering exit",
+        {"reason": reason, "after": after},
+    )
+    # #endregion
 
 
 def _append_body_paragraph(
@@ -1313,7 +1438,7 @@ def _append_body_paragraph(
         text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
         cursor.gotoEnd(False)
     # Always: leftover empty list para must not infect h2/body.
-    _clear_para_numbering(cursor)
+    _clear_para_numbering(cursor, reason="append_body")
     resolved = _resolve_para_style(doc, para_style)
     if resolved:
         try:
@@ -1396,19 +1521,93 @@ def _insert_html_at_body_end(
     text = doc.getText()
     cursor = text.createTextCursor()
     cursor.gotoEnd(False)
+    did_lead = False
     if lead_break and _doc_body_nonempty(doc):
         text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
         cursor.gotoEnd(False)
-    _clear_para_numbering(cursor)
+        did_lead = True
+    html_s = html or ""
+    # #region agent log
+    _dbg_agent_log(
+        "E",
+        "writer_importer.py:_insert_html_at_body_end:pre_clear",
+        "before pre-insert numbering clear",
+        {
+            "html": html_s[:240],
+            "has_start": "start=" in html_s,
+            "is_ol": "<ol" in html_s.lower(),
+            "is_ul": "<ul" in html_s.lower(),
+            "is_bq": "<blockquote" in html_s.lower(),
+            "exit_list": exit_list,
+            "lead_break": lead_break,
+            "did_lead": did_lead,
+            "cursor": _dbg_cursor_num(cursor),
+            "paras": _dbg_doc_paras(doc),
+        },
+    )
+    # #endregion
+    _clear_para_numbering(cursor, reason="pre_insert")
+    # #region agent log
+    _dbg_agent_log(
+        "A",
+        "writer_importer.py:_insert_html_at_body_end:after_pre_clear",
+        "after pre-insert numbering clear, before HTML insert",
+        {
+            "html": html_s[:240],
+            "has_start": "start=" in html_s,
+            "cursor": _dbg_cursor_num(cursor),
+        },
+    )
+    # #endregion
     from plugin.writer.html_import import insert_html_fragment_at_cursor
 
     try:
         insert_html_fragment_at_cursor(cursor, _wrap_html_fragment(html), wrap=False)
+        # #region agent log
+        _dbg_agent_log(
+            "B",
+            "writer_importer.py:_insert_html_at_body_end:after_insert",
+            "immediately after insertDocumentFromURL, before exit_list",
+            {
+                "html": html_s[:240],
+                "has_start": "start=" in html_s,
+                "exit_list": exit_list,
+                "cursor": _dbg_cursor_num(cursor),
+                "paras": _dbg_doc_paras(doc),
+            },
+        )
+        # #endregion
         if exit_list:
             end = text.createTextCursor()
             end.gotoEnd(False)
-            _clear_para_numbering(end)
+            _clear_para_numbering(end, reason="exit_list")
+            # #region agent log
+            _dbg_agent_log(
+                "C",
+                "writer_importer.py:_insert_html_at_body_end:after_exit_list",
+                "after exit_list clear",
+                {
+                    "html": html_s[:240],
+                    "has_start": "start=" in html_s,
+                    "end": _dbg_cursor_num(end),
+                    "paras": _dbg_doc_paras(doc),
+                },
+            )
+            # #endregion
         _trim_trailing_empty_paragraph(doc)
+        # #region agent log
+        _dbg_agent_log(
+            "D",
+            "writer_importer.py:_insert_html_at_body_end:after_trim",
+            "after trailing empty trim",
+            {
+                "html": html_s[:240],
+                "has_start": "start=" in html_s,
+                "exit_list": exit_list,
+                "paras": _dbg_doc_paras(doc),
+            },
+        )
+        # #endregion
         return True
     except Exception:
         log.exception("notebook import HTML insert failed; falling back to plain text")

--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -1280,6 +1280,21 @@ def _anchor_control_as_character(shape: Any) -> None:
         log.debug("notebook import TextWrap not applied", exc_info=True)
 
 
+def _clear_para_numbering(cursor: Any) -> None:
+    """Drop inherited list numbering so the next block is not a leftover bullet."""
+    # StarWriter insertDocumentFromURL leaves NumberingRules on the trailing
+    # para. The next heading, body, blockquote, or resumed <ol> then inherits
+    # leftover bullets. Clear both properties on the insertion cursor.
+    try:
+        cursor.setPropertyValue("NumberingStyleName", "")
+    except Exception:
+        log.debug("notebook import NumberingStyleName clear failed", exc_info=True)
+    try:
+        cursor.setPropertyValue("NumberingRules", None)
+    except Exception:
+        log.debug("notebook import NumberingRules clear failed", exc_info=True)
+
+
 def _append_body_paragraph(
     doc: Any,
     content: str,
@@ -1297,6 +1312,8 @@ def _append_body_paragraph(
     if lead_break and _doc_body_nonempty(doc):
         text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
         cursor.gotoEnd(False)
+    # Always: leftover empty list para must not infect h2/body.
+    _clear_para_numbering(cursor)
     resolved = _resolve_para_style(doc, para_style)
     if resolved:
         try:
@@ -1372,7 +1389,9 @@ def _trim_trailing_empty_paragraph(doc: Any) -> None:
         log.debug("notebook import: trim trailing empty paragraph failed", exc_info=True)
 
 
-def _insert_html_at_body_end(doc: Any, html: str, *, lead_break: bool) -> bool:
+def _insert_html_at_body_end(
+    doc: Any, html: str, *, lead_break: bool, exit_list: bool = False
+) -> bool:
     """Insert an HTML fragment at the document end. Returns False on failure."""
     text = doc.getText()
     cursor = text.createTextCursor()
@@ -1380,10 +1399,15 @@ def _insert_html_at_body_end(doc: Any, html: str, *, lead_break: bool) -> bool:
     if lead_break and _doc_body_nonempty(doc):
         text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
         cursor.gotoEnd(False)
+    _clear_para_numbering(cursor)
     from plugin.writer.html_import import insert_html_fragment_at_cursor
 
     try:
         insert_html_fragment_at_cursor(cursor, _wrap_html_fragment(html), wrap=False)
+        if exit_list:
+            end = text.createTextCursor()
+            end.gotoEnd(False)
+            _clear_para_numbering(end)
         _trim_trailing_empty_paragraph(doc)
         return True
     except Exception:
@@ -1426,7 +1450,7 @@ def _append_markdown_cell(
         elif kind in ("ul", "ol"):
             items = payload if isinstance(payload, list) else [payload]
             html = _list_block_to_html(items)
-            if not _insert_html_at_body_end(doc, html, lead_break=block_lead):
+            if not _insert_html_at_body_end(doc, html, lead_break=block_lead, exit_list=True):
                 for i, item in enumerate(items):
                     if isinstance(item, tuple) and len(item) >= 4:
                         text = str(item[3])

--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -133,6 +133,8 @@ _HTML_ATTR_RE = re.compile(
     r"""(?is)([a-z_:][-a-z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))"""
 )
 _IN_PROMPT_RE = re.compile(r"^In \[[0-9 ]*\]:")
+# One-item resumed list: ``<ol start="3"><li>Ask for help…</li></ol>``.
+_OL_START_RE = re.compile(r"""(?is)<ol\b[^>]*\bstart\s*=\s*["']?(\d+)""")
 
 
 def _mono_ms(t0: float) -> int:
@@ -1052,6 +1054,22 @@ def _list_block_to_html(items: list[Any]) -> str:
     return html
 
 
+def _single_ol_start(html: str) -> int | None:
+    """Return *start* when *html* is a one-item ``<ol start="N">`` with N > 1.
+
+    Multi-item lists already get numbering from StarWriter. The 1-item
+    ``start=N`` fragment is the one that inherits leftover nested-ul level
+    or drops numbering entirely.
+    """
+    if (html or "").lower().count("<li") != 1:
+        return None
+    match = _OL_START_RE.search(html or "")
+    if not match:
+        return None
+    start = int(match.group(1))
+    return start if start > 1 else None
+
+
 def _iter_markdown_blocks(source: str) -> list[tuple[str, Any]]:
     """Split CommonMark source into ATX headings, lists, quotes, images, paragraphs.
 
@@ -1387,6 +1405,92 @@ def _dbg_doc_paras(doc: Any, *, limit: int = 30) -> list[dict[str, Any]]:
     return rows
 
 
+def _numbering_kind(name: str) -> str:
+    """``none`` / ``outline`` / ``list`` — Outline is heading chapter numbering."""
+    lowered = (name or "").strip().lower()
+    if not lowered:
+        return "none"
+    if lowered == "outline" or "outline" in lowered:
+        return "outline"
+    return "list"
+
+
+def _copy_previous_outer_list(cursor: Any) -> bool:
+    """Copy NumberingStyleName + NumberingRules from the nearest level-0 list para."""
+    try:
+        text_obj = cursor.getText()
+        prev = text_obj.createTextCursorByRange(cursor)
+    except Exception:
+        return False
+    steps = 0
+    while steps < 32:
+        steps += 1
+        try:
+            if not prev.gotoPreviousParagraph(False):
+                return False
+            style = str(prev.getPropertyValue("NumberingStyleName") or "")
+            if _numbering_kind(style) != "list":
+                continue
+            level = int(prev.getPropertyValue("NumberingLevel") or 0)
+            if level != 0:
+                continue
+            rules = prev.getPropertyValue("NumberingRules")
+            if rules is None:
+                continue
+            cursor.setPropertyValue("NumberingStyleName", style)
+            cursor.setPropertyValue("NumberingRules", rules)
+            return True
+        except Exception:
+            continue
+    return False
+
+
+def _promote_para_to_outer_ol(cursor: Any, *, start: int) -> bool:
+    """Put *cursor*'s paragraph on the outer ordered list at *start*.
+
+    Skip-pre-clear left Ask for help on leftover nested-ul NumberingLevel=1
+    (same style as ChatGPT). Full pre-clear made insertDocumentFromURL drop
+    numbering on a 1-item ``<ol start=N>``. Keep the list style, force level 0,
+    restart at N.
+    """
+    try:
+        style = str(cursor.getPropertyValue("NumberingStyleName") or "")
+    except Exception:
+        style = ""
+    kind = _numbering_kind(style)
+    if kind == "outline":
+        return False
+    if kind == "none" and not _copy_previous_outer_list(cursor):
+        return False
+    try:
+        cursor.setPropertyValue("NumberingLevel", 0)
+        cursor.setPropertyValue("NumberingStartValue", int(start))
+        cursor.setPropertyValue("ParaIsNumberingRestart", True)
+        return True
+    except Exception:
+        log.debug("notebook import promote outer ol start=%s failed", start, exc_info=True)
+        return False
+
+
+def _last_nonempty_para_cursor(text: Any) -> Any | None:
+    try:
+        cursor = text.createTextCursor()
+        cursor.gotoEnd(False)
+    except Exception:
+        return None
+    steps = 0
+    while steps < 16:
+        steps += 1
+        if not _cursor_para_is_empty(cursor):
+            return cursor
+        try:
+            if not cursor.gotoPreviousParagraph(False):
+                return None
+        except Exception:
+            return None
+    return None
+
+
 def _cursor_para_is_empty(cursor: Any) -> bool:
     """True when *cursor*'s paragraph has no visible text (trailing list leftover)."""
     try:
@@ -1545,12 +1649,13 @@ def _insert_html_at_body_end(
         cursor.gotoEnd(False)
         did_lead = True
     html_s = html or ""
-    # List HTML: do not pre-clear leftover NumberingRules. The first <li>
-    # merges into this paragraph. A 1-item ``<ol start="N">`` inserted after
-    # NumberingStyleName="" / NumberingRules=None is imported as plain Text
-    # body (Ask for help). Blockquotes and other HTML still pre-clear so they
-    # do not inherit leftover bullets from the previous list item.
+    # List HTML: do not pre-clear leftover NumberingRules (a 1-item
+    # ``<ol start="N">`` then imports as plain Text body). Do not leave
+    # leftover nested-ul NumberingLevel=1 either — that is the same style
+    # as ChatGPT bullets, not outer ol start=N. Promote that case to level 0
+    # and restart at N. Blockquotes still pre-clear.
     skip_pre_clear = bool(exit_list)
+    ol_start = _single_ol_start(html_s)
     # #region agent log
     _dbg_agent_log(
         "E",
@@ -1559,6 +1664,7 @@ def _insert_html_at_body_end(
         {
             "html": html_s[:240],
             "has_start": "start=" in html_s,
+            "ol_start": ol_start,
             "is_ol": "<ol" in html_s.lower(),
             "is_ul": "<ul" in html_s.lower(),
             "is_bq": "<blockquote" in html_s.lower(),
@@ -1571,8 +1677,11 @@ def _insert_html_at_body_end(
         },
     )
     # #endregion
+    promoted_before = False
     if not skip_pre_clear:
         _clear_para_numbering(cursor, reason="pre_insert")
+    elif ol_start is not None:
+        promoted_before = _promote_para_to_outer_ol(cursor, start=ol_start)
     # #region agent log
     _dbg_agent_log(
         "A",
@@ -1581,7 +1690,9 @@ def _insert_html_at_body_end(
         {
             "html": html_s[:240],
             "has_start": "start=" in html_s,
+            "ol_start": ol_start,
             "skip_pre_clear": skip_pre_clear,
+            "promoted_before": promoted_before,
             "cursor": _dbg_cursor_num(cursor),
         },
     )
@@ -1598,12 +1709,31 @@ def _insert_html_at_body_end(
             {
                 "html": html_s[:240],
                 "has_start": "start=" in html_s,
+                "ol_start": ol_start,
                 "exit_list": exit_list,
                 "cursor": _dbg_cursor_num(cursor),
                 "paras": _dbg_doc_paras(doc),
             },
         )
         # #endregion
+        promoted_after = False
+        if ol_start is not None:
+            target = _last_nonempty_para_cursor(text)
+            if target is not None:
+                promoted_after = _promote_para_to_outer_ol(target, start=ol_start)
+            # #region agent log
+            _dbg_agent_log(
+                "B",
+                "writer_importer.py:_insert_html_at_body_end:after_promote",
+                "after promote 1-item ol to outer start=N",
+                {
+                    "ol_start": ol_start,
+                    "promoted_after": promoted_after,
+                    "target": _dbg_cursor_num(target) if target is not None else None,
+                    "paras": _dbg_doc_paras(doc),
+                },
+            )
+            # #endregion
         if exit_list:
             end = text.createTextCursor()
             end.gotoEnd(False)

--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -1298,113 +1298,6 @@ def _anchor_control_as_character(shape: Any) -> None:
         log.debug("notebook import TextWrap not applied", exc_info=True)
 
 
-def _dbg_safe(val: Any) -> Any:
-    if val is None or isinstance(val, (bool, int, float)):
-        return val
-    if isinstance(val, str):
-        return val[:160]
-    try:
-        text = str(val)
-    except Exception:
-        return type(val).__name__
-    if "MagicMock" in text:
-        return "MagicMock"
-    return text[:120]
-
-
-def _dbg_agent_log(hypothesis_id: str, location: str, message: str, data: dict[str, Any]) -> None:
-    # #region agent log
-    try:
-        import json as _json
-
-        with open("/opt/cursor/logs/debug.log", "a", encoding="utf-8") as fh:
-            fh.write(
-                _json.dumps(
-                    {
-                        "hypothesisId": hypothesis_id,
-                        "location": location,
-                        "message": message,
-                        "data": data,
-                        "timestamp": int(time.time() * 1000),
-                    },
-                    default=str,
-                )
-                + "\n"
-            )
-    except Exception:
-        pass
-    # #endregion
-
-
-def _dbg_cursor_num(obj: Any) -> dict[str, Any]:
-    out: dict[str, Any] = {}
-    for name in (
-        "NumberingStyleName",
-        "NumberingIsNumber",
-        "NumberingLevel",
-        "NumberingStartValue",
-        "ParaIsNumberingRestart",
-        "ParaStyleName",
-    ):
-        try:
-            out[name] = _dbg_safe(obj.getPropertyValue(name))
-        except Exception as exc:
-            out[name] = "err:" + type(exc).__name__
-    try:
-        rules = obj.getPropertyValue("NumberingRules")
-        if rules is None:
-            out["NumberingRules"] = None
-        else:
-            rname = type(rules).__name__
-            out["NumberingRules"] = "MagicMock" if "MagicMock" in rname else rname
-    except Exception as exc:
-        out["NumberingRules"] = "err:" + type(exc).__name__
-    try:
-        text_obj = obj.getText() if hasattr(obj, "getText") else None
-        if text_obj is not None:
-            rng = text_obj.createTextCursorByRange(obj)
-            rng.gotoStartOfParagraph(False)
-            rng.gotoEndOfParagraph(True)
-            out["para_text"] = _dbg_safe(rng.getString() or "")
-        else:
-            out["para_text"] = _dbg_safe(obj.getString() or "")
-    except Exception as exc:
-        try:
-            out["para_text"] = _dbg_safe(obj.getString() or "")
-        except Exception:
-            out["para_text"] = "err:" + type(exc).__name__
-    return out
-
-
-def _dbg_doc_paras(doc: Any, *, limit: int = 30) -> list[dict[str, Any]]:
-    rows: list[dict[str, Any]] = []
-    try:
-        enum = doc.getText().createEnumeration()
-    except Exception:
-        return rows
-    i = 0
-    steps = 0
-    while steps < 64 and i < limit:
-        steps += 1
-        try:
-            more = enum.hasMoreElements()
-            if more is not True and more != 1:
-                break
-            el = enum.nextElement()
-        except Exception:
-            break
-        try:
-            if hasattr(el, "supportsService") and not el.supportsService("com.sun.star.text.Paragraph"):
-                continue
-        except Exception:
-            continue
-        row = _dbg_cursor_num(el)
-        row["i"] = i
-        rows.append(row)
-        i += 1
-    return rows
-
-
 def _numbering_kind(name: str) -> str:
     """``none`` / ``outline`` / ``list`` — Outline is heading chapter numbering."""
     lowered = (name or "").strip().lower()
@@ -1508,21 +1401,12 @@ def _cursor_para_is_empty(cursor: Any) -> bool:
         return False
 
 
-def _clear_para_numbering(cursor: Any, *, reason: str = "") -> None:
+def _clear_para_numbering(cursor: Any) -> None:
     """Drop inherited list numbering so the next block is not a leftover bullet."""
     # StarWriter insertDocumentFromURL leaves NumberingRules on the last list
     # item. A following paragraph break inherits that leftover. Clear both
     # properties on heading/body/blockquote insertion cursors — not on the
     # list fragment itself (see ``_insert_html_at_body_end``).
-    # #region agent log
-    before = _dbg_cursor_num(cursor)
-    _dbg_agent_log(
-        "A",
-        "writer_importer.py:_clear_para_numbering:before",
-        "clear numbering enter",
-        {"reason": reason, "before": before},
-    )
-    # #endregion
     try:
         cursor.setPropertyValue("NumberingStyleName", "")
     except Exception:
@@ -1531,15 +1415,6 @@ def _clear_para_numbering(cursor: Any, *, reason: str = "") -> None:
         cursor.setPropertyValue("NumberingRules", None)
     except Exception:
         log.debug("notebook import NumberingRules clear failed", exc_info=True)
-    # #region agent log
-    after = _dbg_cursor_num(cursor)
-    _dbg_agent_log(
-        "A",
-        "writer_importer.py:_clear_para_numbering:after",
-        "clear numbering exit",
-        {"reason": reason, "after": after},
-    )
-    # #endregion
 
 
 def _append_body_paragraph(
@@ -1560,7 +1435,7 @@ def _append_body_paragraph(
         text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
         cursor.gotoEnd(False)
     # Always: leftover empty list para must not infect h2/body.
-    _clear_para_numbering(cursor, reason="append_body")
+    _clear_para_numbering(cursor)
     resolved = _resolve_para_style(doc, para_style)
     if resolved:
         try:
@@ -1643,133 +1518,35 @@ def _insert_html_at_body_end(
     text = doc.getText()
     cursor = text.createTextCursor()
     cursor.gotoEnd(False)
-    did_lead = False
     if lead_break and _doc_body_nonempty(doc):
         text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
         cursor.gotoEnd(False)
-        did_lead = True
-    html_s = html or ""
     # List HTML: do not pre-clear leftover NumberingRules (a 1-item
     # ``<ol start="N">`` then imports as plain Text body). Do not leave
     # leftover nested-ul NumberingLevel=1 either — that is the same style
     # as ChatGPT bullets, not outer ol start=N. Promote that case to level 0
     # and restart at N. Blockquotes still pre-clear.
-    skip_pre_clear = bool(exit_list)
-    ol_start = _single_ol_start(html_s)
-    # #region agent log
-    _dbg_agent_log(
-        "E",
-        "writer_importer.py:_insert_html_at_body_end:pre_clear",
-        "before pre-insert numbering clear",
-        {
-            "html": html_s[:240],
-            "has_start": "start=" in html_s,
-            "ol_start": ol_start,
-            "is_ol": "<ol" in html_s.lower(),
-            "is_ul": "<ul" in html_s.lower(),
-            "is_bq": "<blockquote" in html_s.lower(),
-            "exit_list": exit_list,
-            "skip_pre_clear": skip_pre_clear,
-            "lead_break": lead_break,
-            "did_lead": did_lead,
-            "cursor": _dbg_cursor_num(cursor),
-            "paras": _dbg_doc_paras(doc),
-        },
-    )
-    # #endregion
-    promoted_before = False
-    if not skip_pre_clear:
-        _clear_para_numbering(cursor, reason="pre_insert")
+    ol_start = _single_ol_start(html or "")
+    if not exit_list:
+        _clear_para_numbering(cursor)
     elif ol_start is not None:
-        promoted_before = _promote_para_to_outer_ol(cursor, start=ol_start)
-    # #region agent log
-    _dbg_agent_log(
-        "A",
-        "writer_importer.py:_insert_html_at_body_end:after_pre_clear",
-        "after pre-insert numbering decision, before HTML insert",
-        {
-            "html": html_s[:240],
-            "has_start": "start=" in html_s,
-            "ol_start": ol_start,
-            "skip_pre_clear": skip_pre_clear,
-            "promoted_before": promoted_before,
-            "cursor": _dbg_cursor_num(cursor),
-        },
-    )
-    # #endregion
+        _promote_para_to_outer_ol(cursor, start=ol_start)
     from plugin.writer.html_import import insert_html_fragment_at_cursor
 
     try:
         insert_html_fragment_at_cursor(cursor, _wrap_html_fragment(html), wrap=False)
-        # #region agent log
-        _dbg_agent_log(
-            "B",
-            "writer_importer.py:_insert_html_at_body_end:after_insert",
-            "immediately after insertDocumentFromURL, before exit_list",
-            {
-                "html": html_s[:240],
-                "has_start": "start=" in html_s,
-                "ol_start": ol_start,
-                "exit_list": exit_list,
-                "cursor": _dbg_cursor_num(cursor),
-                "paras": _dbg_doc_paras(doc),
-            },
-        )
-        # #endregion
-        promoted_after = False
         if ol_start is not None:
             target = _last_nonempty_para_cursor(text)
             if target is not None:
-                promoted_after = _promote_para_to_outer_ol(target, start=ol_start)
-            # #region agent log
-            _dbg_agent_log(
-                "B",
-                "writer_importer.py:_insert_html_at_body_end:after_promote",
-                "after promote 1-item ol to outer start=N",
-                {
-                    "ol_start": ol_start,
-                    "promoted_after": promoted_after,
-                    "target": _dbg_cursor_num(target) if target is not None else None,
-                    "paras": _dbg_doc_paras(doc),
-                },
-            )
-            # #endregion
+                _promote_para_to_outer_ol(target, start=ol_start)
         if exit_list:
             end = text.createTextCursor()
             end.gotoEnd(False)
             # Only the empty trailing para. Clearing the last <li> would
             # un-number Ask for help when insertDocumentFromURL left no extra para.
-            end_empty = _cursor_para_is_empty(end)
-            if end_empty:
-                _clear_para_numbering(end, reason="exit_list")
-            # #region agent log
-            _dbg_agent_log(
-                "C",
-                "writer_importer.py:_insert_html_at_body_end:after_exit_list",
-                "after exit_list clear",
-                {
-                    "html": html_s[:240],
-                    "has_start": "start=" in html_s,
-                    "end_empty": end_empty,
-                    "end": _dbg_cursor_num(end),
-                    "paras": _dbg_doc_paras(doc),
-                },
-            )
-            # #endregion
+            if _cursor_para_is_empty(end):
+                _clear_para_numbering(end)
         _trim_trailing_empty_paragraph(doc)
-        # #region agent log
-        _dbg_agent_log(
-            "D",
-            "writer_importer.py:_insert_html_at_body_end:after_trim",
-            "after trailing empty trim",
-            {
-                "html": html_s[:240],
-                "has_start": "start=" in html_s,
-                "exit_list": exit_list,
-                "paras": _dbg_doc_paras(doc),
-            },
-        )
-        # #endregion
         return True
     except Exception:
         log.exception("notebook import HTML insert failed; falling back to plain text")

--- a/plugin/notebook/writer_importer.py
+++ b/plugin/notebook/writer_importer.py
@@ -1387,11 +1387,29 @@ def _dbg_doc_paras(doc: Any, *, limit: int = 30) -> list[dict[str, Any]]:
     return rows
 
 
+def _cursor_para_is_empty(cursor: Any) -> bool:
+    """True when *cursor*'s paragraph has no visible text (trailing list leftover)."""
+    try:
+        text_obj = cursor.getText()
+        rng = text_obj.createTextCursorByRange(cursor)
+        rng.gotoStartOfParagraph(False)
+        rng.gotoEndOfParagraph(True)
+        raw = rng.getString()
+        if raw is None:
+            return True
+        if not isinstance(raw, str):
+            return False
+        return raw.strip() == ""
+    except Exception:
+        return False
+
+
 def _clear_para_numbering(cursor: Any, *, reason: str = "") -> None:
     """Drop inherited list numbering so the next block is not a leftover bullet."""
-    # StarWriter insertDocumentFromURL leaves NumberingRules on the trailing
-    # para. The next heading, body, blockquote, or resumed <ol> then inherits
-    # leftover bullets. Clear both properties on the insertion cursor.
+    # StarWriter insertDocumentFromURL leaves NumberingRules on the last list
+    # item. A following paragraph break inherits that leftover. Clear both
+    # properties on heading/body/blockquote insertion cursors — not on the
+    # list fragment itself (see ``_insert_html_at_body_end``).
     # #region agent log
     before = _dbg_cursor_num(cursor)
     _dbg_agent_log(
@@ -1527,6 +1545,12 @@ def _insert_html_at_body_end(
         cursor.gotoEnd(False)
         did_lead = True
     html_s = html or ""
+    # List HTML: do not pre-clear leftover NumberingRules. The first <li>
+    # merges into this paragraph. A 1-item ``<ol start="N">`` inserted after
+    # NumberingStyleName="" / NumberingRules=None is imported as plain Text
+    # body (Ask for help). Blockquotes and other HTML still pre-clear so they
+    # do not inherit leftover bullets from the previous list item.
+    skip_pre_clear = bool(exit_list)
     # #region agent log
     _dbg_agent_log(
         "E",
@@ -1539,6 +1563,7 @@ def _insert_html_at_body_end(
             "is_ul": "<ul" in html_s.lower(),
             "is_bq": "<blockquote" in html_s.lower(),
             "exit_list": exit_list,
+            "skip_pre_clear": skip_pre_clear,
             "lead_break": lead_break,
             "did_lead": did_lead,
             "cursor": _dbg_cursor_num(cursor),
@@ -1546,15 +1571,17 @@ def _insert_html_at_body_end(
         },
     )
     # #endregion
-    _clear_para_numbering(cursor, reason="pre_insert")
+    if not skip_pre_clear:
+        _clear_para_numbering(cursor, reason="pre_insert")
     # #region agent log
     _dbg_agent_log(
         "A",
         "writer_importer.py:_insert_html_at_body_end:after_pre_clear",
-        "after pre-insert numbering clear, before HTML insert",
+        "after pre-insert numbering decision, before HTML insert",
         {
             "html": html_s[:240],
             "has_start": "start=" in html_s,
+            "skip_pre_clear": skip_pre_clear,
             "cursor": _dbg_cursor_num(cursor),
         },
     )
@@ -1580,7 +1607,11 @@ def _insert_html_at_body_end(
         if exit_list:
             end = text.createTextCursor()
             end.gotoEnd(False)
-            _clear_para_numbering(end, reason="exit_list")
+            # Only the empty trailing para. Clearing the last <li> would
+            # un-number Ask for help when insertDocumentFromURL left no extra para.
+            end_empty = _cursor_para_is_empty(end)
+            if end_empty:
+                _clear_para_numbering(end, reason="exit_list")
             # #region agent log
             _dbg_agent_log(
                 "C",
@@ -1589,6 +1620,7 @@ def _insert_html_at_body_end(
                 {
                     "html": html_s[:240],
                     "has_start": "start=" in html_s,
+                    "end_empty": end_empty,
                     "end": _dbg_cursor_num(end),
                     "paras": _dbg_doc_paras(doc),
                 },

--- a/tests/fixtures/markdown-lists-quotes.ipynb
+++ b/tests/fixtures/markdown-lists-quotes.ipynb
@@ -22,6 +22,13 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "## After the list\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "> **Note:** Important to remember `ndarray` is the core type.\n"
       ]
     },

--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -269,11 +269,11 @@ def test_insert_html_list_skips_pre_clear_numbering(monkeypatch):
     """
     doc, _body_text, body_cursor = _writer_doc_mock()
     body_cursor.getString.return_value = ""
-    cleared: list[str] = []
+    cleared: list[int] = []
     promoted: list[int] = []
 
-    def fake_clear(cursor, *, reason=""):
-        cleared.append(reason)
+    def fake_clear(cursor):
+        cleared.append(1)
 
     def fake_promote(cursor, *, start):
         promoted.append(start)
@@ -290,8 +290,7 @@ def test_insert_html_list_skips_pre_clear_numbering(monkeypatch):
     wi._insert_html_at_body_end(
         doc, '<ol start="3"><li>Ask for help</li></ol>', lead_break=False, exit_list=True
     )
-    assert "pre_insert" not in cleared
-    assert "exit_list" in cleared
+    assert len(cleared) == 1
     assert 3 in promoted
 
 
@@ -324,10 +323,10 @@ def test_insert_html_blockquote_still_pre_clears(monkeypatch):
     """Non-list HTML still pre-clears so a quote does not inherit leftover bullets."""
     doc, _body_text, body_cursor = _writer_doc_mock()
     body_cursor.getString.return_value = ""
-    cleared: list[str] = []
+    cleared: list[int] = []
 
-    def fake_clear(cursor, *, reason=""):
-        cleared.append(reason)
+    def fake_clear(cursor):
+        cleared.append(1)
 
     monkeypatch.setattr("plugin.notebook.writer_importer._clear_para_numbering", fake_clear)
     monkeypatch.setattr("plugin.writer.html_import.insert_html_fragment_at_cursor", lambda *a, **k: None)
@@ -336,7 +335,7 @@ def test_insert_html_blockquote_still_pre_clears(monkeypatch):
     import plugin.notebook.writer_importer as wi
 
     wi._insert_html_at_body_end(doc, "<blockquote><p>Note</p></blockquote>", lead_break=False)
-    assert cleared == ["pre_insert"]
+    assert len(cleared) == 1
 
 
 def _writer_doc_mock(*, with_bookmarks: bool = False):

--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -972,7 +972,7 @@ def test_import_nested_lists_and_blockquotes_fixture(monkeypatch):
 
     monkeypatch.setattr("plugin.writer.html_import.insert_html_fragment_at_cursor", fake_insert_html)
     stats = import_ipynb_to_writer(doc, str(ipynb))
-    assert stats["markdown"] == 3
+    assert stats["markdown"] == 4
     joined = "\n".join(html_calls)
     assert "<ul>" in joined
     assert "<li>" in joined

--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -270,11 +270,17 @@ def test_insert_html_list_skips_pre_clear_numbering(monkeypatch):
     doc, _body_text, body_cursor = _writer_doc_mock()
     body_cursor.getString.return_value = ""
     cleared: list[str] = []
+    promoted: list[int] = []
 
     def fake_clear(cursor, *, reason=""):
         cleared.append(reason)
 
+    def fake_promote(cursor, *, start):
+        promoted.append(start)
+        return True
+
     monkeypatch.setattr("plugin.notebook.writer_importer._clear_para_numbering", fake_clear)
+    monkeypatch.setattr("plugin.notebook.writer_importer._promote_para_to_outer_ol", fake_promote)
     monkeypatch.setattr("plugin.writer.html_import.insert_html_fragment_at_cursor", lambda *a, **k: None)
     monkeypatch.setattr("plugin.notebook.writer_importer._trim_trailing_empty_paragraph", lambda _doc: None)
     monkeypatch.setattr("plugin.notebook.writer_importer._cursor_para_is_empty", lambda _c: True)
@@ -286,6 +292,32 @@ def test_insert_html_list_skips_pre_clear_numbering(monkeypatch):
     )
     assert "pre_insert" not in cleared
     assert "exit_list" in cleared
+    assert 3 in promoted
+
+
+def test_single_ol_start_only_one_item():
+    from plugin.notebook.writer_importer import _single_ol_start
+
+    assert _single_ol_start('<ol start="3"><li>Ask for help</li></ol>') == 3
+    assert _single_ol_start("<ol><li>cheat</li><li>search</li></ol>") is None
+    assert _single_ol_start('<ol start="3"><li>a</li><li>b</li></ol>') is None
+    assert _single_ol_start("<blockquote><p>Note</p></blockquote>") is None
+
+
+def test_promote_para_to_outer_ol_nested_level():
+    from plugin.notebook.writer_importer import _promote_para_to_outer_ol
+
+    cursor = MagicMock()
+    props = {
+        "NumberingStyleName": "1698400711",
+        "NumberingLevel": 1,
+        "NumberingRules": object(),
+    }
+    cursor.getPropertyValue.side_effect = lambda name: props[name]
+    assert _promote_para_to_outer_ol(cursor, start=3) is True
+    cursor.setPropertyValue.assert_any_call("NumberingLevel", 0)
+    cursor.setPropertyValue.assert_any_call("NumberingStartValue", 3)
+    cursor.setPropertyValue.assert_any_call("ParaIsNumberingRestart", True)
 
 
 def test_insert_html_blockquote_still_pre_clears(monkeypatch):

--- a/tests/notebook/test_writer_importer.py
+++ b/tests/notebook/test_writer_importer.py
@@ -260,6 +260,53 @@ def test_insert_html_at_body_end_calls_trim(monkeypatch):
     assert trim_called is True
 
 
+def test_insert_html_list_skips_pre_clear_numbering(monkeypatch):
+    """List HTML must keep leftover NumberingRules on the insertion para.
+
+    StarWriter merges the first <li> into that para. Clearing NumberingStyleName
+    and NumberingRules first made a 1-item <ol start="3"> import as plain text
+    (Ask for help lost its list style).
+    """
+    doc, _body_text, body_cursor = _writer_doc_mock()
+    body_cursor.getString.return_value = ""
+    cleared: list[str] = []
+
+    def fake_clear(cursor, *, reason=""):
+        cleared.append(reason)
+
+    monkeypatch.setattr("plugin.notebook.writer_importer._clear_para_numbering", fake_clear)
+    monkeypatch.setattr("plugin.writer.html_import.insert_html_fragment_at_cursor", lambda *a, **k: None)
+    monkeypatch.setattr("plugin.notebook.writer_importer._trim_trailing_empty_paragraph", lambda _doc: None)
+    monkeypatch.setattr("plugin.notebook.writer_importer._cursor_para_is_empty", lambda _c: True)
+
+    import plugin.notebook.writer_importer as wi
+
+    wi._insert_html_at_body_end(
+        doc, '<ol start="3"><li>Ask for help</li></ol>', lead_break=False, exit_list=True
+    )
+    assert "pre_insert" not in cleared
+    assert "exit_list" in cleared
+
+
+def test_insert_html_blockquote_still_pre_clears(monkeypatch):
+    """Non-list HTML still pre-clears so a quote does not inherit leftover bullets."""
+    doc, _body_text, body_cursor = _writer_doc_mock()
+    body_cursor.getString.return_value = ""
+    cleared: list[str] = []
+
+    def fake_clear(cursor, *, reason=""):
+        cleared.append(reason)
+
+    monkeypatch.setattr("plugin.notebook.writer_importer._clear_para_numbering", fake_clear)
+    monkeypatch.setattr("plugin.writer.html_import.insert_html_fragment_at_cursor", lambda *a, **k: None)
+    monkeypatch.setattr("plugin.notebook.writer_importer._trim_trailing_empty_paragraph", lambda _doc: None)
+
+    import plugin.notebook.writer_importer as wi
+
+    wi._insert_html_at_body_end(doc, "<blockquote><p>Note</p></blockquote>", lead_break=False)
+    assert cleared == ["pre_insert"]
+
+
 def _writer_doc_mock(*, with_bookmarks: bool = False):
     body_cursor = MagicMock()
     body_text = MagicMock()

--- a/tests/notebook/test_writer_importer_uno.py
+++ b/tests/notebook/test_writer_importer_uno.py
@@ -78,6 +78,21 @@ def _paragraphs_with_numbering(doc) -> list[tuple[str, str, str]]:
     return out
 
 
+def _is_leftover_list_numbering(numbering: str) -> bool:
+    """True when NumberingStyleName is a list style, not heading Outline.
+
+    Heading 2 keeps chapter ``Outline`` from the paragraph style. That is not
+    leftover ``insertDocumentFromURL`` list NumberingRules.
+    """
+    name = (numbering or "").strip()
+    if not name:
+        return False
+    lowered = name.lower()
+    if lowered == "outline" or "outline" in lowered:
+        return False
+    return True
+
+
 def _style_is_heading(style: str, level: int) -> bool:
     compact = (style or "").lower().replace(" ", "")
     return compact == f"heading{level}"
@@ -920,7 +935,7 @@ def test_import_nested_lists_blockquotes_and_in_keep_style(ctx, doc):
         if "Where can I get help?" in text
     ]
     assert help_heading, f"help heading missing: {numbered_paras!r}"
-    assert help_heading[0][1] == "", (
+    assert not _is_leftover_list_numbering(help_heading[0][1]), (
         f"help heading inherited leftover numbering: {help_heading!r}"
     )
     ask = [
@@ -939,7 +954,7 @@ def test_import_nested_lists_blockquotes_and_in_keep_style(ctx, doc):
         if "After the list" in text
     ]
     assert after_list, f"After the list heading missing: {numbered_paras!r}"
-    assert after_list[0][1] == "", (
+    assert not _is_leftover_list_numbering(after_list[0][1]), (
         f"list-then-h2 leaked numbering onto After the list: {after_list!r}"
     )
     unique_quote = [

--- a/tests/notebook/test_writer_importer_uno.py
+++ b/tests/notebook/test_writer_importer_uno.py
@@ -60,9 +60,9 @@ def _paragraphs(doc) -> list[tuple[str, str]]:
     return out
 
 
-def _paragraphs_with_numbering(doc) -> list[tuple[str, str, str]]:
-    """(ParaStyleName, NumberingStyleName, text) for leftover-list leak checks."""
-    out: list[tuple[str, str, str]] = []
+def _paragraphs_with_numbering(doc) -> list[tuple[str, str, str, int]]:
+    """(ParaStyleName, NumberingStyleName, text, NumberingLevel) for leftover-list leak checks."""
+    out: list[tuple[str, str, str, int]] = []
     enum = doc.getText().createEnumeration()
     while enum.hasMoreElements():
         el = enum.nextElement()
@@ -72,9 +72,13 @@ def _paragraphs_with_numbering(doc) -> list[tuple[str, str, str]]:
             style = str(el.getPropertyValue("ParaStyleName") or "")
             numbering = str(el.getPropertyValue("NumberingStyleName") or "")
             text = str(el.getString() or "")
+            try:
+                level = int(el.getPropertyValue("NumberingLevel") or 0)
+            except Exception:
+                level = 0
         except Exception:
             continue
-        out.append((style, numbering, text))
+        out.append((style, numbering, text, level))
     return out
 
 
@@ -930,8 +934,8 @@ def test_import_nested_lists_blockquotes_and_in_keep_style(ctx, doc):
     assert not any(t.lstrip().startswith("1.") and "Ask for help" in t for t in numbered)
     numbered_paras = _paragraphs_with_numbering(doc)
     help_heading = [
-        (style, numbering, text)
-        for style, numbering, text in numbered_paras
+        (style, numbering, text, level)
+        for style, numbering, text, level in numbered_paras
         if "Where can I get help?" in text
     ]
     assert help_heading, f"help heading missing: {numbered_paras!r}"
@@ -939,18 +943,21 @@ def test_import_nested_lists_blockquotes_and_in_keep_style(ctx, doc):
         f"help heading inherited leftover numbering: {help_heading!r}"
     )
     ask = [
-        (style, numbering, text)
-        for style, numbering, text in numbered_paras
+        (style, numbering, text, level)
+        for style, numbering, text, level in numbered_paras
         if "Ask for help" in text
     ]
     assert ask, f"Ask for help missing from numbered paras: {numbered_paras!r}"
     assert ask[0][1], f"Ask for help lost list numbering: {ask!r}"
-    assert not any(t.lstrip().startswith("1.") for _s, _n, t in ask), (
+    assert ask[0][3] == 0, (
+        f"Ask for help is leftover nested-ul (level {ask[0][3]}), not outer ol: {ask!r}"
+    )
+    assert not any(t.lstrip().startswith("1.") for _s, _n, t, _lvl in ask), (
         f"Ask for help restarted as literal 1.: {ask!r}"
     )
     after_list = [
-        (style, numbering, text)
-        for style, numbering, text in numbered_paras
+        (style, numbering, text, level)
+        for style, numbering, text, level in numbered_paras
         if "After the list" in text
     ]
     assert after_list, f"After the list heading missing: {numbered_paras!r}"
@@ -958,8 +965,8 @@ def test_import_nested_lists_blockquotes_and_in_keep_style(ctx, doc):
         f"list-then-h2 leaked numbering onto After the list: {after_list!r}"
     )
     unique_quote = [
-        (style, numbering, text)
-        for style, numbering, text in numbered_paras
+        (style, numbering, text, level)
+        for style, numbering, text, level in numbered_paras
         if "unique elements" in text
     ]
     assert unique_quote, f"unique-elements quote missing: {numbered_paras!r}"
@@ -971,12 +978,12 @@ def test_import_nested_lists_blockquotes_and_in_keep_style(ctx, doc):
         f"unique-elements quote inherited leftover numbering: {unique_quote!r}"
     )
     note_quote = [
-        (style, numbering, text)
-        for style, numbering, text in numbered_paras
+        (style, numbering, text, level)
+        for style, numbering, text, level in numbered_paras
         if "ndarray" in text or "Note:" in text
     ]
     assert note_quote, f"Note/ndarray blockquote missing: {numbered_paras!r}"
-    assert all(numbering == "" for _s, numbering, _t in note_quote), (
+    assert all(numbering == "" for _s, numbering, _t, _lvl in note_quote), (
         f"Note/ndarray blockquote inherited leftover numbering: {note_quote!r}"
     )
     families = doc.getStyleFamilies()

--- a/tests/notebook/test_writer_importer_uno.py
+++ b/tests/notebook/test_writer_importer_uno.py
@@ -60,6 +60,24 @@ def _paragraphs(doc) -> list[tuple[str, str]]:
     return out
 
 
+def _paragraphs_with_numbering(doc) -> list[tuple[str, str, str]]:
+    """(ParaStyleName, NumberingStyleName, text) for leftover-list leak checks."""
+    out: list[tuple[str, str, str]] = []
+    enum = doc.getText().createEnumeration()
+    while enum.hasMoreElements():
+        el = enum.nextElement()
+        try:
+            if hasattr(el, "supportsService") and not el.supportsService("com.sun.star.text.Paragraph"):
+                continue
+            style = str(el.getPropertyValue("ParaStyleName") or "")
+            numbering = str(el.getPropertyValue("NumberingStyleName") or "")
+            text = str(el.getString() or "")
+        except Exception:
+            continue
+        out.append((style, numbering, text))
+    return out
+
+
 def _style_is_heading(style: str, level: int) -> bool:
     compact = (style or "").lower().replace(" ", "")
     return compact == f"heading{level}"
@@ -884,6 +902,7 @@ def test_import_nested_lists_blockquotes_and_in_keep_style(ctx, doc):
     assert "NumPy documentation" in body
     assert "Note:" in body or "Important to remember" in body
     assert "how to find unique elements" in body
+    assert "After the list" in body
     # Literal markdown markers must not survive as body text.
     assert "* [NumPy" not in body
     assert "> **Note" not in body
@@ -894,6 +913,57 @@ def test_import_nested_lists_blockquotes_and_in_keep_style(ctx, doc):
     # Writer may show "3." or keep list numbering in Numbering; do not accept a
     # restarted "1. **Ask for help**" from a fresh <ol>.
     assert not any(t.lstrip().startswith("1.") and "Ask for help" in t for t in numbered)
+    numbered_paras = _paragraphs_with_numbering(doc)
+    help_heading = [
+        (style, numbering, text)
+        for style, numbering, text in numbered_paras
+        if "Where can I get help?" in text
+    ]
+    assert help_heading, f"help heading missing: {numbered_paras!r}"
+    assert help_heading[0][1] == "", (
+        f"help heading inherited leftover numbering: {help_heading!r}"
+    )
+    ask = [
+        (style, numbering, text)
+        for style, numbering, text in numbered_paras
+        if "Ask for help" in text
+    ]
+    assert ask, f"Ask for help missing from numbered paras: {numbered_paras!r}"
+    assert ask[0][1], f"Ask for help lost list numbering: {ask!r}"
+    assert not any(t.lstrip().startswith("1.") for _s, _n, t in ask), (
+        f"Ask for help restarted as literal 1.: {ask!r}"
+    )
+    after_list = [
+        (style, numbering, text)
+        for style, numbering, text in numbered_paras
+        if "After the list" in text
+    ]
+    assert after_list, f"After the list heading missing: {numbered_paras!r}"
+    assert after_list[0][1] == "", (
+        f"list-then-h2 leaked numbering onto After the list: {after_list!r}"
+    )
+    unique_quote = [
+        (style, numbering, text)
+        for style, numbering, text in numbered_paras
+        if "unique elements" in text
+    ]
+    assert unique_quote, f"unique-elements quote missing: {numbered_paras!r}"
+    unique_style = (unique_quote[0][0] or "").lower()
+    assert "block" in unique_style or "quot" in unique_style, (
+        f"unique-elements quote style is not block quotation: {unique_quote!r}"
+    )
+    assert unique_quote[0][1] == "", (
+        f"unique-elements quote inherited leftover numbering: {unique_quote!r}"
+    )
+    note_quote = [
+        (style, numbering, text)
+        for style, numbering, text in numbered_paras
+        if "ndarray" in text or "Note:" in text
+    ]
+    assert note_quote, f"Note/ndarray blockquote missing: {numbered_paras!r}"
+    assert all(numbering == "" for _s, numbering, _t in note_quote), (
+        f"Note/ndarray blockquote inherited leftover numbering: {note_quote!r}"
+    )
     families = doc.getStyleFamilies()
     para_styles = families.getByName("ParagraphStyles")
     assert para_styles.hasByName(_STYLE_NOTEBOOK_IN)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
StarWriter HTML list insert leaked NumberingRules into the next heading/blockquote/ol. Clear leftover numbering on body/h2/blockquote insertion and on an empty trailing para after list insert. Headed look of Bourke introduction-to-numpy.ipynb already signed off (cell 5 nested ul + ol start=3, cell 8 Block Quotation).

## What changed

- `_clear_para_numbering` drops `NumberingStyleName` and `NumberingRules` on heading/body/blockquote cursors so leftover list rules do not infect the next block.
- List HTML does **not** pre-clear leftover numbering: a 1-item `<ol start="N">` then imports as plain Text body (CI: “Ask for help lost list numbering”).
- That 1-item fragment is promoted to outer-list `NumberingLevel=0` and restarted at N, so it is not leftover nested-ul level 1 (same style as ChatGPT bullets).
- After list insert, clear leftover numbering only on an empty trailing paragraph (`exit_list=True`).
- UNO test treats leftover list leak as a non-empty `NumberingStyleName` that is not Heading 2 `Outline`. “Ask for help” must keep list numbering at level 0 and must not start with literal `1.`. Blockquotes still fail if they pick up list numbering.
- Fixture `markdown-lists-quotes.ipynb` adds a `## After the list` cell after the list cell.

CommonMark continuation join is unchanged; this does not re-parse markdown.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eab36a5-93c0-4bbb-a16d-2b58f8816350?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eab36a5-93c0-4bbb-a16d-2b58f8816350&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

