### PR TITLE
ODS mtime cache for DuckDB sibling XLSX/XLS ingress

### DIFF
--- a/docs/calc/duckdb-dev-plan.md
+++ b/docs/calc/duckdb-dev-plan.md
@@ -13,7 +13,7 @@ todos:
     status: completed
   - id: phase-a-plus-ods-cache
     content: "Phase A+: writeragent_ods_cache/ beside folder; mtime invalidation for xlsx/xls → cached ods; open cache on hit"
-    status: pending
+    status: completed
   - id: phase-a-tests
     content: "Phase A: pytest for path guard + folder SQL round-trip (temp dir fixtures)"
     status: completed
@@ -33,7 +33,7 @@ isProject: false
 
 Back to [Enabling NumPy & Python in LibreOffice](../enabling_numpy_in_libreoffice.md).
 
-**Status:** Phase A + A+ + B + C landed (multi-table catalog with named ranges + named folder files). Phase D deferred. See execution plan and implementation notes below.
+**Status:** Phase A + A+ (including ODS mtime cache) + B + C landed (multi-table catalog with named ranges + named folder files). Phase D deferred. See execution plan and implementation notes below.
 
 ### Pretty demo (SQL / DuckDB sheet)
 
@@ -64,7 +64,7 @@ That writes the ODS/XLSX and copies `zip_income.csv` next to them. Happy-path pr
 - Host handles: scoped dir resolution, hidden LO opens for .xlsx/.ods, active doc reads for ranges, size limits, preloading.
 - Worker: registers preloaded via `coerce_to_dataframe`, flat files via `read_csv`/`read_parquet` etc. under provided names. Read-only guards.
 - Templates: `[SQL] query_folder_sql` and `query_sheet_sql` in Run Python Script.
-- Limitations: no write-back, no shared kernel cache yet, default first sheet for office files when `#SheetName` is omitted. Sibling `.xlsx`/`.ods` now read the sheet **used range** (same `createCursor` / `gotoStartOfUsedArea` / `gotoEndOfUsedArea` path as `SheetAnalyzer` / ingest) — open / missing-sheet / empty-range failures are tool errors. ODS mtime cache (`writeragent_ods_cache/`) is still pending.
+- Limitations: no write-back, no shared kernel cache yet, default first sheet for office files when `#SheetName` is omitted. Sibling `.xlsx`/`.ods` now read the sheet **used range** (same `createCursor` / `gotoStartOfUsedArea` / `gotoEndOfUsedArea` path as `SheetAnalyzer` / ingest) — open / missing-sheet / empty-range failures are tool errors. Sibling `.xlsx`/`.xls` reuse `writeragent_ods_cache/` (mtime+size key; `calc.ods_cache_enabled`, default true). Native `.ods` and the live workbook are not cached.
 - Usage: Mix tables + files for joins, e.g. live sheet identity + sibling CSVs. See [Table source identity](#table-source-identity).
 
 **Audience:** Product, senior engineers, and future implementers. This doc captures why DuckDB fits WriterAgent, what users get, and how to build on existing Calc↔venv infrastructure without a new architectural pillar.
@@ -99,7 +99,7 @@ CSV / Parquet / JSON remain **direct DuckDB file reads** in the venv (no UNO).
 
 **Question:** Should WriterAgent maintain an `ods_cache` (or `writeragent_ods_cache/`) beside the document folder and reuse converted ODS files instead of re-importing XLSX every time?
 
-**Recommendation: yes, with mtime invalidation — but not in Phase A (CSV-only).** Add when sibling XLSX ingress ships (Phase A+).
+**Recommendation: yes, with mtime invalidation.** Shipped in Phase A+ (`plugin/calc/ods_cache.py`).
 
 | Approach | Pros | Cons |
 |----------|------|------|
@@ -125,11 +125,11 @@ CSV / Parquet / JSON remain **direct DuckDB file reads** in the venv (no UNO).
 
 **Do not cache:** native `.ods` / live active workbook (open source directly). **Do cache:** `.xlsx`, `.xls` only.
 
-**Settings (optional):** `duckdb.ods_cache_enabled` (default `true`), `duckdb.ods_cache_max_mb` prune LRU.
+**Settings:** `calc.ods_cache_enabled` (default `true`; plan name was `duckdb.ods_cache_enabled`). `duckdb.ods_cache_max_mb` LRU prune is still optional / not shipped.
 
 **Why not skip cache:** SQL workflows often re-query the same sibling Excel file many times (chat iterations, `=PY()` recalc, analysis sub-agent). LO’s XLSX filter is the fidelity win; cache makes that win **affordable**.
 
-**MVP shortcut:** Phase A+ can ship **mtime-checked cache** only (no LRU) — enough for v1.
+**Shipped MVP:** mtime+size-checked cache only (no LRU). Disable with `calc.ods_cache_enabled: false` in `writeragent.json`.
 
 ---
 
@@ -435,7 +435,7 @@ No cloud telemetry required. Suggested signals:
 | 1 | Separate `sql` specialized domain vs helpers under `analysis`? | PM + API |
 | 2 | Allow LLM-authored SQL verbatim vs template-only (file list from host)? | Security |
 | 3 | ~~XLSX via DuckDB vs host~~ | **Resolved:** LO import + UNO read (this doc § Decision). |
-| 4 | ~~ODS cache on disk?~~ | **Resolved:** per-folder `writeragent_ods_cache/` with mtime invalidation (§ ODS cache directory). Defer until XLSX ingress. |
+| 4 | ~~ODS cache on disk?~~ | **Resolved / shipped:** per-folder `writeragent_ods_cache/` with mtime+size invalidation (§ ODS cache directory). |
 | 5 | Auto-export sheet snapshot to temp Parquet for huge ranges (Phase C perf) | Eng, defer |
 | 6 | Relationship to deferred **pyarrow** / Parquet export from Calc | Roadmap |
 
@@ -470,3 +470,4 @@ No cloud telemetry required. Suggested signals:
 | 2026-09-05 | SQL_DuckDB RESULTS are formula-safe: SQL lives only in cells; the `=PY()` payload is a short runner that reads `data[1]` (SQL cell/range) plus `data[0]` (sheet range). |
 | 2026-09-05 | SQL_DuckDB sheet-only RESULTS leave 15 empty rows × 5 cols under the formula so a Region×Category spill (header+12) does not `#SPILL!` into the next section title. The live RESULTS formula cell is unmerged (no ODS `span_cols` / XLSX A:H) so spill targets are real cells. |
 | 2026-09-05 | Stable table identity: `{sheet}` (used range), `{named_range}` (named or database range), sibling `file.xlsx#Sheet` / `files={name: "file.xlsx#Sheet"}`. Frozen `{range: A1}` kept. Catalog does not store expanded A1. |
+| 2026-09-05 | Phase A+ ODS cache: sibling `.xlsx`/`.xls` → `writeragent_ods_cache/` (hash of abs path + mtime + size); open cached ODS on hit; native `.ods` and the live workbook skip cache. Setting `calc.ods_cache_enabled` (default true). |

--- a/docs/writeragent-config-schema.md
+++ b/docs/writeragent-config-schema.md
@@ -67,6 +67,7 @@ Top-level keys from the config dataclass (Settings dialog, chat, images).
 | Key | Type | Default | Range | Description |
 | --- | --- | --- | --- | --- |
 | `max_rows_display` | `int` | `1000` | `100`–`100000` | Max Rows Display |
+| `ods_cache_enabled` | `boolean` | `true` |  | Convert sibling .xlsx/.xls to writeragent_ods_cache/ beside the folder so repeated DuckDB SQL reuses the ODS. Native .ods and the live workbook are never cached. Set calc.ods_cache_enabled false in writeragent.json to disable. |
 
 ## MCP (`mcp`)
 

--- a/plugin/calc/duckdb_tools.py
+++ b/plugin/calc/duckdb_tools.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from plugin.calc.address_utils import split_sheet_prefix
@@ -531,6 +532,97 @@ def _sibling_office_error(full_path: str, message: str, *, sheet: str | None = N
     return ToolExecutionError(f"Sibling spreadsheet {bn!r}: {message}", code=code)
 
 
+def _source_is_open_workbook(ctx: Any, full_path: str) -> bool:
+    """True when *full_path* is already loaded on the desktop.
+
+    The live workbook must not go through the ODS cache: unsaved edits would
+    be skipped, and ``storeToURL`` would export a user-visible document.
+    """
+    try:
+        import uno
+
+        from plugin.framework.uno_context import resolve_document_by_url
+
+        url = uno.systemPathToFileUrl(os.path.normpath(os.path.abspath(full_path)))
+        existing, _typ = resolve_document_by_url(ctx, url)
+        return existing is not None
+    except Exception:
+        return False
+
+
+def _export_model_to_cached_ods(model: Any, dest: Path) -> None:
+    """Save As ODS to *dest* (atomic replace via a ``.partial`` sibling)."""
+    import uno
+
+    from plugin.writer.format import create_property_value
+
+    store = getattr(model, "storeToURL", None)
+    if not callable(store):
+        raise TypeError("document cannot storeToURL")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(dest.name + ".partial")
+    try:
+        if tmp.exists():
+            tmp.unlink()
+        url = uno.systemPathToFileUrl(str(tmp.resolve()))
+        props = (
+            create_property_value("FilterName", "calc8"),
+            create_property_value("Overwrite", True),
+        )
+        store(url, props)
+        os.replace(str(tmp), str(dest))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _resolve_sibling_open_path(ctx: Any, full_path: str) -> tuple[str, bool]:
+    """Return ``(path_to_open, cache_hit)`` for a sibling spreadsheet.
+
+    Cache only ``.xlsx``/``.xls`` that are not already open. Native ``.ods``
+    and the live workbook always open the source path.
+    """
+    from plugin.calc.ods_cache import is_cacheable_office_source, lookup_cached_ods, ods_cache_enabled
+
+    if not is_cacheable_office_source(full_path) or not ods_cache_enabled():
+        return full_path, False
+    if _source_is_open_workbook(ctx, full_path):
+        return full_path, False
+    hit = lookup_cached_ods(full_path)
+    if hit is not None:
+        return str(hit), True
+    return full_path, False
+
+
+def _maybe_write_ods_cache(ctx: Any, model: Any, full_path: str, *, opened_flag: bool, cache_hit: bool) -> None:
+    """On a conversion miss, Save As the imported XLSX/XLS into the folder cache."""
+    from plugin.calc.ods_cache import (
+        cache_entry_paths,
+        is_cacheable_office_source,
+        ods_cache_enabled,
+        write_sidecar_meta,
+    )
+
+    if cache_hit or not opened_flag:
+        return
+    if not is_cacheable_office_source(full_path) or not ods_cache_enabled():
+        return
+    if _source_is_open_workbook(ctx, full_path):
+        return
+    paths = cache_entry_paths(full_path)
+    if paths is None:
+        return
+    ods_path, meta_path = paths
+    try:
+        _export_model_to_cached_ods(model, ods_path)
+        write_sidecar_meta(meta_path, full_path)
+    except Exception:
+        log.exception("Failed to write ODS cache for %s", full_path)
+
+
 def _read_sibling_office_file_as_grid(
     ctx: Any,
     full_path: str,
@@ -546,6 +638,11 @@ def _read_sibling_office_file_as_grid(
     ``named_range`` and ``range_a1`` are the same identities as the ``tables``
     catalog. Returns ``(table_name, grid)``. Raises ``ToolExecutionError`` on
     open, missing sheet/name, or empty/unusable used-range — never ``(None, None)``.
+
+    Sibling ``.xlsx``/``.xls`` reuse ``writeragent_ods_cache/`` when the
+    source mtime/size still match. Native ``.ods`` and the live workbook
+    skip the cache. Table name stays the *source* stem so a cache-hit open
+    does not register a hash filename.
     """
     if named_range:
         parsed: dict[str, Any] = {
@@ -575,10 +672,24 @@ def _read_sibling_office_file_as_grid(
             "headers": True,
         }
 
+    open_path, cache_hit = _resolve_sibling_open_path(ctx, full_path)
     model = None
     opened_flag = False
     try:
-        model, doc_type, err, opened_flag = open_document_for_read(ctx, full_path)
+        model, doc_type, err, opened_flag = open_document_for_read(ctx, open_path)
+        if cache_hit and (err or model is None):
+            # Stale or unreadable cache file: fall back to the source XLSX/XLS
+            # and rewrite the cache after a successful read.
+            log.warning("Cached ODS unreadable for %s; re-importing source", full_path)
+            if model is not None and opened_flag:
+                try:
+                    close_document_research_document(model, opened_for_document_research=opened_flag)
+                except Exception:
+                    pass
+            model = None
+            opened_flag = False
+            cache_hit = False
+            model, doc_type, err, opened_flag = open_document_for_read(ctx, full_path)
         if err or model is None:
             raise _sibling_office_error(full_path, err or "LibreOffice failed to open the file")
         if doc_type != "calc":
@@ -600,6 +711,8 @@ def _read_sibling_office_file_as_grid(
                 "used range is empty; nothing to register for SQL",
                 sheet=str(identity) if identity else None,
             )
+
+        _maybe_write_ods_cache(ctx, model, full_path, opened_flag=opened_flag, cache_hit=cache_hit)
 
         tbl_name = _sanitize_sql_table_name(os.path.splitext(os.path.basename(full_path))[0])
         return tbl_name, grid

--- a/plugin/calc/duckdb_tools.py
+++ b/plugin/calc/duckdb_tools.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from plugin.calc.address_utils import split_sheet_prefix
@@ -20,6 +19,8 @@ from plugin.framework.queue_executor import execute_on_main_thread
 from plugin.scripting.config_limits import configured_python_max_data_cells
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from plugin.framework.tool import ToolContext
 
 log = logging.getLogger("writeragent.calc.duckdb")
@@ -597,8 +598,14 @@ def _resolve_sibling_open_path(ctx: Any, full_path: str) -> tuple[str, bool]:
     return full_path, False
 
 
-def _maybe_write_ods_cache(ctx: Any, model: Any, full_path: str, *, opened_flag: bool, cache_hit: bool) -> None:
-    """On a conversion miss, Save As the imported XLSX/XLS into the folder cache."""
+def _maybe_write_ods_cache(model: Any, full_path: str, *, opened_flag: bool, cache_hit: bool) -> None:
+    """On a conversion miss, Save As the imported XLSX/XLS into the folder cache.
+
+    ``opened_flag`` is the live-workbook guard: False means we reused a
+    desktop document, so we must not ``storeToURL`` it. Do not call
+    ``_source_is_open_workbook`` here — after a hidden open the source
+    *is* loaded, which would skip every miss write.
+    """
     from plugin.calc.ods_cache import (
         cache_entry_paths,
         is_cacheable_office_source,
@@ -609,8 +616,6 @@ def _maybe_write_ods_cache(ctx: Any, model: Any, full_path: str, *, opened_flag:
     if cache_hit or not opened_flag:
         return
     if not is_cacheable_office_source(full_path) or not ods_cache_enabled():
-        return
-    if _source_is_open_workbook(ctx, full_path):
         return
     paths = cache_entry_paths(full_path)
     if paths is None:
@@ -712,7 +717,7 @@ def _read_sibling_office_file_as_grid(
                 sheet=str(identity) if identity else None,
             )
 
-        _maybe_write_ods_cache(ctx, model, full_path, opened_flag=opened_flag, cache_hit=cache_hit)
+        _maybe_write_ods_cache(model, full_path, opened_flag=opened_flag, cache_hit=cache_hit)
 
         tbl_name = _sanitize_sql_table_name(os.path.splitext(os.path.basename(full_path))[0])
         return tbl_name, grid

--- a/plugin/calc/module.yaml
+++ b/plugin/calc/module.yaml
@@ -12,3 +12,14 @@ config:
     widget: number
     label: Max Rows Display
     public: true
+
+  ods_cache_enabled:
+    type: boolean
+    default: true
+    widget: checkbox
+    label: Cache Excel siblings as ODS
+    helper: >-
+      Convert sibling .xlsx/.xls to writeragent_ods_cache/ beside the folder so
+      repeated DuckDB SQL reuses the ODS. Native .ods and the live workbook are
+      never cached. Set calc.ods_cache_enabled false in writeragent.json to disable.
+    public: true

--- a/plugin/calc/ods_cache.py
+++ b/plugin/calc/ods_cache.py
@@ -1,0 +1,153 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Per-folder ODS cache for DuckDB sibling XLSX/XLS ingress.
+
+Amortizes LibreOffice's Excel import across chat re-queries. Layout mirrors
+``writeragent_embeddings/`` (see ``docs/calc/duckdb-dev-plan.md`` § ODS cache
+directory):
+
+    <scoped_dir>/writeragent_ods_cache/<sha256(path+mtime+size)>.ods
+    <scoped_dir>/writeragent_ods_cache/<sha256(path+mtime+size)>.meta.json
+
+Native ``.ods`` and the live active workbook are never cached — those open
+the source (or the already-loaded model) directly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("writeragent.calc.duckdb")
+
+ODS_CACHE_DIRNAME = "writeragent_ods_cache"
+CACHE_FORMAT_VERSION = 1
+CACHEABLE_EXTENSIONS = frozenset({".xlsx", ".xls"})
+# Schema key lives on the calc module (module.yaml). Plan name was duckdb.ods_cache_enabled.
+ODS_CACHE_ENABLED_KEY = "calc.ods_cache_enabled"
+
+
+def normalize_source_path(source_path: str) -> str:
+    """Absolute, normalized filesystem path used in the cache key."""
+    return os.path.normpath(os.path.abspath(source_path))
+
+
+def is_cacheable_office_source(source_path: str) -> bool:
+    """True for sibling Excel files. Native ``.ods`` is never cached."""
+    return os.path.splitext(source_path)[1].lower() in CACHEABLE_EXTENSIONS
+
+
+def source_stat(source_path: str) -> tuple[str, int, int]:
+    """Return ``(abs_path, mtime_ns, size)`` for the cache key."""
+    abs_path = normalize_source_path(source_path)
+    st = os.stat(abs_path)
+    mtime_ns = int(getattr(st, "st_mtime_ns", int(st.st_mtime * 1_000_000_000)))
+    return abs_path, mtime_ns, int(st.st_size)
+
+
+def cache_key(abs_path: str, mtime_ns: int, size: int) -> str:
+    """Hash of absolute path + mtime + size (content hash only if mtime is flaky)."""
+    payload = f"{abs_path}\n{mtime_ns}\n{size}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def ods_cache_dir(source_path: str, *, create: bool = False) -> Path:
+    """``writeragent_ods_cache/`` beside the scoped folder that holds *source_path*."""
+    root = Path(normalize_source_path(source_path)).parent / ODS_CACHE_DIRNAME
+    if create:
+        root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def cache_entry_paths(source_path: str) -> tuple[Path, Path] | None:
+    """``(cached.ods, sidecar.meta.json)`` for the current source stat, or None."""
+    try:
+        abs_path, mtime_ns, size = source_stat(source_path)
+    except OSError:
+        return None
+    key = cache_key(abs_path, mtime_ns, size)
+    folder = ods_cache_dir(source_path, create=False)
+    return folder / f"{key}.ods", folder / f"{key}.meta.json"
+
+
+def read_sidecar_meta(meta_path: Path) -> dict[str, Any] | None:
+    """Load sidecar JSON; missing or corrupt meta is a cache miss."""
+    if not meta_path.is_file():
+        return None
+    try:
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        log.debug("ods cache meta unreadable: %s", meta_path, exc_info=True)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def meta_matches_source(meta: dict[str, Any], abs_path: str, mtime_ns: int, size: int) -> bool:
+    """True when sidecar still describes this source and format version."""
+    try:
+        version = int(meta.get("cache_format_version", -1))
+        stored_mtime = int(meta.get("mtime_ns", -1))
+        stored_size = int(meta.get("size", -1))
+    except (TypeError, ValueError):
+        return False
+    if version != CACHE_FORMAT_VERSION:
+        return False
+    if str(meta.get("source_path") or "") != abs_path:
+        return False
+    return stored_mtime == mtime_ns and stored_size == size
+
+
+def lookup_cached_ods(source_path: str) -> Path | None:
+    """Return the cached ODS path on hit; None on miss or invalidation.
+
+    Invalidate when the source mtime/size changes (new key), the sidecar is
+    missing, or ``cache_format_version`` does not match.
+    """
+    if not is_cacheable_office_source(source_path):
+        return None
+    paths = cache_entry_paths(source_path)
+    if paths is None:
+        return None
+    ods_path, meta_path = paths
+    if not ods_path.is_file() or not meta_path.is_file():
+        return None
+    meta = read_sidecar_meta(meta_path)
+    if meta is None:
+        return None
+    try:
+        abs_path, mtime_ns, size = source_stat(source_path)
+    except OSError:
+        return None
+    if not meta_matches_source(meta, abs_path, mtime_ns, size):
+        return None
+    return ods_path
+
+
+def write_sidecar_meta(meta_path: Path, source_path: str) -> None:
+    """Write source path / mtime / size / format version next to the cached ODS."""
+    abs_path, mtime_ns, size = source_stat(source_path)
+    payload = {
+        "cache_format_version": CACHE_FORMAT_VERSION,
+        "source_path": abs_path,
+        "mtime_ns": mtime_ns,
+        "size": size,
+    }
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def ods_cache_enabled() -> bool:
+    """Settings ``calc.ods_cache_enabled`` (default true). Missing schema → enabled."""
+    try:
+        from plugin.framework.config import get_config
+        from plugin.framework.config_schema import as_bool
+
+        return as_bool(get_config(ODS_CACHE_ENABLED_KEY))
+    except Exception:
+        return True

--- a/tests/calc/test_duckdb_tools.py
+++ b/tests/calc/test_duckdb_tools.py
@@ -734,14 +734,16 @@ def test_xlsx_skips_cache_when_disabled(
 @patch("plugin.calc.inspector.CellInspector.read_range")
 @patch("plugin.calc.duckdb_tools.open_document_for_read")
 def test_live_workbook_skips_cache(mock_open, mock_read, _mock_close, mock_export, _mock_open_wb, tmp_path):
+    """Already-open workbook: skip cache hit and do not storeToURL (opened_flag=False)."""
     xlsx, _ods = _write_office_fixtures(tmp_path)
-    mock_open.return_value = (_fake_model(), "calc", None, True)
+    mock_open.return_value = (_fake_model(), "calc", None, False)
     mock_read.side_effect = _grid_for_requested_range
 
     _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Actuals")
 
     assert os.path.normpath(mock_open.call_args[0][1]) == os.path.normpath(str(xlsx))
     mock_export.assert_not_called()
+    _mock_close.assert_not_called()
 
 
 @patch("plugin.calc.duckdb_tools._source_is_open_workbook", return_value=False)

--- a/tests/calc/test_duckdb_tools.py
+++ b/tests/calc/test_duckdb_tools.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -17,6 +18,7 @@ from plugin.calc.duckdb_tools import (
     parse_table_source_spec,
     resolve_table_source_a1,
 )
+from plugin.calc.ods_cache import ODS_CACHE_DIRNAME, cache_entry_paths, write_sidecar_meta
 from plugin.framework.errors import ToolExecutionError
 
 
@@ -642,3 +644,150 @@ def test_execute_tables_file_sheet_identity(
     pre = mock_run.call_args.kwargs.get("preloaded") or {}
     assert "sales" in pre
     assert pre["sales"]["grid"][0] == ["Region", "Sales"]
+
+
+def _fake_export_writes_ods(model, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(b"PK\x03\x04cached-ods")
+
+
+@patch("plugin.calc.duckdb_tools._source_is_open_workbook", return_value=False)
+@patch("plugin.calc.duckdb_tools._export_model_to_cached_ods", side_effect=_fake_export_writes_ods)
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_xlsx_cache_miss_then_hit_mtime_invalidates(
+    mock_open, mock_read, _mock_close, _mock_export, _mock_open_wb, tmp_path
+):
+    """First XLSX open writes cache; second opens the ODS; mtime change misses."""
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    opened: list[str] = []
+
+    def _open(_ctx, path):
+        opened.append(os.path.normpath(str(path)))
+        return (_fake_model(), "calc", None, True)
+
+    mock_open.side_effect = _open
+    mock_read.side_effect = _grid_for_requested_range
+
+    _tbl, grid1 = _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Actuals")
+    assert grid1[0] == ["Region", "Sales"]
+    assert opened[0] == os.path.normpath(str(xlsx))
+    paths = cache_entry_paths(str(xlsx))
+    assert paths is not None
+    cached_ods, meta_path = paths
+    assert cached_ods.is_file()
+    assert meta_path.is_file()
+
+    _tbl, grid2 = _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Actuals")
+    assert grid2[0] == ["Region", "Sales"]
+    assert opened[1] == os.path.normpath(str(cached_ods))
+
+    st = os.stat(xlsx)
+    os.utime(xlsx, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+    _tbl, grid3 = _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Actuals")
+    assert grid3[0] == ["Region", "Sales"]
+    assert opened[2] == os.path.normpath(str(xlsx))
+
+
+@patch("plugin.calc.duckdb_tools._source_is_open_workbook", return_value=False)
+@patch("plugin.calc.duckdb_tools._export_model_to_cached_ods", side_effect=_fake_export_writes_ods)
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_ods_source_skips_cache(mock_open, mock_read, _mock_close, mock_export, _mock_open_wb, tmp_path):
+    _xlsx, ods = _write_office_fixtures(tmp_path)
+    mock_open.return_value = (_fake_model(), "calc", None, True)
+    mock_read.side_effect = _grid_for_requested_range
+
+    _read_sibling_office_file_as_grid(object(), str(ods))
+
+    mock_open.assert_called_once()
+    assert os.path.normpath(mock_open.call_args[0][1]) == os.path.normpath(str(ods))
+    mock_export.assert_not_called()
+    assert not (tmp_path / ODS_CACHE_DIRNAME).exists()
+
+
+@patch("plugin.calc.ods_cache.ods_cache_enabled", return_value=False)
+@patch("plugin.calc.duckdb_tools._source_is_open_workbook", return_value=False)
+@patch("plugin.calc.duckdb_tools._export_model_to_cached_ods")
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_xlsx_skips_cache_when_disabled(
+    mock_open, mock_read, _mock_close, mock_export, _mock_open_wb, _enabled, tmp_path
+):
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    mock_open.return_value = (_fake_model(), "calc", None, True)
+    mock_read.side_effect = _grid_for_requested_range
+
+    _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Actuals")
+
+    assert os.path.normpath(mock_open.call_args[0][1]) == os.path.normpath(str(xlsx))
+    mock_export.assert_not_called()
+    assert not (tmp_path / ODS_CACHE_DIRNAME).exists()
+
+
+@patch("plugin.calc.duckdb_tools._source_is_open_workbook", return_value=True)
+@patch("plugin.calc.duckdb_tools._export_model_to_cached_ods")
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+def test_live_workbook_skips_cache(mock_open, mock_read, _mock_close, mock_export, _mock_open_wb, tmp_path):
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    mock_open.return_value = (_fake_model(), "calc", None, True)
+    mock_read.side_effect = _grid_for_requested_range
+
+    _read_sibling_office_file_as_grid(object(), str(xlsx), sheet_hint="Actuals")
+
+    assert os.path.normpath(mock_open.call_args[0][1]) == os.path.normpath(str(xlsx))
+    mock_export.assert_not_called()
+
+
+@patch("plugin.calc.duckdb_tools._source_is_open_workbook", return_value=False)
+@patch("plugin.calc.duckdb_tools.close_document_research_document")
+@patch("plugin.calc.inspector.CellInspector.read_range")
+@patch("plugin.calc.duckdb_tools.open_document_for_read")
+@patch("plugin.calc.duckdb_tools.execute_on_main_thread")
+@patch("plugin.scripting.client.run_folder_sql")
+@patch("plugin.calc.duckdb_tools.resolve_listing_directory")
+def test_sql_path_uses_cache_on_second_query(
+    mock_resolve, mock_run, mock_exec, mock_open, mock_read, _mock_close, _mock_open_wb, tmp_path
+):
+    """query_folder_sql still preloads the used-range grid when the open is a cache hit."""
+    xlsx, _ods = _write_office_fixtures(tmp_path)
+    (tmp_path / "sales.csv").write_text("region,amount\nNorth,1\n")
+    mock_resolve.return_value = str(tmp_path)
+    mock_run.return_value = {"status": "ok", "helper": "query_folder_sql", "total_rows": 1}
+    mock_exec.side_effect = lambda fn: fn()
+    mock_read.side_effect = _grid_for_requested_range
+
+    opened: list[str] = []
+
+    def _open(_ctx, path):
+        opened.append(os.path.normpath(str(path)))
+        return (_fake_model(), "calc", None, True)
+
+    mock_open.side_effect = _open
+
+    # Seed a valid cache entry so the SQL open is a hit.
+    paths = cache_entry_paths(str(xlsx))
+    assert paths is not None
+    cached_ods, meta_path = paths
+    cached_ods.parent.mkdir(parents=True, exist_ok=True)
+    cached_ods.write_bytes(b"PK\x03\x04cached-ods")
+    write_sidecar_meta(meta_path, str(xlsx))
+
+    t = QueryFolderSqlTool()
+    res = t.execute(
+        _mk_ctx(),
+        sql="SELECT * FROM budget",
+        files=["sales.csv", "budget.xlsx#Actuals"],
+    )
+    assert res["status"] == "ok"
+    assert opened == [os.path.normpath(str(cached_ods))]
+    pre = mock_run.call_args.kwargs.get("preloaded") or {}
+    assert "budget.xlsx" in pre
+    assert pre["budget.xlsx"]["grid"] == [["Region", "Sales"], ["North", 100]]
+    flat = mock_run.call_args.kwargs.get("flat_files") or {}
+    assert any(str(v).endswith("sales.csv") for v in flat.values())

--- a/tests/calc/test_duckdb_tools_uno.py
+++ b/tests/calc/test_duckdb_tools_uno.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 
 import uno
@@ -17,6 +18,7 @@ from plugin.calc.duckdb_tools import (
     parse_table_source_spec,
     read_model_table_grid,
 )
+from plugin.calc.ods_cache import ODS_CACHE_DIRNAME, cache_entry_paths, lookup_cached_ods
 from plugin.framework.errors import ToolExecutionError
 from plugin.testing_runner import native_test
 from plugin.tests.testing_utils import TestingFactory, with_native_doc
@@ -49,15 +51,7 @@ def _store_sibling(doc, path: str, *, xlsx: bool = False) -> None:
 def _cleanup_dir(temp_dir: str) -> None:
     if not temp_dir or not os.path.isdir(temp_dir):
         return
-    for name in os.listdir(temp_dir):
-        try:
-            os.remove(os.path.join(temp_dir, name))
-        except OSError:
-            pass
-    try:
-        os.rmdir(temp_dir)
-    except OSError:
-        pass
+    shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 @native_test
@@ -298,3 +292,64 @@ def test_query_folder_sql_sheet_identity_host_path(ctx, doc):
     assert grid is not None
     assert len(grid) == 2
     assert grid[0][0] == "Region"
+
+
+@native_test
+@with_native_doc("calc")
+def test_sibling_xlsx_writes_ods_cache_and_reuses_it(ctx, doc):
+    """Miss: LO import + Save As cache. Hit: cached ODS has the same used-range grid."""
+    temp_dir = tempfile.mkdtemp(prefix="wa_duckdb_odscache_")
+    sibling = TestingFactory.create_native_doc(ctx, "calc", hidden=True)
+    try:
+        _fill_offset_table(sibling)
+        xlsx_path = os.path.join(temp_dir, "budget.xlsx")
+        _store_sibling(sibling, xlsx_path, xlsx=True)
+        TestingFactory.close_doc(sibling)
+        sibling = None
+
+        _tbl, grid1 = _read_sibling_office_file_as_grid(ctx, xlsx_path, sheet_hint="Actuals")
+        assert grid1[0][0] == "Region"
+        assert len(grid1) == 2
+
+        cached = lookup_cached_ods(xlsx_path)
+        assert cached is not None, "first XLSX read must write writeragent_ods_cache/"
+        assert cached.is_file()
+        paths = cache_entry_paths(xlsx_path)
+        assert paths is not None
+        assert paths[1].is_file()
+        assert os.path.isdir(os.path.join(temp_dir, ODS_CACHE_DIRNAME))
+
+        _tbl2, grid_from_cache = _read_sibling_office_file_as_grid(
+            ctx, str(cached), sheet_hint="Actuals"
+        )
+        assert len(grid_from_cache) == 2
+        assert grid_from_cache[0][0] == "Region"
+
+        _tbl3, grid2 = _read_sibling_office_file_as_grid(ctx, xlsx_path, sheet_hint="Actuals")
+        assert grid2[0][0] == "Region"
+        assert len(grid2) == 2
+    finally:
+        if sibling is not None:
+            TestingFactory.close_doc(sibling)
+        _cleanup_dir(temp_dir)
+
+
+@native_test
+@with_native_doc("calc")
+def test_sibling_ods_does_not_write_ods_cache(ctx, doc):
+    temp_dir = tempfile.mkdtemp(prefix="wa_duckdb_odsskip_")
+    sibling = TestingFactory.create_native_doc(ctx, "calc", hidden=True)
+    try:
+        _fill_offset_table(sibling)
+        ods_path = os.path.join(temp_dir, "budget.ods")
+        _store_sibling(sibling, ods_path)
+        TestingFactory.close_doc(sibling)
+        sibling = None
+
+        _read_sibling_office_file_as_grid(ctx, ods_path, sheet_hint="Actuals")
+        cache_dir = os.path.join(temp_dir, ODS_CACHE_DIRNAME)
+        assert not os.path.isdir(cache_dir), "native .ods must not create writeragent_ods_cache/"
+    finally:
+        if sibling is not None:
+            TestingFactory.close_doc(sibling)
+        _cleanup_dir(temp_dir)

--- a/tests/calc/test_ods_cache.py
+++ b/tests/calc/test_ods_cache.py
@@ -1,0 +1,124 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Tests for plugin.calc.ods_cache (mtime key, hit/miss, ODS skip)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from plugin.calc.ods_cache import (
+    CACHE_FORMAT_VERSION,
+    ODS_CACHE_DIRNAME,
+    cache_entry_paths,
+    cache_key,
+    is_cacheable_office_source,
+    lookup_cached_ods,
+    meta_matches_source,
+    ods_cache_dir,
+    ods_cache_enabled,
+    source_stat,
+    write_sidecar_meta,
+)
+
+
+def _write_xlsx(path: Path, payload: bytes = b"PK\x03\x04xlsx") -> Path:
+    path.write_bytes(payload)
+    return path
+
+
+def _seed_cache(xlsx: Path, *, ods_bytes: bytes = b"PK\x03\x04cached-ods") -> tuple[Path, Path]:
+    paths = cache_entry_paths(str(xlsx))
+    assert paths is not None
+    ods_path, meta_path = paths
+    ods_path.parent.mkdir(parents=True, exist_ok=True)
+    ods_path.write_bytes(ods_bytes)
+    write_sidecar_meta(meta_path, str(xlsx))
+    return ods_path, meta_path
+
+
+def test_is_cacheable_office_source_xlsx_only():
+    assert is_cacheable_office_source("/tmp/budget.xlsx")
+    assert is_cacheable_office_source("/tmp/legacy.xls")
+    assert not is_cacheable_office_source("/tmp/ledger.ods")
+    assert not is_cacheable_office_source("/tmp/sales.csv")
+
+
+def test_cache_key_changes_with_mtime_or_size(tmp_path: Path):
+    xlsx = _write_xlsx(tmp_path / "budget.xlsx")
+    abs_path, mtime_ns, size = source_stat(str(xlsx))
+    first = cache_key(abs_path, mtime_ns, size)
+    assert first == cache_key(abs_path, mtime_ns, size)
+    assert first != cache_key(abs_path, mtime_ns + 1, size)
+    assert first != cache_key(abs_path, mtime_ns, size + 1)
+    assert first != cache_key(abs_path + "x", mtime_ns, size)
+
+
+def test_lookup_hit_then_mtime_change_misses(tmp_path: Path):
+    xlsx = _write_xlsx(tmp_path / "budget.xlsx")
+    ods_path, _meta = _seed_cache(xlsx)
+    hit = lookup_cached_ods(str(xlsx))
+    assert hit == ods_path
+
+    st = os.stat(xlsx)
+    os.utime(xlsx, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+    assert lookup_cached_ods(str(xlsx)) is None
+
+
+def test_lookup_size_change_misses(tmp_path: Path):
+    xlsx = _write_xlsx(tmp_path / "budget.xlsx")
+    _seed_cache(xlsx)
+    xlsx.write_bytes(xlsx.read_bytes() + b"x")
+    assert lookup_cached_ods(str(xlsx)) is None
+
+
+def test_lookup_missing_meta_is_miss(tmp_path: Path):
+    xlsx = _write_xlsx(tmp_path / "budget.xlsx")
+    ods_path, meta_path = _seed_cache(xlsx)
+    meta_path.unlink()
+    assert ods_path.is_file()
+    assert lookup_cached_ods(str(xlsx)) is None
+
+
+def test_lookup_format_version_bump_is_miss(tmp_path: Path):
+    xlsx = _write_xlsx(tmp_path / "budget.xlsx")
+    _ods_path, meta_path = _seed_cache(xlsx)
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["cache_format_version"] = CACHE_FORMAT_VERSION + 1
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+    assert lookup_cached_ods(str(xlsx)) is None
+
+
+def test_ods_source_never_looks_up_cache(tmp_path: Path):
+    ods = tmp_path / "ledger.ods"
+    ods.write_bytes(b"PK\x03\x04ods")
+    assert lookup_cached_ods(str(ods)) is None
+    assert not (tmp_path / ODS_CACHE_DIRNAME).exists()
+
+
+def test_ods_cache_dir_is_beside_source_folder(tmp_path: Path):
+    xlsx = _write_xlsx(tmp_path / "budget.xlsx")
+    assert ods_cache_dir(str(xlsx)) == tmp_path / ODS_CACHE_DIRNAME
+
+
+def test_meta_matches_source_rejects_wrong_path(tmp_path: Path):
+    xlsx = _write_xlsx(tmp_path / "budget.xlsx")
+    abs_path, mtime_ns, size = source_stat(str(xlsx))
+    meta = {
+        "cache_format_version": CACHE_FORMAT_VERSION,
+        "source_path": abs_path,
+        "mtime_ns": mtime_ns,
+        "size": size,
+    }
+    assert meta_matches_source(meta, abs_path, mtime_ns, size)
+    assert not meta_matches_source(meta, abs_path + ".bak", mtime_ns, size)
+
+
+def test_ods_cache_enabled_defaults_true_when_config_missing():
+    from unittest.mock import patch
+
+    with patch("plugin.framework.config.get_config", side_effect=Exception("no schema")):
+        assert ods_cache_enabled() is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase A+ **ODS mtime cache** for DuckDB sibling spreadsheet ingress. Repeated SQL over the same Excel file no longer re-runs LibreOffice’s XLSX filter every query.

- Cache dir: `writeragent_ods_cache/` beside the scoped document folder
- Key: SHA-256 of absolute source path + mtime_ns + size
- Hit: open cached `.ods` via the same used-range / `#SheetName` / fail-loud path
- Miss: hidden LO import → `storeToURL` (`calc8`) → read range(s) → sidecar meta
- Invalidate when source mtime/size changes, meta is missing, or `cache_format_version` bumps
- **Not cached:** native `.ods`, live already-open workbook
- Setting: `calc.ods_cache_enabled` (default `true`) in Settings / `writeragent.json`

## How to enable / disable

Enabled by default. To turn off:

```json
"calc.ods_cache_enabled": false
```

in `writeragent.json`, or uncheck **Cache Excel siblings as ODS** in Calc settings.

## Tests

- `tests/calc/test_ods_cache.py` — key, hit/miss, mtime/size invalidation, missing meta, version bump, ODS skip
- `tests/calc/test_duckdb_tools.py` — sibling open hit vs miss, ODS skip, live workbook skip, SQL preload through a cache hit
- `tests/calc/test_duckdb_tools_uno.py` — live LO Save As + reuse; native ODS does not create the cache dir

`make typecheck` passed. Preserves #595 used-range / fail-loud and #604 stable identity.

## Docs

`docs/calc/duckdb-dev-plan.md` — Phase A+ todo completed, status/changelog, setting name `calc.ods_cache_enabled`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3774d5a-8cb6-4b39-b84b-2cb0630d8ea7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3774d5a-8cb6-4b39-b84b-2cb0630d8ea7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

