### PR TITLE
Off cover-all 33797534946 leftovers (formula_edit, payload_codec, sheet_filter)

### DIFF
--- a/plugin/calc/python/formula_edit.py
+++ b/plugin/calc/python/formula_edit.py
@@ -191,6 +191,8 @@ def _is_data_arg_separator(rest: str) -> bool:
 
 def extract_python_code_loose(formula: str) -> str | None:
     """Best-effort code extraction from a PY/PYTHON-like formula string."""
+    # crosshair: off
+    # cover-all 33797534946 (~4.4h formula_edit module, 201 examples). Combinatoric loose parse. Doable later with tiny PY alphabet.
     parts = parse_python_formula(formula)
     if parts is not None:
         return parts.code
@@ -230,6 +232,8 @@ def normalize_formula_string(formula: str) -> str:
 
 def build_new_python_formula(code: str) -> str:
     """Build a fresh ``=PY("…")`` formula (single code argument, no data range)."""
+    # crosshair: off
+    # cover-all 33797534946 (~4.4h formula_edit module, 297 examples). Thin escape wrapper. Doable later with DEAL_MAX_SOURCE code alphabet.
     escaped = escape_code_for_formula(code)
     return f'={CALC_PYTHON_FN}("{escaped}")'
 
@@ -399,7 +403,8 @@ def sanitize_inline_py_code(code: str) -> str:
 @deal.post(lambda result: isinstance(result, list) and all(isinstance(x, str) for x in result))
 def inline_py_code_has_lexer_collisions(code: str) -> list[str]:
     """Return token names still present that ``sanitize_inline_py_code`` would rewrite."""
-    # crosshair: off  # four regex searches on free strings (cover-all 33314946731: ~5.3h, 500k lines). Same rewrite-regex class as sanitize. Doable later with a tiny token alphabet.
+    # crosshair: off
+    # four regex searches on free strings (cover-all 33314946731: ~5.3h, 500k lines). Same rewrite-regex class as sanitize. Doable later with a tiny token alphabet.
     hits: list[str] = []
     if _LEXER_COLLISION_FLOAT_RE.search(code):
         hits.append("float")
@@ -427,6 +432,8 @@ def escape_code_for_formula(code: str) -> str:
 
 def escape_code_for_excel_formula(code: str) -> str:
     """Quote-escape Python for Excel ``=PY("…")`` / OOXML — no Calc sanitizer rewrites."""
+    # crosshair: off
+    # cover-all 33797534946 (~4.4h formula_edit module, 270 examples). Free-string quote doubling. Doable later with DEAL_MAX_SOURCE alphabet.
     return (code or "").replace('"', '""')
 
 
@@ -609,6 +616,8 @@ def build_data_suffix(data_args: list[str], *, separator: str = ";", excel_range
 
     *separator* is ``;`` for Calc formulas and ``,`` for Excel OOXML formulas.
     """
+    # crosshair: off
+    # cover-all 33797534946 (~4.4h formula_edit module, 192 examples). Combinatoric list+formatter. Doable later with tiny data_args alphabet.
     # Call unwrapped bodies so a nested formatter pre cannot PreconditionFailed
     # if quoting grows the string (same class as #449 dtype=float growth).
     sep = separator if separator in (";", ",") else ";"
@@ -653,7 +662,8 @@ def py_code_arg_is_cell_ref(code: str) -> bool:
     ``=PY($A$1; data)`` / ``=PY(Sheet.A1)`` store source in that cell. Ranges
     (``A1:B10``) and unquoted Python (``sp.prime(100)``) return False.
     """
-    # crosshair: off  # parse_address/split_sheet_prefix on free strings (cover-all 33314946731: ~14m, 22k lines). Doable later with the closed A1/_deal_range_addr_ok domain.
+    # crosshair: off
+    # parse_address/split_sheet_prefix on free strings (cover-all 33314946731: ~14m, 22k lines). Doable later with the closed A1/_deal_range_addr_ok domain.
     if type(code) is not str:
         return False
     s = code.strip()
@@ -674,6 +684,8 @@ def py_code_arg_is_cell_ref(code: str) -> bool:
 
 def py_formula_has_unquoted_code_ref(formula: str) -> bool:
     """True when the formula is ``=PY($A$1; …)`` (unquoted), not ``=PY(\"A1\")``."""
+    # crosshair: off
+    # cover-all 33797534946 (~4.4h formula_edit module, 200 examples). Combinatoric parse+cell-ref. Doable later with closed A1 PY alphabet.
     parts = parse_python_formula(formula)
     if parts is None or not py_code_arg_is_cell_ref(parts.code):
         return False
@@ -699,6 +711,8 @@ def rebuild_python_formula_with_code_ref(
     Avoids Calc ``MAXSTRLEN`` by keeping Python source out of the formula string.
     *code_ref* is a sheet-qualified address (``py_code_Pivots.A1`` or ``py_code_Pivots!A1``).
     """
+    # crosshair: off
+    # cover-all 33797534946 (~4.4h formula_edit module, 126 examples). Combinatoric rebuild+formatter. Doable later with closed A1/data_args domain.
     use_excel = excel_ranges or separator == ","
     fmt = format_excel_data_range if use_excel else format_py_data_range
     ref = fmt(code_ref.strip())
@@ -708,6 +722,8 @@ def rebuild_python_formula_with_code_ref(
 
 def cell_looks_python_like(formula: str) -> bool:
     """True if *formula* appears to be a PY/PYTHON call (even if strict parse failed)."""
+    # crosshair: off
+    # cover-all 33797534946 (~4.4h formula_edit module, 201 examples). Thin parse/loose wrapper. Doable later with tiny PY alphabet.
     if not formula:
         return False
     if parse_python_formula(formula) is not None:
@@ -717,6 +733,8 @@ def cell_looks_python_like(formula: str) -> bool:
 
 def replace_python_code(formula: str, new_code: str) -> str | None:
     """Return a new formula with the first ``code`` string argument replaced."""
+    # crosshair: off
+    # cover-all 33797534946 (~4.4h formula_edit module, 136 examples). Thin parse+rebuild wrapper. Doable later with DEAL_MAX_SOURCE alphabet.
     parts = parse_python_formula(normalize_formula_string(formula))
     if parts is None:
         return None

--- a/plugin/calc/sheet_filter_criteria.py
+++ b/plugin/calc/sheet_filter_criteria.py
@@ -49,6 +49,8 @@ FILTER_OPERATOR2_LABELS: tuple[str, ...] = _FILTER_OPERATOR2_CODE_NAMES
 @deal.pre(lambda code: isinstance(code, int) and -8 <= code < 32)
 def filter_operator2_code_to_name(code: int) -> str:
     """Map UNO ``FilterOperator2`` *code* (long) to a stable string label."""
+    # crosshair: off
+    # cover-all 33797534946 (~39m module, 18732 examples). Doable later: closed enum codes 0..17 only.
     if 0 <= code < len(_FILTER_OPERATOR2_CODE_NAMES):
         return _FILTER_OPERATOR2_CODE_NAMES[code]
     return str(int(code))
@@ -112,7 +114,8 @@ def parse_sheet_filter_criterion(raw: dict[str, Any], is_first: bool) -> tuple[i
     Later rows: missing ``connection`` defaults to AND; ``OR`` links this row to the
     previous condition only (linear chain — not arbitrary parentheses).
     """
-    # crosshair: off  # nested dict Any (field/value) still combinatoric (cover-all 33337516899: 86k lines, 1559 examples). Doable later with a closed criterion schema.
+    # crosshair: off
+    # nested dict Any (field/value) still combinatoric (cover-all 33337516899: 86k lines, 1559 examples). Doable later with a closed criterion schema.
     if "field" not in raw:
         raise UnoObjectError("Each criterion needs 'field' (0-based column index within range).")
     try:

--- a/plugin/scripting/payload_codec.py
+++ b/plugin/scripting/payload_codec.py
@@ -480,6 +480,8 @@ def find_image_payloads(obj: Any) -> list[dict[str, Any]]:
 
 def image_payload_suffix(payload: dict[str, Any]) -> str:
     """Return a temp-file suffix for *payload* (``.svg`` or ``.png``)."""
+    # crosshair: off
+    # cover-all 33797534946 (~46.5m payload_codec, 710 examples). Dict Any format probe. Doable later with closed format Literal.
     fmt = str(payload.get("format") or "png").lower()
     return ".svg" if fmt == "svg" else ".png"
 
@@ -612,6 +614,8 @@ def column_kinds_for_grid(grid: list[Any] | list[list[Any]]) -> list[str]:
 
 def _uniform_column_kind(kinds: list[str]) -> str | None:
     """Return the kind when every column matches; else None (mixed columns)."""
+    # crosshair: off
+    # cover-all 33797534946 (~46.5m payload_codec, 634 examples). Combinatoric kinds list. Doable later with tiny kind alphabet.
     if not kinds:
         return None
     first = kinds[0]
@@ -639,6 +643,8 @@ def envelope_uniform_column_kind(envelope: dict[str, Any], *, ncols: int) -> str
 
 
 def _host_cell_from_float(val: float, *, kind: str) -> Any:  # pyright: ignore[reportUnusedFunction]  # test helper for host cell kind coercion
+    # crosshair: off
+    # cover-all 33797534946 (~46.5m payload_codec). Float/kind coercion leftover. Doable later with closed kind Literal.
     if math.isnan(val):
         return None
     return int(val) if kind == "int" else val
@@ -791,6 +797,8 @@ def binary_envelope_skip_reason(
     force: ForceBinary = "auto",
 ) -> str | None:
     """Human-readable reason split_grid was not used; None if envelope would be used."""
+    # crosshair: off
+    # cover-all 33797534946 (~46.5m payload_codec, 937 examples). Combinatoric skip-reason strings. Keep should_use_binary_envelope on (_CROSSHAIR_TARGETS). Doable later with closed force/shape domain.
     if should_use_binary_envelope(shape, min_cells=min_cells, force=force):
         return None
     if force == "never":

--- a/tests/calc/python/test_formula_edit_verification.py
+++ b/tests/calc/python/test_formula_edit_verification.py
@@ -61,6 +61,15 @@ _REWRITE_WRAPPERS_OFF = (
     "_rewrite_token_calls",
     "format_data_binding_display",
     "parse_data_binding_text",
+    # cover-all 33797534946 leftovers (~4.4h formula_edit)
+    "extract_python_code_loose",
+    "build_new_python_formula",
+    "escape_code_for_excel_formula",
+    "build_data_suffix",
+    "py_formula_has_unquoted_code_ref",
+    "rebuild_python_formula_with_code_ref",
+    "cell_looks_python_like",
+    "replace_python_code",
 )
 
 # Avoid Hypothesis inventing NULs / unpaired surrogates that confuse quote lexers.
@@ -271,20 +280,32 @@ def test_rewrite_wrappers_dropped_from_check_all_fqns() -> None:
 
     format_data_binding_display / parse_data_binding_text are also off
     (deep check-all run 32840960268: Prev 95:09 / 15:20). Range formatters
-    stay on — closed A1/sheet alphabet, no regex.
+    stay on — closed A1/sheet alphabet, no regex. cover-all 33797534946
+    offs (extract/build/escape/rebuild wrappers) also stay out of cover FQNs.
     """
     skip_if_release_build("scripts/ not in stripped release tree")
     from scripts.crosshair_stream import cover_fqns_for_module
 
-    fqns = cover_fqns_for_module(
-        Path("plugin/calc/python/formula_edit.py"), require_deal=True
-    )
+    path = Path("plugin/calc/python/formula_edit.py")
+    fqns = cover_fqns_for_module(path, require_deal=True)
     for name in _REWRITE_WRAPPERS_OFF:
         assert not any(f.endswith(f".{name}") for f in fqns), name
     assert any(f.endswith(".parse_python_formula") for f in fqns)
     assert any(f.endswith(".normalize_formula_string") for f in fqns)
     assert any(f.endswith(".format_py_data_range") for f in fqns)
     assert any(f.endswith(".format_excel_data_range") for f in fqns)
+    cover_fqns = cover_fqns_for_module(path)
+    for name in (
+        "extract_python_code_loose",
+        "build_new_python_formula",
+        "escape_code_for_excel_formula",
+        "build_data_suffix",
+        "py_formula_has_unquoted_code_ref",
+        "rebuild_python_formula_with_code_ref",
+        "cell_looks_python_like",
+        "replace_python_code",
+    ):
+        assert not any(f.endswith(f".{name}") for f in cover_fqns), name
     preprocess = cover_fqns_for_module(
         Path("plugin/calc/spreadsheet_import/preprocess.py"), require_deal=True
     )

--- a/tests/calc/test_calc_dep_and_filter_verification.py
+++ b/tests/calc/test_calc_dep_and_filter_verification.py
@@ -146,3 +146,16 @@ def test_calc_addin_data_to_python_rectangular_invariant(data) -> None:
                 assert isinstance(row, list)
                 assert len(row) == first_len
 
+
+def test_filter_operator2_code_to_name_is_off_cover_all() -> None:
+    """cover-all 33797534946 leftover (~39m sheet_filter); code→name off, doable later."""
+    from pathlib import Path
+
+    from tests.strip_bundle import skip_if_release_build
+
+    skip_if_release_build("scripts/ not in stripped release tree")
+    from scripts.crosshair_stream import cover_fqns_for_module
+
+    fqns = cover_fqns_for_module(Path("plugin/calc/sheet_filter_criteria.py"))
+    assert not any(f.endswith(".filter_operator2_code_to_name") for f in fqns)
+

--- a/tests/scripting/test_payload_codec_policy_verification.py
+++ b/tests/scripting/test_payload_codec_policy_verification.py
@@ -273,6 +273,24 @@ def test_host_pack_split_grid_is_split_grid() -> None:
     assert is_multi_data(packed) is False
 
 
+def test_payload_codec_cover_all_33797534946_offs() -> None:
+    """cover-all 33797534946 leftovers (~46.5m); skip-reason/image/kinds off, policy stays on."""
+    from tests.strip_bundle import skip_if_release_build
+
+    skip_if_release_build("scripts/ not in stripped release tree")
+    from scripts.crosshair_stream import cover_fqns_for_module
+
+    fqns = cover_fqns_for_module(Path("plugin/scripting/payload_codec.py"))
+    for name in (
+        "binary_envelope_skip_reason",
+        "image_payload_suffix",
+        "_uniform_column_kind",
+        "_host_cell_from_float",
+    ):
+        assert not any(f.endswith(f".{name}") for f in fqns), name
+    assert any(f.endswith(".should_use_binary_envelope") for f in fqns)
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("target", _CROSSHAIR_TARGETS)
 def test_crosshair_payload_codec_policy_fqn_if_available(target: str) -> None:


### PR DESCRIPTION
## Cover-all settle (run 33797534946)

- Run: https://github.com/KeithCu/writeragent/actions/runs/33797534946
- Workflow: CrossHair Verification (Deep / On-Demand), **cover-all only**, start-at **31**, SHA `49285fd4` (master when kicked). This PR bases on current master tip `f5254866`.
- Wall: cancelled at the **360-minute** GitHub job limit (~6h). Annotation: exceeded maximum execution time.
- **0 COVER FAIL / engine crash**
- Flushed **9/26** COVER TIMING modules from this run's relative pool (finish-order banners). Absolute progress: **39/56** modules have flushed COVER TIMING across runs. Remaining schedule after these 9 starts at `plugin/...` module index **40**.

### Flushed COVER TIMING (this run)

| Module | Seconds | Notes |
| --- | ---: | --- |
| `plugin/calc/python/formula_edit.py` | 15932.8 (~4.4h) | dominant rewrite/rebuild/loose wrappers |
| `plugin/scripting/payload_codec.py` | 2788.8 (~46.5m) | `binary_envelope_skip_reason` 937; `image_payload_suffix` 710; `_uniform_column_kind` 634 |
| `plugin/scripting/sandbox.py` | 2623.7 (~43.7m) | left alone (`scrub_subprocess_env` stay-on; dual-profile already) |
| `plugin/calc/sheet_filter_criteria.py` | 2360.3 (~39.3m) | `filter_operator2_code_to_name` 18732 ex |
| `audio_silence_detector` | 19.6 | cheap |
| `sandbox_cache` | 17.1 | cheap |
| `word_diff_split` | 2.0 | cheap |
| `send_state` | 0.5 | cheap |
| `mcp_state` | 0.0 | cheap |

## What changed

Same strategy as 512/517/529/540/578: combinatoric leftovers that already burned deep time get `# crosshair: off` with a doable-later comment on its **own** line. Never `# crosshair: off  # …` (InvalidDirective). Did **not** module-off any file.

### `plugin/calc/sheet_filter_criteria.py` (~39.3m)
Offed `filter_operator2_code_to_name` (18732 examples). Doable later: closed enum codes 0..17 only. Split the same-line InvalidDirective on `parse_sheet_filter_criterion` to two-line form.

### `plugin/calc/python/formula_edit.py` (~4.4h)
Offed combinatoric leftovers: `extract_python_code_loose`, `build_new_python_formula`, `escape_code_for_excel_formula`, `build_data_suffix`, `py_formula_has_unquoted_code_ref`, `rebuild_python_formula_with_code_ref`, `cell_looks_python_like`, `replace_python_code`. Split same-line InvalidDirective on `inline_py_code_has_lexer_collisions` / `py_code_arg_is_cell_ref`. Left **on**: `parse_python_formula`, `normalize_formula_string`, `format_py_data_range`, `format_excel_data_range`, `_parse_quoted_string` (check-all stay-ons).

### `plugin/scripting/payload_codec.py` (~46.5m)
Offed `binary_envelope_skip_reason`, `image_payload_suffix`, `_uniform_column_kind`, `_host_cell_from_float`. Left **on**: `should_use_binary_envelope` (`_CROSSHAIR_TARGETS`).

### Tests
- Extended `_REWRITE_WRAPPERS_OFF` + cover FQN asserts in `test_formula_edit_verification.py`.
- Assert `filter_operator2_code_to_name` off via `cover_fqns_for_module` in `test_calc_dep_and_filter_verification.py`.
- Assert payload_codec fours off and `should_use_binary_envelope` on in `test_payload_codec_policy_verification.py`.

Did **not** off `scrub_subprocess_env`, `should_use_binary_envelope`, or the formula_edit stay-ons above.

## Next

- **Next start-at = 40** (= 31 + 9 flushed COVER TIMING).
- Full 56 did **not** finish under 6h.
- After this PR merges, Keith kicks the next cover-all from 40 (or from-1 once these offs land). Hang-check stays paused. **Do not stack a run from this PR.**