### PR TITLE
DuckDB sibling spreadsheets: used-range reads and loud failures

### DIFF
--- a/docs/calc/duckdb-dev-plan.md
+++ b/docs/calc/duckdb-dev-plan.md
@@ -51,7 +51,7 @@ That writes the ODS/XLSX and copies `zip_income.csv` next to them. Happy-path pr
 - Host handles: scoped dir resolution, hidden LO opens for .xlsx/.ods, active doc reads for ranges, size limits, preloading.
 - Worker: registers preloaded via `coerce_to_dataframe`, flat files via `read_csv`/`read_parquet` etc. under provided names. Read-only guards.
 - Templates: `[SQL] query_folder_sql` and `query_sheet_sql` in Run Python Script.
-- Limitations: no write-back, no shared kernel cache yet, default first sheet for office files, simple range reads (large fixed range).
+- Limitations: no write-back, no shared kernel cache yet, default first sheet for office files when `#SheetName` is omitted. Sibling `.xlsx`/`.ods` now read the sheet **used range** (same `createCursor` / `gotoStartOfUsedArea` / `gotoEndOfUsedArea` path as `SheetAnalyzer` / ingest) — open / missing-sheet / empty-range failures are tool errors. ODS mtime cache (`writeragent_ods_cache/`) is still pending.
 - Usage: Mix tables + files for joins, e.g. live ranges + sibling CSVs. See tool parameters and plan for request shapes.
 
 **Audience:** Product, senior engineers, and future implementers. This doc captures why DuckDB fits WriterAgent, what users get, and how to build on existing Calc↔venv infrastructure without a new architectural pillar.
@@ -418,3 +418,4 @@ No cloud telemetry required. Suggested signals:
 | 2026-06-18 | Phase B: data_range support in tool for active sheet (registers as 'data' table, respects headers). Unified preloaded handling (structured for headers), template for query_sheet_sql, descriptions. |
 | 2026-06-18 | Phase C: multi-table 'tables' param (named ranges on active), files as dict for named flat+office. Worker supports flat_files dict for direct named registration (no chdir). Host prepares preloaded + flat_files. Tool + client updated. |
 | 2026-09-05 | Pretty demo: same ODS as the =PY() showcase gets a SQL_DuckDB sheet (SQL in cells) + ZIP on sales + sibling ACS `zip_income.csv`. Tests run `query_folder_sql` against those assets. |
+| 2026-09-05 | Sibling office ingress: used-range (not `A1:AK2000` / `A1:AZ5000`); fail loud on open / `#SheetName` / empty range. ODS mtime cache still pending. |

--- a/plugin/calc/duckdb_tools.py
+++ b/plugin/calc/duckdb_tools.py
@@ -147,11 +147,18 @@ class QueryFolderSqlTool(ToolCalcAnalysisBase):
                 full_path = os.path.join(scoped, bn) if scoped else bn
                 if scoped and os.path.isfile(full_path):
                     if ext in OFFICE_EXTS:
-                        tbl, office_grid = _read_sibling_office_file_as_grid(ctx.ctx, full_path, sheet_hint=sheet_hint)
-                        if tbl and office_grid:
-                            use_name = name_hint or bn
-                            preloaded[use_name] = {"grid": office_grid, "headers": headers}
-                            continue
+                        # Office files that exist must preload or fail loud. A silent
+                        # (None, None) skip used to append the basename to direct_files
+                        # so SQL ran without the table and looked like a missing FROM.
+                        try:
+                            _tbl, office_grid = _read_sibling_office_file_as_grid(
+                                ctx.ctx, full_path, sheet_hint=sheet_hint
+                            )
+                        except ToolExecutionError as exc:
+                            return self._tool_error(str(exc), code=getattr(exc, "code", "DUCKDB_SQL_ERROR"))
+                        use_name = name_hint or bn
+                        preloaded[use_name] = {"grid": office_grid, "headers": headers}
+                        continue
                     else:
                         # flat file -> use flat_files for named direct DuckDB read (Phase C)
                         use_name = name_hint or bn
@@ -187,57 +194,90 @@ class QueryFolderSqlTool(ToolCalcAnalysisBase):
         return {"status": "ok", "result": result}
 
 
-def _read_sibling_office_file_as_grid(ctx: Any, full_path: str, sheet_hint: str | None = None) -> tuple[str | None, list[list[Any]] | None]:
-    """Open a sibling .xlsx/.ods hidden+readonly, read a sheet into a grid of values.
+def _grid_has_usable_values(grid: list[list[Any]] | None) -> bool:
+    """True when *grid* has at least one non-empty cell (0 / False count as data)."""
+    if not grid:
+        return False
+    for row in grid:
+        if not row:
+            continue
+        for cell in row:
+            if cell is not None and cell != "":
+                return True
+    return False
 
-    sheet_hint: optional sheet name (e.g. from "file.xlsx#Sales").
-    Returns (table_name, grid) or (None, None) on failure.
-    Table name is the basename without extension (safe for SQL).
+
+def _sheet_qualified_a1(sheet_name: str, range_str: str) -> str:
+    """Qualify an A1 range so CellInspector hits *sheet_name* without setActiveSheet.
+
+    Hidden sibling opens often lack a usable controller; a sheet prefix is the
+    same resolve path live-range tools already use (``CalcBridge.resolve``).
     """
+    if any(ch in sheet_name for ch in " .!'"):
+        return f"'{sheet_name}'.{range_str}"
+    return f"{sheet_name}.{range_str}"
+
+
+def _sibling_office_error(full_path: str, message: str, *, sheet: str | None = None, code: str = "DUCKDB_SQL_ERROR") -> ToolExecutionError:
+    bn = os.path.basename(full_path)
+    if sheet:
+        return ToolExecutionError(f"Sibling spreadsheet {bn!r} sheet {sheet!r}: {message}", code=code)
+    return ToolExecutionError(f"Sibling spreadsheet {bn!r}: {message}", code=code)
+
+
+def _read_sibling_office_file_as_grid(ctx: Any, full_path: str, sheet_hint: str | None = None) -> tuple[str, list[list[Any]]]:
+    """Open a sibling .xlsx/.ods hidden+readonly and read the sheet used range.
+
+    *sheet_hint* is the optional ``#SheetName`` from the files spec.
+    Returns ``(table_name, grid)``. Raises ``ToolExecutionError`` on open,
+    missing sheet, or empty/unusable used-range — never ``(None, None)``.
+
+    Used-range uses the same ``createCursor`` + ``gotoStart/EndOfUsedArea``
+    path as ``SheetAnalyzer`` / ``ingest._used_range_address``. The previous
+    hardcoded ``A1:AK2000`` / ``A1:AZ5000`` fallback padded most tables with
+    thousands of empty cells and hid open/sheet failures as a silent skip.
+    """
+    from plugin.calc.bridge import CalcBridge
+    from plugin.calc.calc_addin_data import values_from_inspector_range
+    from plugin.calc.inspector import CellInspector
+    from plugin.calc.spreadsheet_import.ingest import _used_range_address, used_range_string_from_address
+
     model = None
     opened_flag = False
     try:
         model, doc_type, err, opened_flag = open_document_for_read(ctx, full_path)
-        if err or model is None or doc_type != "calc":
-            return None, None
-
-        from plugin.calc.bridge import CalcBridge
-        from plugin.calc.inspector import CellInspector
-        from plugin.calc.calc_addin_data import values_from_inspector_range
+        if err or model is None:
+            raise _sibling_office_error(full_path, err or "LibreOffice failed to open the file")
+        if doc_type != "calc":
+            raise _sibling_office_error(full_path, f"not a spreadsheet (type={doc_type!r})")
 
         bridge = CalcBridge(model)
-
-        # Try to activate the desired sheet so inspector.read_range uses it
-        target_sheet = None
         sheets = model.getSheets()
         if sheet_hint:
+            # CalcBridge.get_sheet lists available names — do not fall back to sheet 0.
             try:
-                target_sheet = sheets.getByName(sheet_hint)
-            except Exception:
-                pass
-        if target_sheet is None:
-            # default to first sheet
+                target_sheet = bridge.get_sheet(sheet_hint)
+            except ValueError as exc:
+                raise _sibling_office_error(full_path, str(exc), sheet=sheet_hint) from exc
+        else:
+            if sheets.getCount() < 1:
+                raise _sibling_office_error(full_path, "workbook has no sheets")
             target_sheet = sheets.getByIndex(0)
 
-        # For hidden docs, try to set active sheet on controller if possible
-        try:
-            controller = model.getCurrentController()
-            if controller and hasattr(controller, "setActiveSheet") and target_sheet:
-                controller.setActiveSheet(target_sheet)
-        except Exception:
-            pass  # hidden docs sometimes lack full controller; fall back to first anyway
+        sheet_name = str(target_sheet.getName())
+        addr = _used_range_address(target_sheet)
+        range_str = used_range_string_from_address(addr)
+        qualified = _sheet_qualified_a1(sheet_name, range_str)
 
         inspector = CellInspector(bridge)
-
-        # Use a large but reasonable range. For production this could compute actual used area.
-        # "A1:AK2000" covers most practical tables (columns A-AK = 37 cols).
-        range_str = "A1:AK2000"
-        try:
-            raw = inspector.read_range(range_str)
-            grid = values_from_inspector_range(raw)
-        except Exception:
-            raw = inspector.read_range("A1:AZ5000")
-            grid = values_from_inspector_range(raw)
+        raw = inspector.read_range(qualified)
+        grid = values_from_inspector_range(raw)
+        if not _grid_has_usable_values(grid):
+            raise _sibling_office_error(
+                full_path,
+                f"used range {range_str} is empty; nothing to register for SQL",
+                sheet=sheet_name,
+            )
 
         tbl_name = os.path.splitext(os.path.basename(full_path))[0]
         tbl_name = "".join(c if c.isalnum() or c in "_$" else "_" for c in tbl_name)
@@ -245,9 +285,11 @@ def _read_sibling_office_file_as_grid(ctx: Any, full_path: str, sheet_hint: str 
             tbl_name = "sheet_" + tbl_name
 
         return tbl_name, grid
-    except Exception as e:
-        log.warning("Failed to read sibling office file %s for DuckDB: %s", full_path, e)
-        return None, None
+    except ToolExecutionError:
+        raise
+    except Exception as exc:
+        log.exception("Failed to read sibling office file %s for DuckDB", full_path)
+        raise _sibling_office_error(full_path, f"failed to read used range: {exc}") from exc
     finally:
         if model is not None and opened_flag:
             try:

--- a/tests/calc/test_duckdb_tools.py
+++ b/tests/calc/test_duckdb_tools.py
@@ -6,15 +6,109 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-
-from plugin.calc.duckdb_tools import QueryFolderSqlTool
+from plugin.calc.address_utils import parse_range_string, split_sheet_prefix
+from plugin.calc.duckdb_tools import (
+    QueryFolderSqlTool,
+    _read_sibling_office_file_as_grid,
+)
+from plugin.framework.errors import ToolExecutionError
 
 
 def _mk_ctx():
     return SimpleNamespace(ctx=object(), doc=object(), doc_type="calc", active_domain="analysis")
+
+
+def _write_office_fixtures(tmp_path: Path) -> tuple[Path, Path]:
+    """Small xlsx/ods on disk so the host preload path sees real sibling files.
+
+    Content is for the fixture; unit tests mock UNO used-area / read_range.
+    """
+    xlsx = tmp_path / "budget.xlsx"
+    ods = tmp_path / "ledger.ods"
+    try:
+        from openpyxl import Workbook
+
+        wb = Workbook()
+        ws = wb.active
+        assert ws is not None
+        ws.title = "Actuals"
+        ws["C5"] = "Region"
+        ws["D5"] = "Sales"
+        ws["C6"] = "North"
+        ws["D6"] = 100
+        wb.save(xlsx)
+    except ImportError:
+        xlsx.write_bytes(b"PK\x03\x04xlsx")
+    ods.write_bytes(b"PK\x03\x04ods")
+    return xlsx, ods
+
+
+def _fake_addr(start_col: int = 2, start_row: int = 4, end_col: int = 3, end_row: int = 5):
+    """C5:D6 by default — data that is *not* at A1, so A1:AK2000 would pad."""
+    return SimpleNamespace(StartColumn=start_col, StartRow=start_row, EndColumn=end_col, EndRow=end_row)
+
+
+def _fake_sheet(name: str = "Actuals", addr=None):
+    addr = addr or _fake_addr()
+    cursor = SimpleNamespace(
+        gotoStartOfUsedArea=lambda expand: None,
+        gotoEndOfUsedArea=lambda expand: None,
+        getRangeAddress=lambda: addr,
+    )
+    return SimpleNamespace(getName=lambda: name, createCursor=lambda: cursor)
+
+
+def _fake_sheets(names: tuple[str, ...] = ("Actuals", "Summary"), addr=None):
+    sheets = {n: _fake_sheet(n, addr=addr) for n in names}
+
+    class Sheets:
+        def hasByName(self, name: str) -> bool:
+            return name in sheets
+
+        def getByName(self, name: str):
+            if name not in sheets:
+                raise Exception(f"no sheet {name}")
+            return sheets[name]
+
+        def getByIndex(self, idx: int):
+            return sheets[names[idx]]
+
+        def getElementNames(self) -> tuple[str, ...]:
+            return names
+
+        def getCount(self) -> int:
+            return len(names)
+
+    return Sheets()
+
+
+def _fake_model(sheets=None):
+    sheets = sheets or _fake_sheets()
+    return SimpleNamespace(
+        getSheets=lambda: sheets,
+        getCurrentController=lambda: None,
+        NamedRanges=SimpleNamespace(hasByName=lambda _n: False),
+    )
+
+
+def _grid_for_requested_range(range_name: str) -> list[list[dict]]:
+    """Size the mock grid to the *requested* A1 range so a giant fallback is visible."""
+    _prefix, bare = split_sheet_prefix(range_name)
+    (start_col, start_row), (end_col, end_row) = parse_range_string(bare)
+    data = {
+        (2, 4): "Region",
+        (3, 4): "Sales",
+        (2, 5): "North",
+        (3, 5): 100,
+    }
+    grid = []
+    for row in range(start_row, end_row + 1):
+        grid.append([{"value": data.get((col, row))} for col in range(start_col, end_col + 1)])
+    return grid
 
 
 def test_query_folder_sql_tool_basic_schema():
@@ -60,7 +154,7 @@ def test_query_folder_sql_calls_host_with_resolved_dir(mock_resolve, mock_run, m
 def test_query_folder_sql_handles_office_files_and_sheet_hint(
     mock_resolve, mock_run, mock_exec, mock_read_office, _mock_isfile
 ):
-    """Polished A+: office files are preloaded on host, not passed as direct files; sheet hint supported."""
+    """Office files are preloaded on host; #SheetName is forwarded; CSV stays flat."""
     mock_resolve.return_value = "/tmp/project"
     mock_read_office.return_value = ("budget", [["Region", "Sales"], ["North", 100]])
     mock_run.return_value = {"status": "ok", "total_rows": 1}
@@ -68,22 +162,206 @@ def test_query_folder_sql_handles_office_files_and_sheet_hint(
 
     t = QueryFolderSqlTool()
     ctx = _mk_ctx()
-    # Mix direct + office with sheet hint
     res = t.execute(ctx, sql="SELECT * FROM budget", files=["sales.csv", "budget.xlsx#Actuals"])
 
     assert res["status"] == "ok"
     mock_read_office.assert_called_once()
-    # Check that run_folder_sql received preloaded (keyed by original bn) and only direct files
+    _args, kwargs = mock_read_office.call_args
+    assert _args[1].endswith("budget.xlsx")
+    assert kwargs.get("sheet_hint") == "Actuals"
+
     call_args = mock_run.call_args
-    pre = call_args.kwargs.get("preloaded") if call_args.kwargs else None
-    if not pre and len(call_args[0]) > 4:
-        pre = call_args[0][4]
-    assert pre and ("budget.xlsx" in pre or any("budget" in k for k in pre))
-    direct = call_args.kwargs.get("files") if call_args.kwargs else None
+    pre = call_args.kwargs.get("preloaded")
+    assert pre is not None
+    assert "budget.xlsx" in pre
+    assert pre["budget.xlsx"]["grid"] == [["Region", "Sales"], ["North", 100]]
+
+    flat = call_args.kwargs.get("flat_files") or {}
+    direct = call_args.kwargs.get("files")
     if direct is None and len(call_args[0]) > 3:
         direct = call_args[0][3]
-    # direct may be list of remaining or None if all processed to flat/pre
     direct = direct or []
-    assert "sales.csv" in str(direct) or True  # loose for Phase C changes
-    # assert not any office in direct
+    assert any("sales.csv" in str(v) for v in (flat.values() if isinstance(flat, dict) else [])) or (
+        "sales.csv" in str(direct)
+    )
+    assert "budget.xlsx" not in str(direct)
+    assert not any("budget.xlsx" in str(v) for v in (flat.values() if isinstance(flat, dict) else []))
 
+
+@patch("plugin.calc.duckdb_tools.os.path.isfile", return_value=True)
+@patch("plugin.calc.duckdb_tools._read_sibling_office_file_as_grid")
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_query_folder_sql_office_read_error_does_not_skip(
+    mock_resolve, mock_run, mock_exec, mock_read_office, _mock_isfile
+):
+    """Open/sheet/empty failures must surface; SQL must not run without the table."""
+    mock_resolve.return_value = "/tmp/project"
+    mock_read_office.side_effect = ToolExecutionError(
+        "Sibling spreadsheet 'budget.xlsx' sheet 'Nope': No sheet named 'Nope'. Available: Actuals",
+        code="DUCKDB_SQL_ERROR",
+    )
+    mock_exec.side_effect = lambda fn: fn()
+
+    t = QueryFolderSqlTool()
+    res = t.execute(_mk_ctx(), sql="SELECT * FROM budget", files=["budget.xlsx#Nope"])
+
+    assert res["status"] == "error"
+    assert "budget.xlsx" in res["message"]
+    assert "Nope" in res["message"]
+    mock_run.assert_not_called()
+
+
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_read_sibling_used_range_skips_giant_padding(mock_open, mock_read, _mock_close, tmp_path):
+    """Used-area C5:D6 must not ship A1:AK2000 / A1:AZ5000 empty padding."""
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    mock_open.return_value = (_fake_model(), "calc", None, True)
+    mock_read.side_effect = _grid_for_requested_range
+
+    _tbl, grid = _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Actuals")
+
+    requested = mock_read.call_args[0][0]
+    assert "AK2000" not in requested
+    assert "AZ5000" not in requested
+    _prefix, bare = split_sheet_prefix(requested)
+    assert _prefix == "Actuals"
+    assert bare == "C5:D6"
+    assert len(grid) == 2
+    assert all(len(row) == 2 for row in grid)
+    assert grid[0] == ["Region", "Sales"]
+    assert grid[1] == ["North", 100]
+
+
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_read_sibling_ods_used_range(mock_open, mock_read, _mock_close, tmp_path):
+    _xlsx, ods = _write_office_fixtures(tmp_path)
+    mock_open.return_value = (_fake_model(), "calc", None, True)
+    mock_read.side_effect = _grid_for_requested_range
+
+    _tbl, grid = _read_sibling_office_file_as_grid(object(), str(ods))
+
+    requested = mock_read.call_args[0][0]
+    assert "AK2000" not in requested
+    assert len(grid) == 2
+    assert len(grid[0]) == 2
+
+
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_read_sibling_missing_sheet_hint_errors(mock_open, mock_read, _mock_close, tmp_path):
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    mock_open.return_value = (_fake_model(), "calc", None, True)
+
+    try:
+        _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Nope")
+    except ToolExecutionError as exc:
+        assert "budget.xlsx" in str(exc)
+        assert "Nope" in str(exc)
+        assert "Actuals" in str(exc)
+    else:
+        raise AssertionError("expected ToolExecutionError for missing sheet hint")
+    mock_read.assert_not_called()
+
+
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_read_sibling_open_failure_errors(mock_open, _mock_close, tmp_path):
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    mock_open.return_value = (None, None, "Failed to open /tmp/budget.xlsx", False)
+
+    try:
+        _read_sibling_office_file_as_grid(object(), str(xlsx))
+    except ToolExecutionError as exc:
+        assert "budget.xlsx" in str(exc)
+        assert "Failed to open" in str(exc)
+    else:
+        raise AssertionError("expected ToolExecutionError when LibreOffice open fails")
+
+
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_read_sibling_empty_used_range_errors(mock_open, mock_read, _mock_close, tmp_path):
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    empty_addr = _fake_addr(0, 0, 0, 0)
+    mock_open.return_value = (_fake_model(sheets=_fake_sheets(addr=empty_addr)), "calc", None, True)
+    mock_read.return_value = [[{"value": None}]]
+
+    try:
+        _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Actuals")
+    except ToolExecutionError as exc:
+        msg = str(exc)
+        assert "budget.xlsx" in msg
+        assert "Actuals" in msg
+        assert "empty" in msg.lower()
+    else:
+        raise AssertionError("expected ToolExecutionError for empty used range")
+
+
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_preload_path_ships_used_range_grid(
+    mock_resolve, mock_run, mock_exec, _mock_close, mock_open, mock_read, tmp_path
+):
+    """End-to-end host preload: fixture files + used-range, no giant padding."""
+    xlsx, ods = _write_office_fixtures(tmp_path)
+    (tmp_path / "sales.csv").write_text("region,amount\nNorth,1\n")
+    mock_resolve.return_value = str(tmp_path)
+    mock_open.return_value = (_fake_model(), "calc", None, True)
+    mock_read.side_effect = _grid_for_requested_range
+    mock_run.return_value = {"status": "ok", "total_rows": 1}
+    mock_exec.side_effect = lambda fn: fn()
+
+    t = QueryFolderSqlTool()
+    res = t.execute(
+        _mk_ctx(),
+        sql="SELECT * FROM budget",
+        files=["sales.csv", "budget.xlsx#Actuals", "ledger.ods"],
+    )
+    assert res["status"] == "ok"
+
+    pre = mock_run.call_args.kwargs.get("preloaded") or {}
+    assert "budget.xlsx" in pre
+    assert "ledger.ods" in pre
+    budget_grid = pre["budget.xlsx"]["grid"]
+    assert len(budget_grid) == 2
+    assert len(budget_grid[0]) == 2
+    assert budget_grid[0] == ["Region", "Sales"]
+    for requested in (c[0][0] for c in mock_read.call_args_list):
+        assert "AK2000" not in requested
+        assert "AZ5000" not in requested
+
+
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_preload_path_bad_sheet_hint_errors(
+    mock_resolve, mock_run, mock_exec, _mock_close, mock_open, mock_read, tmp_path
+):
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    mock_resolve.return_value = str(tmp_path)
+    mock_open.return_value = (_fake_model(), "calc", None, True)
+    mock_exec.side_effect = lambda fn: fn()
+
+    t = QueryFolderSqlTool()
+    res = t.execute(_mk_ctx(), sql="SELECT * FROM budget", files=[f"{xlsx.name}#MissingSheet"])
+
+    assert res["status"] == "error"
+    assert "budget.xlsx" in res["message"]
+    assert "MissingSheet" in res["message"]
+    mock_run.assert_not_called()
+    mock_read.assert_not_called()

--- a/tests/calc/test_duckdb_tools_uno.py
+++ b/tests/calc/test_duckdb_tools_uno.py
@@ -1,0 +1,154 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""UNO tests for DuckDB sibling spreadsheet used-range ingress."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import uno
+
+from plugin.calc.duckdb_tools import _read_sibling_office_file_as_grid
+from plugin.framework.errors import ToolExecutionError
+from plugin.testing_runner import native_test
+from plugin.tests.testing_utils import TestingFactory, with_native_doc
+from plugin.writer.format import create_property_value
+
+
+def _fill_offset_table(doc) -> None:
+    """Write a 2x2 table at C5 so A1:AK2000 would include huge empty padding."""
+    sheets = doc.getSheets()
+    if sheets.hasByName("Actuals"):
+        sheet = sheets.getByName("Actuals")
+    else:
+        sheets.insertNewByName("Actuals", 0)
+        sheet = sheets.getByName("Actuals")
+    sheet.getCellByPosition(2, 4).setString("Region")
+    sheet.getCellByPosition(3, 4).setString("Sales")
+    sheet.getCellByPosition(2, 5).setString("North")
+    sheet.getCellByPosition(3, 5).setValue(100)
+
+
+def _store_sibling(doc, path: str, *, xlsx: bool = False) -> None:
+    url = uno.systemPathToFileUrl(path)
+    if xlsx:
+        props = (create_property_value("FilterName", "Calc MS Excel 2007 XML"),)
+        doc.storeToURL(url, props)
+    else:
+        doc.storeAsURL(url, ())
+
+
+def _cleanup_dir(temp_dir: str) -> None:
+    if not temp_dir or not os.path.isdir(temp_dir):
+        return
+    for name in os.listdir(temp_dir):
+        try:
+            os.remove(os.path.join(temp_dir, name))
+        except OSError:
+            pass
+    try:
+        os.rmdir(temp_dir)
+    except OSError:
+        pass
+
+
+@native_test
+@with_native_doc("calc")
+def test_sibling_ods_used_range_is_tight(ctx, doc):
+    temp_dir = tempfile.mkdtemp(prefix="wa_duckdb_sib_")
+    sibling = TestingFactory.create_native_doc(ctx, "calc", hidden=True)
+    try:
+        _fill_offset_table(sibling)
+        ods_path = os.path.join(temp_dir, "budget.ods")
+        _store_sibling(sibling, ods_path)
+        TestingFactory.close_doc(sibling)
+        sibling = None
+
+        _tbl, grid = _read_sibling_office_file_as_grid(ctx, ods_path, sheet_hint="Actuals")
+        assert len(grid) == 2, f"used-range padded rows: {len(grid)}"
+        assert len(grid[0]) == 2, f"used-range padded cols: {len(grid[0])}"
+        assert grid[0][0] == "Region"
+        assert grid[0][1] == "Sales"
+        assert grid[1][0] == "North"
+        assert grid[1][1] == 100
+    finally:
+        if sibling is not None:
+            TestingFactory.close_doc(sibling)
+        _cleanup_dir(temp_dir)
+
+
+@native_test
+@with_native_doc("calc")
+def test_sibling_xlsx_used_range_is_tight(ctx, doc):
+    temp_dir = tempfile.mkdtemp(prefix="wa_duckdb_sibx_")
+    sibling = TestingFactory.create_native_doc(ctx, "calc", hidden=True)
+    try:
+        _fill_offset_table(sibling)
+        xlsx_path = os.path.join(temp_dir, "budget.xlsx")
+        _store_sibling(sibling, xlsx_path, xlsx=True)
+        TestingFactory.close_doc(sibling)
+        sibling = None
+
+        _tbl, grid = _read_sibling_office_file_as_grid(ctx, xlsx_path, sheet_hint="Actuals")
+        assert len(grid) == 2, f"used-range padded rows: {len(grid)}"
+        assert len(grid[0]) == 2, f"used-range padded cols: {len(grid[0])}"
+        assert grid[0] == ["Region", "Sales"] or grid[0][0] == "Region"
+        assert grid[1][0] == "North"
+    finally:
+        if sibling is not None:
+            TestingFactory.close_doc(sibling)
+        _cleanup_dir(temp_dir)
+
+
+@native_test
+@with_native_doc("calc")
+def test_sibling_bad_sheet_hint_errors(ctx, doc):
+    temp_dir = tempfile.mkdtemp(prefix="wa_duckdb_hint_")
+    sibling = TestingFactory.create_native_doc(ctx, "calc", hidden=True)
+    try:
+        _fill_offset_table(sibling)
+        ods_path = os.path.join(temp_dir, "budget.ods")
+        _store_sibling(sibling, ods_path)
+        TestingFactory.close_doc(sibling)
+        sibling = None
+
+        try:
+            _read_sibling_office_file_as_grid(ctx, ods_path, sheet_hint="MissingSheet")
+        except ToolExecutionError as exc:
+            msg = str(exc)
+            assert "budget.ods" in msg
+            assert "MissingSheet" in msg
+        else:
+            raise AssertionError("missing #SheetName hint must fail loud")
+    finally:
+        if sibling is not None:
+            TestingFactory.close_doc(sibling)
+        _cleanup_dir(temp_dir)
+
+
+@native_test
+@with_native_doc("calc")
+def test_sibling_empty_sheet_errors(ctx, doc):
+    temp_dir = tempfile.mkdtemp(prefix="wa_duckdb_empty_")
+    sibling = TestingFactory.create_native_doc(ctx, "calc", hidden=True)
+    try:
+        ods_path = os.path.join(temp_dir, "empty.ods")
+        _store_sibling(sibling, ods_path)
+        TestingFactory.close_doc(sibling)
+        sibling = None
+
+        try:
+            _read_sibling_office_file_as_grid(ctx, ods_path)
+        except ToolExecutionError as exc:
+            msg = str(exc).lower()
+            assert "empty.ods" in str(exc)
+            assert "empty" in msg
+        else:
+            raise AssertionError("empty used-range must fail loud")
+    finally:
+        if sibling is not None:
+            TestingFactory.close_doc(sibling)
+        _cleanup_dir(temp_dir)

--- a/tests/scripting/test_duckdb_sql.py
+++ b/tests/scripting/test_duckdb_sql.py
@@ -99,6 +99,21 @@ def test_query_folder_sql_requires_scoped_and_files(tmp_path):
     assert "NO_ALLOWED" in res.get("code", "") or "allowed" in res.get("message", "").lower()
 
 
+def test_query_folder_sql_preloaded_compact_grid(tmp_path):
+    """Host used-range path ships a tight grid; worker must register it as-is (no padding)."""
+    grid = [["Region", "Sales"], ["North", 100], ["South", 200]]
+    res = query_folder_sql(
+        str(tmp_path),
+        "SELECT Region, Sales FROM budget ORDER BY 1",
+        files=None,
+        preloaded={"budget": {"grid": grid, "headers": True}},
+    )
+    assert res["status"] == "ok", res
+    assert res["total_rows"] == 2
+    assert len(res["columns"]) == 2
+    assert not any(len(row) > 2 for row in res["rows"])
+
+
 def _pretty_demo_sales_grid():
     from scripts.generate_pretty_demo_spreadsheet import get_sales_dataset
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal
Make DuckDB sibling spreadsheet ingress correct: real used-range reads, loud failures, and tests that would catch a regression to giant fixed ranges or a silent skip.

## What changed
- **`_read_sibling_office_file_as_grid`** no longer hardcodes `A1:AK2000` / `A1:AZ5000`. It reuses the same used-area cursor as `SheetAnalyzer` / `ingest._used_range_address` (`createCursor` + `gotoStartOfUsedArea` + `gotoEndOfUsedArea`), then `CellInspector.read_range` on a sheet-qualified A1 range.
- **Fail loud:** LibreOffice open failure, missing `#SheetName` hint, or empty/unusable used-range now raise a `ToolExecutionError` that names the file and sheet. The host loop no longer treats `(None, None)` as “skip and hope SQL works.”
- Multi-file loop is unchanged: each sibling still opens one-by-one on the main thread and registers under the dict name / basename.
- **ODS mtime cache is not implemented** (correctness first; still pending in the plan).

## Rebase
Rebased onto current `master` after #594. Pretty-demo section, changelog row, and `query_folder_sql` pretty-demo tests are kept; used-range limitations note, compact-grid worker test, and fail-loud host path are unchanged.

## Tests
- Fixture xlsx/ods (generated in tmp) through the preload path.
- Used-range mock sizes the grid to the *requested* A1 range, so a return to `A1:AK2000` would ship huge empty padding and fail.
- Bad sheet hint, open failure, and empty used-range must error; SQL is not started.
- Dead `or True` assert in `tests/calc/test_duckdb_tools.py` replaced with real flat-file / preloaded checks.
- Worker test for a compact preloaded grid.
- UNO tests for real ODS/XLSX used-range tightness, missing sheet hint, and empty sheet.

## Docs
`docs/calc/duckdb-dev-plan.md` limitations: used-range is fixed; ODS cache still pending. Pretty-demo section from #594 retained.

## Out of scope
- Pretty demo / ACS zip_income / PR 594 work (already on master; kept, not reworked).
- Phase D shared kernel.
- Replacing the substring SQL read-only firewall.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b96a7450-2ee8-446f-8e82-343a6898d7fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b96a7450-2ee8-446f-8e82-343a6898d7fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

