### PR TITLE
Add stable sheet/named-range identity for DuckDB table sources

### DIFF
--- a/docs/calc/analysis-tools.md
+++ b/docs/calc/analysis-tools.md
@@ -14,7 +14,8 @@ Previously, tools lived under the **`analysis`** specialized domain (`delegate_t
 
 See [specialized-toolsets.md](specialized-toolsets.md) for delegation mechanics and [Analysis Sub-Agent](analysis-sub-agent.md) for the broader plan. DuckDB SQL support (up to Phase C): 
 - `query_folder_sql` for folder files (CSV/Parquet/JSON direct + .xlsx/.ods via LO import) and/or live ranges.
-- Use `tables` (named ranges), `files` (list or named dict), `data_range` (single range → 'data' table).
+- Use `tables` with a **stable identity**: `{sheet: "Sales"}` (used range), `{named_range: "SalesData"}` (named or database range), or frozen `{range: "Sales.A1:F500"}`. Sibling sheet: `files={"sales": "budget.xlsx#Sales"}` (dict key is the SQL table). See [duckdb-dev-plan.md § Table source identity](duckdb-dev-plan.md#table-source-identity).
+- `data_range` is still frozen A1 → table `data`.
 - Available in analysis domain chat or Run Python Script → SQL Helpers.
 Full plan and status: [duckdb-dev-plan.md](duckdb-dev-plan.md).
 

--- a/docs/calc/duckdb-dev-plan.md
+++ b/docs/calc/duckdb-dev-plan.md
@@ -60,12 +60,12 @@ That writes the ODS/XLSX and copies `zip_income.csv` next to them. Happy-path pr
 
 ### Current Implementation (as of latest increment)
 - Core: `query_folder_sql` in venv (supports `sql`, legacy `files` list, `preloaded` grids, `flat_files` for named direct reads).
-- Tool: `query_folder_sql` (analysis domain) accepts `sql`, `files` (list or `{name: spec}`), `tables` (named ranges on active doc), `data_range`, `headers`.
+- Tool: `query_folder_sql` (analysis domain) accepts `sql`, `files` (list or `{name: spec}`), `tables` (stable sheet / named-range / frozen A1 identity), `data_range`, `headers`.
 - Host handles: scoped dir resolution, hidden LO opens for .xlsx/.ods, active doc reads for ranges, size limits, preloading.
 - Worker: registers preloaded via `coerce_to_dataframe`, flat files via `read_csv`/`read_parquet` etc. under provided names. Read-only guards.
 - Templates: `[SQL] query_folder_sql` and `query_sheet_sql` in Run Python Script.
 - Limitations: no write-back, no shared kernel cache yet, default first sheet for office files when `#SheetName` is omitted. Sibling `.xlsx`/`.ods` now read the sheet **used range** (same `createCursor` / `gotoStartOfUsedArea` / `gotoEndOfUsedArea` path as `SheetAnalyzer` / ingest) — open / missing-sheet / empty-range failures are tool errors. ODS mtime cache (`writeragent_ods_cache/`) is still pending.
-- Usage: Mix tables + files for joins, e.g. live ranges + sibling CSVs. See tool parameters and plan for request shapes.
+- Usage: Mix tables + files for joins, e.g. live sheet identity + sibling CSVs. See [Table source identity](#table-source-identity).
 
 **Audience:** Product, senior engineers, and future implementers. This doc captures why DuckDB fits WriterAgent, what users get, and how to build on existing Calc↔venv infrastructure without a new architectural pillar.
 
@@ -291,8 +291,8 @@ Folder discovery aligns with [document research](../chat/multi-document-dev-plan
 ```json
 {
   "tables": {
-    "sales": {"range": "Sales.A1:F500", "headers": true},
-    "costs": {"range": "Costs.A1:D200", "headers": true}
+    "sales": {"sheet": "Sales", "headers": true},
+    "costs": {"named_range": "CostData", "headers": true}
   },
   "files": {
     "ledger": "ledger.parquet"
@@ -301,6 +301,8 @@ Folder discovery aligns with [document research](../chat/multi-document-dev-plan
   "sql": "SELECT s.region, SUM(s.amount) - SUM(c.cost) FROM sales s JOIN costs c ON ..."
 }
 ```
+
+Frozen A1 (`{"range": "Sales.A1:F500"}`) remains valid. Prefer `sheet` / `named_range` so the catalog does not drift — see [Table source identity](#table-source-identity).
 
 **Host responsibilities:**
 
@@ -317,6 +319,38 @@ Folder discovery aligns with [document research](../chat/multi-document-dev-plan
 - LLM-generated SQL injection: prefer host-supplied table **names** only; validate SQL is read-only.
 
 **Implementation note:** Host (tool) resolves all UNO-dependent data (ranges + office files) into `preloaded` + `flat_files`; worker registers by name and executes. `tables` + `files` (as dict) now supported in the tool. Legacy paths preserved.
+
+### Table source identity {#table-source-identity}
+
+The catalog stores **identity**, not expanded A1. Host resolves bounds **at read time** so a later insert/append does not require rewriting the catalog.
+
+| Spec | Meaning | Grows when |
+|------|---------|------------|
+| `{sheet: "Sales_Analytics"}` | Used range of that sheet on the active workbook | Rows/cols are added inside the used area |
+| `{named_range: "SalesData"}` | Calc **named range** or **database range** (current referred / data-area bounds) | The name’s definition expands (Calc updates named refs on insert; or the user edits the name) |
+| `{range: "Sales.A1:F500"}` | Frozen absolute A1 (also `Sheet.A1:F500`) | Never — leftover from Phase C; still accepted |
+| `{file: "budget.xlsx", sheet: "Sales"}` or `{file: "budget.xlsx#Sales"}` | Same sheet used-range identity on a **sibling** workbook | Same as `{sheet}` on that file |
+| `files={"sales": "budget.xlsx#Sales"}` | Same sibling sheet used-range; **dict key is the SQL table name** | Same as `{sheet}` |
+
+Bare string `tables={"sales": "Sales.A1:F500"}` is still `{range}`. `data_range` still becomes table `data` with frozen A1 — prefer `tables={data: {sheet}}` or `{named_range}` for a stable id.
+
+**Do not** store the resolved `C5:J40` back into the catalog. Re-query with the same `{sheet}` / `{named_range}` after the sheet grows.
+
+```json
+{
+  "tables": {
+    "sales": {"sheet": "Sales_Analytics"},
+    "costs": {"named_range": "CostData"}
+  },
+  "files": {
+    "income": "zip_income.csv",
+    "budget": "budget.xlsx#Actuals"
+  },
+  "sql": "SELECT s.region, SUM(s.amount) FROM sales s GROUP BY 1"
+}
+```
+
+Exactly one of `sheet`, `named_range`, or `range` per `tables` entry (a sibling `file` alone means first-sheet used range). Missing sheet / name / empty used-range fail loud.
 
 ---
 
@@ -435,3 +469,4 @@ No cloud telemetry required. Suggested signals:
 | 2026-09-05 | SQL_DuckDB live RESULTS `=PY()` formulas quote SQL with Python single quotes inside the formula `"…"` payload. Triple-double quotes closed the formula string early (Calc Err:508). |
 | 2026-09-05 | SQL_DuckDB RESULTS are formula-safe: SQL lives only in cells; the `=PY()` payload is a short runner that reads `data[1]` (SQL cell/range) plus `data[0]` (sheet range). |
 | 2026-09-05 | SQL_DuckDB sheet-only RESULTS leave 15 empty rows × 5 cols under the formula so a Region×Category spill (header+12) does not `#SPILL!` into the next section title. The live RESULTS formula cell is unmerged (no ODS `span_cols` / XLSX A:H) so spill targets are real cells. |
+| 2026-09-05 | Stable table identity: `{sheet}` (used range), `{named_range}` (named or database range), sibling `file.xlsx#Sheet` / `files={name: "file.xlsx#Sheet"}`. Frozen `{range: A1}` kept. Catalog does not store expanded A1. |

--- a/plugin/calc/duckdb_tools.py
+++ b/plugin/calc/duckdb_tools.py
@@ -10,12 +10,13 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
+from plugin.calc.address_utils import split_sheet_prefix
 from plugin.calc.base import ToolCalcAnalysisBase
+from plugin.calc.calc_addin_data import check_python_data_size
 from plugin.doc.document_research import get_document_directory, resolve_listing_directory, open_document_for_read, close_document_research_document
 from plugin.framework.errors import ToolExecutionError
 from plugin.framework.queue_executor import execute_on_main_thread
 from plugin.scripting.config_limits import configured_python_max_data_cells
-from plugin.calc.calc_addin_data import check_python_data_size
 
 if TYPE_CHECKING:
     from plugin.framework.tool import ToolContext
@@ -24,41 +25,70 @@ log = logging.getLogger("writeragent.calc.duckdb")
 
 
 class QueryFolderSqlTool(ToolCalcAnalysisBase):
-    """Run read-only SQL (DuckDB) over folder files and/or live active sheet ranges.
+    """Run read-only SQL (DuckDB) over folder files and/or live Calc table sources.
 
-    Supports files (direct + LO for spreadsheets) and data_range (active sheet -> table 'data').
-    Lives under analysis domain. Host performs all UNO reads and validation; worker registers tables
-    and executes read-only SQL.
+    ``tables`` catalog entries store a *stable identity* (sheet name, named /
+    database range, or frozen A1) — not expanded used-range bounds. Host
+    resolves bounds at read time so a later insert/append does not require
+    rewriting the catalog. Sibling ``files={"sales": "budget.xlsx#Sales"}``
+    is the same sheet used-range identity; the dict key is the SQL table name.
     """
 
     name = "query_folder_sql"
     description = (
         "Run read-only SQL (via DuckDB) against folder files and/or live Calc ranges (Phase C multi-table). "
-        "Use tables={name: {range, headers}} for multiple named ranges from active doc. "
-        "files as list or {name: spec} for folder. "
-        "Tables registered by name (FROM sales etc). Host prepares all UNO data + validates."
+        "Prefer stable table identity: tables={name: {sheet: \"Sales_Analytics\"}} (sheet used range) "
+        "or {named_range: \"SalesData\"} (Calc named/database range). "
+        "Absolute range: {range: \"Sales.A1:F500\"} stays frozen A1. "
+        "Sibling sheet used-range: files={name: \"budget.xlsx#Sales\"} (dict key is the SQL table). "
+        "Optional tables file=\"budget.xlsx\" reads that sibling instead of the active doc. "
+        "Host prepares all UNO data + validates."
     )
     parameters = {
         "type": "object",
         "properties": {
-            "sql": {"type": "string", "description": "The SQL query. Use FROM data for active sheet range, or FROM 'file.csv' / 'budget.xlsx' for folder files."},
+            "sql": {"type": "string", "description": "The SQL query. Use FROM data for active sheet range, or FROM 'file.csv' / registered table names for folder files."},
             "files": {
                 "type": "object",
                 "additionalProperties": {"type": "string"},
-                "description": "Folder files as name -> basename/spec (e.g. {\"ledger\": \"ledger.parquet\"}). A list of basenames is still accepted. Office files auto-preloaded with name as table.",
+                "description": (
+                    "Folder files as name -> basename/spec. "
+                    "Sibling spreadsheet used-range: {\"sales\": \"budget.xlsx#Sales\"} "
+                    "(#SheetName is the sheet identity; the dict key is the SQL table). "
+                    "A list of basenames is still accepted."
+                ),
             },
-            "data_range": {"type": "string", "description": "A1 range on the active sheet (e.g. 'Sheet1.A1:F500' or 'A1:D100'). Becomes table 'data' (use headers param)."},
+            "data_range": {"type": "string", "description": "Frozen A1 on the active sheet (e.g. 'Sheet1.A1:F500'). Becomes table 'data'. Prefer tables={data: {sheet}} or {named_range} for stable identity."},
             "headers": {"type": "boolean", "description": "First row of data_range (or preloaded) contains column headers (default true)."},
             "tables": {
                 "type": "object",
                 "additionalProperties": {
                     "type": "object",
                     "properties": {
-                        "range": {"type": "string"},
-                        "headers": {"type": "boolean"}
-                    }
+                        "sheet": {
+                            "type": "string",
+                            "description": "Sheet name: register that sheet's used range (resolved at read time).",
+                        },
+                        "named_range": {
+                            "type": "string",
+                            "description": "Calc named range or database range; current referred bounds at read time.",
+                        },
+                        "range": {
+                            "type": "string",
+                            "description": "Frozen absolute A1 (e.g. 'Sales.A1:F500'). Does not grow with inserts.",
+                        },
+                        "file": {
+                            "type": "string",
+                            "description": "Sibling workbook basename, optionally #SheetName (budget.xlsx#Sales).",
+                        },
+                        "headers": {"type": "boolean"},
+                    },
                 },
-                "description": "Multi-table catalog for Phase C: named ranges from active doc. e.g. {\"sales\": {\"range\": \"Sales.A1:F500\", \"headers\": true}, \"costs\": {\"range\": \"Costs.A1:D200\"}}. Mix with files."
+                "description": (
+                    "Multi-table catalog. Exactly one identity per entry: sheet, named_range, or range. "
+                    "e.g. {\"sales\": {\"sheet\": \"Sales_Analytics\"}, \"costs\": {\"named_range\": \"CostData\"}}. "
+                    "Mix with files."
+                ),
             },
             "task_hint": {"type": "string", "description": "Optional hint for logging/context."},
         },
@@ -103,25 +133,22 @@ class QueryFolderSqlTool(ToolCalcAnalysisBase):
             direct_files: list[str] = []
             flat_files: dict[str, str] = {}
 
-            # Phase C: named tables from ranges on the *active/current* document (multi supported)
+            # Catalog stores identity (sheet / named_range / frozen A1), not
+            # expanded used-range. Bounds are resolved at read time below.
             for tbl_name, spec in (tables or {}).items():
                 if not tbl_name:
                     continue
-                rng = spec.get("range") if isinstance(spec, dict) else spec
-                th = bool(spec.get("headers", headers)) if isinstance(spec, dict) else headers
-                if not rng:
-                    continue
                 try:
-                    from plugin.calc.inspector import CellInspector
-                    from plugin.calc.bridge import CalcBridge
-                    from plugin.calc.calc_addin_data import values_from_inspector_range
-                    bridge = CalcBridge(ctx.doc)
-                    inspector = CellInspector(bridge)
-                    raw = inspector.read_range(str(rng))
-                    grid = values_from_inspector_range(raw)
-                    preloaded[tbl_name] = {"grid": grid, "headers": th}
+                    parsed = parse_table_source_spec(spec, default_headers=headers)
+                    grid = read_table_source_grid(ctx.ctx, ctx.doc, scoped, parsed)
+                    preloaded[str(tbl_name)] = {"grid": grid, "headers": bool(parsed["headers"])}
+                except ToolExecutionError as exc:
+                    return self._tool_error(
+                        f"Failed to read table '{tbl_name}': {exc}",
+                        code=getattr(exc, "code", "DUCKDB_SQL_ERROR"),
+                    )
                 except Exception as e:
-                    return self._tool_error(f"Failed to read table '{tbl_name}' range '{rng}': {e}")
+                    return self._tool_error(f"Failed to read table '{tbl_name}': {e}")
 
             # Separate direct DuckDB-readable files from office files that need LO import.
             # Support "file.xlsx" or "file.xlsx#SheetName" syntax for sheets.
@@ -207,6 +234,285 @@ def _grid_has_usable_values(grid: list[list[Any]] | None) -> bool:
     return False
 
 
+def _sanitize_sql_table_name(raw: str) -> str:
+    tbl_name = "".join(c if c.isalnum() or c in "_$" else "_" for c in raw)
+    if not tbl_name or tbl_name[0].isdigit():
+        return "sheet_" + tbl_name
+    return tbl_name
+
+
+def parse_table_source_spec(spec: Any, *, default_headers: bool = True) -> dict[str, Any]:
+    """Normalize a ``tables`` catalog entry to a source identity.
+
+    The catalog stores identity — sheet name, named/database range, or frozen
+    A1 — not the expanded used-range. Read-time helpers resolve current bounds
+    so callers can re-query after rows/columns are inserted without rewriting
+    A1 in the catalog.
+
+    Exactly one of ``sheet``, ``named_range``, or ``range`` is required, except
+    a sibling ``file`` alone (or ``file.xlsx#Sheet``) which means that sheet's
+    used range.
+    """
+    if isinstance(spec, str):
+        spec = {"range": spec}
+    if not isinstance(spec, dict):
+        raise ToolExecutionError(
+            f"Table spec must be a string range or an object with sheet, "
+            f"named_range, or range; got {type(spec).__name__}",
+            code="DUCKDB_SQL_ERROR",
+        )
+
+    headers = bool(spec.get("headers", default_headers))
+    file_spec = str(spec.get("file") or "").strip() or None
+    sheet = str(spec.get("sheet") or "").strip() or None
+    named_range = str(spec.get("named_range") or "").strip() or None
+    range_a1 = str(spec.get("range") or "").strip() or None
+
+    # Sibling shorthand: budget.xlsx#Sales is sheet used-range identity.
+    if file_spec and "#" in file_spec:
+        file_part, sheet_part = file_spec.rsplit("#", 1)
+        file_spec = os.path.basename(file_part.strip()) or None
+        hash_sheet = sheet_part.strip() or None
+        if hash_sheet:
+            if sheet and sheet != hash_sheet:
+                raise ToolExecutionError(
+                    f"Table spec file {file_spec!r}# sheet {hash_sheet!r} "
+                    f"disagrees with sheet {sheet!r}",
+                    code="DUCKDB_SQL_ERROR",
+                )
+            sheet = hash_sheet
+    elif file_spec:
+        file_spec = os.path.basename(file_spec)
+
+    present: list[str] = []
+    if sheet:
+        present.append("sheet")
+    if named_range:
+        present.append("named_range")
+    if range_a1:
+        present.append("range")
+
+    if len(present) > 1:
+        raise ToolExecutionError(
+            f"Table spec must use exactly one of sheet, named_range, or range "
+            f"(got {', '.join(present)})",
+            code="DUCKDB_SQL_ERROR",
+        )
+    if not present:
+        if file_spec:
+            kind = "sheet"
+        else:
+            raise ToolExecutionError(
+                "Table spec needs sheet (used range), named_range, or range (absolute A1)",
+                code="DUCKDB_SQL_ERROR",
+            )
+    else:
+        kind = present[0]
+
+    return {
+        "kind": kind,
+        "sheet": sheet,
+        "named_range": named_range,
+        "range": range_a1,
+        "file": file_spec,
+        "headers": headers,
+    }
+
+
+def _container_element_names(container: Any) -> list[str]:
+    if container is None or not hasattr(container, "getElementNames"):
+        return []
+    try:
+        return [str(n) for n in container.getElementNames()]
+    except Exception:
+        return []
+
+
+def _available_named_sources(doc: Any) -> str:
+    named = _container_element_names(getattr(doc, "NamedRanges", None))
+    db_ranges = _container_element_names(getattr(doc, "DatabaseRanges", None))
+    parts: list[str] = []
+    if named:
+        parts.append(", ".join(named))
+    if db_ranges:
+        parts.append(", ".join(f"{n} (database)" for n in db_ranges))
+    return "; ".join(parts)
+
+
+def _lookup_named_range_object(doc: Any, name: str) -> Any | None:
+    """Find a Calc NamedRange by name (global, sheet-qualified, or active-sheet local)."""
+    prefix, bare = split_sheet_prefix(name)
+
+    if prefix and hasattr(doc, "getSheets"):
+        sheets = doc.getSheets()
+        if sheets.hasByName(prefix):
+            sheet = sheets.getByName(prefix)
+            nrs = getattr(sheet, "NamedRanges", None)
+            if nrs is not None and nrs.hasByName(bare):
+                return nrs.getByName(bare)
+
+    nrs = getattr(doc, "NamedRanges", None)
+    if nrs is not None:
+        if nrs.hasByName(name):
+            return nrs.getByName(name)
+        if bare != name and nrs.hasByName(bare):
+            return nrs.getByName(bare)
+
+    try:
+        controller = doc.getCurrentController()
+        if controller is not None and hasattr(controller, "getActiveSheet"):
+            sheet = controller.getActiveSheet()
+            local = getattr(sheet, "NamedRanges", None)
+            if local is not None:
+                if local.hasByName(name):
+                    return local.getByName(name)
+                if local.hasByName(bare):
+                    return local.getByName(bare)
+    except Exception:
+        pass
+    return None
+
+
+def _lookup_database_range_object(doc: Any, name: str) -> Any | None:
+    dbrs = getattr(doc, "DatabaseRanges", None)
+    if dbrs is None or not hasattr(dbrs, "hasByName"):
+        return None
+    bare = split_sheet_prefix(name)[1]
+    for candidate in (name, bare):
+        if candidate and dbrs.hasByName(candidate):
+            return dbrs.getByName(candidate)
+    return None
+
+
+def _range_address_to_qualified_a1(doc: Any, addr: Any) -> str:
+    from plugin.calc.spreadsheet_import.ingest import used_range_string_from_address
+
+    sheet_idx = int(getattr(addr, "Sheet", 0))
+    sheet_name = str(doc.getSheets().getByIndex(sheet_idx).getName())
+    return _sheet_qualified_a1(sheet_name, used_range_string_from_address(addr))
+
+
+def used_range_qualified_a1(sheet: Any) -> str:
+    """Sheet used-range as sheet-qualified A1 (resolved now, not stored)."""
+    from plugin.calc.spreadsheet_import.ingest import _used_range_address, used_range_string_from_address
+
+    addr = _used_range_address(sheet)
+    return _sheet_qualified_a1(str(sheet.getName()), used_range_string_from_address(addr))
+
+
+def _named_object_to_qualified_a1(doc: Any, obj: Any, *, label: str) -> str:
+    addr = None
+    if hasattr(obj, "getReferredCells"):
+        try:
+            cells = obj.getReferredCells()
+        except Exception:
+            cells = None
+        if cells is not None and hasattr(cells, "getRangeAddress"):
+            addr = cells.getRangeAddress()
+    if addr is None and hasattr(obj, "getDataArea"):
+        try:
+            addr = obj.getDataArea()
+        except Exception:
+            addr = None
+    if addr is None:
+        raise ToolExecutionError(
+            f"{label} does not refer to a cell range",
+            code="DUCKDB_SQL_ERROR",
+        )
+    return _range_address_to_qualified_a1(doc, addr)
+
+
+def resolve_table_source_a1(model: Any, parsed: dict[str, Any]) -> str:
+    """Resolve a parsed identity to sheet-qualified A1 at read time.
+
+    Sheet → current used range. named_range → current NamedRanges /
+    DatabaseRanges bounds. range → the frozen A1 the caller stored.
+    """
+    from plugin.calc.bridge import CalcBridge
+
+    kind = parsed.get("kind")
+    if kind == "sheet":
+        bridge = CalcBridge(model)
+        sheet_name = parsed.get("sheet")
+        if sheet_name:
+            try:
+                target = bridge.get_sheet(str(sheet_name))
+            except ValueError as exc:
+                raise ToolExecutionError(str(exc), code="DUCKDB_SQL_ERROR") from exc
+        else:
+            sheets = model.getSheets()
+            if sheets.getCount() < 1:
+                raise ToolExecutionError("workbook has no sheets", code="DUCKDB_SQL_ERROR")
+            target = sheets.getByIndex(0)
+        return used_range_qualified_a1(target)
+
+    if kind == "named_range":
+        name = str(parsed.get("named_range") or "")
+        nr = _lookup_named_range_object(model, name)
+        if nr is not None:
+            return _named_object_to_qualified_a1(model, nr, label=f"Named range {name!r}")
+        dbr = _lookup_database_range_object(model, name)
+        if dbr is not None:
+            return _named_object_to_qualified_a1(model, dbr, label=f"Database range {name!r}")
+        available = _available_named_sources(model)
+        extra = f" Available: {available}" if available else ""
+        raise ToolExecutionError(
+            f"No named range or database range named {name!r}.{extra}",
+            code="DUCKDB_SQL_ERROR",
+        )
+
+    if kind == "range":
+        return str(parsed.get("range") or "")
+
+    raise ToolExecutionError(f"Unknown table identity {kind!r}", code="DUCKDB_SQL_ERROR")
+
+
+def read_model_table_grid(model: Any, parsed: dict[str, Any]) -> list[list[Any]]:
+    """Read values for a parsed identity from an already-open Calc model."""
+    from plugin.calc.bridge import CalcBridge
+    from plugin.calc.calc_addin_data import values_from_inspector_range
+    from plugin.calc.inspector import CellInspector
+
+    qualified = resolve_table_source_a1(model, parsed)
+    inspector = CellInspector(CalcBridge(model))
+    raw = inspector.read_range(qualified)
+    return values_from_inspector_range(raw)
+
+
+def read_table_source_grid(
+    ctx: Any,
+    active_doc: Any,
+    scoped_dir: str | None,
+    parsed: dict[str, Any],
+) -> list[list[Any]]:
+    """Read a catalog entry: active doc, or sibling ``file`` opened hidden."""
+    file_bn = parsed.get("file")
+    if not file_bn:
+        grid = read_model_table_grid(active_doc, parsed)
+        if parsed.get("kind") in ("sheet", "named_range") and not _grid_has_usable_values(grid):
+            raise ToolExecutionError(
+                f"Table identity {parsed.get('kind')} resolved to an empty range; "
+                "nothing to register for SQL",
+                code="DUCKDB_SQL_ERROR",
+            )
+        return grid
+
+    full_path = os.path.join(scoped_dir, str(file_bn)) if scoped_dir else str(file_bn)
+    if not os.path.isfile(full_path):
+        raise ToolExecutionError(
+            f"Sibling spreadsheet {file_bn!r} not found under the document folder",
+            code="DUCKDB_SQL_ERROR",
+        )
+    _tbl, grid = _read_sibling_office_file_as_grid(
+        ctx,
+        full_path,
+        sheet_hint=parsed.get("sheet"),
+        named_range=parsed.get("named_range"),
+        range_a1=parsed.get("range"),
+    )
+    return grid
+
+
 def _sheet_qualified_a1(sheet_name: str, range_str: str) -> str:
     """Qualify an A1 range so CellInspector hits *sheet_name* without setActiveSheet.
 
@@ -225,22 +531,49 @@ def _sibling_office_error(full_path: str, message: str, *, sheet: str | None = N
     return ToolExecutionError(f"Sibling spreadsheet {bn!r}: {message}", code=code)
 
 
-def _read_sibling_office_file_as_grid(ctx: Any, full_path: str, sheet_hint: str | None = None) -> tuple[str, list[list[Any]]]:
-    """Open a sibling .xlsx/.ods hidden+readonly and read the sheet used range.
+def _read_sibling_office_file_as_grid(
+    ctx: Any,
+    full_path: str,
+    sheet_hint: str | None = None,
+    *,
+    named_range: str | None = None,
+    range_a1: str | None = None,
+) -> tuple[str, list[list[Any]]]:
+    """Open a sibling .xlsx/.ods hidden+readonly and read a table identity.
 
-    *sheet_hint* is the optional ``#SheetName`` from the files spec.
-    Returns ``(table_name, grid)``. Raises ``ToolExecutionError`` on open,
-    missing sheet, or empty/unusable used-range — never ``(None, None)``.
-
-    Used-range uses the same ``createCursor`` + ``gotoStart/EndOfUsedArea``
-    path as ``SheetAnalyzer`` / ``ingest._used_range_address``. The previous
-    hardcoded ``A1:AK2000`` / ``A1:AZ5000`` fallback padded most tables with
-    thousands of empty cells and hid open/sheet failures as a silent skip.
+    Default / ``#SheetName`` is that sheet's used range (same
+    ``createCursor`` + ``gotoStart/EndOfUsedArea`` path as ``SheetAnalyzer``).
+    ``named_range`` and ``range_a1`` are the same identities as the ``tables``
+    catalog. Returns ``(table_name, grid)``. Raises ``ToolExecutionError`` on
+    open, missing sheet/name, or empty/unusable used-range — never ``(None, None)``.
     """
-    from plugin.calc.bridge import CalcBridge
-    from plugin.calc.calc_addin_data import values_from_inspector_range
-    from plugin.calc.inspector import CellInspector
-    from plugin.calc.spreadsheet_import.ingest import _used_range_address, used_range_string_from_address
+    if named_range:
+        parsed: dict[str, Any] = {
+            "kind": "named_range",
+            "sheet": None,
+            "named_range": named_range,
+            "range": None,
+            "file": os.path.basename(full_path),
+            "headers": True,
+        }
+    elif range_a1:
+        parsed = {
+            "kind": "range",
+            "sheet": None,
+            "named_range": None,
+            "range": range_a1,
+            "file": os.path.basename(full_path),
+            "headers": True,
+        }
+    else:
+        parsed = {
+            "kind": "sheet",
+            "sheet": (sheet_hint or "").strip() or None,
+            "named_range": None,
+            "range": None,
+            "file": os.path.basename(full_path),
+            "headers": True,
+        }
 
     model = None
     opened_flag = False
@@ -251,39 +584,24 @@ def _read_sibling_office_file_as_grid(ctx: Any, full_path: str, sheet_hint: str 
         if doc_type != "calc":
             raise _sibling_office_error(full_path, f"not a spreadsheet (type={doc_type!r})")
 
-        bridge = CalcBridge(model)
-        sheets = model.getSheets()
-        if sheet_hint:
-            # CalcBridge.get_sheet lists available names — do not fall back to sheet 0.
-            try:
-                target_sheet = bridge.get_sheet(sheet_hint)
-            except ValueError as exc:
-                raise _sibling_office_error(full_path, str(exc), sheet=sheet_hint) from exc
-        else:
-            if sheets.getCount() < 1:
-                raise _sibling_office_error(full_path, "workbook has no sheets")
-            target_sheet = sheets.getByIndex(0)
-
-        sheet_name = str(target_sheet.getName())
-        addr = _used_range_address(target_sheet)
-        range_str = used_range_string_from_address(addr)
-        qualified = _sheet_qualified_a1(sheet_name, range_str)
-
-        inspector = CellInspector(bridge)
-        raw = inspector.read_range(qualified)
-        grid = values_from_inspector_range(raw)
-        if not _grid_has_usable_values(grid):
+        try:
+            grid = read_model_table_grid(model, parsed)
+        except ToolExecutionError as exc:
+            identity = parsed.get("sheet") or parsed.get("named_range")
             raise _sibling_office_error(
                 full_path,
-                f"used range {range_str} is empty; nothing to register for SQL",
-                sheet=sheet_name,
+                str(exc),
+                sheet=str(identity) if identity else None,
+            ) from exc
+        if parsed["kind"] in ("sheet", "named_range") and not _grid_has_usable_values(grid):
+            identity = parsed.get("named_range") or parsed.get("sheet") or os.path.basename(full_path)
+            raise _sibling_office_error(
+                full_path,
+                "used range is empty; nothing to register for SQL",
+                sheet=str(identity) if identity else None,
             )
 
-        tbl_name = os.path.splitext(os.path.basename(full_path))[0]
-        tbl_name = "".join(c if c.isalnum() or c in "_$" else "_" for c in tbl_name)
-        if not tbl_name or tbl_name[0].isdigit():
-            tbl_name = "sheet_" + tbl_name
-
+        tbl_name = _sanitize_sql_table_name(os.path.splitext(os.path.basename(full_path))[0])
         return tbl_name, grid
     except ToolExecutionError:
         raise

--- a/tests/calc/test_duckdb_tools.py
+++ b/tests/calc/test_duckdb_tools.py
@@ -14,6 +14,8 @@ from plugin.calc.address_utils import parse_range_string, split_sheet_prefix
 from plugin.calc.duckdb_tools import (
     QueryFolderSqlTool,
     _read_sibling_office_file_as_grid,
+    parse_table_source_spec,
+    resolve_table_source_a1,
 )
 from plugin.framework.errors import ToolExecutionError
 
@@ -86,12 +88,53 @@ def _fake_sheets(names: tuple[str, ...] = ("Actuals", "Summary"), addr=None):
     return Sheets()
 
 
-def _fake_model(sheets=None):
+def _named_container(items: dict | None = None):
+    items = items or {}
+
+    class Container:
+        def hasByName(self, name: str) -> bool:
+            return name in items
+
+        def getByName(self, name: str):
+            return items[name]
+
+        def getElementNames(self) -> tuple[str, ...]:
+            return tuple(items.keys())
+
+    return Container()
+
+
+def _fake_named_range(addr, *, sheet_idx: int = 0):
+    cells = SimpleNamespace(
+        getRangeAddress=lambda: SimpleNamespace(
+            Sheet=sheet_idx,
+            StartColumn=addr.StartColumn,
+            StartRow=addr.StartRow,
+            EndColumn=addr.EndColumn,
+            EndRow=addr.EndRow,
+        )
+    )
+    return SimpleNamespace(getReferredCells=lambda: cells, getDataArea=lambda: None)
+
+
+def _fake_database_range(addr, *, sheet_idx: int = 0):
+    data_area = SimpleNamespace(
+        Sheet=sheet_idx,
+        StartColumn=addr.StartColumn,
+        StartRow=addr.StartRow,
+        EndColumn=addr.EndColumn,
+        EndRow=addr.EndRow,
+    )
+    return SimpleNamespace(getReferredCells=lambda: None, getDataArea=lambda: data_area)
+
+
+def _fake_model(sheets=None, named_ranges=None, database_ranges=None):
     sheets = sheets or _fake_sheets()
     return SimpleNamespace(
         getSheets=lambda: sheets,
         getCurrentController=lambda: None,
-        NamedRanges=SimpleNamespace(hasByName=lambda _n: False),
+        NamedRanges=named_ranges if named_ranges is not None else _named_container(),
+        DatabaseRanges=database_ranges if database_ranges is not None else _named_container(),
     )
 
 
@@ -117,6 +160,11 @@ def test_query_folder_sql_tool_basic_schema():
     p = t.parameters
     assert "sql" in p["properties"]
     assert "sql" in p.get("required", [])
+    tbl_props = p["properties"]["tables"]["additionalProperties"]["properties"]
+    assert "sheet" in tbl_props
+    assert "named_range" in tbl_props
+    assert "range" in tbl_props
+    assert "file" in tbl_props
 
 
 def test_query_folder_sql_requires_sql():
@@ -365,3 +413,232 @@ def test_preload_path_bad_sheet_hint_errors(
     assert "MissingSheet" in res["message"]
     mock_run.assert_not_called()
     mock_read.assert_not_called()
+
+
+def test_parse_table_source_spec_identities():
+    sheet = parse_table_source_spec({"sheet": "Sales_Analytics", "headers": False})
+    assert sheet["kind"] == "sheet"
+    assert sheet["sheet"] == "Sales_Analytics"
+    assert sheet["range"] is None
+    assert sheet["headers"] is False
+
+    named = parse_table_source_spec({"named_range": "SalesData"})
+    assert named["kind"] == "named_range"
+    assert named["named_range"] == "SalesData"
+
+    frozen = parse_table_source_spec({"range": "Sales.A1:F500"})
+    assert frozen["kind"] == "range"
+    assert frozen["range"] == "Sales.A1:F500"
+
+    legacy = parse_table_source_spec("Costs.A1:D200")
+    assert legacy["kind"] == "range"
+    assert legacy["range"] == "Costs.A1:D200"
+
+    sibling = parse_table_source_spec({"file": "budget.xlsx#Sales"})
+    assert sibling["kind"] == "sheet"
+    assert sibling["sheet"] == "Sales"
+    assert sibling["file"] == "budget.xlsx"
+
+
+def test_parse_table_source_spec_rejects_mixed_or_empty():
+    try:
+        parse_table_source_spec({"sheet": "Sales", "range": "A1:B2"})
+    except ToolExecutionError as exc:
+        assert "exactly one" in str(exc)
+    else:
+        raise AssertionError("mixed sheet+range must fail")
+
+    try:
+        parse_table_source_spec({})
+    except ToolExecutionError as exc:
+        assert "sheet" in str(exc)
+        assert "named_range" in str(exc)
+    else:
+        raise AssertionError("empty spec must fail")
+
+
+def test_sheet_identity_rereads_used_range_not_cached_a1():
+    """Same {sheet} spec must pick up a grown used-range — catalog is not expanded A1."""
+    addr = _fake_addr(2, 4, 3, 5)
+    model = _fake_model(sheets=_fake_sheets(names=("Actuals",), addr=addr))
+    parsed = parse_table_source_spec({"sheet": "Actuals"})
+
+    first = resolve_table_source_a1(model, parsed)
+    assert first.endswith("C5:D6")
+    assert parsed["range"] is None
+    assert parsed["sheet"] == "Actuals"
+
+    addr.EndRow = 7
+    second = resolve_table_source_a1(model, parsed)
+    assert second.endswith("C5:D8")
+    assert parsed["range"] is None
+
+
+def test_named_range_identity_follows_referred_bounds():
+    addr = _fake_addr(2, 4, 3, 5)
+    nr = _fake_named_range(addr)
+    model = _fake_model(
+        sheets=_fake_sheets(names=("Actuals",), addr=addr),
+        named_ranges=_named_container({"SalesData": nr}),
+    )
+    parsed = parse_table_source_spec({"named_range": "SalesData"})
+
+    first = resolve_table_source_a1(model, parsed)
+    assert first.endswith("C5:D6")
+    addr.EndRow = 8
+    second = resolve_table_source_a1(model, parsed)
+    assert second.endswith("C5:D9")
+    assert parsed["named_range"] == "SalesData"
+    assert parsed["range"] is None
+
+
+def test_database_range_identity_uses_data_area():
+    addr = _fake_addr(0, 0, 1, 3)
+    dbr = _fake_database_range(addr)
+    model = _fake_model(
+        sheets=_fake_sheets(names=("Actuals",), addr=addr),
+        database_ranges=_named_container({"CostDB": dbr}),
+    )
+    parsed = parse_table_source_spec({"named_range": "CostDB"})
+    qualified = resolve_table_source_a1(model, parsed)
+    assert qualified.endswith("A1:B4")
+
+
+def test_named_range_identity_missing_errors():
+    model = _fake_model()
+    parsed = parse_table_source_spec({"named_range": "Nope"})
+    try:
+        resolve_table_source_a1(model, parsed)
+    except ToolExecutionError as exc:
+        assert "Nope" in str(exc)
+    else:
+        raise AssertionError("missing named range must fail loud")
+
+
+def test_frozen_range_identity_is_not_used_range():
+    addr = _fake_addr(2, 4, 3, 5)
+    model = _fake_model(sheets=_fake_sheets(names=("Actuals",), addr=addr))
+    parsed = parse_table_source_spec({"range": "Actuals.A1:B2"})
+    assert resolve_table_source_a1(model, parsed) == "Actuals.A1:B2"
+
+
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_execute_sheet_identity_preloads_used_range(mock_resolve, mock_run, mock_exec, mock_read):
+    mock_resolve.return_value = "/tmp/project"
+    mock_run.return_value = {"status": "ok", "total_rows": 1}
+    mock_exec.side_effect = lambda fn: fn()
+    mock_read.side_effect = _grid_for_requested_range
+
+    ctx = _mk_ctx()
+    ctx.doc = _fake_model()
+    res = QueryFolderSqlTool().execute(
+        ctx,
+        sql="SELECT * FROM sales",
+        tables={"sales": {"sheet": "Actuals"}},
+    )
+    assert res["status"] == "ok"
+    requested = mock_read.call_args[0][0]
+    assert "C5:D6" in requested
+    assert "AK2000" not in requested
+    pre = mock_run.call_args.kwargs.get("preloaded") or {}
+    assert "sales" in pre
+    assert pre["sales"]["grid"][0] == ["Region", "Sales"]
+
+
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_execute_named_range_identity(mock_resolve, mock_run, mock_exec, mock_read):
+    mock_resolve.return_value = "/tmp/project"
+    mock_run.return_value = {"status": "ok"}
+    mock_exec.side_effect = lambda fn: fn()
+    mock_read.side_effect = _grid_for_requested_range
+    addr = _fake_addr()
+    ctx = _mk_ctx()
+    ctx.doc = _fake_model(named_ranges=_named_container({"SalesData": _fake_named_range(addr)}))
+
+    res = QueryFolderSqlTool().execute(
+        ctx,
+        sql="SELECT * FROM sales",
+        tables={"sales": {"named_range": "SalesData"}},
+    )
+    assert res["status"] == "ok"
+    requested = mock_read.call_args[0][0]
+    assert "C5:D6" in requested
+    pre = mock_run.call_args.kwargs.get("preloaded") or {}
+    assert "sales" in pre
+
+
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_execute_frozen_range_stays_absolute(mock_resolve, mock_run, mock_exec, mock_read):
+    mock_resolve.return_value = "/tmp/project"
+    mock_run.return_value = {"status": "ok"}
+    mock_exec.side_effect = lambda fn: fn()
+    mock_read.side_effect = _grid_for_requested_range
+    ctx = _mk_ctx()
+    ctx.doc = _fake_model()
+
+    res = QueryFolderSqlTool().execute(
+        ctx,
+        sql="SELECT * FROM sales",
+        tables={"sales": {"range": "Actuals.A1:B2"}},
+    )
+    assert res["status"] == "ok"
+    requested = mock_read.call_args[0][0]
+    _prefix, bare = split_sheet_prefix(requested)
+    assert _prefix == "Actuals"
+    assert bare == "A1:B2"
+
+
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_execute_missing_named_range_does_not_run_sql(mock_resolve, mock_run, mock_exec):
+    mock_resolve.return_value = "/tmp/project"
+    mock_exec.side_effect = lambda fn: fn()
+    ctx = _mk_ctx()
+    ctx.doc = _fake_model()
+
+    res = QueryFolderSqlTool().execute(
+        ctx,
+        sql="SELECT * FROM sales",
+        tables={"sales": {"named_range": "MissingName"}},
+    )
+    assert res["status"] == "error"
+    assert "MissingName" in res["message"]
+    mock_run.assert_not_called()
+
+
+@patch("plugin.calc.duckdb_tools.os.path.isfile", return_value=True)
+@patch("plugin.calc.duckdb_tools._read_sibling_office_file_as_grid")
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_execute_tables_file_sheet_identity(
+    mock_resolve, mock_run, mock_exec, mock_read_office, _mock_isfile
+):
+    """tables={name: {file, sheet}} uses the sibling used-range path; catalog name is the key."""
+    mock_resolve.return_value = "/tmp/project"
+    mock_read_office.return_value = ("budget", [["Region", "Sales"], ["North", 100]])
+    mock_run.return_value = {"status": "ok"}
+    mock_exec.side_effect = lambda fn: fn()
+
+    res = QueryFolderSqlTool().execute(
+        _mk_ctx(),
+        sql="SELECT * FROM sales",
+        tables={"sales": {"file": "budget.xlsx", "sheet": "Actuals"}},
+    )
+    assert res["status"] == "ok"
+    _args, kwargs = mock_read_office.call_args
+    assert _args[1].endswith("budget.xlsx")
+    assert kwargs.get("sheet_hint") == "Actuals"
+    pre = mock_run.call_args.kwargs.get("preloaded") or {}
+    assert "sales" in pre
+    assert pre["sales"]["grid"][0] == ["Region", "Sales"]

--- a/tests/calc/test_duckdb_tools_uno.py
+++ b/tests/calc/test_duckdb_tools_uno.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 KeithCu (modifications and relicensing)
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""UNO tests for DuckDB sibling spreadsheet used-range ingress."""
+"""UNO tests for DuckDB sibling used-range ingress and table source identity."""
 
 from __future__ import annotations
 
@@ -11,7 +11,12 @@ import tempfile
 
 import uno
 
-from plugin.calc.duckdb_tools import _read_sibling_office_file_as_grid
+from plugin.calc.duckdb_tools import (
+    QueryFolderSqlTool,
+    _read_sibling_office_file_as_grid,
+    parse_table_source_spec,
+    read_model_table_grid,
+)
 from plugin.framework.errors import ToolExecutionError
 from plugin.testing_runner import native_test
 from plugin.tests.testing_utils import TestingFactory, with_native_doc
@@ -152,3 +157,144 @@ def test_sibling_empty_sheet_errors(ctx, doc):
         if sibling is not None:
             TestingFactory.close_doc(sibling)
         _cleanup_dir(temp_dir)
+
+
+def _sales_on_sheet(sheet) -> None:
+    sheet.getCellByPosition(2, 4).setString("Region")
+    sheet.getCellByPosition(3, 4).setString("Sales")
+    sheet.getCellByPosition(2, 5).setString("North")
+    sheet.getCellByPosition(3, 5).setValue(100)
+
+
+def _append_south_row(sheet) -> None:
+    sheet.getCellByPosition(2, 6).setString("South")
+    sheet.getCellByPosition(3, 6).setValue(50)
+
+
+@native_test
+@with_native_doc("calc")
+def test_sheet_identity_used_range_grows(ctx, doc):
+    """{sheet} is stable identity: append a row and the same spec reads the new used range."""
+    sheet = doc.getSheets().getByIndex(0)
+    sheet_name = sheet.getName()
+    _sales_on_sheet(sheet)
+    parsed = parse_table_source_spec({"sheet": sheet_name})
+
+    first = read_model_table_grid(doc, parsed)
+    assert len(first) == 2
+    assert first[0] == ["Region", "Sales"]
+    assert parsed.get("range") is None
+
+    _append_south_row(sheet)
+    second = read_model_table_grid(doc, parsed)
+    assert len(second) == 3
+    assert second[2][0] == "South"
+    assert parsed["sheet"] == sheet_name
+    assert parsed.get("range") is None
+
+
+@native_test
+@with_native_doc("calc")
+def test_named_range_identity_follows_current_bounds(ctx, doc):
+    """{named_range} resolves referred cells at read time, not a stored A1."""
+    from com.sun.star.table import CellAddress
+
+    sheet = doc.getSheets().getByIndex(0)
+    sheet_name = sheet.getName()
+    _sales_on_sheet(sheet)
+    if doc.NamedRanges.hasByName("SalesData"):
+        doc.NamedRanges.removeByName("SalesData")
+    doc.NamedRanges.addNewByName(
+        "SalesData",
+        f"${sheet_name}.$C$5:$D$6",
+        CellAddress(Sheet=0, Column=2, Row=4),
+        0,
+    )
+    parsed = parse_table_source_spec({"named_range": "SalesData"})
+
+    first = read_model_table_grid(doc, parsed)
+    assert len(first) == 2
+    assert first[1][0] == "North"
+
+    _append_south_row(sheet)
+    doc.NamedRanges.getByName("SalesData").setContent(f"${sheet_name}.$C$5:$D$7")
+    second = read_model_table_grid(doc, parsed)
+    assert len(second) == 3
+    assert second[2][0] == "South"
+    assert parsed["named_range"] == "SalesData"
+    assert parsed.get("range") is None
+
+    if doc.NamedRanges.hasByName("SalesData"):
+        doc.NamedRanges.removeByName("SalesData")
+
+
+@native_test
+@with_native_doc("calc")
+def test_frozen_range_identity_does_not_grow(ctx, doc):
+    """{range: A1} stays pinned when the sheet used-range grows."""
+    sheet = doc.getSheets().getByIndex(0)
+    sheet_name = sheet.getName()
+    _sales_on_sheet(sheet)
+    parsed = parse_table_source_spec({"range": f"{sheet_name}.C5:D6"})
+
+    first = read_model_table_grid(doc, parsed)
+    assert len(first) == 2
+    _append_south_row(sheet)
+    second = read_model_table_grid(doc, parsed)
+    assert len(second) == 2
+    assert [row[0] for row in second] == ["Region", "North"]
+
+
+@native_test
+@with_native_doc("calc")
+def test_database_range_identity_reads_data_area(ctx, doc):
+    from com.sun.star.table import CellRangeAddress
+
+    sheet = doc.getSheets().getByIndex(0)
+    _sales_on_sheet(sheet)
+    if doc.DatabaseRanges.hasByName("SalesDB"):
+        doc.DatabaseRanges.removeByName("SalesDB")
+    addr = CellRangeAddress()
+    addr.Sheet = 0
+    addr.StartColumn = 2
+    addr.StartRow = 4
+    addr.EndColumn = 3
+    addr.EndRow = 5
+    doc.DatabaseRanges.addNewByName("SalesDB", addr)
+
+    parsed = parse_table_source_spec({"named_range": "SalesDB"})
+    grid = read_model_table_grid(doc, parsed)
+    assert len(grid) == 2
+    assert grid[0] == ["Region", "Sales"]
+
+    if doc.DatabaseRanges.hasByName("SalesDB"):
+        doc.DatabaseRanges.removeByName("SalesDB")
+
+
+@native_test
+@with_native_doc("calc")
+def test_query_folder_sql_sheet_identity_host_path(ctx, doc):
+    """Host preload registers the catalog key from {sheet} used-range."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    sheet = doc.getSheets().getByIndex(0)
+    _sales_on_sheet(sheet)
+    captured: dict = {}
+
+    def _fake_run(*_args, **kwargs):
+        captured["preloaded"] = kwargs.get("preloaded")
+        return {"status": "ok", "helper": "query_folder_sql", "total_rows": 1}
+
+    tctx = SimpleNamespace(ctx=ctx, doc=doc, doc_type="calc", active_domain="analysis")
+    with patch("plugin.scripting.client.run_folder_sql", side_effect=_fake_run):
+        res = QueryFolderSqlTool().execute(
+            tctx,
+            sql="SELECT * FROM sales",
+            tables={"sales": {"sheet": sheet.getName()}},
+        )
+    assert res.get("status") == "ok", res
+    grid = (captured.get("preloaded") or {}).get("sales", {}).get("grid")
+    assert grid is not None
+    assert len(grid) == 2
+    assert grid[0][0] == "Region"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

DuckDB / `query_folder_sql` multi-table catalogs can now name a **sheet** or **named range** instead of pinning absolute A1 bounds that drift when rows or columns are inserted.

Identity is stored in the catalog; used-range / referred bounds are resolved **at read time**.

## How a caller specifies a stable table

```python
# Active workbook — sheet used range (grows with the sheet)
tables = {"sales": {"sheet": "Sales_Analytics"}}

# Active workbook — Calc named range or database range (current bounds)
tables = {"sales": {"named_range": "SalesData"}}

# Sibling workbook — same sheet used-range; dict key is the SQL table name
files = {"sales": "budget.xlsx#Sales"}
# or
tables = {"sales": {"file": "budget.xlsx", "sheet": "Sales"}}

# Still valid: frozen A1 (does not grow)
tables = {"sales": {"range": "Sales.A1:F500"}}
```

`data_range` remains frozen A1 → table `data`. Prefer `tables={data: {sheet}}` or `{named_range}` for a stable id.

## Changes

- Host preload in `plugin/calc/duckdb_tools.py` parses `sheet` / `named_range` / `range` (exactly one) and optional sibling `file`.
- Named-range lookup covers global, sheet-qualified, and active-sheet local NamedRanges, then DatabaseRanges.
- Missing sheet / name / empty used-range fail loud (same as sibling `#SheetName`).
- Docs: `docs/calc/duckdb-dev-plan.md` § Table source identity; short note in `docs/calc/analysis-tools.md`.
- Tests: unit (identity parse, grow-on-reread, host execute) + UNO (used-range grow, named-range bounds, frozen A1 pin, database range, host path).

## Verification

- `make typecheck` — ruff, basedpyright, mypy, ty, bandit, pyspector, opengrep, thread-safety all clean
- `pytest tests/calc/test_duckdb_tools.py tests/framework/test_tool_schema_convert.py` — 55 passed
- `plugin/testing_runner.py tests/calc/test_duckdb_tools_uno.py` — 9 passed (sheet grow, named-range bounds, frozen A1 pin, database range, host path)

ODS mtime cache (`writeragent_ods_cache/`) is still pending and not part of this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bc714eb-af3e-4cb5-9d84-27fb691dccb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bc714eb-af3e-4cb5-9d84-27fb691dccb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

