### PR TITLE
CrossHair: fix check-all 33928341275 CHECK FAILs (deal.pre holes)

### DIFF
--- a/plugin/calc/excel_py_convert/to_dag.py
+++ b/plugin/calc/excel_py_convert/to_dag.py
@@ -189,7 +189,9 @@ def _header_mode_from_keywords(node: ast.Call) -> HeaderMode:
 
 
 @deal.pre(
-    lambda src, i, *_unused, **__: str_bounded(src, _DEAL_REWRITE_SRC)
+    # Match wrapper alphabet/len (_deal_excel_src_ok); _DEAL_REWRITE_SRC=1 was
+    # tighter than CrossHair wrappers (len<=2) and CHECK-failed on _find_xl_calls('\t"').
+    lambda src, i, *_unused, **__: _deal_excel_src_ok(src)
     and type(i) is int
     and 0 <= i < len(src)
 )
@@ -680,11 +682,21 @@ def convert_cell_to_dag(
 
 
 @deal.pre(
+    # Also bound each cell like convert_cell_to_dag — otherwise CrossHair builds
+    # models that pass this wrapper then PreconditionFail inside the loop
+    # (check-all 33928341275: deps=['','',''] with _DEAL_CONVERT_LIST=1).
     lambda model, *_unused, **__: isinstance(model.scripts, list)
     and len(model.scripts) <= _DEAL_CONVERT_LIST
     and all(isinstance(s, str) and str_bounded(s, _DEAL_CONVERT_STR) for s in model.scripts)
     and isinstance(model.cells, list)
     and len(model.cells) <= _DEAL_CONVERT_LIST
+    and all(
+        type(c.script_index) is int
+        and isinstance(c.deps, list)
+        and len(c.deps) <= _DEAL_CONVERT_LIST
+        and all(isinstance(d, str) and ascii_bounded(d, _DEAL_CONVERT_STR) for d in c.deps)
+        for c in model.cells
+    )
 )
 def convert_model_to_dag(model: ExcelWorkbookModel, *, best_effort: bool = False) -> ConversionReport:
     """Convert every PY cell in *model* to DAG-style ``=PY`` formulas."""

--- a/plugin/embeddings/embeddings_split.py
+++ b/plugin/embeddings/embeddings_split.py
@@ -36,6 +36,26 @@ _deal_sentence_locale_ok = (
 )
 
 
+# NUL/controls are isascii() but ICU SentenceBreaker TypeErrors on them
+# (check-all 33928341275: split_passage_to_sentences('\x00', locale=DEFAULT)).
+def _deal_passage_text_ok_pytest(text: object) -> bool:
+    return str_bounded(text, DEAL_MAX_SOURCE)
+
+
+def _deal_passage_text_ok_crosshair(text: object) -> bool:
+    return (
+        isinstance(text, str)
+        and len(text) <= _DEAL_PASSAGE_LEN
+        and text.isascii()
+        and all(c.isprintable() or c in "\n\t\r" for c in text)
+    )
+
+
+_deal_passage_text_ok = (
+    _deal_passage_text_ok_crosshair if UNDER_CROSSHAIR else _deal_passage_text_ok_pytest
+)
+
+
 def _embeddings_pip_install_hint() -> str:
     from plugin.embeddings.venv.embeddings_index import EMBEDDINGS_VENV_PIP_INSTALL
 
@@ -60,7 +80,7 @@ def _import_splitter() -> Any:
 
 
 @deal.pre(
-    lambda text, locale=DEFAULT_SENTENCE_LOCALE, *_unused, **__: str_bounded(text, _DEAL_PASSAGE_LEN)
+    lambda text, locale=DEFAULT_SENTENCE_LOCALE, *_unused, **__: _deal_passage_text_ok(text)
     and _deal_sentence_locale_ok(locale)
 )
 def split_passage_to_sentences(text: str, locale: str = DEFAULT_SENTENCE_LOCALE) -> list[tuple[int, int, str]]:
@@ -294,11 +314,24 @@ def _split_non_prose_passage_to_spans(passage: str) -> list[tuple[int, int]]:
 
 
 @deal.pre(
+    # Match split_passage_to_chunk_meta meta bounds — weak dict-only pre let
+    # CrossHair pass {'': '\x80'} then PreconditionFail on the nested call
+    # (check-all 33928341275).
     lambda text, runs, base_meta, *_unused, **__: ascii_bounded(text, _DEAL_PASSAGE_LEN)
     and isinstance(runs, list)
     and len(runs) <= _DEAL_SENT_LIST_LEN
-    and isinstance(base_meta, dict)
+    and type(base_meta) is dict
     and len(base_meta) <= _DEAL_SENT_LIST_LEN
+    and all(
+        type(k) is str
+        and ascii_bounded(k, DEAL_MAX_TOKEN)
+        and (
+            v is None
+            or type(v) in (int, float, bool)
+            or (isinstance(v, str) and ascii_bounded(v, DEAL_MAX_TOKEN))
+        )
+        for k, v in base_meta.items()
+    )
 )
 def split_passage_locale_runs_to_chunk_meta(
     text: str,


### PR DESCRIPTION
## Summary
Follow-up from check-all deep run [33928341275](https://github.com/KeithCu/writeragent/actions/runs/33928341275) on `02602906` (start-at 1 → **56/56** in ~75m ET; **2 failed modules / 4 CHECK FAILs**).

### `plugin/calc/excel_py_convert/to_dag.py` (2 FAILs)
1. **`_find_xl_calls('\t"')` → `_skip_string` PreconditionFailed** — PR 544 switched wrappers to `_deal_excel_src_ok` (CrossHair `len<=2` + alphabet) but left `_skip_string` on `str_bounded(..., _DEAL_REWRITE_SRC=1)`. Nested call with a 2-char quote/tab string failed.
2. **`convert_model_to_dag` → `convert_cell_to_dag` PreconditionFailed** — wrapper allowed cells whose `deps` exceeded `_DEAL_CONVERT_LIST` (counterexample `deps=['','','']`). Deal's message showed the first clause of the callee pre.

### `plugin/embeddings/embeddings_split.py` (2 FAILs)
1. **`split_passage_to_sentences('\x00', locale=DEFAULT)` TypeError** — `str_bounded` / `isascii()` admit NUL; ICU `SentenceBreaker` TypeErrors.
2. **`split_passage_locale_runs_to_chunk_meta` → `split_passage_to_chunk_meta` PreconditionFailed** — outer pre only checked `isinstance(base_meta, dict)`; nested required ascii-bounded values (`{'': '\x80'}`).

### Fixes (tiny deal.pre only — no `# crosshair: off`)
- `_skip_string` uses `_deal_excel_src_ok`
- `convert_model_to_dag` also bounds each cell's `deps` / `script_index` like `convert_cell_to_dag`
- Dual-profile `_deal_passage_text_ok` (CrossHair: printable ASCII; pytest: prior `str_bounded`)
- `split_passage_locale_runs_to_chunk_meta` matches `split_passage_to_chunk_meta` meta bounds

## Test plan
- [ ] PR CI Test & Typecheck green
- [ ] After merge, Keith kicks a fresh check-all deep (start-at 1); expect 0 CHECK FAILs on these four holes
- [ ] Cover-all next start-at remains **1** (prior segment cover-all succeeded)