### PR TITLE
Calc: sort via ranges + relative formula directives

### DIFF
--- a/docs/eval/oss-20b-eval.md
+++ b/docs/eval/oss-20b-eval.md
@@ -103,10 +103,10 @@ Keep diffs short.
 
 - Do `delegate_to_specialized_calc_toolset(domain="ranges")` then
   `sort_range` to reorder rows (multi-key = two stable one-column
-  passes). Prefer that over `write_formula_range` / `=PY` for sort
-  **because** those overwrite the range including headers.
-- Do pass `has_header=true` when row 1 is labels **because** otherwise
-  the header sorts like a value.
+  passes) because `write_formula_range` / `=PY` overwrite the range
+  including headers.
+- Do pass `has_header=true` when row 1 is labels because otherwise
+  labels sort as values.
 - Do write each row's formula with that row's cells (`Banana` → `B3`,
   not a stamped `B2`).
 
@@ -124,8 +124,8 @@ Keep diffs short.
 **Tool descriptions:**
 
 - `sort_range`: full contract — stable one-column; multi-key = multiple
-  calls; labeled tables → `has_header=true` (DO-first, because otherwise
-  the header sorts like a value).
+  calls; labeled tables → `has_header=true` (Do pass it when row 1 is
+  labels because otherwise labels sort as values).
 - `write_formula_range`: no sort-half sentence (slim surface). Relative
   / tax formula rule stays in Calc directives only.
 

--- a/docs/eval/oss-20b-eval.md
+++ b/docs/eval/oss-20b-eval.md
@@ -10,9 +10,10 @@ Related: [benchmarks.md](benchmarks.md), [eval-dev-plan.md](eval-dev-plan.md),
 
 **Status:** First A/B: 20b gained `data_sorting`; 120b regressed
 (`header row is not first` — used `sort_range` but treated Product/Revenue
-as a data row). Wording revised DO-first + slimmed (no `CALC_WORKFLOW`
-duplicate; no `write_formula_range` sort-half; `has_header` on
-`sort_range.description` plus a brief directive echo). Tax relative rule
+as a data row). Wording revised to one-sentence **Do Z because Y** + slimmed (no
+`CALC_WORKFLOW` duplicate; no `write_formula_range` sort-half; no
+Don't/Prefer-over opener; `has_header` on `sort_range.description`
+plus a brief directive echo). Tax relative rule
 stayed helpful for 120b. Shared prompt; no 20b fork. Re-A/B pending.
 
 ## Snapshot

--- a/docs/eval/oss-20b-eval.md
+++ b/docs/eval/oss-20b-eval.md
@@ -8,13 +8,12 @@ Related: [benchmarks.md](benchmarks.md), [eval-dev-plan.md](eval-dev-plan.md),
 [string-harness-upgrade.md](string-harness-upgrade.md),
 [dspy-prompt-optimization-plan.md](dspy-prompt-optimization-plan.md).
 
-**Status:** First A/B: 20b gained `data_sorting`; 120b regressed
-(`header row is not first` — used `sort_range` but treated Product/Revenue
-as a data row). Wording revised to compact **Do B and D because Y**
-(sort + `has_header` in one line; no `CALC_WORKFLOW` duplicate; no
-`write_formula_range` sort-half; no Don't/Prefer-over opener;
-`has_header` contract on `sort_range.description`). Tax relative rule
-stayed helpful for 120b. Shared prompt; no 20b fork. Re-A/B pending.
+**Status:** A/B: 20b gained `data_sorting`; header misses persist (models
+likely pass `has_header=false` explicitly — runtime already defaults True
+when omitted). `sort_range` now **requires** `has_header`. Calc directives
+are two short **Do Z because Y** lines (sort routing + `has_header`), not
+a mashed one-liner. Tax relative rule stayed helpful for 120b. Shared
+prompt; no 20b fork. Re-A/B pending.
 
 ## Snapshot
 
@@ -103,10 +102,11 @@ Keep diffs short.
 **Calc** (`CALC_CORE_DIRECTIVES` only for sort; slim `CALC_WORKFLOW`):
 
 - Do `delegate_to_specialized_calc_toolset(domain="ranges")` then
-  `sort_range` with `has_header=true` when row 1 is labels (multi-key
-  = two stable one-column passes) because `write_formula_range` /
-  `=PY` overwrite the range including headers and otherwise labels
-  sort as values.
+  `sort_range` to reorder rows (multi-key = two stable one-column
+  passes) because `write_formula_range` / `=PY` overwrite the range
+  including headers.
+- Do pass `has_header=true` on `sort_range` when row 1 is labels
+  because otherwise labels sort as values.
 - Do write each row's formula with that row's cells (`Banana` → `B3`,
   not a stamped `B2`).
 
@@ -123,9 +123,9 @@ Keep diffs short.
 
 **Tool descriptions:**
 
-- `sort_range`: full contract — stable one-column; multi-key = multiple
-  calls; labeled tables → `has_header=true` (Do pass it when row 1 is
-  labels because otherwise labels sort as values).
+- `sort_range`: stable one-column; multi-key = multiple calls; Do pass
+  `has_header=true` when row 1 is labels because otherwise labels sort
+  as values. Schema `required` is `["range", "has_header"]`.
 - `write_formula_range`: no sort-half sentence (slim surface). Relative
   / tax formula rule stays in Calc directives only.
 
@@ -213,7 +213,8 @@ production-compatible version of a demo is 2–3 lines in
 
 - [x] Draft the Calc directive patches + `sort_range` description (DO-first sort + `has_header`; relative formulas; slimmed after 120b miss)
 - [x] First 5-task A/B on 20b and 120b — 20b gained `data_sorting`; 120b `has_header` miss (`header row is not first`)
-- [ ] Re-A/B after DO-first + `has_header` wording (confirm 20b keep + 120b recover)
+- [x] Re-A/B after wording — header misses persist; likely explicit `has_header=false`
+- [ ] Re-A/B after required `has_header` + split DO lines
 - [ ] Full 17 if the A/B is a win and 120b does not regress
 - [ ] Tool-subset sweep if `data_sorting` still fails
 - [ ] Wrap `llm_chat_eval` as a DSPy module; GEPA on Calc/Draw blobs

--- a/docs/eval/oss-20b-eval.md
+++ b/docs/eval/oss-20b-eval.md
@@ -217,5 +217,4 @@ production-compatible version of a demo is 2–3 lines in
 - [ ] Full 17 if the A/B is a win and 120b does not regress
 - [ ] Tool-subset sweep if `data_sorting` still fails
 - [ ] Wrap `llm_chat_eval` as a DSPy module; GEPA on Calc/Draw blobs
-- [ ] Prompt-text pins in `tests/scripts/test_eval_prompts.py` for any
-  shipped wording
+- [x] Prompt-text pins in `tests/scripts/test_eval_prompts.py` for shipped Calc wording

--- a/docs/eval/oss-20b-eval.md
+++ b/docs/eval/oss-20b-eval.md
@@ -8,7 +8,9 @@ Related: [benchmarks.md](benchmarks.md), [eval-dev-plan.md](eval-dev-plan.md),
 [string-harness-upgrade.md](string-harness-upgrade.md),
 [dspy-prompt-optimization-plan.md](dspy-prompt-optimization-plan.md).
 
-**Status:** analysis only. No prompt or optimizer change yet.
+**Status:** Calc sort + relative-formula directives and the two tool-description
+lines are drafted (shared prompt; no 20b fork). Draw/Writer needle lines are
+out of scope. 5-task A/B on 20b/120b still pending.
 
 ## Snapshot
 
@@ -116,8 +118,9 @@ Keep diffs short.
 **Tool descriptions:**
 
 - `sort_range`: one-column, stable; two-key sorts are two calls.
-- `write_formula_range`: do not use `=PY` to sort or to stamp the same
-  formula on every tax row.
+- `write_formula_range`: sort half only (don't reorder rows with this
+  tool because it overwrites the range; use ranges/`sort_range`). The
+  relative/tax formula rule stays in Calc directives, not this description.
 
 Then eval only the five fails, both models:
 
@@ -201,7 +204,7 @@ production-compatible version of a demo is 2–3 lines in
 
 ## Open
 
-- [ ] Draft the three directive patches + two tool-description lines
+- [x] Draft the Calc directive patches + two tool-description lines (sort + relative formulas; sort-only on `write_formula_range`)
 - [ ] 5-task A/B on 20b and 120b
 - [ ] Full 17 if the A/B is a win and 120b does not regress
 - [ ] Tool-subset sweep if `data_sorting` still fails

--- a/docs/eval/oss-20b-eval.md
+++ b/docs/eval/oss-20b-eval.md
@@ -10,10 +10,10 @@ Related: [benchmarks.md](benchmarks.md), [eval-dev-plan.md](eval-dev-plan.md),
 
 **Status:** First A/B: 20b gained `data_sorting`; 120b regressed
 (`header row is not first` — used `sort_range` but treated Product/Revenue
-as a data row). Wording revised to one-sentence **Do Z because Y** + slimmed (no
-`CALC_WORKFLOW` duplicate; no `write_formula_range` sort-half; no
-Don't/Prefer-over opener; `has_header` on `sort_range.description`
-plus a brief directive echo). Tax relative rule
+as a data row). Wording revised to compact **Do B and D because Y**
+(sort + `has_header` in one line; no `CALC_WORKFLOW` duplicate; no
+`write_formula_range` sort-half; no Don't/Prefer-over opener;
+`has_header` contract on `sort_range.description`). Tax relative rule
 stayed helpful for 120b. Shared prompt; no 20b fork. Re-A/B pending.
 
 ## Snapshot
@@ -103,11 +103,10 @@ Keep diffs short.
 **Calc** (`CALC_CORE_DIRECTIVES` only for sort; slim `CALC_WORKFLOW`):
 
 - Do `delegate_to_specialized_calc_toolset(domain="ranges")` then
-  `sort_range` to reorder rows (multi-key = two stable one-column
-  passes) because `write_formula_range` / `=PY` overwrite the range
-  including headers.
-- Do pass `has_header=true` when row 1 is labels because otherwise
-  labels sort as values.
+  `sort_range` with `has_header=true` when row 1 is labels (multi-key
+  = two stable one-column passes) because `write_formula_range` /
+  `=PY` overwrite the range including headers and otherwise labels
+  sort as values.
 - Do write each row's formula with that row's cells (`Banana` → `B3`,
   not a stamped `B2`).
 

--- a/docs/eval/oss-20b-eval.md
+++ b/docs/eval/oss-20b-eval.md
@@ -8,9 +8,12 @@ Related: [benchmarks.md](benchmarks.md), [eval-dev-plan.md](eval-dev-plan.md),
 [string-harness-upgrade.md](string-harness-upgrade.md),
 [dspy-prompt-optimization-plan.md](dspy-prompt-optimization-plan.md).
 
-**Status:** Calc sort + relative-formula directives and the two tool-description
-lines are drafted (shared prompt; no 20b fork). Draw/Writer needle lines are
-out of scope. 5-task A/B on 20b/120b still pending.
+**Status:** First A/B: 20b gained `data_sorting`; 120b regressed
+(`header row is not first` — used `sort_range` but treated Product/Revenue
+as a data row). Wording revised DO-first + slimmed (no `CALC_WORKFLOW`
+duplicate; no `write_formula_range` sort-half; `has_header` on
+`sort_range.description` plus a brief directive echo). Tax relative rule
+stayed helpful for 120b. Shared prompt; no 20b fork. Re-A/B pending.
 
 ## Snapshot
 
@@ -96,13 +99,16 @@ Do **not** start with `python run_optimize.py --model openai/gpt-oss-20b`.
 Draft in `plugin/framework/prompts.py` and the two Calc tool descriptions.
 Keep diffs short.
 
-**Calc** (`CALC_CORE_DIRECTIVES` / `CALC_WORKFLOW`):
+**Calc** (`CALC_CORE_DIRECTIVES` only for sort; slim `CALC_WORKFLOW`):
 
-- Sort / reorder rows → `delegate_to_specialized_calc_toolset(domain="ranges")`
-  then `sort_range`. Two-key sorts are two stable one-column passes
-  (Revenue desc, then Product asc). Do **not** use `=PY` to sort in place.
-- Relative formulas must use *this* row (`Banana` → `=B3*0.08`, not a
-  copied `B2`).
+- Do `delegate_to_specialized_calc_toolset(domain="ranges")` then
+  `sort_range` to reorder rows (multi-key = two stable one-column
+  passes). Prefer that over `write_formula_range` / `=PY` for sort
+  **because** those overwrite the range including headers.
+- Do pass `has_header=true` when row 1 is labels **because** otherwise
+  the header sorts like a value.
+- Do write each row's formula with that row's cells (`Banana` → `B3`,
+  not a stamped `B2`).
 
 **Draw** (workflow / `DRAW_CORE_DIRECTIVES`):
 
@@ -117,10 +123,11 @@ Keep diffs short.
 
 **Tool descriptions:**
 
-- `sort_range`: one-column, stable; two-key sorts are two calls.
-- `write_formula_range`: sort half only (don't reorder rows with this
-  tool because it overwrites the range; use ranges/`sort_range`). The
-  relative/tax formula rule stays in Calc directives, not this description.
+- `sort_range`: full contract — stable one-column; multi-key = multiple
+  calls; labeled tables → `has_header=true` (DO-first, because otherwise
+  the header sorts like a value).
+- `write_formula_range`: no sort-half sentence (slim surface). Relative
+  / tax formula rule stays in Calc directives only.
 
 Then eval only the five fails, both models:
 
@@ -204,8 +211,9 @@ production-compatible version of a demo is 2–3 lines in
 
 ## Open
 
-- [x] Draft the Calc directive patches + two tool-description lines (sort + relative formulas; sort-only on `write_formula_range`)
-- [ ] 5-task A/B on 20b and 120b
+- [x] Draft the Calc directive patches + `sort_range` description (DO-first sort + `has_header`; relative formulas; slimmed after 120b miss)
+- [x] First 5-task A/B on 20b and 120b — 20b gained `data_sorting`; 120b `has_header` miss (`header row is not first`)
+- [ ] Re-A/B after DO-first + `has_header` wording (confirm 20b keep + 120b recover)
 - [ ] Full 17 if the A/B is a win and 120b does not regress
 - [ ] Tool-subset sweep if `data_sorting` still fails
 - [ ] Wrap `llm_chat_eval` as a DSPy module; GEPA on Calc/Draw blobs

--- a/plugin/calc/cells.py
+++ b/plugin/calc/cells.py
@@ -198,7 +198,9 @@ class WriteCellRange(ToolBase):
         "YYYY-MM-DDTHH:MM[:SS]. These become real Calc date/time values. Elapsed/stopwatch values: "
         "use PTnHnMnS (e.g. PT30H, PT1H30M); these become duration serials with elapsed formatting. "
         "Do not include a timezone offset or Z, and do not use locale forms like 08/05/2026; those "
-        "are stored as text. Prefix with an apostrophe ('2026-08-08) to force text."
+        "are stored as text. Prefix with an apostrophe ('2026-08-08) to force text. "
+        "Don't use this tool to reorder rows because it overwrites the range (including headers); "
+        'do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range instead.'
     )
     parameters = {
         "type": "object",
@@ -483,7 +485,11 @@ class SortRange(ToolCalcRangeBase):
 
     name = "sort_range"
     intent = "edit"
-    description = "Sorts the specified range(s) by a column. Use for ordering rows by values in one column. Supports lists for non-contiguous areas."
+    description = (
+        "Stable one-column sort of the specified range(s) by values in one column "
+        "(has_header keeps the first row in place). Multi-key sorts are multiple calls "
+        "(two stable one-column passes). Supports lists for non-contiguous areas."
+    )
     parameters = {
         "type": "object",
         "properties": {

--- a/plugin/calc/cells.py
+++ b/plugin/calc/cells.py
@@ -496,9 +496,15 @@ class SortRange(ToolCalcRangeBase):
             "range": {"type": "array", "items": {"type": "string"}, "description": ('Range(s) to sort (e.g. ["A1:D10"] or ["A1:B10", "D1:E10"]).')},
             "sort_column": {"type": "integer", "description": ("0-based column index within the range to sort by (default: 0)")},
             "ascending": {"type": "boolean", "description": ("True for ascending, False for descending (default: true)")},
-            "has_header": {"type": "boolean", "description": ("Is the first row a header that should not be sorted? (default: true)")},
+            "has_header": {
+                "type": "boolean",
+                "description": (
+                    "true when row 1 is labels; false only for a headerless block "
+                    "(default: true)."
+                ),
+            },
         },
-        "required": ["range"],
+        "required": ["range", "has_header"],
     }
     uno_services = ["com.sun.star.sheet.SpreadsheetDocument"]
     is_mutation = True

--- a/plugin/calc/cells.py
+++ b/plugin/calc/cells.py
@@ -486,8 +486,8 @@ class SortRange(ToolCalcRangeBase):
     description = (
         "Stable one-column sort of the specified range(s) by values in one column. "
         "Multi-key sorts are multiple calls (two stable one-column passes). "
-        "Do pass has_header=true when row 1 is labels because otherwise the header "
-        "sorts like a value and leaves the top of the sheet. "
+        "Do pass has_header=true when row 1 is labels because otherwise labels "
+        "sort as values. "
         "Supports lists for non-contiguous areas."
     )
     parameters = {

--- a/plugin/calc/cells.py
+++ b/plugin/calc/cells.py
@@ -198,9 +198,7 @@ class WriteCellRange(ToolBase):
         "YYYY-MM-DDTHH:MM[:SS]. These become real Calc date/time values. Elapsed/stopwatch values: "
         "use PTnHnMnS (e.g. PT30H, PT1H30M); these become duration serials with elapsed formatting. "
         "Do not include a timezone offset or Z, and do not use locale forms like 08/05/2026; those "
-        "are stored as text. Prefix with an apostrophe ('2026-08-08) to force text. "
-        "Don't use this tool to reorder rows because it overwrites the range (including headers); "
-        'do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range instead.'
+        "are stored as text. Prefix with an apostrophe ('2026-08-08) to force text."
     )
     parameters = {
         "type": "object",
@@ -486,9 +484,11 @@ class SortRange(ToolCalcRangeBase):
     name = "sort_range"
     intent = "edit"
     description = (
-        "Stable one-column sort of the specified range(s) by values in one column "
-        "(has_header keeps the first row in place). Multi-key sorts are multiple calls "
-        "(two stable one-column passes). Supports lists for non-contiguous areas."
+        "Stable one-column sort of the specified range(s) by values in one column. "
+        "Multi-key sorts are multiple calls (two stable one-column passes). "
+        "Do pass has_header=true when row 1 is labels because otherwise the header "
+        "sorts like a value and leaves the top of the sheet. "
+        "Supports lists for non-contiguous areas."
     )
     parameters = {
         "type": "object",

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -383,13 +383,16 @@ CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_H
 - You MUST NOT ask the user where the file is stored, or to upload, paste, or share its contents.
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
-Python on sheet data: write_formula_range of =PY (that tool's description)."""
+Python on sheet data: write_formula_range of =PY (that tool's description).
+Don't sort or reorder rows with write_formula_range or =PY because that overwrites the range (including headers) and fights Calc's own sort; do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range instead (multi-key sorts are two stable one-column passes).
+Don't copy one prototype formula onto every fill row because cell refs stay pinned to the first row; do write each row's formula with that row's cells instead (e.g. Banana row uses B3, not a stamped B2)."""
 
 
 CALC_WORKFLOW = """WORKFLOW:
 1. get_sheet_summary for size/headers.
    read_cell_range only for a small peek (headers or a few dozen cells).
    A large range in chat overloads the model context — for transforms, pass the A1 address to =PY instead of reading the values.
+   Don't sort or reorder rows with write_formula_range or =PY because that overwrites the range (including headers) and fights Calc's own sort; do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range instead (multi-key sorts are two stable one-column passes).
 2. Do the work with tools. Use ranges, not one cell at a time.
 3. Short confirmation; if you changed cells, name the range (e.g. "Wrote totals in B5:B8")."""
 

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -384,7 +384,8 @@ CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_H
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
 Python on sheet data: write_formula_range of =PY (that tool's description).
-Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range with has_header=true when row 1 is labels (multi-key sorts are two stable one-column passes) because write_formula_range or =PY overwrite the range including headers and otherwise labels sort as values.
+Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range to reorder rows (multi-key sorts are two stable one-column passes) because write_formula_range or =PY overwrite the range including headers.
+Do pass has_header=true on sort_range when row 1 is labels because otherwise labels sort as values.
 Do write each row's formula with that row's cells because copying one prototype pins cell refs to the first row (e.g. Banana row uses B3, not a stamped B2)."""
 
 

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -384,15 +384,15 @@ CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_H
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
 Python on sheet data: write_formula_range of =PY (that tool's description).
-Don't sort or reorder rows with write_formula_range or =PY because that overwrites the range (including headers) and fights Calc's own sort; do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range instead (multi-key sorts are two stable one-column passes).
-Don't copy one prototype formula onto every fill row because cell refs stay pinned to the first row; do write each row's formula with that row's cells instead (e.g. Banana row uses B3, not a stamped B2)."""
+Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range to reorder rows (multi-key sorts are two stable one-column passes). Prefer that over write_formula_range or =PY for sort because those overwrite the range including headers.
+Do pass has_header=true on sort_range when row 1 is labels because otherwise the header sorts like a value and leaves the top of the sheet.
+Do write each row's formula with that row's cells because copying one prototype pins cell refs to the first row (e.g. Banana row uses B3, not a stamped B2)."""
 
 
 CALC_WORKFLOW = """WORKFLOW:
 1. get_sheet_summary for size/headers.
    read_cell_range only for a small peek (headers or a few dozen cells).
    A large range in chat overloads the model context — for transforms, pass the A1 address to =PY instead of reading the values.
-   Don't sort or reorder rows with write_formula_range or =PY because that overwrites the range (including headers) and fights Calc's own sort; do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range instead (multi-key sorts are two stable one-column passes).
 2. Do the work with tools. Use ranges, not one cell at a time.
 3. Short confirmation; if you changed cells, name the range (e.g. "Wrote totals in B5:B8")."""
 

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -384,8 +384,7 @@ CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_H
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
 Python on sheet data: write_formula_range of =PY (that tool's description).
-Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range to reorder rows (multi-key sorts are two stable one-column passes) because write_formula_range or =PY overwrite the range including headers.
-Do pass has_header=true on sort_range when row 1 is labels because otherwise labels sort as values.
+Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range with has_header=true when row 1 is labels (multi-key sorts are two stable one-column passes) because write_formula_range or =PY overwrite the range including headers and otherwise labels sort as values.
 Do write each row's formula with that row's cells because copying one prototype pins cell refs to the first row (e.g. Banana row uses B3, not a stamped B2)."""
 
 

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -384,8 +384,8 @@ CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_H
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
 Python on sheet data: write_formula_range of =PY (that tool's description).
-Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range to reorder rows (multi-key sorts are two stable one-column passes). Prefer that over write_formula_range or =PY for sort because those overwrite the range including headers.
-Do pass has_header=true on sort_range when row 1 is labels because otherwise the header sorts like a value and leaves the top of the sheet.
+Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range to reorder rows (multi-key sorts are two stable one-column passes) because write_formula_range or =PY overwrite the range including headers.
+Do pass has_header=true on sort_range when row 1 is labels because otherwise labels sort as values.
 Do write each row's formula with that row's cells because copying one prototype pins cell refs to the first row (e.g. Banana row uses B3, not a stamped B2)."""
 
 

--- a/tests/scripts/test_eval_prompts.py
+++ b/tests/scripts/test_eval_prompts.py
@@ -53,13 +53,12 @@ def test_calc_draw_eval_prompts_use_production_builder() -> None:
 # Rule shape: Do Z because Y (lead with Do). Shared prompt — no 20b fork.
 _CALC_SORT_ROUTING = (
     'Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range '
-    "to reorder rows (multi-key sorts are two stable one-column passes). "
-    "Prefer that over write_formula_range or =PY for sort because those "
-    "overwrite the range including headers."
+    "to reorder rows (multi-key sorts are two stable one-column passes) "
+    "because write_formula_range or =PY overwrite the range including headers."
 )
 _CALC_HAS_HEADER = (
     "Do pass has_header=true on sort_range when row 1 is labels because "
-    "otherwise the header sorts like a value and leaves the top of the sheet."
+    "otherwise labels sort as values."
 )
 _CALC_RELATIVE_FORMULA = (
     "Do write each row's formula with that row's cells because copying one "
@@ -67,8 +66,8 @@ _CALC_RELATIVE_FORMULA = (
     "stamped B2)."
 )
 _SORT_RANGE_HAS_HEADER = (
-    "Do pass has_header=true when row 1 is labels because otherwise the header "
-    "sorts like a value and leaves the top of the sheet."
+    "Do pass has_header=true when row 1 is labels because otherwise labels "
+    "sort as values."
 )
 
 

--- a/tests/scripts/test_eval_prompts.py
+++ b/tests/scripts/test_eval_prompts.py
@@ -47,3 +47,45 @@ def test_calc_draw_eval_prompts_use_production_builder() -> None:
     draw = get_draw_eval_chat_system_prompt()
     assert "get_draw_tree" in draw
     assert EVAL_HARNESS_NOTE in draw
+
+
+# gpt-oss-20b data_sorting / tax_column routing (docs/eval/oss-20b-eval.md).
+# Rule shape: Don't X because Y; do Z instead. Shared prompt — no 20b fork.
+_CALC_SORT_ROUTING = (
+    "Don't sort or reorder rows with write_formula_range or =PY because that "
+    "overwrites the range (including headers) and fights Calc's own sort; do "
+    'delegate_to_specialized_calc_toolset(domain="ranges") then sort_range instead '
+    "(multi-key sorts are two stable one-column passes)."
+)
+_CALC_RELATIVE_FORMULA = (
+    "Don't copy one prototype formula onto every fill row because cell refs stay "
+    "pinned to the first row; do write each row's formula with that row's cells "
+    "instead (e.g. Banana row uses B3, not a stamped B2)."
+)
+_WRITE_FORMULA_RANGE_SORT_ONLY = (
+    "Don't use this tool to reorder rows because it overwrites the range "
+    "(including headers); do delegate_to_specialized_calc_toolset"
+    '(domain="ranges") then sort_range instead.'
+)
+
+
+def test_calc_eval_prompt_pins_sort_and_relative_formula_rules() -> None:
+    calc = get_calc_eval_chat_system_prompt()
+    assert _CALC_SORT_ROUTING in calc
+    assert _CALC_RELATIVE_FORMULA in calc
+    # Writer/Draw needle lines stay out of this shared Calc prompt.
+    assert "NEMA 4" not in calc
+    assert "flowchart" not in calc.lower()
+
+
+def test_calc_tool_descriptions_pin_sort_routing_not_tax() -> None:
+    from plugin.calc.cells import SortRange, WriteCellRange
+
+    write_desc = WriteCellRange.description
+    assert _WRITE_FORMULA_RANGE_SORT_ONLY in write_desc
+    assert "Banana" not in write_desc
+    assert "stamped B2" not in write_desc
+    sort_desc = SortRange.description
+    assert "Stable one-column sort" in sort_desc
+    assert "Multi-key sorts are multiple calls" in sort_desc
+    assert "two stable one-column passes" in sort_desc

--- a/tests/scripts/test_eval_prompts.py
+++ b/tests/scripts/test_eval_prompts.py
@@ -50,12 +50,15 @@ def test_calc_draw_eval_prompts_use_production_builder() -> None:
 
 
 # gpt-oss-20b data_sorting / tax_column routing (docs/eval/oss-20b-eval.md).
-# Rule shape: compact Do B and D because Y. Shared prompt — no 20b fork.
-_CALC_SORT_AND_HAS_HEADER = (
+# Rule shape: Do Z because Y (two short sort lines). Shared prompt — no 20b fork.
+_CALC_SORT_ROUTING = (
     'Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range '
-    "with has_header=true when row 1 is labels (multi-key sorts are two "
-    "stable one-column passes) because write_formula_range or =PY overwrite "
-    "the range including headers and otherwise labels sort as values."
+    "to reorder rows (multi-key sorts are two stable one-column passes) "
+    "because write_formula_range or =PY overwrite the range including headers."
+)
+_CALC_HAS_HEADER = (
+    "Do pass has_header=true on sort_range when row 1 is labels because "
+    "otherwise labels sort as values."
 )
 _CALC_RELATIVE_FORMULA = (
     "Do write each row's formula with that row's cells because copying one "
@@ -72,10 +75,12 @@ def test_calc_eval_prompt_pins_sort_and_relative_formula_rules() -> None:
     from plugin.framework.prompts import CALC_WORKFLOW
 
     calc = get_calc_eval_chat_system_prompt()
-    assert _CALC_SORT_AND_HAS_HEADER in calc
+    assert _CALC_SORT_ROUTING in calc
+    assert _CALC_HAS_HEADER in calc
     assert _CALC_RELATIVE_FORMULA in calc
     # Slim surface: sort routing lives in CALC_CORE_DIRECTIVES only.
-    assert _CALC_SORT_AND_HAS_HEADER not in CALC_WORKFLOW
+    assert _CALC_SORT_ROUTING not in CALC_WORKFLOW
+    assert _CALC_HAS_HEADER not in CALC_WORKFLOW
     # Writer/Draw needle lines stay out of this shared Calc prompt.
     assert "NEMA 4" not in calc
     assert "flowchart" not in calc.lower()
@@ -93,3 +98,6 @@ def test_calc_tool_descriptions_pin_sort_has_header_not_tax() -> None:
     assert "Multi-key sorts are multiple calls" in sort_desc
     assert "two stable one-column passes" in sort_desc
     assert _SORT_RANGE_HAS_HEADER in sort_desc
+    assert SortRange.parameters["required"] == ["range", "has_header"]
+    assert "true when row 1 is labels" in SortRange.parameters["properties"]["has_header"]["description"]
+    assert "false only for a headerless block" in SortRange.parameters["properties"]["has_header"]["description"]

--- a/tests/scripts/test_eval_prompts.py
+++ b/tests/scripts/test_eval_prompts.py
@@ -50,15 +50,12 @@ def test_calc_draw_eval_prompts_use_production_builder() -> None:
 
 
 # gpt-oss-20b data_sorting / tax_column routing (docs/eval/oss-20b-eval.md).
-# Rule shape: Do Z because Y (lead with Do). Shared prompt — no 20b fork.
-_CALC_SORT_ROUTING = (
+# Rule shape: compact Do B and D because Y. Shared prompt — no 20b fork.
+_CALC_SORT_AND_HAS_HEADER = (
     'Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range '
-    "to reorder rows (multi-key sorts are two stable one-column passes) "
-    "because write_formula_range or =PY overwrite the range including headers."
-)
-_CALC_HAS_HEADER = (
-    "Do pass has_header=true on sort_range when row 1 is labels because "
-    "otherwise labels sort as values."
+    "with has_header=true when row 1 is labels (multi-key sorts are two "
+    "stable one-column passes) because write_formula_range or =PY overwrite "
+    "the range including headers and otherwise labels sort as values."
 )
 _CALC_RELATIVE_FORMULA = (
     "Do write each row's formula with that row's cells because copying one "
@@ -75,11 +72,10 @@ def test_calc_eval_prompt_pins_sort_and_relative_formula_rules() -> None:
     from plugin.framework.prompts import CALC_WORKFLOW
 
     calc = get_calc_eval_chat_system_prompt()
-    assert _CALC_SORT_ROUTING in calc
-    assert _CALC_HAS_HEADER in calc
+    assert _CALC_SORT_AND_HAS_HEADER in calc
     assert _CALC_RELATIVE_FORMULA in calc
     # Slim surface: sort routing lives in CALC_CORE_DIRECTIVES only.
-    assert _CALC_SORT_ROUTING not in CALC_WORKFLOW
+    assert _CALC_SORT_AND_HAS_HEADER not in CALC_WORKFLOW
     # Writer/Draw needle lines stay out of this shared Calc prompt.
     assert "NEMA 4" not in calc
     assert "flowchart" not in calc.lower()

--- a/tests/scripts/test_eval_prompts.py
+++ b/tests/scripts/test_eval_prompts.py
@@ -50,42 +50,51 @@ def test_calc_draw_eval_prompts_use_production_builder() -> None:
 
 
 # gpt-oss-20b data_sorting / tax_column routing (docs/eval/oss-20b-eval.md).
-# Rule shape: Don't X because Y; do Z instead. Shared prompt — no 20b fork.
+# Rule shape: Do Z because Y (lead with Do). Shared prompt — no 20b fork.
 _CALC_SORT_ROUTING = (
-    "Don't sort or reorder rows with write_formula_range or =PY because that "
-    "overwrites the range (including headers) and fights Calc's own sort; do "
-    'delegate_to_specialized_calc_toolset(domain="ranges") then sort_range instead '
-    "(multi-key sorts are two stable one-column passes)."
+    'Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range '
+    "to reorder rows (multi-key sorts are two stable one-column passes). "
+    "Prefer that over write_formula_range or =PY for sort because those "
+    "overwrite the range including headers."
+)
+_CALC_HAS_HEADER = (
+    "Do pass has_header=true on sort_range when row 1 is labels because "
+    "otherwise the header sorts like a value and leaves the top of the sheet."
 )
 _CALC_RELATIVE_FORMULA = (
-    "Don't copy one prototype formula onto every fill row because cell refs stay "
-    "pinned to the first row; do write each row's formula with that row's cells "
-    "instead (e.g. Banana row uses B3, not a stamped B2)."
+    "Do write each row's formula with that row's cells because copying one "
+    "prototype pins cell refs to the first row (e.g. Banana row uses B3, not a "
+    "stamped B2)."
 )
-_WRITE_FORMULA_RANGE_SORT_ONLY = (
-    "Don't use this tool to reorder rows because it overwrites the range "
-    "(including headers); do delegate_to_specialized_calc_toolset"
-    '(domain="ranges") then sort_range instead.'
+_SORT_RANGE_HAS_HEADER = (
+    "Do pass has_header=true when row 1 is labels because otherwise the header "
+    "sorts like a value and leaves the top of the sheet."
 )
 
 
 def test_calc_eval_prompt_pins_sort_and_relative_formula_rules() -> None:
+    from plugin.framework.prompts import CALC_WORKFLOW
+
     calc = get_calc_eval_chat_system_prompt()
     assert _CALC_SORT_ROUTING in calc
+    assert _CALC_HAS_HEADER in calc
     assert _CALC_RELATIVE_FORMULA in calc
+    # Slim surface: sort routing lives in CALC_CORE_DIRECTIVES only.
+    assert _CALC_SORT_ROUTING not in CALC_WORKFLOW
     # Writer/Draw needle lines stay out of this shared Calc prompt.
     assert "NEMA 4" not in calc
     assert "flowchart" not in calc.lower()
 
 
-def test_calc_tool_descriptions_pin_sort_routing_not_tax() -> None:
+def test_calc_tool_descriptions_pin_sort_has_header_not_tax() -> None:
     from plugin.calc.cells import SortRange, WriteCellRange
 
     write_desc = WriteCellRange.description
-    assert _WRITE_FORMULA_RANGE_SORT_ONLY in write_desc
+    assert "sort_range" not in write_desc
     assert "Banana" not in write_desc
     assert "stamped B2" not in write_desc
     sort_desc = SortRange.description
     assert "Stable one-column sort" in sort_desc
     assert "Multi-key sorts are multiple calls" in sort_desc
     assert "two stable one-column passes" in sort_desc
+    assert _SORT_RANGE_HAS_HEADER in sort_desc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`gpt-oss-20b` misses two Calc routing tasks on the 17-task string pack:

- **`data_sorting`:** first A/B — 20b uses `sort_range` and passes. Later A/B: header misses persist on both sizes (models likely emit `has_header=false` explicitly; runtime already defaults True when omitted).
- **`tax_column`:** stamps `=B2*0.08` onto every fruit row (Banana should use `B3`). Relative-formula rule stayed helpful for 120b.

Shared prompt only — no 20b fork. Re-A/B on 20b/120b will be run separately before merge.

## What changed

- **`sort_range` schema:** `required` is `["range", "has_header"]`. Runtime still defaults `has_header=True` if missing.
- **`CALC_CORE_DIRECTIVES`:** two short **Do Z because Y** lines (sort routing + `has_header`) plus relative formulas. No mashed one-liner.
- **`CALC_WORKFLOW`:** no duplicate sort line.
- **`sort_range.description`:** stable one-column; multi-key = multiple calls; Do pass `has_header=true` when row 1 is labels because otherwise labels sort as values.
- **`has_header` property:** `true` when row 1 is labels; `false` only for a headerless block (default: true).
- **`write_formula_range.description`:** no sort-half sentence.
- Prompt-text pins in `tests/scripts/test_eval_prompts.py`.

## Rule shape

**Do Z because Y** (brief why). Bare Don't only for real forks. No Don't stacks.

- Do `delegate_to_specialized_calc_toolset(domain="ranges")` then `sort_range` to reorder rows (multi-key sorts are two stable one-column passes) because `write_formula_range` or `=PY` overwrite the range including headers.
- Do pass `has_header=true` on `sort_range` when row 1 is labels because otherwise labels sort as values.
- Do write each row's formula with that row's cells because copying one prototype pins cell refs to the first row (Banana → `B3`, not a stamped `B2`).

## Out of scope

- Draw / flowchart / shapes routing
- Writer preserve-tokens / `10k` / `NEMA 4` needles
- Production few-shot examples / Action-Observation blocks
- A 20b-only prompt fork
- Running eval / OpenRouter from this change

## Test plan

- Pins in `tests/scripts/test_eval_prompts.py` for the two DO lines, tool description, and `required: ["range", "has_header"]`
- `make typecheck` and targeted pytest
- Re-A/B on 20b/120b separately before merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b1dfb37-072b-4895-a17c-c3e33e3fc2d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b1dfb37-072b-4895-a17c-c3e33e3fc2d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

