### PR TITLE
vision: native PDF input, table spans, MathML and Writer table chrome

### DIFF
--- a/docs/images/recognition.md
+++ b/docs/images/recognition.md
@@ -188,7 +188,7 @@ Mirror [../calc/analysis-sub-agent.md § Current Code State](../calc/analysis-su
 | Image export (selection + name) | [`export_graphic_object_to_bytes`](../../plugin/writer/images/image_tools.py), [`resolve_vision_image_bytes`](../../plugin/vision/vision_runner.py), [`graphic_objects_in_selection`](../../plugin/doc/visual_helpers.py), [`_get_graphic_object`](../../plugin/writer/images/images.py) |
 | Run Python vision fast path | [`python_runner.py`](../../plugin/scripting/python_runner.py) — `insert_vision_result` (Writer + Calc) |
 | Calc vision egress | [`plugin/calc/vision_egress.py`](../../plugin/calc/vision_egress.py) — `calc_output_anchor_from_graphic`, `insert_vision_html_into_calc` |
-| HTML export (Docling / Paddle) | [`vision_html_export.py`](../../plugin/vision/venv/vision_html_export.py) — `export_docling_to_html`, `prepare_html_for_lo_import` (**css-inline** required; heading/body augment) |
+| HTML export (Docling / Paddle) | [`vision_html_export.py`](../../plugin/vision/venv/vision_html_export.py) — `export_docling_to_html`, `prepare_html_for_lo_import` (**css-inline** required; heading/body/table/MathML augment) |
 | Script picker (Writer + Calc) | [`document_scripts.py`](../../plugin/scripting/document_scripts.py) — `SCRIPT_ORIGIN_VISION`, `_vision_script_section` |
 | Monaco built-in guards | [`scripts_manager.js`](../../plugin/contrib/scripting/assets/editor/scripts_manager.js) — Attach/Save/Delete disabled for `origin === "vision"` |
 | Analysis trusted stack (reference) | [`analysis.py`](../../plugin/scripting/analysis.py), [`analysis_client.py`](../../plugin/framework/client/analysis_client.py), [`analysis_runner.py`](../../plugin/calc/analysis_runner.py) |
@@ -612,7 +612,7 @@ def is_vision_result(value: Any) -> bool:
 
 | Field | Required | Notes |
 |-------|----------|-------|
-| `html` | **Yes** on success | **Document insert uses this** — Docling/Paddle HTML through **`prepare_html_for_lo_import`**: `css-inline` → heading/body inline augment → single-wrap StarWriter insert ([`vision_html_export.py`](../../plugin/vision/venv/vision_html_export.py)) |
+| `html` | **Yes** on success | **Document insert uses this** — Docling/Paddle HTML through **`prepare_html_for_lo_import`**: `css-inline` → heading/body/table/MathML augment → single-wrap StarWriter insert ([`vision_html_export.py`](../../plugin/vision/venv/vision_html_export.py)) |
 | `full_text` | Yes (may be `""`) | Plain reading-order text for metrics / debugging; not inserted into documents |
 | `regions` | Yes (may be `[]`) | `box`: `[x, y, w, h]` pixels, PNG space, origin top-left |
 | `regions[].confidence` | Per line | Float 0–1 |
@@ -622,12 +622,15 @@ def is_vision_result(value: Any) -> bool:
 
 ### HTML insert pipeline and expectations
 
-1. Docling `export_to_html` (or Paddle HTML builders) → **`css_inline.inline()`** (required).
+1. Docling `export_to_html` (`formula_to_mathml=True`, or Paddle HTML builders) → **`css_inline.inline()`** (required).
 2. **`augment_lo_heading_styles`** — merge `font-size` / `font-weight` onto `<h1>`–`<h6>` (Docling’s h2 CSS is color/margins only).
 3. **`augment_lo_body_paragraph_styles`** — Arial + line-height on bare `<p>` tags.
-4. Host [`insert_vision_result`](../../plugin/vision/vision_egress.py) → [`prepare_vision_writer_insert`](../../plugin/vision/vision_egress.py) (paragraph after graphic + collapse UI caret) → [`insert_html_at_cursor`](../../plugin/writer/format.py) (StarWriter filter; full documents are stripped to body markup before wrap).
+4. **`convert_latex_delimiters_to_mathml`** — leftover `$$…$$` / `\[…\]` / `\(...\)` (and conservative `$…$`) → `<math display="block|inline">` via vendored `latex2mathml`, so Writer’s mixed HTML+math insert creates native editable Math objects. Currency like `$ 35,934` is left alone. Conversion is skipped if `latex2mathml` is missing.
+5. **`promote_table_header_rows`** — first row that already has `<th>` is wrapped in `<thead>` (remaining rows `<tbody>`). Layout tables with `border:none` (two-column bbox HTML) are skipped. Section rows such as `ASSETS:` stay in the body.
+6. **`augment_lo_table_styles`** — `border="1"` plus `border-collapse` / `1px solid #ccc` on data tables and cells; `<th>` gets `background-color: #f0f0f0; font-weight: bold`. StarWriter often drops stylesheet table rules; the HTML attribute plus inline CSS keep gridlines.
+7. Host [`insert_vision_result`](../../plugin/vision/vision_egress.py) → [`prepare_vision_writer_insert`](../../plugin/vision/vision_egress.py) (paragraph after graphic + collapse UI caret) → [`insert_html_at_cursor`](../../plugin/writer/format.py) (StarWriter filter; full documents are stripped to body markup before wrap).
 
-**What you should see:** section headings **bold and larger** than body paragraphs; table borders when Docling exports tables. **Not expected:** flyer colors, multi-column layout, or panel backgrounds (Docling does not export that visual design). For a **future dev plan** to improve visual fidelity, see [§21 Visual/layout HTML fidelity (deferred dev plan)](#21-visuallayout-html-fidelity-deferred-dev-plan).
+**What you should see:** section headings **bold and larger** than body paragraphs; **visible table gridlines** and distinct header rows (`<thead>` / shaded `<th>`, which LibreOffice can repeat on each page); LaTeX formulas as **editable LibreOffice Math** objects when Docling emitted TeX or MathML. **Not expected:** flyer colors, multi-column layout, or panel backgrounds (Docling does not export that visual design). For a **future dev plan** to improve visual fidelity, see [§21 Visual/layout HTML fidelity (deferred dev plan)](#21-visuallayout-html-fidelity-deferred-dev-plan).
 
 **Troubleshooting (Writer):** grep `writeragent_debug.log` for `insert_vision_result:` — a successful run logs `helper`, `html_len`, `h_tags`, and `style_attrs`. Missing line → old extension or insert path not reached; `h_tags=0` → upstream HTML has no headings. If the **image disappears** after insert, redeploy the extension (older builds imported HTML at the graphic anchor and replaced the selection). Current builds insert a paragraph break after the anchor first; a regression surfaces as `The image was removed during OCR insert.`
 
@@ -928,7 +931,7 @@ Copy when handing work to an coding agent:
 | Layer | Limit |
 |-------|--------|
 | **Docling `export_to_html`** | Semantic tree → HTML with a generic Docling stylesheet. Section labels become `<h2>`; body lines become plain `<p>`. **No** panel backgrounds, **no** column grid, **no** per-line colors from the raster. |
-| **css-inline + augment** ([`vision_html_export.py`](../../plugin/vision/venv/vision_html_export.py)) | Fixes LO’s dropped `<style>` blocks and adds bold/size on headings + Arial on bare `<p>`. Still **monochrome flow** in one column. |
+| **css-inline + augment** ([`vision_html_export.py`](../../plugin/vision/venv/vision_html_export.py)) | Fixes LO’s dropped `<style>` blocks; adds bold/size on headings, Arial on bare `<p>`, table gridlines/`<thead>`, and TeX→MathML. Still **monochrome flow** in one column. |
 | **HTML (StarWriter) import** ([`format.py`](../../plugin/writer/format.py)) | Inline `style=` on tags survives for **font-weight**, **font-size**, **color**, and **background-color** on simple blocks — but **not** reliable CSS grid/flex, and nested `<div>` layout often collapses to stacked paragraphs. |
 | **Akihabara fixture** | Docling yields **9× `<h2>`, 7× `<p>`, 0 tables** — layout information exists in **block bboxes** in the Docling model, not in exported HTML. |
 

--- a/docs/images/recognition.md
+++ b/docs/images/recognition.md
@@ -435,12 +435,20 @@ Template params for OCR research (in `# writeragent:vision … params=…`):
 | Param | Default | Values |
 |-------|---------|--------|
 | `engine` | `"docling"` | `"docling"` \| `"paddle"` |
-| `ocr_backend` | `"rapidocr_paddle"` | `"auto"`, `"rapidocr"`, `"rapidocr_paddle"`, `"easyocr"`, `"tesseract"`, `"surya"` (requires `docling-surya` + `allow_external_plugins`) |
+| `ocr_backend` | `"rapidocr"` | `"auto"`, `"rapidocr"`, `"rapidocr_paddle"`, `"easyocr"`, `"tesseract"`, `"surya"` (requires `docling-surya` + `allow_external_plugins`) |
+| `format` | `"auto"` | `"auto"` \| `"image"` \| `"pdf"`. `auto` sniffs `%PDF` so vector PDFs use Docling's PDF backend instead of IMAGE OCR |
+| `ocr_mode` | derived | `"full_page"` forces RapidOCR `OcrMode.FULL_PAGE`. Images default to full-page OCR; PDFs keep native text (`do_ocr=True` still OCRs scanned pages) |
 | `fallback_engine` | `true` | When Docling is missing, or a Docling runtime `VISION_ERROR` looks like a layout API/AttributeError (`get_engine_config` / `LayoutModelConfig`), auto-fallback to Paddle if installed |
 
 **Docling layout `model_spec` (issue 587):** `layout_model=heron` / `egret_large` maps to `LayoutObjectDetectionOptions` / `ObjectDetectionModelSpec` (`layout_heron_default` / `layout_egret_large`) on Docling ≥ **2.118.0** (released **2026-08-03**). On ≤ 2.117 the same keys still assign `DOCLING_LAYOUT_*` (`LayoutModelConfig`) onto legacy `LayoutOptions`. The legacy branch is removable once WriterAgent assumes Docling ≥ 2.118.0. When Docling is installed, `tests/vision/venv/test_vision_docling.py` imports it and calls `_build_pipeline_options` / `extract_text` without mocking layout types (skips if Docling, PIL, rapidocr, or onnxruntime is missing). The removable legacy `LayoutModelConfig` branch is not unit-tested.
 
-Success payloads may include `metrics.engine` and `metrics.ocr_backend` for provenance.
+Success payloads may include `metrics.engine`, `metrics.ocr_backend`, and `metrics.input_format` (`image` or `pdf`) for provenance.
+
+**Writer insert stays HTML, not PDF.** Docling 2.x exports HTML / markdown / JSON — it does not generate a PDF to paste back. LibreOffice's PDF import lands in Draw (or as a graphic), not as editable Writer tables. Corpus checks (Apple 10-K page 34) show Docling HTML already carries `colspan` and correct figures; the quality win is feeding **PDF bytes** into Docling and preserving those spans on the Calc grid.
+
+**`extract_structure` vs `extract_text`:** both convert with table structure on. `extract_structure` is the better Calc path (native cells + merged spans). `extract_text` now also returns `tables[]` so the JSON is not a dead end.
+
+Verification fixtures: [`tests/fixtures/ocr_verification_corpus/`](../../tests/fixtures/ocr_verification_corpus/).
 
 ### 7.2 Why not OpenCV / Tesseract / EasyOCR as defaults?
 
@@ -677,7 +685,7 @@ Same [`is_vision_result()`](../../plugin/vision/vision_egress.py) guard as [§10
 | `html` | **Yes** on success | **Document insert uses this** (structure + tables as HTML) |
 | `full_text` | Yes (may be `""`) | Plain reading-order text; not inserted into documents |
 | `blocks` | Yes (may be `[]`) | Layout regions from PP-Structure |
-| `tables` | Yes (may be `[]`) | Structured table dicts (also reflected in `html`) |
+| `tables` | Yes (may be `[]`) | Structured table dicts (also reflected in `html`). Each table may include `spans`: `{row, col, rowspan, colspan}` 0-based in the header+body grid (text only in the origin cell — do not repeat spanned labels) |
 | `metrics.block_count` | Recommended | Length of `blocks` |
 | `metrics.table_count` | Recommended | Length of `tables` |
 | `warnings` | Yes (may be `[]`) | e.g. `"No structure detected."` |

--- a/plugin/calc/vision_egress.py
+++ b/plugin/calc/vision_egress.py
@@ -27,9 +27,37 @@ def _append_blank(rows: list[list[Any]]) -> None:
         rows.append([])
 
 
-def format_vision_structure_for_calc(result: dict[str, Any]) -> list[list[Any]]:
-    """Turn extract_structure tables/blocks into a row-major grid for write_formula_range."""
+def _table_span_merges(
+    table: dict[str, Any],
+    *,
+    header_grid_row: int,
+) -> list[tuple[int, int, int, int]]:
+    """Return (r1, c1, r2, c2) 0-based grid coords for Docling cell spans."""
+    merges: list[tuple[int, int, int, int]] = []
+    spans = table.get("spans")
+    if not isinstance(spans, list):
+        return merges
+    for span in spans:
+        if not isinstance(span, dict):
+            continue
+        row = int(span.get("row") or 0)
+        col = int(span.get("col") or 0)
+        rowspan = max(int(span.get("rowspan") or 1), 1)
+        colspan = max(int(span.get("colspan") or 1), 1)
+        if rowspan <= 1 and colspan <= 1:
+            continue
+        r1 = header_grid_row + row
+        c1 = col
+        r2 = r1 + rowspan - 1
+        c2 = c1 + colspan - 1
+        merges.append((r1, c1, r2, c2))
+    return merges
+
+
+def _vision_structure_calc_layout(result: dict[str, Any]) -> tuple[list[list[Any]], list[tuple[int, int, int, int]]]:
+    """Grid plus merge boxes (grid-relative) for extract_structure Calc insert."""
     rows: list[list[Any]] = []
+    merges: list[tuple[int, int, int, int]] = []
     helper = str(result.get("helper") or "extract_structure")
     rows.append([helper])
 
@@ -61,14 +89,18 @@ def format_vision_structure_for_calc(result: dict[str, Any]) -> list[list[Any]]:
             table_count += 1
             _append_blank(rows)
             rows.append([str(table.get("name") or f"table_{table_count}")])
+            header_grid_row = len(rows)
             if isinstance(columns, list) and columns:
                 rows.append([str(col) for col in columns])
+            else:
+                header_grid_row = len(rows)
             if isinstance(table_rows, list):
                 for row in table_rows:
                     if isinstance(row, list):
                         rows.append([_cell(cell) for cell in row])
                     else:
                         rows.append([_cell(row)])
+            merges.extend(_table_span_merges(table, header_grid_row=header_grid_row))
             if table.get("truncated"):
                 total = table.get("total_rows")
                 note = f"(showing first rows; {total} total)" if total is not None else "(truncated)"
@@ -76,7 +108,13 @@ def format_vision_structure_for_calc(result: dict[str, Any]) -> list[list[Any]]:
 
     if len(rows) == 1:
         rows.append(["(no tabular output)"])
-    return rows
+    return rows, merges
+
+
+def format_vision_structure_for_calc(result: dict[str, Any]) -> list[list[Any]]:
+    """Turn extract_structure tables/blocks into a row-major grid for write_formula_range."""
+    grid, _merges = _vision_structure_calc_layout(result)
+    return grid
 
 
 def structure_calc_grid_has_content(grid: list[list[Any]]) -> bool:
@@ -135,7 +173,7 @@ def insert_vision_structure_into_calc(doc: Any, uno_ctx: Any, result: dict[str, 
     """Write extract_structure blocks/tables as native Calc cells below the graphic anchor."""
     del uno_ctx
     col, row = calc_output_anchor_from_graphic(doc)
-    grid = format_vision_structure_for_calc(result)
+    grid, merges = _vision_structure_calc_layout(result)
     if not structure_calc_grid_has_content(grid):
         raise ToolExecutionError(
             _("No structured tables or text blocks to insert."),
@@ -146,4 +184,9 @@ def insert_vision_structure_into_calc(doc: Any, uno_ctx: Any, result: dict[str, 
     manipulator = CellManipulator(bridge)
     addr = f"{index_to_column(col)}{row + 1}"
     manipulator.write_formula_range(addr, grid)
+    for r1, c1, r2, c2 in merges:
+        start = f"{index_to_column(col + c1)}{row + r1 + 1}"
+        end = f"{index_to_column(col + c2)}{row + r2 + 1}"
+        if start != end:
+            manipulator.merge_cells(f"{start}:{end}", center=False)
     return len(grid)

--- a/plugin/scripting/sandbox.py
+++ b/plugin/scripting/sandbox.py
@@ -134,6 +134,8 @@ VENV_AUTHORIZED_IMPORTS: tuple[str, ...] = (
     "plugin.vision.venv.vision_paddle",
     "plugin.vision.venv.vision_html_export",
     "css_inline",
+    "latex2mathml",
+    "latex2mathml.*",
     "plugin.scripting.viz",
     "plugin.scripting.symbolic",
     "plugin.scripting.units",

--- a/plugin/vision/venv/vision_docling.py
+++ b/plugin/vision/venv/vision_docling.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 from plugin.vision.vision_common import (
     MAX_TABLE_ROWS,
     css_inline_unavailable_result,
+    detect_vision_input_format,
     is_css_inline_import_error,
     _error_result,
     _ok_result,
@@ -31,13 +32,14 @@ def _import_docling() -> Any:
     return importlib.import_module("docling.document_converter")
 
 
-def _cache_key(params: dict[str, Any], *, for_structure: bool) -> tuple[Any, ...]:
+def _cache_key(params: dict[str, Any], *, for_structure: bool, input_format: str) -> tuple[Any, ...]:
     backend = resolve_ocr_backend(params)
     lang = str(params.get("lang") or "en").strip() or "en"
     return (
         backend,
         lang,
         for_structure,
+        input_format,
         True,
         float(params.get("images_scale") or 1.0),
         str(params.get("device") or "auto"),
@@ -50,6 +52,7 @@ def _cache_key(params: dict[str, Any], *, for_structure: bool) -> tuple[Any, ...
         bool(params.get("do_code_enrichment", False)),
         float(params.get("text_score") or 0.5),
         bool(params.get("force_full_page_ocr", True)),
+        str(params.get("ocr_mode") or ""),
         float(params.get("document_timeout") or 0),
         str(params.get("artifacts_path") or ""),
     )
@@ -83,8 +86,6 @@ def _resolve_ocr_options(params: dict[str, Any]) -> Any:
         text_score = params.get("text_score")
         if text_score is not None and hasattr(ocr_opts, "text_score"):
             ocr_opts.text_score = float(text_score)
-        if bool(params.get("force_full_page_ocr", False)) and hasattr(ocr_opts, "force_full_page_ocr"):
-            ocr_opts.force_full_page_ocr = True
         return ocr_opts
 
     if backend == "easyocr":
@@ -241,7 +242,50 @@ def _apply_pipeline_params(pipeline_options: Any, params: dict[str, Any], *, for
     del for_structure  # table structure enabled at construction time
 
 
-def _build_pipeline_options(params: dict[str, Any], *, for_structure: bool) -> Any:
+def _want_full_page_ocr(params: dict[str, Any], *, input_format: str) -> bool:
+    """Images default to full-page OCR; PDFs keep native text unless overridden.
+
+    Vector PDFs (10-K, arXiv) already have a text layer — forcing full-page OCR
+    rasterizes them. Scanned PDFs still OCR via ``do_ocr=True`` when there is no
+    text. ``ocr_mode`` / ``force_full_page_ocr`` remain explicit overrides.
+    """
+    explicit_mode = str(params.get("ocr_mode") or "").strip().lower()
+    if explicit_mode in ("full_page", "full-page"):
+        return True
+    if explicit_mode in ("default", "layout_regions", "pdf_aware_layout_regions"):
+        return False
+    if input_format == "pdf":
+        return False
+    return bool(params.get("force_full_page_ocr", True))
+
+
+def _apply_ocr_mode(pipeline_options: Any, params: dict[str, Any], *, input_format: str) -> None:
+    """Prefer Docling ``OcrMode.FULL_PAGE`` over deprecated ``force_full_page_ocr``."""
+    ocr_opts = getattr(pipeline_options, "ocr_options", None)
+    if ocr_opts is None:
+        return
+    want_full = _want_full_page_ocr(params, input_format=input_format)
+    pipeline_mod = importlib.import_module("docling.datamodel.pipeline_options")
+    ocr_mode_cls = getattr(pipeline_mod, "OcrMode", None)
+    if ocr_mode_cls is not None and hasattr(ocr_opts, "mode"):
+        full_page = getattr(ocr_mode_cls, "FULL_PAGE", None)
+        default_mode = getattr(ocr_mode_cls, "DEFAULT", None)
+        if want_full and full_page is not None:
+            ocr_opts.mode = full_page
+            return
+        if default_mode is not None:
+            ocr_opts.mode = default_mode
+            return
+    if hasattr(ocr_opts, "force_full_page_ocr"):
+        ocr_opts.force_full_page_ocr = want_full
+
+
+def _build_pipeline_options(
+    params: dict[str, Any],
+    *,
+    for_structure: bool,
+    input_format: str = "image",
+) -> Any:
     pipeline_options_mod = importlib.import_module("docling.datamodel.pipeline_options")
     pdf_opts_cls = pipeline_options_mod.PdfPipelineOptions
     backend = resolve_ocr_backend(params)
@@ -260,17 +304,21 @@ def _build_pipeline_options(params: dict[str, Any], *, for_structure: bool) -> A
     )
     if ocr_options is not None:
         pipeline_options.ocr_options = ocr_options
-        if bool(params.get("force_full_page_ocr", False)) and hasattr(pipeline_options.ocr_options, "force_full_page_ocr"):
-            pipeline_options.ocr_options.force_full_page_ocr = True
     if backend == "surya":
         # Docling sets this at runtime for the Surya plugin; stubs omit ocr_model.
         setattr(pipeline_options, "ocr_model", "suryaocr")
     _apply_pipeline_params(pipeline_options, params, for_structure=for_structure)
+    _apply_ocr_mode(pipeline_options, params, input_format=input_format)
     return pipeline_options
 
 
-def _get_docling_converter(params: dict[str, Any], *, for_structure: bool) -> Any:
-    key = _cache_key(params, for_structure=for_structure)
+def _get_docling_converter(
+    params: dict[str, Any],
+    *,
+    for_structure: bool,
+    input_format: str = "image",
+) -> Any:
+    key = _cache_key(params, for_structure=for_structure, input_format=input_format)
     cached = _converter_cache.get(key)
     if cached is not None:
         return cached
@@ -278,14 +326,21 @@ def _get_docling_converter(params: dict[str, Any], *, for_structure: bool) -> An
     _import_docling()
     base_models = importlib.import_module("docling.datamodel.base_models")
     converter_mod = importlib.import_module("docling.document_converter")
-    input_format = base_models.InputFormat
-    image_format_option = converter_mod.ImageFormatOption
+    input_format_enum = base_models.InputFormat
     document_converter_cls = converter_mod.DocumentConverter
 
-    pipeline_options = _build_pipeline_options(params, for_structure=for_structure)
+    pipeline_options = _build_pipeline_options(
+        params, for_structure=for_structure, input_format=input_format
+    )
+    if input_format == "pdf":
+        format_option_cls = converter_mod.PdfFormatOption
+        allowed = input_format_enum.PDF
+    else:
+        format_option_cls = converter_mod.ImageFormatOption
+        allowed = input_format_enum.IMAGE
     converter = document_converter_cls(
-        allowed_formats=[input_format.IMAGE],
-        format_options={input_format.IMAGE: image_format_option(pipeline_options=pipeline_options)},
+        allowed_formats=[allowed],
+        format_options={allowed: format_option_cls(pipeline_options=pipeline_options)},
     )
     _converter_cache[key] = converter
     return converter
@@ -295,12 +350,19 @@ def _convert_image_bytes(image: Any, params: dict[str, Any], *, for_structure: b
     if image is None or not isinstance(image, (bytes, bytearray)):
         raise ValueError("image must be raw bytes")
 
+    payload = bytes(image)
+    input_format = detect_vision_input_format(payload, params)
     _import_docling()
     base_models = importlib.import_module("docling.datamodel.base_models")
-    buf = BytesIO(bytes(image))
+    buf = BytesIO(payload)
     buf.seek(0)
-    stream = base_models.DocumentStream(name="image.png", stream=buf)
-    converter = _get_docling_converter(params, for_structure=for_structure)
+    # Filename extension must match the sniffed format so Docling's stream
+    # MIME guess agrees with allowed_formats (PDF magic vs IMAGE).
+    stream_name = "document.pdf" if input_format == "pdf" else "image.png"
+    stream = base_models.DocumentStream(name=stream_name, stream=buf)
+    converter = _get_docling_converter(
+        params, for_structure=for_structure, input_format=input_format
+    )
     result = converter.convert(stream)
     document = getattr(result, "document", None)
     if document is None:
@@ -308,8 +370,130 @@ def _convert_image_bytes(image: Any, params: dict[str, Any], *, for_structure: b
     return document
 
 
+def _cell_text(cell: Any) -> str:
+    if isinstance(cell, dict):
+        return str(cell.get("text") or cell.get("value") or "").strip()
+    return str(getattr(cell, "text", None) or cell or "").strip()
+
+
+def _cell_int(cell: Any, *names: str, default: int = 0) -> int:
+    for name in names:
+        if isinstance(cell, dict) and name in cell:
+            try:
+                return int(cell[name])
+            except (TypeError, ValueError):
+                return default
+        value = getattr(cell, name, None)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+    return default
+
+
+def _table_from_span_cells(
+    cells: list[Any],
+    num_rows: int,
+    num_cols: int,
+    *,
+    name: str,
+) -> dict[str, Any] | None:
+    """Build a rectangular grid with span metadata; text only in the origin cell.
+
+    Docling's expanded ``grid`` repeats spanned text (``ASSETS:`` in every
+    column). Calc/Writer need one origin cell plus colspan/rowspan instead.
+    """
+    if num_rows <= 0 or num_cols <= 0 or not cells:
+        return None
+    grid = [[""] * num_cols for _ in range(num_rows)]
+    spans: list[dict[str, int]] = []
+    for cell in cells:
+        row = _cell_int(cell, "start_row_offset_idx", "start_row")
+        col = _cell_int(cell, "start_col_offset_idx", "start_col")
+        rowspan = max(_cell_int(cell, "row_span", default=1), 1)
+        colspan = max(_cell_int(cell, "col_span", default=1), 1)
+        if row < 0 or col < 0 or row >= num_rows or col >= num_cols:
+            continue
+        grid[row][col] = _cell_text(cell)
+        if rowspan > 1 or colspan > 1:
+            spans.append({"row": row, "col": col, "rowspan": rowspan, "colspan": colspan})
+
+    columns = [str(c) for c in grid[0]]
+    data_rows = [[str(c) for c in row] for row in grid[1:]]
+    if not columns and data_rows:
+        width = max(len(r) for r in data_rows)
+        columns = [f"col_{i + 1}" for i in range(width)]
+    limited = data_rows[:MAX_TABLE_ROWS]
+    # Drop spans that land only in truncated body rows.
+    kept_spans = [
+        span
+        for span in spans
+        if span["row"] == 0 or span["row"] - 1 < len(limited)
+    ]
+    return {
+        "name": name,
+        "columns": columns,
+        "rows": limited,
+        "spans": kept_spans,
+        "truncated": len(data_rows) > MAX_TABLE_ROWS,
+        "total_rows": len(data_rows),
+    }
+
+
+def _table_from_docling_item(table_item: Any, *, name: str) -> dict[str, Any] | None:
+    data = getattr(table_item, "data", None)
+    if data is not None:
+        cells = getattr(data, "table_cells", None)
+        num_rows = getattr(data, "num_rows", None)
+        num_cols = getattr(data, "num_cols", None)
+        if cells and num_rows and num_cols:
+            mapped = _table_from_span_cells(list(cells), int(num_rows), int(num_cols), name=name)
+            if mapped:
+                return mapped
+    if isinstance(table_item, dict):
+        return _table_from_docling_dict(table_item, name=name)
+    dumped = None
+    if hasattr(table_item, "export_to_dict"):
+        try:
+            dumped = table_item.export_to_dict()
+        except Exception:
+            dumped = None
+    if isinstance(dumped, dict):
+        return _table_from_docling_dict(dumped, name=name)
+    return None
+
+
 def _table_from_docling_dict(table_item: dict[str, Any], *, name: str) -> dict[str, Any] | None:
     data = table_item.get("data") if isinstance(table_item.get("data"), dict) else table_item
+    if isinstance(data, dict):
+        cells = data.get("table_cells")
+        num_rows = data.get("num_rows")
+        num_cols = data.get("num_cols")
+        if isinstance(cells, list) and cells and not isinstance(cells[0], list):
+            first = cells[0]
+            looks_like_cells = isinstance(first, dict) and (
+                "start_row_offset_idx" in first or "row_span" in first
+            )
+            if looks_like_cells:
+                if not num_rows or not num_cols:
+                    max_r = 0
+                    max_c = 0
+                    for cell in cells:
+                        end_r = _cell_int(cell, "end_row_offset_idx")
+                        end_c = _cell_int(cell, "end_col_offset_idx")
+                        start_r = _cell_int(cell, "start_row_offset_idx", "start_row")
+                        start_c = _cell_int(cell, "start_col_offset_idx", "start_col")
+                        rs = max(_cell_int(cell, "row_span", default=1), 1)
+                        cs = max(_cell_int(cell, "col_span", default=1), 1)
+                        max_r = max(max_r, end_r, start_r + rs)
+                        max_c = max(max_c, end_c, start_c + cs)
+                    num_rows = int(num_rows or max_r)
+                    num_cols = int(num_cols or max_c)
+                mapped = _table_from_span_cells(cells, int(num_rows), int(num_cols), name=name)
+                if mapped:
+                    return mapped
+
     grid = None
     if isinstance(data, dict):
         grid = data.get("grid") or data.get("table_cells") or data.get("cells")
@@ -344,6 +528,7 @@ def _table_from_docling_dict(table_item: dict[str, Any], *, name: str) -> dict[s
         "name": name,
         "columns": columns,
         "rows": limited,
+        "spans": [],
         "truncated": len(data_rows) > MAX_TABLE_ROWS,
         "total_rows": len(data_rows),
     }
@@ -408,22 +593,52 @@ def _map_docling_structure(document: Any) -> tuple[list[dict[str, Any]], list[di
         if text:
             text_parts.append(text)
 
-    for item in doc_dict.get("tables") or []:
-        if not isinstance(item, dict):
-            continue
-        table_index += 1
-        box = _prov_bbox_to_xywh(item.get("prov"))
-        table = _table_from_docling_dict(item, name=f"table_{table_index}")
-        block_text = ""
-        if table:
-            tables.append(table)
-            if table.get("columns"):
-                text_parts.append("\t".join(str(c) for c in table["columns"]))
-            for row in table.get("rows") or []:
-                if isinstance(row, list):
-                    text_parts.append("\t".join(str(c) for c in row))
-            block_text = "\n".join(text_parts[-1:] if text_parts else [])
-        blocks.append({"type": "table", "text": block_text, "box": box})
+    live_tables = getattr(document, "tables", None)
+    mapped_from_live = False
+    if isinstance(live_tables, list) and live_tables:
+        for item in live_tables:
+            table_index += 1
+            table = _table_from_docling_item(item, name=f"table_{table_index}")
+            box = [0, 0, 0, 0]
+            if hasattr(item, "prov") or hasattr(item, "export_to_dict"):
+                try:
+                    dumped = item.export_to_dict() if hasattr(item, "export_to_dict") else {}
+                    if isinstance(dumped, dict):
+                        box = _prov_bbox_to_xywh(dumped.get("prov"))
+                except Exception:
+                    box = [0, 0, 0, 0]
+            block_text = ""
+            if table:
+                mapped_from_live = True
+                tables.append(table)
+                if table.get("columns"):
+                    text_parts.append("\t".join(str(c) for c in table["columns"]))
+                for row in table.get("rows") or []:
+                    if isinstance(row, list):
+                        text_parts.append("\t".join(str(c) for c in row if str(c)))
+                block_text = "\n".join(text_parts[-1:] if text_parts else [])
+            blocks.append({"type": "table", "text": block_text, "box": box})
+
+    if not mapped_from_live:
+        table_index = 0
+        # Drop live-table placeholder blocks if dict mapping will re-add them.
+        blocks = [block for block in blocks if str(block.get("type") or "") != "table"]
+        for item in doc_dict.get("tables") or []:
+            if not isinstance(item, dict):
+                continue
+            table_index += 1
+            box = _prov_bbox_to_xywh(item.get("prov"))
+            table = _table_from_docling_dict(item, name=f"table_{table_index}")
+            block_text = ""
+            if table:
+                tables.append(table)
+                if table.get("columns"):
+                    text_parts.append("\t".join(str(c) for c in table["columns"]))
+                for row in table.get("rows") or []:
+                    if isinstance(row, list):
+                        text_parts.append("\t".join(str(c) for c in row if str(c)))
+                block_text = "\n".join(text_parts[-1:] if text_parts else [])
+            blocks.append({"type": "table", "text": block_text, "box": box})
 
     if not text_parts and hasattr(document, "export_to_markdown"):
         try:
@@ -438,8 +653,11 @@ def _map_docling_structure(document: Any) -> tuple[list[dict[str, Any]], list[di
     return blocks, tables, text_parts
 
 
-def _metrics_base(params: dict[str, Any]) -> dict[str, Any]:
-    return {"engine": "docling", "ocr_backend": resolve_ocr_backend(params)}
+def _metrics_base(params: dict[str, Any], image: Any = None) -> dict[str, Any]:
+    metrics: dict[str, Any] = {"engine": "docling", "ocr_backend": resolve_ocr_backend(params)}
+    if image is not None:
+        metrics["input_format"] = detect_vision_input_format(image, params)
+    return metrics
 
 
 def _root_import_error(exc: BaseException) -> str:
@@ -492,6 +710,7 @@ def extract_text(image: Any, params: dict[str, Any]) -> dict[str, Any]:
 
         html = export_docling_to_html(document, params)
         full_text, regions = _map_docling_text(document)
+        _blocks, tables, _text_parts = _map_docling_structure(document)
     except ImportError as exc:
         if is_css_inline_import_error(exc):
             return _handle_css_inline_import_error(helper)
@@ -510,14 +729,15 @@ def extract_text(image: Any, params: dict[str, Any]) -> dict[str, Any]:
     mean_confidence = sum(confidences) / len(confidences) if confidences else 0.0
     line_count = len(regions) if regions else (0 if not full_text else len(full_text.splitlines()))
 
-    metrics = _metrics_base(params)
-    metrics.update({"line_count": line_count, "mean_confidence": mean_confidence})
+    metrics = _metrics_base(params, image)
+    metrics.update({"line_count": line_count, "mean_confidence": mean_confidence, "table_count": len(tables)})
 
     return _ok_result(
         helper,
         html=html,
         full_text=full_text,
         regions=regions,
+        tables=tables,
         metrics=metrics,
         warnings=warnings,
     )
@@ -546,7 +766,7 @@ def extract_structure(image: Any, params: dict[str, Any]) -> dict[str, Any]:
     if not full_text and not tables and not blocks:
         warnings.append("No structure detected.")
 
-    metrics = _metrics_base(params)
+    metrics = _metrics_base(params, image)
     metrics.update({"block_count": len(blocks), "table_count": len(tables)})
 
     return _ok_result(

--- a/plugin/vision/venv/vision_html_export.py
+++ b/plugin/vision/venv/vision_html_export.py
@@ -112,9 +112,11 @@ def export_docling_to_html(document: Any, params: dict[str, Any]) -> str:
     image_ref_mode = docling_doc_mod.ImageRefMode
 
     if hasattr(document, "export_to_html"):
+        # PLACEHOLDER: do not embed source/figure PNGs back into Writer (EMBEDDED
+        # dumps data:image payloads that StarWriter inserts as extra graphics).
         raw = str(
             document.export_to_html(
-                image_mode=image_ref_mode.EMBEDDED,
+                image_mode=image_ref_mode.PLACEHOLDER,
                 split_page_view=False,
             )
             or ""
@@ -146,25 +148,49 @@ def _paddle_block_tag(block_type: str) -> str:
     return "p"
 
 
-def _html_table_from_columns_rows(columns: list[Any], rows: list[list[Any]]) -> str:
+def _html_table_from_columns_rows(
+    columns: list[Any],
+    rows: list[list[Any]],
+    spans: list[dict[str, Any]] | None = None,
+) -> str:
     if not columns and not rows:
         return ""
+    grid = [list(columns)] if columns else []
+    for row in rows:
+        if isinstance(row, list):
+            grid.append(list(row))
+    if not grid:
+        return ""
+    covered: set[tuple[int, int]] = set()
+    span_at: dict[tuple[int, int], tuple[int, int]] = {}
+    for span in spans or []:
+        if not isinstance(span, dict):
+            continue
+        origin_row = int(span.get("row") or 0)
+        origin_col = int(span.get("col") or 0)
+        rowspan = max(int(span.get("rowspan") or 1), 1)
+        colspan = max(int(span.get("colspan") or 1), 1)
+        span_at[(origin_row, origin_col)] = (rowspan, colspan)
+        for rr in range(origin_row, origin_row + rowspan):
+            for cc in range(origin_col, origin_col + colspan):
+                if (rr, cc) != (origin_row, origin_col):
+                    covered.add((rr, cc))
+
     lines = ["<table>"]
-    if columns:
-        lines.append("<thead><tr>")
-        for col in columns:
-            lines.append(f"<th>{html_module.escape(str(col))}</th>")
-        lines.append("</tr></thead>")
-    if rows:
-        lines.append("<tbody>")
-        for row in rows:
-            if not isinstance(row, list):
+    for r_idx, row in enumerate(grid):
+        tag = "th" if r_idx == 0 and columns else "td"
+        lines.append("<tr>")
+        for c_idx, cell in enumerate(row):
+            if (r_idx, c_idx) in covered:
                 continue
-            lines.append("<tr>")
-            for cell in row:
-                lines.append(f"<td>{html_module.escape(str(cell))}</td>")
-            lines.append("</tr>")
-        lines.append("</tbody>")
+            rowspan, colspan = span_at.get((r_idx, c_idx), (1, 1))
+            attrs = ""
+            if rowspan > 1:
+                attrs += f' rowspan="{rowspan}"'
+            if colspan > 1:
+                attrs += f' colspan="{colspan}"'
+            lines.append(f"<{tag}{attrs}>{html_module.escape(str(cell))}</{tag}>")
+        lines.append("</tr>")
     lines.append("</table>")
     return "".join(lines)
 
@@ -196,6 +222,7 @@ def html_from_paddle_structure(
         table_html = _html_table_from_columns_rows(
             list(table.get("columns") or []),
             [list(r) for r in (table.get("rows") or []) if isinstance(r, list)],
+            list(table.get("spans") or []) if isinstance(table.get("spans"), list) else None,
         )
         if table_html:
             parts.append(table_html)
@@ -236,6 +263,7 @@ def structured_html_from_vision_result(result: dict[str, Any]) -> str:
             table_html = _html_table_from_columns_rows(
                 list(table.get("columns") or []),
                 [list(row) for row in (table.get("rows") or []) if isinstance(row, list)],
+                list(table.get("spans") or []) if isinstance(table.get("spans"), list) else None,
             )
             if table_html:
                 body = f"{body}\n{table_html}" if body else table_html

--- a/plugin/vision/venv/vision_html_export.py
+++ b/plugin/vision/venv/vision_html_export.py
@@ -31,19 +31,34 @@ _PLAIN_P_TAG_RE = re.compile(r"<p(?![^>]*\bstyle\s*=)(\s[^>]*)?>", re.IGNORECASE
 _LO_BODY_PARAGRAPH_INLINE = "font-family: Arial, sans-serif; line-height: 1.6;"
 
 # Minimal stylesheet for Paddle-built fragments before css-inline hoists rules.
+# Cell borders use HTML + inline CSS so StarWriter draws grids even when a
+# <style> block is dropped. Header fill matches the post-inline th augment.
 _PADDLE_HTML_STYLE = """<style>
 body { font-family: Arial, sans-serif; line-height: 1.6; }
 h2 { font-size: 1.25em; font-weight: bold; margin: 0.75em 0 0.35em; }
 p { margin: 0.35em 0; }
-table { border-collapse: collapse; margin: 0.5em 0; width: 100%; }
-th, td { border: 1px solid #ddd; padding: 6px 8px; text-align: left; }
-th { background-color: #f2f2f2; font-weight: bold; }
+table { border-collapse: collapse; margin: 0.5em 0; width: 100%; border: 1px solid #ccc; }
+th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
+th { background-color: #f0f0f0; font-weight: bold; }
 </style>"""
 
+# StarWriter often ignores stylesheet table rules; HTML border="1" plus these
+# inline decls make gridlines and header chrome survive css-inline + import.
+_LO_TABLE_INLINE = "border-collapse: collapse; border: 1px solid #ccc;"
+_LO_CELL_BORDER_INLINE = "border: 1px solid #ccc;"
+_LO_TH_INLINE = "background-color: #f0f0f0; font-weight: bold;"
 
-def _merge_inline_style_on_open_tag(match: re.Match[str], extra: str) -> str:
-    tag = match.group(1).lower()
-    attrs = match.group(2) or ""
+_TABLE_OPEN_RE = re.compile(r"<table(\s[^>]*)?>", re.IGNORECASE)
+_TD_TH_OPEN_RE = re.compile(r"<(td|th)(\s[^>]*)?>", re.IGNORECASE)
+_TH_OPEN_RE = re.compile(r"<th(\s[^>]*)?>", re.IGNORECASE)
+_TABLE_BLOCK_RE = re.compile(r"(<table\b[^>]*>)(.*?)(</table>)", re.IGNORECASE | re.DOTALL)
+_TR_BLOCK_RE = re.compile(r"<tr\b[^>]*>.*?</tr>", re.IGNORECASE | re.DOTALL)
+_MATH_BLOCK_RE = re.compile(r"<math\b[^>]*>.*?</math>", re.IGNORECASE | re.DOTALL)
+
+
+def _open_tag_with_style(tag: str, attrs: str, extra: str) -> str:
+    if not extra:
+        return f"<{tag}{attrs}>"
     if re.search(r'style\s*=\s*"', attrs, re.IGNORECASE):
         return re.sub(
             r'(style\s*=\s*")',
@@ -53,6 +68,41 @@ def _merge_inline_style_on_open_tag(match: re.Match[str], extra: str) -> str:
             flags=re.IGNORECASE,
         )
     return f'<{tag} style="{extra}"{attrs}>'
+
+
+def _merge_inline_style_on_open_tag(match: re.Match[str], extra: str) -> str:
+    tag = match.group(1).lower()
+    attrs = match.group(2) or ""
+    return _open_tag_with_style(tag, attrs, extra)
+
+
+def _style_attr(attrs: str) -> str:
+    match = re.search(r'style\s*=\s*"([^"]*)"', attrs, flags=re.IGNORECASE)
+    return match.group(1) if match else ""
+
+
+def _style_has_property(style: str, prop: str) -> bool:
+    return re.search(rf"(?:^|;)\s*{re.escape(prop)}\s*:", style, flags=re.IGNORECASE) is not None
+
+
+def _style_has_border_none(attrs: str) -> bool:
+    """True for layout-only tables (two-column bbox HTML uses border:none)."""
+    return bool(re.search(r"(?:^|;)\s*border\s*:\s*none\b", _style_attr(attrs), flags=re.IGNORECASE))
+
+
+def _new_style_decls(attrs: str, extra: str) -> str:
+    """Return extra ``prop: val;`` pieces whose properties are not already in style=."""
+    existing = _style_attr(attrs)
+    kept: list[str] = []
+    for part in extra.split(";"):
+        piece = part.strip()
+        if not piece or ":" not in piece:
+            continue
+        prop = piece.split(":", 1)[0].strip()
+        if not prop or _style_has_property(existing, prop):
+            continue
+        kept.append(f"{piece};")
+    return " ".join(kept)
 
 
 def augment_lo_heading_styles(html: str) -> str:
@@ -78,6 +128,226 @@ def augment_lo_body_paragraph_styles(html: str) -> str:
     return _PLAIN_P_TAG_RE.sub(_repl, html)
 
 
+def _import_latex2mathml_convert() -> Any | None:
+    """latex2mathml is vendored; Docling also depends on it. Missing → leave TeX as-is."""
+    try:
+        from latex2mathml.converter import convert as latex_to_mathml
+
+        return latex_to_mathml
+    except ImportError:
+        pass
+    import os
+    import sys
+
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+    for extra in (os.path.join(root, "vendor"), os.path.join(root, "plugin", "lib")):
+        if os.path.isdir(os.path.join(extra, "latex2mathml")) and extra not in sys.path:
+            sys.path.insert(0, extra)
+    try:
+        from latex2mathml.converter import convert as latex_to_mathml
+
+        return latex_to_mathml
+    except ImportError:
+        return None
+
+
+def _latex_to_math_element(inner: str, *, display_block: bool, convert_fn: Any) -> str | None:
+    trimmed = (inner or "").strip()
+    if not trimmed:
+        return None
+    display_mode = "block" if display_block else "inline"
+    try:
+        mathml = convert_fn(trimmed, display=display_mode)
+    except Exception as exc:
+        log.debug("latex2mathml convert failed: %s", exc, exc_info=True)
+        return None
+    if not isinstance(mathml, str) or not mathml.strip():
+        return None
+    text = mathml.strip()
+    if not text.lower().startswith("<math"):
+        return None
+    return text
+
+
+def _looks_like_currency_dollar(s: str, idx: int) -> bool:
+    """Skip ``$ 35,934`` / ``$9.00`` so financial tables are not treated as TeX."""
+    j = idx + 1
+    n = len(s)
+    while j < n and s[j] in " \t":
+        j += 1
+    return j < n and s[j].isdigit()
+
+
+def _replace_tex_outside_tags(s: str, convert_fn: Any) -> str:
+    """Turn ``$$…$$`` / ``\\[…\\]`` / ``\\(…\\)`` (and conservative ``$…$``) into ``<math>``."""
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    in_tag = False
+    while i < n:
+        ch = s[i]
+        if not in_tag and ch == "<":
+            in_tag = True
+            out.append(ch)
+            i += 1
+            continue
+        if in_tag:
+            out.append(ch)
+            if ch == ">":
+                in_tag = False
+            i += 1
+            continue
+        if s.startswith("$$", i):
+            close_at = s.find("$$", i + 2)
+            if close_at != -1:
+                mathml = _latex_to_math_element(s[i + 2 : close_at], display_block=True, convert_fn=convert_fn)
+                if mathml is not None:
+                    out.append(mathml)
+                    i = close_at + 2
+                    continue
+        elif s.startswith("\\[", i):
+            close_at = s.find("\\]", i + 2)
+            if close_at != -1:
+                mathml = _latex_to_math_element(s[i + 2 : close_at], display_block=True, convert_fn=convert_fn)
+                if mathml is not None:
+                    out.append(mathml)
+                    i = close_at + 2
+                    continue
+        elif s.startswith("\\(", i):
+            close_at = s.find("\\)", i + 2)
+            if close_at != -1:
+                mathml = _latex_to_math_element(s[i + 2 : close_at], display_block=False, convert_fn=convert_fn)
+                if mathml is not None:
+                    out.append(mathml)
+                    i = close_at + 2
+                    continue
+        elif ch == "$" and not _looks_like_currency_dollar(s, i):
+            close_at = s.find("$", i + 1)
+            if close_at != -1 and close_at > i + 1:
+                inner = s[i + 1 : close_at]
+                # Require a TeX cue so prose like "cost $foo later $bar" stays text.
+                if "\\" in inner or "^" in inner or re.search(r"_[{\\A-Za-z]", inner):
+                    mathml = _latex_to_math_element(inner, display_block=False, convert_fn=convert_fn)
+                    if mathml is not None:
+                        out.append(mathml)
+                        i = close_at + 1
+                        continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def convert_latex_delimiters_to_mathml(html: str) -> str:
+    """Replace leftover Docling TeX delimiters with MathML for native LO Math objects.
+
+    Docling's HTML serializer already sets ``formula_to_mathml=True``, but formula
+    items that fail conversion (or TeX that landed in a ``<p>``) still use
+    ``$$…$$``. Host ``insert_html_at_cursor`` maps ``<math display="block">`` to
+    editable LibreOffice Math embeds. Leave original text if latex2mathml is
+    missing or a fragment does not convert.
+    """
+    convert_fn = _import_latex2mathml_convert()
+    if convert_fn is None:
+        return html
+    parts: list[str] = []
+    pos = 0
+    for math_match in _MATH_BLOCK_RE.finditer(html):
+        parts.append(_replace_tex_outside_tags(html[pos : math_match.start()], convert_fn))
+        parts.append(math_match.group(0))
+        pos = math_match.end()
+    parts.append(_replace_tex_outside_tags(html[pos:], convert_fn))
+    return "".join(parts)
+
+
+def _header_row_to_th(row_html: str) -> str:
+    row_html = re.sub(r"<td\b", "<th", row_html, flags=re.IGNORECASE)
+    return re.sub(r"</td\b", "</th", row_html, flags=re.IGNORECASE)
+
+
+def _promote_first_header_row(inner: str) -> str:
+    """Move the first ``<th>`` row into ``<thead>`` so Writer can repeat header rows."""
+    if re.search(r"<thead\b", inner, flags=re.IGNORECASE):
+        return inner
+    tr_match = _TR_BLOCK_RE.search(inner)
+    if tr_match is None:
+        return inner
+    first = tr_match.group(0)
+    if not re.search(r"<th\b", first, flags=re.IGNORECASE):
+        return inner
+    first = _header_row_to_th(first)
+    before = inner[: tr_match.start()]
+    after = inner[tr_match.end() :]
+    before_stripped = before.strip()
+    after_stripped = after.strip()
+    thead = f"<thead>{first}</thead>"
+    tbody_open = re.match(r"(?is)^<tbody\b[^>]*>$", before_stripped)
+    tbody_close = re.search(r"(?is)</tbody\s*>$", after_stripped)
+    if tbody_open and tbody_close:
+        body_rows = after_stripped[: tbody_close.start()].strip()
+        if body_rows:
+            return f"{thead}<tbody>{body_rows}</tbody>"
+        return thead
+    if re.search(r"(?is)<tbody\b[^>]*>\s*$", before) and re.search(r"(?is)</tbody\s*>", after):
+        after_no_close = re.sub(r"(?is)</tbody\s*>\s*$", "", after_stripped).strip()
+        before_no_open = re.sub(r"(?is)^\s*<tbody\b[^>]*>", "", before_stripped).strip()
+        body = f"{before_no_open}{after_no_close}".strip()
+        if body:
+            return f"{thead}<tbody>{body}</tbody>"
+        return thead
+    rest = f"{before}{after}".strip()
+    if rest:
+        return f"{thead}<tbody>{rest}</tbody>"
+    return thead
+
+
+def promote_table_header_rows(html: str) -> str:
+    """Wrap the first header row of each data table in ``<thead>`` (skip layout tables)."""
+
+    def _repl(match: re.Match[str]) -> str:
+        open_tag, inner, close_tag = match.group(1), match.group(2), match.group(3)
+        attrs = open_tag[6:-1] if len(open_tag) >= 7 else ""
+        if _style_has_border_none(attrs):
+            return match.group(0)
+        return f"{open_tag}{_promote_first_header_row(inner)}{close_tag}"
+
+    return _TABLE_BLOCK_RE.sub(_repl, html)
+
+
+def augment_lo_table_styles(html: str) -> str:
+    """Force visible gridlines and distinct ``<th>`` chrome for StarWriter import."""
+
+    def _table_repl(match: re.Match[str]) -> str:
+        attrs = match.group(1) or ""
+        if _style_has_border_none(attrs):
+            return match.group(0)
+        if not re.search(r"\bborder\s*=", attrs, flags=re.IGNORECASE):
+            attrs = f' border="1"{attrs}'
+        elif re.search(r"""\bborder\s*=\s*(['"]?)0\1""", attrs, flags=re.IGNORECASE):
+            attrs = re.sub(
+                r"""\bborder\s*=\s*(['"]?)0\1""",
+                'border="1"',
+                attrs,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        extra = _new_style_decls(attrs, _LO_TABLE_INLINE)
+        return _open_tag_with_style("table", attrs, extra)
+
+    def _cell_repl(match: re.Match[str]) -> str:
+        tag = match.group(1).lower()
+        attrs = match.group(2) or ""
+        if _style_has_border_none(attrs):
+            return match.group(0)
+        extras = [_new_style_decls(attrs, _LO_CELL_BORDER_INLINE)]
+        if tag == "th":
+            extras.append(_new_style_decls(attrs, _LO_TH_INLINE))
+        extra = " ".join(piece for piece in extras if piece)
+        return _open_tag_with_style(tag, attrs, extra)
+
+    with_tables = _TABLE_OPEN_RE.sub(_table_repl, html)
+    return _TD_TH_OPEN_RE.sub(_cell_repl, with_tables)
+
+
 def prepare_html_for_lo_import(html: str) -> str:
     """Inline CSS so LibreOffice HTML (StarWriter) import keeps typography."""
     try:
@@ -95,7 +365,10 @@ def prepare_html_for_lo_import(html: str) -> str:
         return html or ""
     inlined = css_inline.inline(stripped)
     with_headings = augment_lo_heading_styles(inlined)
-    return augment_lo_body_paragraph_styles(with_headings)
+    with_body = augment_lo_body_paragraph_styles(with_headings)
+    with_math = convert_latex_delimiters_to_mathml(with_body)
+    with_thead = promote_table_header_rows(with_math)
+    return augment_lo_table_styles(with_thead)
 
 
 def _wrap_paddle_fragment(body: str) -> str:
@@ -114,9 +387,13 @@ def export_docling_to_html(document: Any, params: dict[str, Any]) -> str:
     if hasattr(document, "export_to_html"):
         # PLACEHOLDER: do not embed source/figure PNGs back into Writer (EMBEDDED
         # dumps data:image payloads that StarWriter inserts as extra graphics).
+        # formula_to_mathml=True (Docling default): FormulaItem LaTeX → <math>
+        # so Writer can create native Math objects. Leftover $$…$$ is converted
+        # later in prepare_html_for_lo_import.
         raw = str(
             document.export_to_html(
                 image_mode=image_ref_mode.PLACEHOLDER,
+                formula_to_mathml=True,
                 split_page_view=False,
             )
             or ""
@@ -176,9 +453,16 @@ def _html_table_from_columns_rows(
                 if (rr, cc) != (origin_row, origin_col):
                     covered.add((rr, cc))
 
-    lines = ["<table>"]
+    lines = ['<table border="1">']
+    header_is_th = bool(columns)
+    body_opened = False
     for r_idx, row in enumerate(grid):
-        tag = "th" if r_idx == 0 and columns else "td"
+        tag = "th" if r_idx == 0 and header_is_th else "td"
+        if r_idx == 0 and header_is_th:
+            lines.append("<thead>")
+        elif not body_opened:
+            lines.append("<tbody>")
+            body_opened = True
         lines.append("<tr>")
         for c_idx, cell in enumerate(row):
             if (r_idx, c_idx) in covered:
@@ -191,6 +475,10 @@ def _html_table_from_columns_rows(
                 attrs += f' colspan="{colspan}"'
             lines.append(f"<{tag}{attrs}>{html_module.escape(str(cell))}</{tag}>")
         lines.append("</tr>")
+        if r_idx == 0 and header_is_th:
+            lines.append("</thead>")
+    if body_opened:
+        lines.append("</tbody>")
     lines.append("</table>")
     return "".join(lines)
 

--- a/plugin/vision/vision_common.py
+++ b/plugin/vision/vision_common.py
@@ -24,7 +24,11 @@ IMPLEMENTED_HELPERS = frozenset({"extract_text", "extract_structure"})
 DEFAULT_ENGINE = "docling"
 DEFAULT_OCR_BACKEND = "rapidocr"
 
-MAX_TABLE_ROWS = 50
+# Financial statements and comparison tables often exceed 50 body rows.
+MAX_TABLE_ROWS = 200
+
+# PDF magic so corpus / nearby-file bytes can skip the image OCR raster path.
+_PDF_MAGIC = b"%PDF"
 
 # Config keys merged from Settings → vision.* before template param overrides.
 VISION_CONFIG_KEYS = (
@@ -170,6 +174,20 @@ def _prov_bbox_to_xywh(prov: Any) -> list[int]:  # pyright: ignore[reportUnusedF
 
 def resolve_engine(params: dict[str, Any]) -> str:
     return str(params.get("engine") or DEFAULT_ENGINE).strip().lower() or DEFAULT_ENGINE
+
+
+def detect_vision_input_format(data: Any, params: dict[str, Any] | None = None) -> str:
+    """Return ``pdf`` or ``image`` for trusted vision bytes.
+
+    ``params["format"]`` of ``pdf`` / ``image`` wins; ``auto`` (default) sniffs
+    PDF magic so vector PDFs use Docling's PDF backend instead of IMAGE OCR.
+    """
+    explicit = str((params or {}).get("format") or "auto").strip().lower()
+    if explicit in ("pdf", "image"):
+        return explicit
+    if isinstance(data, (bytes, bytearray)) and bytes(data[:4]) == _PDF_MAGIC:
+        return "pdf"
+    return "image"
 
 
 def resolve_ocr_backend(params: dict[str, Any]) -> str:

--- a/plugin/vision/vision_templates.py
+++ b/plugin/vision/vision_templates.py
@@ -30,7 +30,7 @@ _DEFAULT_PARAMS: dict[str, dict[str, Any]] = {
 
 _HELPER_DESCRIPTIONS: dict[str, str] = {
     "extract_text": "OCR selected image(s) to formatted HTML (Docling default, Paddle fallback).",
-    "extract_structure": "Layout and tables as formatted HTML — Docling default, Paddle fallback.",
+    "extract_structure": "Layout and tables as formatted HTML with cell spans — Docling default, Paddle fallback.",
 }
 
 

--- a/tests/calc/test_vision_structure_egress.py
+++ b/tests/calc/test_vision_structure_egress.py
@@ -53,3 +53,24 @@ def test_insert_vision_structure_into_calc(mock_anchor, mock_bridge, mock_manipu
     assert rows >= 3
     manipulator.write_formula_range.assert_called_once()
     assert manipulator.write_formula_range.call_args[0][0] == "B5"
+
+
+@patch("plugin.calc.vision_egress.CellManipulator")
+@patch("plugin.calc.vision_egress.CalcBridge")
+@patch("plugin.calc.vision_egress.calc_output_anchor_from_graphic", return_value=(0, 0))
+def test_insert_vision_structure_merges_colspan(mock_anchor, mock_bridge, mock_manipulator_cls):
+    manipulator = MagicMock()
+    mock_manipulator_cls.return_value = manipulator
+    result = {
+        "helper": "extract_structure",
+        "tables": [
+            {
+                "name": "table_1",
+                "columns": ["ASSETS:", "", ""],
+                "rows": [["Cash", "1", "2"]],
+                "spans": [{"row": 0, "col": 0, "rowspan": 1, "colspan": 3}],
+            }
+        ],
+    }
+    insert_vision_structure_into_calc(MagicMock(), MagicMock(), result)
+    manipulator.merge_cells.assert_called_once_with("A4:C4", center=False)

--- a/tests/vision/test_vision_common.py
+++ b/tests/vision/test_vision_common.py
@@ -8,9 +8,18 @@ from __future__ import annotations
 
 from plugin.vision.vision_common import (
     css_inline_unavailable_result,
+    detect_vision_input_format,
     is_css_inline_import_error,
     resolve_vision_insert_mode,
 )
+
+
+def test_detect_vision_input_format_pdf_magic():
+    assert detect_vision_input_format(b"%PDF-1.7\n%", {}) == "pdf"
+    assert detect_vision_input_format(b"\x89PNG\r\n", {}) == "image"
+    assert detect_vision_input_format(b"%PDF-1.4", {"format": "image"}) == "image"
+    assert detect_vision_input_format(b"not-pdf", {"format": "pdf"}) == "pdf"
+    assert detect_vision_input_format(b"%PDF", {"format": "auto"}) == "pdf"
 
 
 def test_resolve_vision_insert_mode_template_overrides_config():

--- a/tests/vision/venv/test_vision_docling.py
+++ b/tests/vision/venv/test_vision_docling.py
@@ -90,6 +90,69 @@ def test_extract_structure_maps_tables(mock_convert, _mock_html):
     assert result["metrics"]["table_count"] == 1
 
 
+def test_extract_structure_maps_table_cell_spans():
+    mock_convert_doc = _mock_document(
+        texts=[],
+        tables=[
+            {
+                "prov": [],
+                "data": {
+                    "num_rows": 2,
+                    "num_cols": 3,
+                    "table_cells": [
+                        {
+                            "text": "ASSETS:",
+                            "start_row_offset_idx": 0,
+                            "start_col_offset_idx": 0,
+                            "row_span": 1,
+                            "col_span": 3,
+                        },
+                        {
+                            "text": "Cash",
+                            "start_row_offset_idx": 1,
+                            "start_col_offset_idx": 0,
+                            "row_span": 1,
+                            "col_span": 1,
+                        },
+                        {
+                            "text": "10",
+                            "start_row_offset_idx": 1,
+                            "start_col_offset_idx": 1,
+                            "row_span": 1,
+                            "col_span": 1,
+                        },
+                        {
+                            "text": "11",
+                            "start_row_offset_idx": 1,
+                            "start_col_offset_idx": 2,
+                            "row_span": 1,
+                            "col_span": 1,
+                        },
+                    ],
+                },
+            }
+        ],
+    )
+    with patch(
+        "plugin.vision.venv.vision_html_export.export_docling_to_html",
+        return_value="<table></table>",
+    ), patch("plugin.vision.venv.vision_docling._convert_image_bytes", return_value=mock_convert_doc):
+        result = extract_structure(b"png", {})
+
+    table = result["tables"][0]
+    assert table["columns"] == ["ASSETS:", "", ""]
+    assert table["rows"] == [["Cash", "10", "11"]]
+    assert table["spans"] == [{"row": 0, "col": 0, "rowspan": 1, "colspan": 3}]
+    assert table["columns"].count("ASSETS:") == 1
+
+
+def test_want_full_page_ocr_skips_pdfs():
+    assert docling_mod._want_full_page_ocr({}, input_format="image") is True
+    assert docling_mod._want_full_page_ocr({}, input_format="pdf") is False
+    assert docling_mod._want_full_page_ocr({"ocr_mode": "full_page"}, input_format="pdf") is True
+    assert docling_mod._want_full_page_ocr({"force_full_page_ocr": True}, input_format="pdf") is False
+
+
 def test_extract_text_docling_missing():
     with patch("plugin.vision.venv.vision_docling._convert_image_bytes", side_effect=ImportError("docling is not installed")):
         result = extract_text(b"png", {})
@@ -271,4 +334,37 @@ def test_extract_text_real_docling_tiny_png():
     assert isinstance(result.get("full_text"), str)
     assert isinstance(result.get("regions"), list)
     assert result.get("metrics", {}).get("engine") == "docling"
+
+
+@pytest.mark.timeout(300)
+def test_extract_structure_real_docling_pdf_magic():
+    """Vector PDF bytes must use the PDF backend (not IMAGE OCR)."""
+    from pathlib import Path
+
+    _require_installed_od_docling()
+    pytest.importorskip("css_inline")
+    pdf_path = (
+        Path(__file__).resolve().parents[2]
+        / "fixtures"
+        / "ocr_verification_corpus"
+        / "01_sec_10k_apple_balance_sheet_page34.pdf"
+    )
+    if not pdf_path.is_file():
+        pytest.skip(f"corpus PDF missing: {pdf_path}")
+
+    result = extract_structure(
+        pdf_path.read_bytes(),
+        {"layout_model": "heron", "ocr_backend": "rapidocr", "lang": "en", "format": "auto"},
+    )
+    assert not _is_layout_api_error(result), result
+    if result.get("status") != "ok" and _is_missing_weight_or_network_error(result):
+        pytest.skip(f"Docling convert needs weights/network: {result.get('message')}")
+
+    assert result["status"] == "ok"
+    assert result.get("metrics", {}).get("input_format") == "pdf"
+    assert result.get("metrics", {}).get("table_count", 0) >= 1
+    table = (result.get("tables") or [{}])[0]
+    assert any(span.get("colspan", 1) > 1 or span.get("rowspan", 1) > 1 for span in (table.get("spans") or [])), table
+    joined = " ".join(str(c) for c in (table.get("columns") or []))
+    assert joined.count("ASSETS:") <= 1
 

--- a/tests/vision/venv/test_vision_html_export.py
+++ b/tests/vision/venv/test_vision_html_export.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -113,7 +114,7 @@ def test_html_table_from_columns_rows_emits_spans():
     )
     assert 'colspan="3"' in html
     assert html.count("ASSETS:") == 1
-    assert html.count("<td") + html.count("<th") == 7  # 3 header + 1 spanned + 3 cash row
+    assert len(re.findall(r"<t[dh]\b", html)) == 7  # 3 header + 1 spanned + 3 cash row
     assert "<thead>" in html
     assert "<tbody>" in html
     assert "ASSETS:" in html[html.index("<tbody>") :]
@@ -229,7 +230,7 @@ def test_promote_table_header_rows_wraps_first_th_row_only():
     assert "2025" in header
     assert "ASSETS:" not in header
     assert "ASSETS:" in body
-    assert header.count("<th") == 3  # empty corner td promoted to th
+    assert len(re.findall(r"<th\b", header)) == 3  # empty corner td promoted to th
 
 
 def test_promote_table_header_rows_skips_layout_tables():

--- a/tests/vision/venv/test_vision_html_export.py
+++ b/tests/vision/venv/test_vision_html_export.py
@@ -96,18 +96,32 @@ def test_html_from_paddle_structure_table_and_heading():
     assert "<td>1</td>" in html
 
 
+def test_html_table_from_columns_rows_emits_spans():
+    from plugin.vision.venv.vision_html_export import _html_table_from_columns_rows
+
+    html = _html_table_from_columns_rows(
+        ["", "2025", "2024"],
+        [["ASSETS:", "", ""], ["Cash", "1", "2"]],
+        [{"row": 1, "col": 0, "rowspan": 1, "colspan": 3}],
+    )
+    assert 'colspan="3"' in html
+    assert html.count("ASSETS:") == 1
+    assert html.count("<td") + html.count("<th") == 7  # 3 header + 1 spanned + 3 cash row
+
+
+
 def test_export_docling_to_html_default():
     doc = MagicMock()
     doc.export_to_html.return_value = "<p><strong>Hi</strong></p>"
     fake = MagicMock()
-    fake.ImageRefMode.EMBEDDED = "embedded"
+    fake.ImageRefMode.PLACEHOLDER = "placeholder"
     with patch("plugin.vision.venv.vision_html_export.importlib.import_module", return_value=fake), patch(
         "plugin.vision.venv.vision_html_export.prepare_html_for_lo_import",
         side_effect=lambda html: html,
     ):
         out = export_docling_to_html(doc, {})
     assert "strong" in out
-    doc.export_to_html.assert_called_once_with(image_mode=fake.ImageRefMode.EMBEDDED, split_page_view=False)
+    doc.export_to_html.assert_called_once_with(image_mode=fake.ImageRefMode.PLACEHOLDER, split_page_view=False)
 
 
 def test_css_inline_install_cmd():

--- a/tests/vision/venv/test_vision_html_export.py
+++ b/tests/vision/venv/test_vision_html_export.py
@@ -8,15 +8,20 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from plugin.vision.venv.vision_html_export import (
     CSS_INLINE_INSTALL_CMD,
     apply_structured_insert_html,
     augment_lo_body_paragraph_styles,
     augment_lo_heading_styles,
+    augment_lo_table_styles,
+    convert_latex_delimiters_to_mathml,
     export_docling_to_html,
     html_from_paddle_regions,
     html_from_paddle_structure,
     prepare_html_for_lo_import,
+    promote_table_header_rows,
 )
 
 
@@ -92,8 +97,10 @@ def test_html_from_paddle_structure_table_and_heading():
         )
     assert "<h2>Title</h2>" in html
     assert "<table" in html
+    assert "<thead>" in html
     assert "<th>A</th>" in html
     assert "<td>1</td>" in html
+    assert 'border="1"' in html
 
 
 def test_html_table_from_columns_rows_emits_spans():
@@ -107,6 +114,10 @@ def test_html_table_from_columns_rows_emits_spans():
     assert 'colspan="3"' in html
     assert html.count("ASSETS:") == 1
     assert html.count("<td") + html.count("<th") == 7  # 3 header + 1 spanned + 3 cash row
+    assert "<thead>" in html
+    assert "<tbody>" in html
+    assert "ASSETS:" in html[html.index("<tbody>") :]
+    assert "ASSETS:" not in html[html.index("<thead>") : html.index("</thead>")]
 
 
 
@@ -121,7 +132,11 @@ def test_export_docling_to_html_default():
     ):
         out = export_docling_to_html(doc, {})
     assert "strong" in out
-    doc.export_to_html.assert_called_once_with(image_mode=fake.ImageRefMode.PLACEHOLDER, split_page_view=False)
+    doc.export_to_html.assert_called_once_with(
+        image_mode=fake.ImageRefMode.PLACEHOLDER,
+        formula_to_mathml=True,
+        split_page_view=False,
+    )
 
 
 def test_css_inline_install_cmd():
@@ -151,3 +166,89 @@ def test_apply_structured_insert_html_skips_html_mode():
     result = {"status": "ok", "helper": "extract_text", "html": "<p>x</p>", "regions": []}
     out = apply_structured_insert_html(result, {"insert_mode": "html"})
     assert out is result
+
+
+def test_convert_latex_delimiters_to_mathml_display_and_inline():
+    pytest.importorskip("latex2mathml")
+    html = "<p>$$E=mc^2$$</p><p>see \\(a+b\\) in text</p>"
+    out = convert_latex_delimiters_to_mathml(html)
+    assert "$$" not in out
+    assert "\\(" not in out
+    assert "<math" in out
+    assert 'display="block"' in out
+    assert 'display="inline"' in out
+
+
+def test_convert_latex_delimiters_skips_currency_dollars():
+    html = "<td>$ 35,934</td><td>$9.00</td>"
+    out = convert_latex_delimiters_to_mathml(html)
+    assert "$ 35,934" in out
+    assert "$9.00" in out
+    assert "<math" not in out
+
+
+def test_convert_latex_delimiters_leaves_existing_mathml():
+    html = '<p><math display="block"><mi>x</mi></math></p>'
+    assert convert_latex_delimiters_to_mathml(html) == html
+
+
+def test_augment_lo_table_styles_adds_border_and_header_chrome():
+    raw = "<table><tr><th>Year</th></tr><tr><td>1</td></tr></table>"
+    out = augment_lo_table_styles(raw)
+    assert 'border="1"' in out
+    assert "border-collapse: collapse" in out
+    assert "1px solid #ccc" in out
+    assert "background-color: #f0f0f0" in out
+    assert "font-weight: bold" in out
+
+
+def test_augment_lo_table_styles_skips_layout_tables():
+    raw = (
+        '<table style="width:100%;border:none;border-collapse:collapse;">'
+        '<tr><td style="border:none;">Left</td>'
+        '<td style="border:none;">Right</td></tr></table>'
+    )
+    out = augment_lo_table_styles(raw)
+    assert 'border="1"' not in out
+    assert "background-color: #f0f0f0" not in out
+    assert "border:none" in out
+
+
+def test_promote_table_header_rows_wraps_first_th_row_only():
+    raw = (
+        "<table><tbody>"
+        "<tr><td></td><th>2025</th><th>2024</th></tr>"
+        "<tr><th colspan=\"3\">ASSETS:</th></tr>"
+        "<tr><th>Cash</th><td>1</td><td>2</td></tr>"
+        "</tbody></table>"
+    )
+    out = promote_table_header_rows(raw)
+    assert "<thead>" in out
+    header = out[out.index("<thead>") : out.index("</thead>")]
+    body = out[out.index("<tbody>") :]
+    assert "2025" in header
+    assert "ASSETS:" not in header
+    assert "ASSETS:" in body
+    assert header.count("<th") == 3  # empty corner td promoted to th
+
+
+def test_promote_table_header_rows_skips_layout_tables():
+    raw = (
+        '<table style="width:100%;border:none;">'
+        "<tr><td>Left</td><td>Right</td></tr></table>"
+    )
+    out = promote_table_header_rows(raw)
+    assert "<thead>" not in out
+
+
+def test_prepare_html_for_lo_import_applies_table_and_math_augment():
+    raw = "<html><body><p>$$x^2$$</p><table><tr><th>A</th></tr><tr><td>1</td></tr></table></body></html>"
+    with patch(
+        "css_inline.inline",
+        return_value="<p>$$x^2$$</p><table><tr><th>A</th></tr><tr><td>1</td></tr></table>",
+    ):
+        out = prepare_html_for_lo_import(raw)
+    assert "<math" in out
+    assert 'border="1"' in out
+    assert "<thead>" in out
+    assert "background-color: #f0f0f0" in out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves Docling vision helpers against the OCR verification corpus (`tests/fixtures/ocr_verification_corpus/`).

**PDF insert into Writer was tried as an idea and rejected.** Docling 2.x exports HTML/markdown/JSON, not PDF. LibreOffice PDF import lands in Draw (or as a graphic), not as editable Writer tables. Writer still inserts Docling HTML. The quality win is feeding **PDF bytes** into Docling’s PDF backend instead of rasterizing first.

### Changes

- Dual input: `format=auto|image|pdf` (default `auto` sniffs `%PDF`) so vector PDFs skip IMAGE OCR.
- Images use RapidOCR `OcrMode.FULL_PAGE`; PDFs keep native text (`do_ocr=True` still OCRs scanned pages).
- `tables[]` keeps `spans` (`row`/`col`/`rowspan`/`colspan`) with text only in the origin cell — Apple 10-K no longer repeats `ASSETS:` across three columns.
- Calc structured insert merges those spans via `CellManipulator.merge_cells`.
- HTML export uses `ImageRefMode.PLACEHOLDER` so source figures are not re-embedded as `data:image` graphics.
- `extract_text` also returns `tables[]`; `MAX_TABLE_ROWS` raised to 200.
- Writer HTML polish (this follow-up): leftover Docling `$$…$$` / `\[…\]` becomes `<math display="block">` via vendored `latex2mathml` so insert creates native editable Math objects; data tables get `border="1"` + collapse CSS so StarWriter draws gridlines; first `<th>` row is wrapped in `<thead>` with shaded/bold header cells (section rows like `ASSETS:` stay in `<tbody>`). Layout tables with `border:none` are left alone.

### Corpus checks (this VM, Docling 2.126 + RapidOCR)

| File | Result |
|------|--------|
| Apple 10-K p.34 PDF | `input_format=pdf`, 1 table, 2 colspans, figures match; JSON no longer duplicates section headers |
| Attention Is All You Need p.1 PDF | Native PDF path ~0.4s; title/abstract/authors extracted |
| SROIE receipt 000 | Company/date/total `9.00` recovered (some OCR noise on the shop name) |
| IRS 1040 p.1 PDF | Text recovered; still not a clean form table (379 blocks) |
| PubTables sample JPG | Layout treated cells as prose (`table_count=0`) — remaining Docling layout gap |

## Tests

- `tests/vision/venv/test_vision_docling.py` (mocked + real PNG + real Apple PDF)
- `tests/vision/test_vision_common.py`, `tests/vision/venv/test_vision_html_export.py` (MathML, borders, `<thead>`)
- `tests/calc/test_vision_structure_egress.py` (span merge)
- `make typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebdd2237-f378-431f-827f-9d0f74d015f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebdd2237-f378-431f-827f-9d0f74d015f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

