### PR TITLE
Fix vision Docling layout model_spec for ≥2.118 (issue 587)

### DIFF
--- a/docs/images/recognition.md
+++ b/docs/images/recognition.md
@@ -436,7 +436,9 @@ Template params for OCR research (in `# writeragent:vision … params=…`):
 |-------|---------|--------|
 | `engine` | `"docling"` | `"docling"` \| `"paddle"` |
 | `ocr_backend` | `"rapidocr_paddle"` | `"auto"`, `"rapidocr"`, `"rapidocr_paddle"`, `"easyocr"`, `"tesseract"`, `"surya"` (requires `docling-surya` + `allow_external_plugins`) |
-| `fallback_engine` | `true` | When Docling missing, auto-fallback to Paddle if installed |
+| `fallback_engine` | `true` | When Docling is missing, or a Docling runtime `VISION_ERROR` looks like a layout API/AttributeError (`get_engine_config` / `LayoutModelConfig`), auto-fallback to Paddle if installed |
+
+**Docling layout `model_spec` (issue 587):** `layout_model=heron` / `egret_large` maps to `LayoutObjectDetectionOptions` / `ObjectDetectionModelSpec` (`layout_heron_default` / `layout_egret_large`) on Docling ≥ **2.118.0** (released **2026-08-03**). On ≤ 2.117 the same keys still assign `DOCLING_LAYOUT_*` (`LayoutModelConfig`) onto legacy `LayoutOptions`. The legacy branch is removable once WriterAgent assumes Docling ≥ 2.118.0.
 
 Success payloads may include `metrics.engine` and `metrics.ocr_backend` for provenance.
 

--- a/plugin/vision/venv/vision.py
+++ b/plugin/vision/venv/vision.py
@@ -41,6 +41,14 @@ def _run_docling_helper(helper: str, image: Any, params: dict[str, Any]) -> dict
     return docling_backend.extract_structure(image, params)
 
 
+def _docling_api_mismatch_error(result: dict[str, Any]) -> bool:
+    """True for VISION_ERROR that looks like a Docling layout API break (issue 587)."""
+    if result.get("code") != "VISION_ERROR":
+        return False
+    message = str(result.get("message") or "")
+    return "get_engine_config" in message or "LayoutModelConfig" in message
+
+
 def _apply_paddle_fallback(
     docling_result: dict[str, Any],
     helper: str,
@@ -49,7 +57,9 @@ def _apply_paddle_fallback(
 ) -> dict[str, Any]:
     if docling_result.get("status") != "error":
         return docling_result
-    if docling_result.get("code") != "DOCLING_UNAVAILABLE":
+    code = docling_result.get("code")
+    api_mismatch = _docling_api_mismatch_error(docling_result)
+    if code != "DOCLING_UNAVAILABLE" and not api_mismatch:
         return docling_result
     if not fallback_engine_enabled(params):
         return docling_result
@@ -59,7 +69,10 @@ def _apply_paddle_fallback(
         return docling_result
 
     warnings = list(paddle_result.get("warnings") or [])
-    warnings.insert(0, "Docling unavailable; fell back to PaddleOCR.")
+    if api_mismatch:
+        warnings.insert(0, "Docling layout API error; fell back to PaddleOCR.")
+    else:
+        warnings.insert(0, "Docling unavailable; fell back to PaddleOCR.")
     paddle_result["warnings"] = warnings
     metrics = dict(paddle_result.get("metrics") or {})
     metrics["fallback_from"] = "docling"

--- a/plugin/vision/venv/vision_docling.py
+++ b/plugin/vision/venv/vision_docling.py
@@ -105,14 +105,82 @@ def _resolve_ocr_options(params: dict[str, Any]) -> Any:
     raise ValueError(f"Unknown ocr_backend {backend!r}")
 
 
+def _layout_model_key(params: dict[str, Any]) -> str:
+    return str(params.get("layout_model") or "heron").strip().lower() or "heron"
+
+
+def _is_object_detection_layout(layout_opts: Any) -> bool:
+    """True when layout_options expects ObjectDetectionModelSpec (Docling >= 2.118)."""
+    if getattr(layout_opts, "kind", None) == "layout_object_detection":
+        return True
+    if type(layout_opts).__name__ == "LayoutObjectDetectionOptions":
+        return True
+    spec = getattr(layout_opts, "model_spec", None)
+    if spec is None:
+        return False
+    # Inspect the class, not the instance: MagicMock instances invent callable attrs.
+    get_engine = getattr(type(spec), "get_engine_config", None)
+    return callable(get_engine)
+
+
 def _resolve_layout_model_spec(params: dict[str, Any]) -> Any:
-    layout_key = str(params.get("layout_model") or "heron").strip().lower() or "heron"
+    """Legacy LayoutModelConfig from layout_model_specs (Docling <= 2.117 LayoutOptions)."""
+    layout_key = _layout_model_key(params)
     layout_specs = importlib.import_module("docling.datamodel.layout_model_specs")
     mapping = {
         "heron": layout_specs.DOCLING_LAYOUT_HERON,
         "egret_large": getattr(layout_specs, "DOCLING_LAYOUT_EGRET_LARGE", layout_specs.DOCLING_LAYOUT_HERON),
     }
     return mapping.get(layout_key, layout_specs.DOCLING_LAYOUT_HERON)
+
+
+_OD_LAYOUT_PRESETS: dict[str, tuple[str, str]] = {
+    # WriterAgent layout_model -> (from_preset id, stage_model_specs attribute)
+    "heron": ("layout_heron_default", "OBJECT_DETECTION_LAYOUT_HERON"),
+    "egret_large": ("layout_egret_large", "OBJECT_DETECTION_LAYOUT_EGRET_LARGE"),
+}
+
+
+def _resolve_od_layout_model_spec(params: dict[str, Any]) -> Any:
+    """ObjectDetectionModelSpec for LayoutObjectDetectionOptions (Docling >= 2.118).
+
+    Never returns LayoutModelConfig — assigning that onto OD options skips
+    Docling's LayoutOptions→OD shim and convert then raises AttributeError
+    on model_spec.get_engine_config (issue 587).
+    """
+    layout_key = _layout_model_key(params)
+    preset_id, stage_attr = _OD_LAYOUT_PRESETS.get(layout_key, _OD_LAYOUT_PRESETS["heron"])
+
+    pipeline_mod = importlib.import_module("docling.datamodel.pipeline_options")
+    od_cls = getattr(pipeline_mod, "LayoutObjectDetectionOptions", None)
+    from_preset = getattr(od_cls, "from_preset", None) if od_cls is not None else None
+    if callable(from_preset):
+        try:
+            preset_opts = from_preset(preset_id)
+            spec = getattr(preset_opts, "model_spec", None)
+            if spec is not None:
+                return spec
+        except Exception:
+            log.debug("LayoutObjectDetectionOptions.from_preset(%s) failed", preset_id, exc_info=True)
+
+    stage_mod = importlib.import_module("docling.datamodel.stage_model_specs")
+    preset = getattr(stage_mod, stage_attr, None)
+    if preset is None:
+        preset = getattr(stage_mod, "OBJECT_DETECTION_LAYOUT_HERON", None)
+    spec = getattr(preset, "model_spec", None)
+    if spec is not None:
+        return spec
+
+    od_spec_cls = getattr(stage_mod, "ObjectDetectionModelSpec", None)
+    if callable(od_spec_cls):
+        legacy = _resolve_layout_model_spec(params)
+        return od_spec_cls(
+            name=str(getattr(legacy, "name", "") or "layout_heron"),
+            repo_id=str(getattr(legacy, "repo_id", "") or "docling-project/docling-layout-heron"),
+            revision=str(getattr(legacy, "revision", "") or "main"),
+        )
+
+    raise RuntimeError("Docling ObjectDetectionModelSpec is unavailable")
 
 
 def _apply_pipeline_params(pipeline_options: Any, params: dict[str, Any], *, for_structure: bool) -> None:
@@ -156,7 +224,17 @@ def _apply_pipeline_params(pipeline_options: Any, params: dict[str, Any], *, for
         layout_opts.create_orphan_clusters = bool(params.get("create_orphan_clusters"))
     if hasattr(layout_opts, "model_spec"):
         try:
-            layout_opts.model_spec = _resolve_layout_model_spec(params)
+            # Dual-path for Docling layout model_spec (issue 587).
+            # Sunset: the legacy LayoutModelConfig / layout_model_specs branch
+            # can be removed once WriterAgent assumes Docling >= 2.118.0
+            # (released 2026-08-03), when LayoutObjectDetectionOptions became
+            # the PdfPipelineOptions default and assigning LayoutModelConfig
+            # onto model_spec stopped being valid (convert then calls
+            # model_spec.get_engine_config and raises AttributeError).
+            if _is_object_detection_layout(layout_opts):
+                layout_opts.model_spec = _resolve_od_layout_model_spec(params)
+            else:
+                layout_opts.model_spec = _resolve_layout_model_spec(params)
         except Exception:
             log.debug("layout_model spec resolution failed", exc_info=True)
 

--- a/tests/vision/venv/test_vision.py
+++ b/tests/vision/venv/test_vision.py
@@ -122,6 +122,39 @@ def test_extract_text_docling_unavailable_no_fallback(mock_convert):
     assert result["code"] == "DOCLING_UNAVAILABLE"
 
 
+@patch("plugin.vision.venv.vision_docling._convert_image_bytes")
+def test_extract_text_docling_api_error_falls_back_to_paddle(mock_convert):
+    mock_convert.side_effect = AttributeError(
+        "'LayoutModelConfig' object has no attribute 'get_engine_config'"
+    )
+
+    with patch("plugin.vision.venv.vision_paddle._decode_image_bytes") as mock_decode, patch(
+        "plugin.vision.venv.vision_paddle._get_paddle_ocr"
+    ) as mock_get_engine:
+        engine = MagicMock()
+        engine.ocr.return_value = [_sample_ocr_page()]
+        mock_get_engine.return_value = engine
+        mock_decode.return_value = MagicMock()
+
+        result = run_vision({"helper": "extract_text", "params": {}}, b"png-bytes", {})
+
+    assert result["status"] == "ok"
+    assert result["full_text"] == "Hello\nWorld"
+    assert "Docling layout API error; fell back to PaddleOCR." in result["warnings"]
+    assert result["metrics"]["fallback_from"] == "docling"
+
+
+@patch("plugin.vision.venv.vision_docling._convert_image_bytes")
+def test_extract_text_docling_unrelated_vision_error_does_not_fallback(mock_convert):
+    mock_convert.side_effect = RuntimeError("model failed")
+
+    result = run_vision({"helper": "extract_text", "params": {}}, b"png-bytes", {})
+
+    assert result["status"] == "error"
+    assert result["code"] == "VISION_ERROR"
+    assert "model failed" in result["message"]
+
+
 @patch("plugin.vision.venv.vision_paddle._decode_image_bytes")
 @patch("plugin.vision.venv.vision_paddle._get_paddle_ocr")
 def test_extract_text_paddle_engine_maps_regions(mock_get_engine, mock_decode):

--- a/tests/vision/venv/test_vision_docling.py
+++ b/tests/vision/venv/test_vision_docling.py
@@ -6,12 +6,115 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from plugin.vision.venv import vision_docling as docling_mod
 from plugin.vision.venv.vision_docling import extract_structure, extract_text
+
+
+class _LayoutModelConfig:
+    """Stand-in for docling.datamodel.layout_model_specs.LayoutModelConfig (no get_engine_config)."""
+
+    def __init__(self, name: str, repo_id: str, revision: str = "main"):
+        self.name = name
+        self.repo_id = repo_id
+        self.revision = revision
+
+
+class _ObjectDetectionModelSpec:
+    """Stand-in for docling.datamodel.stage_model_specs.ObjectDetectionModelSpec."""
+
+    def __init__(self, name: str, repo_id: str, revision: str = "main"):
+        self.name = name
+        self.repo_id = repo_id
+        self.revision = revision
+
+    def get_engine_config(self, engine_type=None):
+        del engine_type
+        return {"repo_id": self.repo_id, "revision": self.revision}
+
+
+class _LayoutObjectDetectionOptions:
+    kind = "layout_object_detection"
+
+    def __init__(self) -> None:
+        self.model_spec = _ObjectDetectionModelSpec(
+            "layout_heron", "docling-project/docling-layout-heron"
+        )
+        self.create_orphan_clusters = True
+
+    @classmethod
+    def from_preset(cls, preset_id: str):
+        spec = _EGRET_OD if preset_id == "layout_egret_large" else _HERON_OD
+        return SimpleNamespace(model_spec=spec)
+
+
+class _LegacyLayoutOptions:
+    kind = "docling_layout_default"
+
+    def __init__(self) -> None:
+        self.model_spec = _HERON_LEGACY
+        self.create_orphan_clusters = True
+
+
+class _PdfPipelineOptions:
+    def __init__(self, **kwargs):
+        del kwargs
+        self.layout_options = _LayoutObjectDetectionOptions()
+        self.ocr_options = None
+        self.table_structure_options = SimpleNamespace(mode=None, do_cell_matching=True)
+        self.accelerator_options = SimpleNamespace(device="auto", num_threads=4)
+        self.images_scale = 1.0
+        self.document_timeout = None
+        self.artifacts_path = ""
+        self.do_formula_enrichment = False
+        self.do_code_enrichment = False
+
+
+class _LegacyPdfPipelineOptions(_PdfPipelineOptions):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.layout_options = _LegacyLayoutOptions()
+
+
+_HERON_LEGACY = _LayoutModelConfig("heron", "docling-project/docling-layout-heron")
+_EGRET_LEGACY = _LayoutModelConfig("egret_large", "docling-project/docling-layout-egret-large")
+_HERON_OD = _ObjectDetectionModelSpec("layout_heron", "docling-project/docling-layout-heron")
+_EGRET_OD = _ObjectDetectionModelSpec("layout_egret_large", "docling-project/docling-layout-egret-large")
+
+
+def _docling_import_side_effect(*, od_layout: bool = True, with_from_preset: bool = True):
+    pipeline_mod = MagicMock()
+    pipeline_mod.PdfPipelineOptions = _PdfPipelineOptions if od_layout else _LegacyPdfPipelineOptions
+    pipeline_mod.RapidOcrOptions = MagicMock(return_value=MagicMock())
+    pipeline_mod.TableFormerMode.FAST = "FAST"
+    if with_from_preset:
+        pipeline_mod.LayoutObjectDetectionOptions = _LayoutObjectDetectionOptions
+    else:
+        pipeline_mod.LayoutObjectDetectionOptions = None
+
+    layout_specs = MagicMock()
+    layout_specs.DOCLING_LAYOUT_HERON = _HERON_LEGACY
+    layout_specs.DOCLING_LAYOUT_EGRET_LARGE = _EGRET_LEGACY
+
+    stage_specs = MagicMock()
+    stage_specs.ObjectDetectionModelSpec = _ObjectDetectionModelSpec
+    stage_specs.OBJECT_DETECTION_LAYOUT_HERON = SimpleNamespace(model_spec=_HERON_OD)
+    stage_specs.OBJECT_DETECTION_LAYOUT_EGRET_LARGE = SimpleNamespace(model_spec=_EGRET_OD)
+
+    def side_effect(name: str):
+        if name == "docling.datamodel.pipeline_options":
+            return pipeline_mod
+        if name == "docling.datamodel.layout_model_specs":
+            return layout_specs
+        if name == "docling.datamodel.stage_model_specs":
+            return stage_specs
+        return MagicMock()
+
+    return side_effect
 
 
 @pytest.fixture(autouse=True)
@@ -169,4 +272,96 @@ def test_build_pipeline_options_surya():
     )
     assert pdf_opts_instance.ocr_options == "surya-opts"
     assert pdf_opts_instance.ocr_model == "suryaocr"
+
+
+def test_build_pipeline_options_od_layout_heron_has_get_engine_config():
+    """Docling >= 2.118 OD layout_options must keep ObjectDetectionModelSpec (issue 587)."""
+    with patch("importlib.import_module", side_effect=_docling_import_side_effect()):
+        opts = docling_mod._build_pipeline_options(
+            {"ocr_backend": "rapidocr_paddle", "layout_model": "heron"},
+            for_structure=True,
+        )
+
+    spec = opts.layout_options.model_spec
+    assert hasattr(spec, "get_engine_config")
+    assert callable(spec.get_engine_config)
+    assert isinstance(spec, _ObjectDetectionModelSpec)
+    assert spec.name == "layout_heron"
+
+
+def test_build_pipeline_options_od_layout_egret_large_has_get_engine_config():
+    with patch("importlib.import_module", side_effect=_docling_import_side_effect()):
+        opts = docling_mod._build_pipeline_options(
+            {"ocr_backend": "rapidocr_paddle", "layout_model": "egret_large"},
+            for_structure=True,
+        )
+
+    spec = opts.layout_options.model_spec
+    assert hasattr(spec, "get_engine_config")
+    assert callable(spec.get_engine_config)
+    assert isinstance(spec, _ObjectDetectionModelSpec)
+    assert spec.name == "layout_egret_large"
+
+
+def test_build_pipeline_options_must_not_leave_layout_model_config_on_od():
+    """Today's bug: LayoutModelConfig assigned onto OD options (no get_engine_config)."""
+    with patch("importlib.import_module", side_effect=_docling_import_side_effect()):
+        opts = docling_mod._build_pipeline_options(
+            {"ocr_backend": "rapidocr_paddle", "layout_model": "heron"},
+            for_structure=True,
+        )
+
+    spec = opts.layout_options.model_spec
+    assert not isinstance(spec, _LayoutModelConfig)
+    assert hasattr(spec, "get_engine_config")
+
+
+def test_build_pipeline_options_legacy_layout_keeps_layout_model_config():
+    """Docling <= 2.117 LayoutOptions still receives DOCLING_LAYOUT_*."""
+    with patch(
+        "importlib.import_module",
+        side_effect=_docling_import_side_effect(od_layout=False),
+    ):
+        opts = docling_mod._build_pipeline_options(
+            {"ocr_backend": "rapidocr_paddle", "layout_model": "heron"},
+            for_structure=True,
+        )
+
+    spec = opts.layout_options.model_spec
+    assert spec is _HERON_LEGACY
+    assert not hasattr(spec, "get_engine_config")
+
+
+def test_build_pipeline_options_legacy_layout_egret_large():
+    with patch(
+        "importlib.import_module",
+        side_effect=_docling_import_side_effect(od_layout=False),
+    ):
+        opts = docling_mod._build_pipeline_options(
+            {"ocr_backend": "rapidocr_paddle", "layout_model": "egret_large"},
+            for_structure=True,
+        )
+
+    assert opts.layout_options.model_spec is _EGRET_LEGACY
+
+
+def test_apply_pipeline_params_od_path_never_assigns_layout_model_config():
+    layout_opts = _LayoutObjectDetectionOptions()
+    pipeline = SimpleNamespace(
+        layout_options=layout_opts,
+        table_structure_options=SimpleNamespace(),
+        accelerator_options=SimpleNamespace(),
+    )
+
+    with patch("importlib.import_module", side_effect=_docling_import_side_effect()):
+        docling_mod._apply_pipeline_params(
+            pipeline,
+            {"layout_model": "egret_large"},
+            for_structure=True,
+        )
+
+    assert isinstance(layout_opts.model_spec, _ObjectDetectionModelSpec)
+    assert not isinstance(layout_opts.model_spec, _LayoutModelConfig)
+    assert hasattr(layout_opts.model_spec, "get_engine_config")
+    assert layout_opts.model_spec.name == "layout_egret_large"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #587.

Docling ≥ 2.118.0 (released 2026-08-03) changed `PdfPipelineOptions.layout_options` to default to `LayoutObjectDetectionOptions`, whose `model_spec` must be an `ObjectDetectionModelSpec` (has `get_engine_config`). WriterAgent was assigning legacy `DOCLING_LAYOUT_*` (`LayoutModelConfig`) onto that field. Convert then called `model_spec.get_engine_config(...)` and raised:

```
VISION_ERROR: 'LayoutModelConfig' object has no attribute 'get_engine_config'
```

Fresh installs broke; older venvs on Docling ≤ 2.117 still worked because they default to `LayoutOptions()`.

## Dual-path

In `plugin/vision/venv/vision_docling.py`:

- **OD path** (`LayoutObjectDetectionOptions`, `kind == "layout_object_detection"`, or existing `model_spec` has `get_engine_config`): set an `ObjectDetectionModelSpec` via `LayoutObjectDetectionOptions.from_preset(...)` / `OBJECT_DETECTION_LAYOUT_*` presets. Mapping: `heron` → `layout_heron_default` / HERON OD spec; `egret_large` → `layout_egret_large` / EGRET_LARGE OD spec. Never assign `LayoutModelConfig` onto OD options.
- **Legacy path** (`LayoutOptions`): keep today’s `DOCLING_LAYOUT_HERON` / `DOCLING_LAYOUT_EGRET_LARGE` assignment.

A sunset comment next to the branch notes that the legacy `LayoutModelConfig` / `layout_model_specs` path can be removed once WriterAgent assumes Docling ≥ 2.118.0 (released 2026-08-03).

## Narrow Paddle fallback

`_apply_paddle_fallback` also falls back on `VISION_ERROR` whose message looks like a Docling layout API/AttributeError (`get_engine_config` / `LayoutModelConfig`) when `fallback_engine` is enabled. Unrelated runtime errors still do not fall back.

## Tests

- After `_build_pipeline_options` with `layout_model=heron` and `egret_large`, OD layout options keep a spec with `get_engine_config`.
- Building options must not leave a `LayoutModelConfig` on an OD `layout_options` object (the unit that would have failed on today’s bug).
- Legacy `LayoutOptions` still receives `DOCLING_LAYOUT_*`.
- Existing rapidocr_paddle / layout tests stay green.
- Paddle fallback covers the AttributeError; unrelated `VISION_ERROR` does not.

Docling is not pinned; the dual-path is the product fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b0e5546-1d61-4cae-b041-b656d4be6921?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b0e5546-1d61-4cae-b041-b656d4be6921&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

