### PR TITLE
Eval: accept equivalent tax 8% formulas; stop naming write tools in sort why

### DIFF
--- a/docs/eval/eval-dev-plan.md
+++ b/docs/eval/eval-dev-plan.md
@@ -232,6 +232,25 @@ model. Keep `glm-5.3` in the current 613 snapshot since it already ran.
    `poolside/laguna-xs-2.1`) when key budget allows so Pareto is not
    carrying stale Sep 1 bits for those ids.
 
+#### Follow-up (oracle FN + sort because-clause)
+
+Forensics on the four catalog "hurts" (item 1 above):
+
+- Two tax `P→F` rows (`qwen/qwen3.8-27b`, `z-ai/glm-5.3`) were **oracle
+  false-negatives**: models wrote semantically correct relative 8% forms
+  (`=0.08*B{n}`, `=B{n}*8%`) that `_tax_formula_ok` rejected as a
+  string-literal `=B{n}*0.08`. Parser now accepts those equivalents
+  (and `8/100`, `$` / spaces / decimal comma) without loosening wrong
+  row, wrong factor, or Price-column junk. Shared-prompt tax lines stay
+  put so the real tax helps (20b, gemini-3.5-flash-lite, laguna-s-2.1)
+  are not undone.
+- `z-ai/glm-5.3-flash` sort `P→F` was **tool-naming priming**: the sort
+  Do-line because-clause named `write_formula_range` / `=PY`, and the
+  model sorted in its head then hand-rolled that write into A2:B6.
+  Because-clause is now "rewriting values by hand loses the header
+  row" — still `domain="ranges"` then `sort_range`, no tool names in
+  the why.
+
 Cross-links: [`oss-20b-eval.md`](oss-20b-eval.md),
 [PR 610](https://github.com/KeithCu/writeragent/pull/610),
 [PR 613](https://github.com/KeithCu/writeragent/pull/613),
@@ -239,4 +258,4 @@ Cross-links: [`oss-20b-eval.md`](oss-20b-eval.md),
 [`nemotron-35-eval.md`](nemotron-35-eval.md).
 
 ---
-*Updated Dev Plan v2.3 — Phase G retrospective (Sep 2026; PR 610 / PR 613)*
+*Updated Dev Plan v2.3 — Phase G retrospective (Sep 2026; PR 610 / PR 613); oracle/sort follow-up*

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -384,7 +384,7 @@ CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_H
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
 Python on sheet data: write_formula_range of =PY (that tool's description).
-Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range to reorder rows (multi-key sorts are two stable one-column passes) because write_formula_range or =PY overwrite the range including headers.
+Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range to reorder rows (multi-key sorts are two stable one-column passes) because rewriting values by hand loses the header row.
 Do pass has_header=true on sort_range when row 1 is labels because otherwise labels sort as values.
 Do write each row's formula with that row's cells because copying one prototype pins cell refs to the first row (e.g. Banana row uses B3, not a stamped B2)."""
 

--- a/scripts/prompt_optimization/oracles.py
+++ b/scripts/prompt_optimization/oracles.py
@@ -567,16 +567,98 @@ def oracle_py_dest(doc: str) -> list[str]:
     return []
 
 
-def _tax_formula_ok(text: str, row_1based: int) -> bool:
-    compact = (
+# Ranking after PR 610 writes commutated / percent 8% forms (=0.08*B2,
+# =B2*8%). A literal "=B{n}*0.08" match false-failed those.
+_TAX_RATE = 0.08
+_TAX_NUM_RE = re.compile(r"^(?P<body>\d*[.,]?\d+)(?P<pct>%)?$")
+_TAX_FORMULA_RE = re.compile(r"=[^=]+")
+
+
+def _normalize_tax_formula(text: str) -> str:
+    """Strip $, spaces, and newlines; treat LO ';' as ',' (decimal/args)."""
+    return (
         (text or "")
         .replace(" ", "")
+        .replace("\t", "")
         .replace("$", "")
-        .replace(";", "")
+        .replace(";", ",")
         .replace("\n", "")
+        .replace("\r", "")
         .upper()
     )
-    return f"=B{row_1based}*0.08" in compact
+
+
+def _parse_tax_factor(token: str) -> float | None:
+    """Parse 0.08, 0,08, 8%, or 8/100. None for cell refs or other junk."""
+    if not token:
+        return None
+    if "/" in token:
+        left, right = token.split("/", 1)
+        if "/" in right:
+            return None
+        num = _parse_tax_factor(left)
+        den = _parse_tax_factor(right)
+        if num is None or den is None or den == 0:
+            return None
+        return num / den
+    match = _TAX_NUM_RE.fullmatch(token)
+    if match is None:
+        return None
+    body = match.group("body").replace(",", ".")
+    if body in {".", ""}:
+        return None
+    try:
+        value = float(body)
+    except ValueError:
+        return None
+    if match.group("pct"):
+        return value / 100.0
+    return value
+
+
+def _tax_formula_candidates(text: str) -> list[str]:
+    """Split fill-down blobs so each '=…' formula is checked on its own."""
+    chunks: list[str] = []
+    for part in re.split(r"[\n\r]+", text or ""):
+        part = part.strip()
+        if not part:
+            continue
+        found = _TAX_FORMULA_RE.findall(part)
+        chunks.extend(found if found else [part])
+    return chunks
+
+
+def _tax_formula_one(text: str, row_1based: int) -> bool:
+    """True when text is a simple product of this row's B cell and 0.08."""
+    compact = _normalize_tax_formula(text)
+    if not compact.startswith("="):
+        return False
+    expr = compact[1:].strip(",")
+    # Functions / quoted =PY / ranges are not a relative Price*8% write.
+    if not expr or any(ch in expr for ch in "()[]{}\"'\\:"):
+        return False
+    parts = expr.split("*")
+    if len(parts) != 2:
+        return False
+    left, right = parts
+    price = f"B{row_1based}"
+    if left == price:
+        factor = _parse_tax_factor(right)
+    elif right == price:
+        factor = _parse_tax_factor(left)
+    else:
+        return False
+    return factor is not None and abs(factor - _TAX_RATE) < 1e-12
+
+
+def _tax_formula_ok(text: str, row_1based: int) -> bool:
+    """Accept a relative 8% of this row's Price (B), including equivalent forms.
+
+    Must reference B{row} and multiply by 0.08 (0.08, 8%, 8/100; either
+    order; $, spaces, decimal comma). Wrong row, wrong factor, other
+    columns, and non-relative junk still fail.
+    """
+    return any(_tax_formula_one(chunk, row_1based) for chunk in _tax_formula_candidates(text))
 
 
 def oracle_tax_column(doc: str) -> list[str]:

--- a/tests/scripts/test_eval_oracles.py
+++ b/tests/scripts/test_eval_oracles.py
@@ -16,6 +16,7 @@ if str(_PO) not in sys.path:
     sys.path.insert(0, str(_PO))
 
 from oracles import (  # noqa: E402
+    _tax_formula_ok,
     check_oracle,
     haystack_has,
     uses_llm_judge,
@@ -376,6 +377,103 @@ def test_py_dest_d1_with_a1_c8() -> None:
         .replace("A1:H500", "A1:C8")
     )
     assert check_oracle("py_no_bulk_read", doc) == []
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "=B2*0.08",
+        "=0.08*B2",
+        "=B2*8%",
+        "=8%*B2",
+        "=B2*8/100",
+        "=8/100*B2",
+        "= $B2 * 0.08",
+        "=B2*0,08",
+        "=B2*0.08;",
+    ],
+)
+def test_tax_formula_ok_accepts_equivalent_relative_forms(formula: str) -> None:
+    assert _tax_formula_ok(formula, 2)
+    assert not _tax_formula_ok(formula, 3)
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "=B3*0.08",
+        "=0.08*B3",
+        "=B$3*0.08",
+        "=$B$3*0.08",
+        "=B2*0.10",
+        "=B2*0.8",
+        "=B2*8",
+        "=C2*0.08",
+        "=A2*0.08",
+        "=B2",
+        "=0.08",
+        "=B2+0.08",
+        "=B2*B2*0.08",
+        '=PY("result = B2*0.08")',
+        "=SUM(B2)*0.08",
+        "=B2:B5*0.08",
+    ],
+)
+def test_tax_formula_ok_rejects_wrong_row_factor_and_junk(formula: str) -> None:
+    assert not _tax_formula_ok(formula, 2)
+
+
+def test_tax_equivalent_relative_forms_pass_oracle() -> None:
+    doc = json.dumps(
+        {
+            "status": "ok",
+            "snapshot": True,
+            "headers": ["Item", "Price", "Tax"],
+            "formulas": {
+                "C2": "=0.08*B2",
+                "C3": "=B3*8%",
+                "C4": "=8%*B4",
+                "C5": "=B5*0.08",
+            },
+            "grid": [
+                ["Item", "Price", "Tax"],
+                ["Apple", 10, "=0.08*B2"],
+                ["Banana", 5, "=B3*8%"],
+                ["Orange", 8, "=8%*B4"],
+                ["Pear", 12.5, "=B5*0.08"],
+                ["Note", "n/a", ""],
+                ["Total", "?", ""],
+            ],
+        }
+    )
+    assert check_oracle("tax_column", doc) == []
+
+
+def test_tax_formula_wrong_row_still_fails_oracle() -> None:
+    doc = json.dumps(
+        {
+            "status": "ok",
+            "snapshot": True,
+            "headers": ["Item", "Price", "Tax"],
+            "formulas": {
+                "C2": "=B2*0.08",
+                "C3": "=B2*0.08",
+                "C4": "=B4*0.08",
+                "C5": "=B5*0.08",
+            },
+            "grid": [
+                ["Item", "Price", "Tax"],
+                ["Apple", 10, "=B2*0.08"],
+                ["Banana", 5, "=B2*0.08"],
+                ["Orange", 8, "=B4*0.08"],
+                ["Pear", 12.5, "=B5*0.08"],
+                ["Note", "n/a", ""],
+                ["Total", "?", ""],
+            ],
+        }
+    )
+    fails = check_oracle("tax_column", doc)
+    assert any("Banana" in f and "relative" in f.lower() for f in fails), fails
 
 
 def test_tax_fill_down_blob_passes() -> None:

--- a/tests/scripts/test_eval_prompts.py
+++ b/tests/scripts/test_eval_prompts.py
@@ -54,7 +54,7 @@ def test_calc_draw_eval_prompts_use_production_builder() -> None:
 _CALC_SORT_ROUTING = (
     'Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range '
     "to reorder rows (multi-key sorts are two stable one-column passes) "
-    "because write_formula_range or =PY overwrite the range including headers."
+    "because rewriting values by hand loses the header row."
 )
 _CALC_HAS_HEADER = (
     "Do pass has_header=true on sort_range when row 1 is labels because "
@@ -78,6 +78,11 @@ def test_calc_eval_prompt_pins_sort_and_relative_formula_rules() -> None:
     assert _CALC_SORT_ROUTING in calc
     assert _CALC_HAS_HEADER in calc
     assert _CALC_RELATIVE_FORMULA in calc
+    # Naming write_formula_range / =PY in the because-clause primed weak
+    # models to call the tool we want them to avoid (glm-5.3-flash).
+    sort_line = next(line for line in calc.splitlines() if "then sort_range" in line)
+    assert "write_formula_range" not in sort_line
+    assert "=PY" not in sort_line
     # Slim surface: sort routing lives in CALC_CORE_DIRECTIVES only.
     assert _CALC_SORT_ROUTING not in CALC_WORKFLOW
     assert _CALC_HAS_HEADER not in CALC_WORKFLOW


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two surgical follow-ups from the Sep 2026 PR 610 regression analysis. Shared tax prompt lines are unchanged so models that truly improved on tax (gpt-oss-20b, gemini-3.5-flash-lite, laguna-s-2.1) are not undone.

## Tax oracle (highest priority)

`_tax_formula_ok` was a string-literal match for `=B{row}*0.08`. That false-failed semantically correct relative formulas ranking now produces (`=0.08*B2`, `=B2*8%` / `=8%*B2`, plus `8/100`, `$`, spaces, decimal comma / `;`).

The oracle now parses a simple product of this row's B cell and a 0.08 factor. Wrong row, wrong multiplier, absolute pins to the wrong row, Price-column refs, and non-relative junk still fail.

Two tax catalog "hurts" (qwen3.8-27b, glm-5.3) were oracle false-negatives.

## Sort Do-line because-clause

The production Calc sort line still routes through `delegate_to_specialized_calc_toolset(domain="ranges")` then `sort_range`. The because-clause no longer names `write_formula_range` or `=PY` (that primed glm-5.3-flash to sort in its head and hand-write A2:B6). It now says rewriting values by hand loses the header row.

has_header and per-row formula Do-lines are untouched.

## Tests / docs

- Oracle unit + fixture cases for equivalent forms and still-fail junk.
- Prompt pin updated; sort line must not mention `write_formula_range` / `=PY`.
- Phase G retrospective records the forensics (oracle FNs; tool-naming priming).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d563379d-4de7-4825-8dd5-17d0d5300fa3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d563379d-4de7-4825-8dd5-17d0d5300fa3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

