### PR TITLE
Expose one vision OCR tool that extracts text and structure

### DIFF
--- a/docs/images/recognition-multimodal-LLMs.md
+++ b/docs/images/recognition-multimodal-LLMs.md
@@ -152,7 +152,7 @@ Specialized image tools (`image_list`, `image_get_info`, `image_set_properties`)
 
 **Options:**
 - Extend `GetImage.uno_services` to include `SpreadsheetDocument` for `image=` and `selection=` (page render stays Writer-only), **or**
-- Document explicitly that Calc must use `include_images=true` on reads or `extract_text_from_image`.
+- Document explicitly that Calc must use `include_images=true` on reads or `extract_structure_from_image`.
 
 ### 5. Page render fidelity — live UNO test (medium)
 
@@ -266,7 +266,7 @@ Normalization belongs in the `LlmClient` layer (`make_chat_request`) so all chat
 - **Send-path selection:** Raster images in Writer/Calc selection only; Draw/Impress vectors use other paths.
 - **Main chat model only** for send-path attachment; sub-agents/delegates have separate rules.
 - **`get_image` Writer-only** for now; Calc has specialized list/info/set but not core fetch (see follow-up §4).
-- **Complementary OCR:** Use `domain=vision` + `extract_text_from_image` for accurate text + insert; use native multimodal for visual reasoning.
+- **Complementary OCR:** Use `domain=vision` + `extract_structure_from_image` for text and structure + insert; use native multimodal for visual reasoning.
 
 ---
 

--- a/docs/images/recognition.md
+++ b/docs/images/recognition.md
@@ -1,6 +1,6 @@
 # Image Recognition — Design (Local OCR & Detection)
 
-**Status:** **Phase 1 + Phase 1b (Calc) + Phase 2 + Phase 3 + Phase 6 partial (LLM `extract_text`) shipped** — Run Python Script **Vision Helpers** (`[Vision] extract_text`, `[Vision] extract_structure`) on **Writer and Calc**; chat **`domain=vision`** + **`extract_text_from_image`** when Settings → Python venv has Docling/Paddle + css-inline (gated — hidden when stack missing). Draw/Impress egress → **Phase 1b.2** (deferred). Full **`analyze_image`** multi-helper / multimodal chat image parts → later.
+**Status:** **Phase 1 + Phase 1b (Calc) + Phase 2 + Phase 3 + Phase 6 partial (LLM `extract_structure`) shipped** — Run Python Script **Vision Helpers** (`[Vision] extract_text`, `[Vision] extract_structure`) on **Writer and Calc**; chat **`domain=vision`** + **`extract_structure_from_image`** when Settings → Python venv has Docling/Paddle + css-inline (gated — hidden when stack missing). Draw/Impress egress → **Phase 1b.2** (deferred). Full **`analyze_image`** multi-helper / multimodal chat image parts → later.
 
 WriterAgent documents (Writer, Calc, Draw/Impress) embed raster images: scans, screenshots, chart photos, slide exports, logos. **LibreOffice handles graphics I/O** (export, insert, replace, dimensions). **Recognition** (OCR, layout, object detection) runs in the user's venv via the same trusted-module pattern as [`analysis.py`](../../plugin/scripting/analysis.py) and [`embeddings_index.py`](../../plugin/scripting/embeddings_index.py).
 
@@ -168,7 +168,7 @@ Schema source: [`plugin/vision/module.yaml`](../../plugin/vision/module.yaml); r
 
 Only after Vision Helpers work end-to-end:
 
-- **LLM OCR (partial — shipped):** `delegate_to_specialized_*_toolset(domain="vision")` + [`extract_text_from_image`](../../plugin/vision/vision_tools.py) when venv stack is ready ([§18](#18-llm-access))
+- **LLM OCR (partial — shipped):** `delegate_to_specialized_*_toolset(domain="vision")` + [`extract_structure_from_image`](../../plugin/vision/vision_tools.py) when venv stack is ready ([§18](#18-llm-access))
 - **`analyze_image` multi-helper tool** (remaining Phase 6)
 - Chat sidebar sending crops to multimodal models
 
@@ -193,7 +193,7 @@ Mirror [../calc/analysis-sub-agent.md § Current Code State](../calc/analysis-su
 | Monaco built-in guards | [`scripts_manager.js`](../../plugin/contrib/scripting/assets/editor/scripts_manager.js) — Attach/Save/Delete disabled for `origin === "vision"` |
 | Analysis trusted stack (reference) | [`analysis.py`](../../plugin/scripting/analysis.py), [`analysis_client.py`](../../plugin/framework/client/analysis_client.py), [`analysis_runner.py`](../../plugin/calc/analysis_runner.py) |
 | Calc analysis egress | [`analysis_egress.py`](../../plugin/calc/analysis_egress.py) — `is_analysis_result`, `insert_analysis_result_into_calc` |
-| **Vision LLM tools (partial)** | [`vision_tools.py`](../../plugin/vision/vision_tools.py) (`extract_text_from_image`), [`vision_availability.py`](../../plugin/vision/vision_availability.py) (venv gating), [`ToolWriterVisionBase` / `ToolCalcVisionBase`](../../plugin/writer/specialized_base.py) |
+| **Vision LLM tools (partial)** | [`vision_tools.py`](../../plugin/vision/vision_tools.py) (`extract_structure_from_image`), [`vision_availability.py`](../../plugin/vision/vision_availability.py) (venv gating), [`ToolWriterVisionBase` / `ToolCalcVisionBase`](../../plugin/writer/specialized_base.py) |
 | Tests | [`test_vision*.py`](../../tests/scripting/), [`test_vision_tools.py`](../../tests/vision/test_vision_tools.py), [`test_python_runner_vision.py`](../../tests/scripting/test_python_runner_vision.py), [`test_vision_egress.py`](../../tests/calc/test_vision_egress.py), [`test_vision_html_insert_uno.py`](../../tests/writer/test_vision_html_insert_uno.py), [`test_vision_graphic_insert_uno.py`](../../tests/writer/test_vision_graphic_insert_uno.py), [`test_vision_ocr_mock_uno.py`](../../tests/writer/test_vision_ocr_mock_uno.py) (Writer UNO: patches host `run_vision`, unique OCR tokens, document order with text between images; no Docling/Paddle in CI), [`test_document_scripts.py`](../../tests/scripting/test_document_scripts.py) (vision section tests) |
 
 ### Gaps (post–Phase 3)
@@ -789,7 +789,7 @@ Phases prioritize **user exposition**; LLM integration is last.
 | **4** | `detect_objects`, `recognize_pipeline`, Ultralytics helpers + templates | **Yes** |
 | **4v** | **Visual/layout HTML** — colored panels, columns, bbox-driven layout HTML (see [§21](#21-visuallayout-html-fidelity-deferred-dev-plan)) | **Yes** (planned) |
 | **5** | Per-folder vision cache; `perceptual_hash`; optional context menu | Partial |
-| **6** | **`extract_text_from_image`** via `domain=vision` (gated on venv); **`analyze_image`** multi-helper; optional multimodal hybrid | **Partial — shipped** (`extract_text` only) |
+| **6** | **`extract_structure_from_image`** via `domain=vision` (gated on venv); **`analyze_image`** multi-helper; optional multimodal hybrid | **Partial — shipped** (`extract_structure` only) |
 
 **Explicitly not before Phase 6 remainder:** full `analyze_image` helper surface, sidebar multimodal image payloads.
 
@@ -849,13 +849,13 @@ Checklist for implementers / QA:
 
 ## 18. LLM access
 
-**Phase 6 partial (shipped):** local OCR in chat via specialized domain **`vision`** — same `run_trusted_vision` / `extract_text` stack as manual Vision Helpers.
+**Phase 6 partial (shipped):** local OCR in chat via specialized domain **`vision`** — same `run_trusted_vision` / `extract_structure` stack as manual Vision Helpers. LLM/MCP expose only **`extract_structure_from_image`** (text and structure). The `extract_text` venv helper remains for Run Python Script / fallback.
 
-### 18.1 Shipped: `extract_text_from_image`
+### 18.1 Shipped: `extract_structure_from_image`
 
 | Piece | Location |
 |-------|----------|
-| Tool | [`ExtractTextFromImage`](../../plugin/vision/vision_tools.py) — `extract_text_from_image` |
+| Tool | [`ExtractStructureFromImage`](../../plugin/vision/vision_tools.py) — `extract_structure_from_image` |
 | Domain | `delegate_to_specialized_writer_toolset` / `delegate_to_specialized_calc_toolset` with `domain="vision"` — **gateway shortcut** (runs OCR directly, no Smol sub-agent; same pattern as `web_research`; always inserts into document) |
 | Backend | [`run_trusted_vision`](../../plugin/vision/vision_runner.py) → [`run_vision`](../../plugin/scripting/client.py) |
 | Insert | [`insert_vision_result`](../../plugin/vision/vision_egress.py) when `insert_into_document=true` (default) |
@@ -867,7 +867,7 @@ Checklist for implementers / QA:
 | `insert_into_document` | Default `true` — insert HTML at Writer cursor or Calc cell below anchor |
 | `params` | Optional vision overrides (`engine`, `lang`, …) merged with `vision.*` settings |
 
-**Prompt rule:** You must use `domain=vision` delegation (empty `task`) to perform OCR when the venv stack is available — runs on the selected graphic and inserts into the document (no nested sub-agent).
+**Prompt rule:** You must use `domain=vision` delegation (empty `task`) to perform OCR when the venv stack is available — extracts text and structure from the selected graphic and inserts a high-quality representation into the document (no nested sub-agent).
 
 **Multimodal chat models:** Native vision APIs do not receive embedded doc images today — local `vision` remains authoritative for OCR + document insert. Optional future: attach exported graphic bytes to chat for semantic Q&A ([§18.2](#182-multimodal-llm-vision-optional-after-tool)).
 

--- a/docs/scripting/librepy-split.md
+++ b/docs/scripting/librepy-split.md
@@ -43,7 +43,7 @@ Aligned with [../enabling_numpy_in_libreoffice.md](../enabling_numpy_in_libreoff
 | In core extension | WriterAgent extension only |
 |-------------------|---------------------------|
 | `=PYTHON()` / `=PY()` Calc add-in + warm venv worker | `=PROMPT()`, chat sidebar, MCP, grammar |
-| **Run Python Script…**, document scripts, init script, **Reset Python Session**, `wa.scripts` / `wa.doc` named libraries (`named_scripts.py`; host fetch via `host_rpc`, not `writeragent_api`) | Chat tools (`run_venv_python_script`, `analyze_data`, `extract_text_from_image`, …) |
+| **Run Python Script…**, document scripts, init script, **Reset Python Session**, `wa.scripts` / `wa.doc` named libraries (`named_scripts.py`; host fetch via `host_rpc`, not `writeragent_api`) | Chat tools (`run_venv_python_script`, `analyze_data`, `extract_structure_from_image`, …) |
 | **Monaco** (Edit Python in Cell…, Run Python Script editor) | Analysis Sub-Agent, tool loop, LLM client |
 | **LibrePy Python sidebar** (Calc deck: cells + diagnostics; also in WriterAgent.oxt) | WriterAgent chat deck (`WriterAgentDeck`) |
 | **NumPy domain trusted helpers** (Analysis, Viz, Symbolic, Units, Forecast, Optimize, Quant, Text Analytics menu) | Embeddings (`plugin/embeddings/`, folder FTS, hybrid search) |
@@ -469,7 +469,7 @@ Additional files: `plugin/calc/base.py`, `plugin/calc/inspector.py`, `plugin/fra
 | `forecast_data` | [`plugin/calc/forecast.py`](../../plugin/calc/forecast.py) | Run Python Script → Forecast |
 | `optimize_data` | [`plugin/calc/optimize.py`](../../plugin/calc/optimize.py) | Run Python Script → Optimize |
 | `symbolic_math` | [`plugin/calc/symbolic_math.py`](../../plugin/calc/symbolic_math.py) | Run Python Script → Math Helpers |
-| `extract_text_from_image` | [`plugin/vision/vision_tools.py`](../../plugin/vision/vision_tools.py) | Run Python Script → Vision Helpers |
+| `extract_structure_from_image` | [`plugin/vision/vision_tools.py`](../../plugin/vision/vision_tools.py) | Run Python Script → Vision Helpers |
 
 ### Writer chat (venv, no menu insert)
 
@@ -844,7 +844,7 @@ Dev reference only (not OXT): `contrib/scripting/assets/editor/*`
 
 `vision/__init__.py`, `vision/module.yaml`, `vision_common.py`, `vision_templates.py`, `vision_runner.py`, `vision_egress.py`, `vision_availability.py`, `vision/venv/vision.py`, `vision/venv/vision_docling.py`, `vision/venv/vision_paddle.py`, `vision/venv/vision_html_export.py`, `vision/venv/vision_layout_html.py`, `vision/venv/__init__.py`, `calc/vision_egress.py`, `chatbot/module_config_dialog.py`
 
-Omit `vision_tools.py` for menu-only core (chat `extract_text_from_image`).
+Omit `vision_tools.py` for menu-only core (chat `extract_structure_from_image`).
 
 ### Layer 6 adds (~4 paths, overlaps Layer 2)
 
@@ -1092,7 +1092,7 @@ Optional: `jedi` (completion stub in `editor_main.py`).
 
 ## Appendix G — Vision/OCR
 
-Local OCR and document layout via trusted Vision helpers. Manual path first per [../images/recognition.md](../images/recognition.md). Core ships **Run Python Script → Vision Helpers** + **Vision OCR Settings** — not chat `extract_text_from_image`.
+Local OCR and document layout via trusted Vision helpers. Manual path first per [../images/recognition.md](../images/recognition.md). Core ships **Run Python Script → Vision Helpers** + **Vision OCR Settings** — not chat `extract_structure_from_image`.
 
 ```mermaid
 flowchart LR
@@ -1162,6 +1162,6 @@ Models are **not** bundled in the OXT; user venv installs them.
 
 | Path | Role |
 |------|------|
-| [`vision_tools.py`](../../plugin/vision/vision_tools.py) | `extract_text_from_image` LLM tool |
+| [`vision_tools.py`](../../plugin/vision/vision_tools.py) | `extract_structure_from_image` LLM tool |
 | `plugin/framework/tool.py` | Tool registration |
 | Draw/Impress page-positioned OCR | Deferred — [../images/recognition.md](../images/recognition.md) Phase 1b.2 |

--- a/plugin/calc/base.py
+++ b/plugin/calc/base.py
@@ -52,7 +52,7 @@ class ToolCalcImageBase(ToolCalcSpecialBase):
 class ToolCalcVisionBase(ToolCalcSpecialBase):
     specialized_domain = "vision"
     specialized_domain_description: ClassVar[str | None] = (
-        "Local OCR on embedded sheet graphics (Docling/Paddle via Settings → Python venv); extract_text_from_image."
+        "Extract text and structure (layout, tables) from embedded sheet graphics; extract_structure_from_image."
     )
     intent = "media"
     required_core_tools: ClassVar[frozenset[str] | None] = frozenset()

--- a/plugin/calc/specialized.py
+++ b/plugin/calc/specialized.py
@@ -36,7 +36,7 @@ class DelegateToSpecializedCalc(DelegateToSpecializedBase):
     description = (
         f"Delegates a specialized Calc task. document_research {DELEGATION_USER_FILE_DATA_HINT}; "
         f"web_research {DELEGATION_PUBLIC_WEB_HINT}. "
-        "Also: images, shapes, vision (local OCR when venv configured), pivot, sheets, forms, tracking, etc."
+        "Also: images, shapes, vision (extract text and structure from images when configured), pivot, sheets, forms, tracking, etc."
     )
 
     uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]

--- a/plugin/doc/specialized_base.py
+++ b/plugin/doc/specialized_base.py
@@ -132,7 +132,7 @@ class DelegateToSpecializedBase(ToolBase):
 
         if domain == "vision":
             from plugin.vision.vision_availability import vision_venv_configured
-            from plugin.vision.vision_tools import ExtractTextFromImage
+            from plugin.vision.vision_tools import ExtractStructureFromImage
 
             if not vision_venv_configured(ctx.ctx):
                 return self._tool_error(
@@ -146,8 +146,8 @@ class DelegateToSpecializedBase(ToolBase):
             if USE_SUB_AGENT:
                 if status_callback:
                     status_callback(_("Running local OCR on selected image(s)..."))
-                # Gateway shortcut: no sub-agent parses task — always insert OCR after graphic(s).
-                return ExtractTextFromImage().execute(ctx, insert_into_document=True)
+                # Gateway shortcut: no sub-agent parses task — always insert after graphic(s).
+                return ExtractStructureFromImage().execute(ctx, insert_into_document=True)
 
         if domain == "document_research" and not USE_SUB_AGENT:
             return self._tool_error(

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -327,7 +327,7 @@ WRITER_NAVIGATION_RULES = """NAVIGATING LARGE DOCUMENTS (map first, then drill �
 
 WRITER_IMAGES_RULES = """IMAGES:
 - Image tools live in the 'images' domain: image_insert, image_delete, image_replace, image_list, image_get_info (includes crop_mm), image_download.
-  OCR (extract_text_from_image) lives in the 'vision' domain.
+  Extract text and structure (layout, tables) from images with extract_structure_from_image in the 'vision' domain; inserts a high-quality representation into the document.
 - image_set_properties resizes (width_mm/height_mm), repositions (hori_orient/vert_orient — friendly values like left/center/right/top/bottom work), and crops (crop_top_mm / crop_bottom_mm / crop_left_mm / crop_right_mm — mm trimmed per edge).
 - To actually SEE an image (vision-capable models), call get_image — by graphic name, selection=true, or page=N to render that whole page.
   For a bulk read with pictures embedded, pass include_images=true to get_document_content."""
@@ -661,9 +661,9 @@ def get_vision_core_directive(model, ctx) -> str:
         return ""
     delegate = "delegate_to_specialized_calc_toolset" if is_calc(model) else "delegate_to_specialized_writer_toolset"
     return (
-        f"When the user wants OCR or text from an embedded image, {delegate}(domain=\"vision\", task=\"\"). "
-        "That runs local OCR on the selected graphic and inserts the recognized text into the document "
-        "(no sub-agent; task is ignored). You must use this call to perform OCR."
+        f"When the user wants OCR or content from an embedded image, {delegate}(domain=\"vision\", task=\"\"). "
+        "That extracts text and structure from the selected graphic and inserts a high-quality "
+        "representation into the document (no sub-agent; task is ignored). You must use this call to perform OCR."
     )
 
 

--- a/plugin/scripting/writeragent_api.py
+++ b/plugin/scripting/writeragent_api.py
@@ -209,7 +209,7 @@ DOMAIN_TOOLS = {   'bookmark': [   'bookmark_cleanup',
                     'track_changes_show',
                     'track_changes_start',
                     'track_changes_stop'],
-    'vision': ['extract_text_from_image'],
+    'vision': ['extract_structure_from_image'],
     'writer': [   'add_comment',
                   'apply_document_content',
                   'apply_style',
@@ -1164,9 +1164,9 @@ tracking = _TrackingProxy()
 class _VisionProxy:
     """Proxy for vision tools."""
 
-    def extract_text_from_image(self, *, image_name: str | None = None, insert_into_document: bool | None = None, params: dict | None = None) -> dict:
-        """OCR text from embedded document image(s) using local Docling/Paddle (Settings → Python venv)."""
-        return _rpc_call("extract_text_from_image", image_name=image_name, insert_into_document=insert_into_document, params=params)
+    def extract_structure_from_image(self, *, image_name: str | None = None, insert_into_document: bool | None = None, params: dict | None = None) -> dict:
+        """Extract text and structure (layout, tables, etc.) from embedded document image(s)."""
+        return _rpc_call("extract_structure_from_image", image_name=image_name, insert_into_document=insert_into_document, params=params)
 
 vision = _VisionProxy()
 

--- a/plugin/vision/vision_availability.py
+++ b/plugin/vision/vision_availability.py
@@ -19,7 +19,7 @@ from plugin.scripting.venv_diagnostics import _probe_vision_packages, vision_ocr
 log = logging.getLogger(__name__)
 
 _VISION_DOMAIN = "vision"
-_VISION_TOOL_NAME = "extract_text_from_image"
+_VISION_TOOL_NAME = "extract_structure_from_image"
 _DELEGATE_GATEWAY_NAMES = frozenset(
     {
         "delegate_to_specialized_writer_toolset",
@@ -101,7 +101,7 @@ def vision_ocr_available(ctx: Any) -> bool:
 
 
 def filter_vision_specialized_tools(tools: list[Any], ctx: Any) -> list[Any]:
-    """Omit extract_text_from_image when no Settings venv is configured."""
+    """Omit extract_structure_from_image when no Settings venv is configured."""
     if vision_venv_configured(ctx):
         return tools
     return [t for t in tools if getattr(t, "name", None) != _VISION_TOOL_NAME]

--- a/plugin/vision/vision_tools.py
+++ b/plugin/vision/vision_tools.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""LLM tools for local vision/OCR (trusted venv extract_text)."""
+"""LLM/MCP tools for local vision OCR (trusted venv extract_structure)."""
 
 from __future__ import annotations
 
@@ -24,16 +24,16 @@ _VISION_DOCS = [
 ]
 
 
-class ExtractTextFromImage(ToolCalcVisionBase):
-    """Run trusted extract_text OCR on an embedded graphic via the user venv."""
+class ExtractStructureFromImage(ToolCalcVisionBase):
+    """Run trusted extract_structure OCR on an embedded graphic via the user venv."""
 
-    name = "extract_text_from_image"
+    name = "extract_structure_from_image"
     specialized_cross_cutting: ClassVar[bool] = True
     description = (
-        "OCR text from embedded document image(s) using local Docling/Paddle (Settings → Python venv). "
+        "Extract text and structure (layout, tables, etc.) from embedded document image(s). "
         "Leave image_name empty to use the currently selected graphic, or a Writer selection that "
         "contains multiple images (intervening text is ignored). "
-        "By default inserts formatted HTML after each graphic (Writer) or below the Calc anchor."
+        "By default inserts a high-quality representation after each graphic (Writer) or below the Calc anchor."
     )
     parameters = {
         "type": "object",
@@ -44,7 +44,10 @@ class ExtractTextFromImage(ToolCalcVisionBase):
             },
             "insert_into_document": {
                 "type": "boolean",
-                "description": "When true (default), insert OCR HTML into the document. When false, return text only.",
+                "description": (
+                    "When true (default), insert a high-quality representation into the document. "
+                    "When false, return extracted content only."
+                ),
             },
             "params": {
                 "type": "object",
@@ -80,7 +83,7 @@ class ExtractTextFromImage(ToolCalcVisionBase):
             return run_and_insert_vision_for_selection(
                 ctx.ctx,
                 doc,
-                helper="extract_text",
+                helper="extract_structure",
                 params=params_dict or None,
                 insert_into_document=insert_into_document,
             )
@@ -99,7 +102,7 @@ class ExtractTextFromImage(ToolCalcVisionBase):
 
         out = {
             "status": "ok",
-            "helper": "extract_text",
+            "helper": "extract_structure",
             "full_text": str(result.get("full_text") or ""),
             "metrics": result.get("metrics") if isinstance(result.get("metrics"), dict) else {},
             "warnings": result.get("warnings") if isinstance(result.get("warnings"), list) else [],

--- a/plugin/writer/specialized_base.py
+++ b/plugin/writer/specialized_base.py
@@ -62,7 +62,7 @@ class DelegateToSpecializedWriter(DelegateToSpecializedBase):
         "Delegates a specialized task with a focused toolset. "
         f"document_research {DELEGATION_USER_FILE_DATA_HINT}; web_research {DELEGATION_PUBLIC_WEB_HINT}. "
         "Also: charts, fields, styles, page, textframes, embedded (active doc OLE only), shapes, indexes, "
-        "bookmarks, tracking, footnotes, tables, forms, images, mail_merge, vision (local OCR when venv configured)."
+        "bookmarks, tracking, footnotes, tables, forms, images, mail_merge, vision (extract text and structure from images when configured)."
     )
 
     uno_services = ["com.sun.star.text.TextDocument"]
@@ -112,7 +112,7 @@ class ToolWriterVisionBase(ToolWriterSpecialBase):
 
     specialized_domain: ClassVar[str | None] = "vision"
     specialized_domain_description: ClassVar[str | None] = (
-        "Local OCR on embedded graphics (Docling/Paddle via Settings → Python venv); extract_text_from_image."
+        "Extract text and structure (layout, tables) from embedded graphics; extract_structure_from_image."
     )
     intent = "media"
 

--- a/tests/vision/test_vision_tools.py
+++ b/tests/vision/test_vision_tools.py
@@ -21,7 +21,7 @@ from plugin.vision.vision_availability import (
     vision_packages_probe_ready,
     vision_venv_configured,
 )
-from plugin.vision.vision_tools import ExtractTextFromImage
+from plugin.vision.vision_tools import ExtractStructureFromImage
 
 setup_uno_mocks()
 
@@ -53,18 +53,19 @@ def tool_ctx():
 def _registry_with_vision_tool() -> ToolRegistry:
     services = ServiceRegistry()
     registry = ToolRegistry(services)
-    registry.register(ExtractTextFromImage())
+    registry.register(ExtractStructureFromImage())
     return registry
 
 
-def test_extract_text_not_in_default_core_list(writer_doc):
+def test_extract_structure_not_in_default_core_list(writer_doc):
     registry = _registry_with_vision_tool()
     names = {t.name for t in registry.get_tools(doc=writer_doc)}
+    assert "extract_structure_from_image" not in names
     assert "extract_text_from_image" not in names
 
 
 @patch("plugin.vision.vision_availability.vision_venv_configured", return_value=True)
-def test_extract_text_in_vision_domain(_mock_avail, writer_doc, calc_doc):
+def test_extract_structure_in_vision_domain(_mock_avail, writer_doc, calc_doc):
     registry = _registry_with_vision_tool()
     uno_ctx = MagicMock()
     for doc in (writer_doc, calc_doc):
@@ -72,18 +73,29 @@ def test_extract_text_in_vision_domain(_mock_avail, writer_doc, calc_doc):
             t.name
             for t in registry.get_tools(doc=doc, active_domain="vision", exclude_tiers=(), ctx=uno_ctx)
         }
-        assert "extract_text_from_image" in names
+        assert "extract_structure_from_image" in names
+        assert "extract_text_from_image" not in names
 
 
 @patch("plugin.vision.vision_availability.vision_venv_configured", return_value=False)
-def test_extract_text_hidden_when_vision_unavailable(_mock_avail, writer_doc):
+def test_extract_structure_hidden_when_vision_unavailable(_mock_avail, writer_doc):
     registry = _registry_with_vision_tool()
     uno_ctx = MagicMock()
     names = {
         t.name
         for t in registry.get_tools(doc=writer_doc, active_domain="vision", exclude_tiers=(), ctx=uno_ctx)
     }
-    assert "extract_text_from_image" not in names
+    assert "extract_structure_from_image" not in names
+
+
+def test_extract_structure_description_mentions_text_and_structure():
+    tool = ExtractStructureFromImage()
+    text = f"{tool.description} {tool.parameters['properties']['insert_into_document']['description']}"
+    lowered = text.lower()
+    assert "text and structure" in lowered
+    assert "high-quality representation" in lowered
+    for banned in ("html", "docling", "rapidocr", "paddle"):
+        assert banned not in lowered
 
 
 @patch("plugin.vision.vision_availability.vision_venv_configured", return_value=True)
@@ -156,7 +168,7 @@ def test_vision_venv_configured_true_even_when_probe_would_fail(_cfg, _exe, _pro
 
 
 def test_filter_vision_specialized_tools_removes_tool():
-    tool = ExtractTextFromImage()
+    tool = ExtractStructureFromImage()
     other = MagicMock()
     other.name = "specialized_workflow_finished"
     with patch("plugin.vision.vision_availability.vision_venv_configured", return_value=False):
@@ -167,14 +179,14 @@ def test_filter_vision_specialized_tools_removes_tool():
 
 @patch("plugin.framework.queue_executor.execute_on_main_thread")
 @patch("plugin.vision.vision_tools.run_and_insert_vision_for_selection")
-def test_extract_text_happy_path_inserts(
+def test_extract_structure_happy_path_inserts(
     mock_run,
     mock_main_thread,
     tool_ctx,
 ):
     mock_run.return_value = {
         "status": "ok",
-        "helper": "extract_text",
+        "helper": "extract_structure",
         "full_text": "Hello scan",
         "html": "<p>Hello scan</p>",
         "metrics": {"line_count": 1},
@@ -185,27 +197,28 @@ def test_extract_text_happy_path_inserts(
     }
     mock_main_thread.side_effect = lambda fn, *args, **kwargs: fn(*args, **kwargs)
 
-    tool = ExtractTextFromImage()
+    tool = ExtractStructureFromImage()
     result = tool.execute(tool_ctx, insert_into_document=True)
 
     assert result["status"] == "ok"
+    assert result["helper"] == "extract_structure"
     assert result["full_text"] == "Hello scan"
     assert result["inserted"] is True
     mock_run.assert_called_once()
-    assert mock_run.call_args.kwargs["helper"] == "extract_text"
+    assert mock_run.call_args.kwargs["helper"] == "extract_structure"
     assert mock_run.call_args.kwargs["insert_into_document"] is True
 
 
 @patch("plugin.framework.queue_executor.execute_on_main_thread")
 @patch("plugin.vision.vision_tools.run_and_insert_vision_for_selection")
-def test_extract_text_return_only_skips_insert(
+def test_extract_structure_return_only_skips_insert(
     mock_run,
     mock_main_thread,
     tool_ctx,
 ):
     mock_run.return_value = {
         "status": "ok",
-        "helper": "extract_text",
+        "helper": "extract_structure",
         "full_text": "text only",
         "html": "<p>text only</p>",
         "metrics": {},
@@ -216,7 +229,7 @@ def test_extract_text_return_only_skips_insert(
     }
     mock_main_thread.side_effect = lambda fn, *args, **kwargs: fn(*args, **kwargs)
 
-    tool = ExtractTextFromImage()
+    tool = ExtractStructureFromImage()
     result = tool.execute(tool_ctx, insert_into_document=False)
 
     assert result["status"] == "ok"
@@ -224,9 +237,9 @@ def test_extract_text_return_only_skips_insert(
     assert mock_run.call_args.kwargs["insert_into_document"] is False
 
 
-def test_extract_text_rejects_unsupported_doc(tool_ctx):
+def test_extract_structure_rejects_unsupported_doc(tool_ctx):
     tool_ctx.doc_type = "draw"
-    tool = ExtractTextFromImage()
+    tool = ExtractStructureFromImage()
     result = tool.execute(tool_ctx)
     assert result["status"] == "error"
     assert "Writer or Calc" in result.get("message", "")
@@ -242,7 +255,7 @@ def test_get_vision_core_directive_empty_when_unavailable(_mock_avail):
 @patch("plugin.doc.specialized_base.USE_SUB_AGENT", True)
 @patch("plugin.doc.specialized_base.build_toolcalling_agent")
 @patch("plugin.vision.vision_availability.vision_venv_configured", return_value=True)
-@patch.object(ExtractTextFromImage, "execute", return_value={"status": "ok", "full_text": "hi"})
+@patch.object(ExtractStructureFromImage, "execute", return_value={"status": "ok", "full_text": "hi"})
 def test_delegate_vision_runs_ocr_directly(mock_execute, _avail, mock_build_agent):
     from plugin.writer.specialized_base import DelegateToSpecializedWriter
 
@@ -291,6 +304,19 @@ def test_get_vision_core_directive_when_available(_mock_avail, writer_doc):
 
     text = get_vision_core_directive(writer_doc, MagicMock())
     assert "domain=\"vision\"" in text
+    assert "text and structure" in text
+    assert "high-quality" in text
     assert "selected graphic" in text
     assert "task is ignored" in text
     assert "must use this call to perform OCR" in text
+    lowered = text.lower()
+    for banned in ("html", "docling", "rapidocr", "recognized text"):
+        assert banned not in lowered
+
+
+def test_images_guidance_names_structure_tool():
+    from plugin.framework.prompts import WRITER_IMAGES_RULES
+
+    assert "extract_structure_from_image" in WRITER_IMAGES_RULES
+    assert "extract_text_from_image" not in WRITER_IMAGES_RULES
+    assert "text and structure" in WRITER_IMAGES_RULES.lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
LLM and MCP now see a single vision extract tool, `extract_structure_from_image`, which always calls the `extract_structure` helper. Models can no longer choose between plain `extract_text` and structured OCR.

Prompt and tool wording describe **text and structure** (layout, tables) and a **high-quality representation inserted into the document**. LLM/MCP-facing copy does not mention HTML, Docling, RapidOCR, or other internals. The `extract_text` venv helper and Run Python Script templates are unchanged.

## Changes
- Rename `ExtractTextFromImage` / `extract_text_from_image` → `ExtractStructureFromImage` / `extract_structure_from_image`
- Hardcode `helper="extract_structure"` in the LLM tool and vision-domain gateway shortcut
- Update `get_vision_core_directive`, `WRITER_IMAGES_RULES`, and specialized domain/gateway descriptions
- Regenerate `writeragent_api` proxy stubs
- Update recognition and LibrePy docs; no compatibility alias

## Testing
- `make typecheck` — passed (ruff, basedpyright, bandit, opengrep, pyspector, ty, thread-safety, mypy)
- `pytest tests/vision/test_vision_tools.py` — 21 passed
- `pytest tests/vision tests/chatbot/test_agent_manual.py --ignore-glob='*_uno.py'` — 82 passed

No headed LibreOffice run. No GitHub issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3298aad2-1845-49e2-9a19-9f5a89ddd8b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3298aad2-1845-49e2-9a19-9f5a89ddd8b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

