### PR TITLE
Split Calc Do-lines and fail write_formula_range length mismatch

### DIFF
--- a/docs/eval/eval-dev-plan.md
+++ b/docs/eval/eval-dev-plan.md
@@ -251,6 +251,24 @@ Forensics on the four catalog "hurts" (item 1 above):
   row" — still `domain="ranges"` then `sort_range`, no tool names in
   the why.
 
+#### Follow-on: split Do-lines + `write_formula_range` length check
+
+Optional later bucket after the 610/613 retrospective (not a tax-oracle
+change; keeps the PR 616 because-clause above):
+
+- **Prompt shape.** The three Calc teachings stay in
+  `CALC_CORE_DIRECTIVES`, but are no longer three adjacent identical
+  Do-because lines. `FORMULAS:` keeps the per-row Do-because; `SORT:`
+  (last, recency) keeps the only “Do … then tool” routing line; `has_header`
+  is a plain constraint under `SORT`. Hypothesis: identically-shaped
+  adjacent lines blur together for flash models, which then attend to one
+  and drop routing.
+- **Length mismatch.** `write_formula_range` now fails loud when a JSON
+  array’s leaf count does not match the A1 cell count (the schema already
+  said “exactly”; solar-pro4 still passed 4 values into an 8-cell range and
+  zip-style writes silently corrupted the extra cells). Same gate in the
+  string `CalcWorld`.
+
 Cross-links: [`oss-20b-eval.md`](oss-20b-eval.md),
 [PR 610](https://github.com/KeithCu/writeragent/pull/610),
 [PR 613](https://github.com/KeithCu/writeragent/pull/613),
@@ -258,4 +276,4 @@ Cross-links: [`oss-20b-eval.md`](oss-20b-eval.md),
 [`nemotron-35-eval.md`](nemotron-35-eval.md).
 
 ---
-*Updated Dev Plan v2.3 — Phase G retrospective (Sep 2026; PR 610 / PR 613); oracle/sort follow-up*
+*Updated Dev Plan v2.3 — Phase G retrospective (Sep 2026; PR 610 / PR 613); oracle/sort follow-up; Do-line split + length check*

--- a/plugin/calc/cells.py
+++ b/plugin/calc/cells.py
@@ -29,7 +29,7 @@ from typing import Any
 
 from plugin.framework.errors import ToolExecutionError
 from plugin.framework.tool import ToolBase
-from plugin.calc.address_utils import index_to_column, split_sheet_prefix
+from plugin.calc.address_utils import index_to_column, parse_range_string, split_sheet_prefix
 from plugin.calc.bridge import CalcBridge
 from plugin.calc.base import ToolCalcRangeBase
 from plugin.calc.inspector import CellInspector
@@ -105,6 +105,69 @@ def _preview_if_large(bridge, range_name: str) -> dict[str, Any] | None:
     except Exception:
         log.exception("Could not size range %s for read_cell_range cap; reading in full", range_name)
         return None
+
+
+def _leaf_value_count(payload: Any) -> int:
+    """Count scalar cells in a JSON array (nested rows flatten)."""
+    if not isinstance(payload, list):
+        return 1
+    n = 0
+    for item in payload:
+        n += _leaf_value_count(item) if isinstance(item, list) else 1
+    return n
+
+
+def _json_array_value_count(fov: Any) -> int | None:
+    """How many cells a JSON/list ``values`` payload names, or None if not an array write.
+
+    Scalar strings fill the whole range; empty / ``[]`` clears. Those are not
+    length-checked. Named ranges are handled by the caller (unparseable A1).
+    """
+    data: Any
+    if isinstance(fov, list):
+        data = fov
+    elif isinstance(fov, str):
+        stripped = fov.strip()
+        if not stripped.startswith("["):
+            return None
+        try:
+            data = json.loads(stripped)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        if not isinstance(data, list):
+            return None
+    else:
+        return None
+    if not data:
+        return None
+    return _leaf_value_count(data)
+
+
+def _a1_range_shape(range_name: str) -> tuple[int, int, int] | None:
+    """``(cell_count, rows, cols)`` for an A1 range, or None for named/invalid refs."""
+    try:
+        _unused_sheet, local = split_sheet_prefix(range_name)
+        (c0, r0), (c1, r1) = parse_range_string(local)
+    except Exception:
+        # Named ranges and deal.pre misses skip this gate; manipulator still checks 1-D.
+        return None
+    cols = abs(c1 - c0) + 1
+    rows = abs(r1 - r0) + 1
+    return cols * rows, rows, cols
+
+
+def _values_length_mismatch_message(range_name: str, n_vals: int, n_cells: int, rows: int, cols: int) -> str:
+    """Loud error so the model can resize the array or the range (no silent zip/pad)."""
+    hint = ""
+    if cols == 1 and rows > 1:
+        hint = " Write one value per row (each formula uses that row's cells)."
+    elif rows == 1 and cols > 1:
+        hint = " Write one value per column."
+    return (
+        f"Array has {n_vals} values but range {range_name} has {n_cells} cells "
+        f"({rows}×{cols}). JSON array must match range size exactly, or pass a "
+        f"single string to fill the whole range.{hint}"
+    )
 
 
 class ReadCellRange(ToolBase):
@@ -245,6 +308,23 @@ class WriteCellRange(ToolBase):
 
         if len(rn) == 0:
             return self._tool_error("range is required")
+
+        # Schema already says JSON array length must match the range. Models
+        # (solar-pro4) still passed 4 values into an 8-cell range; zip-style
+        # writes silently corrupt the extra cells. Fail before undo so the
+        # model can resize the array or the range. Named/unparseable A1 is
+        # left to the manipulator (it already errors on a 1-D mismatch).
+        n_vals = _json_array_value_count(fov)
+        if n_vals is not None:
+            for r in rn:
+                shape = _a1_range_shape(r)
+                if shape is None:
+                    continue
+                n_cells, rows, cols = shape
+                if n_vals != n_cells:
+                    return self._tool_error(
+                        _values_length_mismatch_message(r, n_vals, n_cells, rows, cols)
+                    )
 
         undo = WriterCompoundUndo(ctx.doc, "WriterAgent: Write formulas")
         try:

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -379,14 +379,26 @@ DEFAULT_WRITER_GREETING = "AI: I can edit or translate your document instantly w
 # ---------------------------------------------------------------------------
 
 # : str so checkers keep this as str (Writer/Draw already are, via a str-returning call).
+#
+# Sort / header / per-row formula used to be three adjacent identical
+# "Do Z because Y" lines. Small models (glm-5.3-flash) merged that blob and
+# dropped routing (hand-rolled write_formula_range instead of sort_range) while
+# still keeping the last teaching. Keep all three meanings, but give each a
+# different shape and a short header, and put SORT last (recency) because that
+# is the line flash dropped. Routing stays the only "Do … then tool" line;
+# has_header is a plain constraint under SORT. Do not restack Don't+Do
+# (duplicates, ~2× prompt). Because-clause is PR 616's: rewriting by hand
+# loses the header row — do not name write_formula_range / =PY in the why.
 CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_HINT} (another file/sheet by name or path, e.g. "my spreadsheet", "cell A9 from PythonInCalc"):
 - You MUST NOT ask the user where the file is stored, or to upload, paste, or share its contents.
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
 Python on sheet data: write_formula_range of =PY (that tool's description).
+FORMULAS:
+Do write each row's formula with that row's cells because copying one prototype pins cell refs to the first row (e.g. Banana row uses B3, not a stamped B2).
+SORT:
 Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range to reorder rows (multi-key sorts are two stable one-column passes) because rewriting values by hand loses the header row.
-Do pass has_header=true on sort_range when row 1 is labels because otherwise labels sort as values.
-Do write each row's formula with that row's cells because copying one prototype pins cell refs to the first row (e.g. Banana row uses B3, not a stamped B2)."""
+When row 1 is labels, pass has_header=true — otherwise labels sort as values."""
 
 
 CALC_WORKFLOW = """WORKFLOW:

--- a/scripts/prompt_optimization/eval_worlds.py
+++ b/scripts/prompt_optimization/eval_worlds.py
@@ -168,6 +168,33 @@ def range_cell_count(rng: str) -> int:
     return max(0, (c1 - c0 + 1) * (r1 - r0 + 1))
 
 
+def _leaf_write_count(values: list[Any]) -> int:
+    n = 0
+    for item in values:
+        n += len(item) if isinstance(item, list) else 1
+    return n
+
+
+def _write_values_length_mismatch(rng: str, values: list[Any]) -> str:
+    """Fail loud when a JSON/list write does not cover every cell (no zip-truncate)."""
+    n_cells = range_cell_count(rng)
+    if n_cells <= 0:
+        return ""
+    n_vals = _leaf_write_count(values)
+    if n_vals == 0:
+        return ""  # empty array clears, same as production
+    # Single scalar fills the whole range — same as production write_formula_range.
+    if n_vals == 1 and n_cells > 1:
+        return ""
+    if n_vals == n_cells:
+        return ""
+    return (
+        f"Array has {n_vals} values but range {rng} has {n_cells} cells. "
+        "JSON array must match range size exactly, or pass a single string to "
+        "fill the whole range."
+    )
+
+
 def normalize_apply_content(content: Any) -> str:
     """Mirror ApplyDocumentContent list/string normalization (content.py)."""
     if isinstance(content, str):
@@ -914,6 +941,9 @@ class CalcWorld:
         dests: list[str] = []
         if ranges:
             for rng in ranges:
+                mismatch = _write_values_length_mismatch(str(rng), values)
+                if mismatch:
+                    return {"status": "error", "message": mismatch}
                 dests.append(str(rng).split(":")[0].split(".")[-1])
                 written += self._write_a1_range(str(rng), values, raw_values)
         elif self._grid and values:

--- a/tests/calc/test_cells.py
+++ b/tests/calc/test_cells.py
@@ -595,3 +595,76 @@ def test_write_cell_range_tool_error_return():
         res = tool.execute(ctx, range=["A1"], values="123")
     assert res["status"] == "error"
     assert "UNO write failure" in res["message"]
+
+
+def test_json_array_value_count_and_a1_shape():
+    from plugin.calc.cells import _a1_range_shape, _json_array_value_count
+
+    assert _json_array_value_count('["a", "b", "c", "d"]') == 4
+    assert _json_array_value_count(["a", "b", "c", "d"]) == 4
+    assert _json_array_value_count([["a"], ["b"], ["c"], ["d"]]) == 4
+    assert _json_array_value_count("=B2+1") is None
+    assert _json_array_value_count("") is None
+    assert _json_array_value_count("[]") is None
+    assert _a1_range_shape("C2:C9") == (8, 8, 1)
+    assert _a1_range_shape("Sheet1.C2:C9") == (8, 8, 1)
+    assert _a1_range_shape("A1:B1") == (2, 1, 2)
+    assert _a1_range_shape("SalesData") is None
+
+
+def test_write_formula_range_rejects_json_length_mismatch():
+    """4 values into an 8-cell column must fail loud — no silent zip/pad."""
+    from plugin.calc.cells import WriteCellRange
+
+    ctx = SimpleNamespace(doc=MagicMock())
+    with (
+        patch("plugin.calc.cells.CalcBridge"),
+        patch("plugin.calc.cells.CellManipulator") as manip_cls,
+    ):
+        result = WriteCellRange().execute(
+            ctx, range=["C2:C9"], values='["a", "b", "c", "d"]'
+        )
+
+    assert result["status"] == "error"
+    assert "4 values" in result["message"]
+    assert "8 cells" in result["message"]
+    assert "one value per row" in result["message"]
+    manip_cls.return_value.write_formula_range.assert_not_called()
+
+
+def test_write_formula_range_rejects_list_length_mismatch():
+    from plugin.calc.cells import WriteCellRange
+
+    ctx = SimpleNamespace(doc=MagicMock())
+    with (
+        patch("plugin.calc.cells.CalcBridge"),
+        patch("plugin.calc.cells.CellManipulator") as manip_cls,
+    ):
+        result = WriteCellRange().execute(
+            ctx, range=["A1:B4"], values=["a", "b", "c", "d"]
+        )
+
+    assert result["status"] == "error"
+    assert "4 values" in result["message"]
+    assert "8 cells" in result["message"]
+    manip_cls.return_value.write_formula_range.assert_not_called()
+
+
+def test_write_formula_range_accepts_matching_json_and_scalar_fill():
+    from plugin.calc.cells import WriteCellRange
+
+    ctx = SimpleNamespace(doc=MagicMock())
+    with (
+        patch("plugin.calc.cells.CalcBridge"),
+        patch("plugin.calc.cells.CellManipulator") as manip_cls,
+        patch("plugin.writer.edit_review.WriterCompoundUndo"),
+    ):
+        manip_cls.return_value.write_formula_range.return_value = "wrote"
+        matched = WriteCellRange().execute(ctx, range=["A1:A2"], values='["x", "y"]')
+        filled = WriteCellRange().execute(ctx, range=["A1:A8"], values="=B2+1")
+        cleared = WriteCellRange().execute(ctx, range=["A1:A8"], values="")
+
+    assert matched["status"] == "ok"
+    assert filled["status"] == "ok"
+    assert cleared["status"] == "ok"
+    assert manip_cls.return_value.write_formula_range.call_count == 3

--- a/tests/scripts/test_eval_prompts.py
+++ b/tests/scripts/test_eval_prompts.py
@@ -50,15 +50,15 @@ def test_calc_draw_eval_prompts_use_production_builder() -> None:
 
 
 # gpt-oss-20b data_sorting / tax_column routing (docs/eval/oss-20b-eval.md).
-# Rule shape: Do Z because Y (two short sort lines). Shared prompt — no 20b fork.
+# Teachings stay; shape is split so flash models cannot merge three adjacent
+# identical Do-because lines. Because-clause text is PR 616's (no write tools).
 _CALC_SORT_ROUTING = (
     'Do delegate_to_specialized_calc_toolset(domain="ranges") then sort_range '
     "to reorder rows (multi-key sorts are two stable one-column passes) "
     "because rewriting values by hand loses the header row."
 )
 _CALC_HAS_HEADER = (
-    "Do pass has_header=true on sort_range when row 1 is labels because "
-    "otherwise labels sort as values."
+    "When row 1 is labels, pass has_header=true — otherwise labels sort as values."
 )
 _CALC_RELATIVE_FORMULA = (
     "Do write each row's formula with that row's cells because copying one "
@@ -72,7 +72,7 @@ _SORT_RANGE_HAS_HEADER = (
 
 
 def test_calc_eval_prompt_pins_sort_and_relative_formula_rules() -> None:
-    from plugin.framework.prompts import CALC_WORKFLOW
+    from plugin.framework.prompts import CALC_CORE_DIRECTIVES, CALC_WORKFLOW
 
     calc = get_calc_eval_chat_system_prompt()
     assert _CALC_SORT_ROUTING in calc
@@ -83,6 +83,13 @@ def test_calc_eval_prompt_pins_sort_and_relative_formula_rules() -> None:
     sort_line = next(line for line in calc.splitlines() if "then sort_range" in line)
     assert "write_formula_range" not in sort_line
     assert "=PY" not in sort_line
+    # Headers + different shapes: not three adjacent identical Do-because lines.
+    assert "FORMULAS:" in CALC_CORE_DIRECTIVES
+    assert "SORT:" in CALC_CORE_DIRECTIVES
+    assert "Do pass has_header=true" not in CALC_CORE_DIRECTIVES
+    formulas_at = CALC_CORE_DIRECTIVES.index("FORMULAS:")
+    sort_at = CALC_CORE_DIRECTIVES.index("SORT:")
+    assert formulas_at < sort_at
     # Slim surface: sort routing lives in CALC_CORE_DIRECTIVES only.
     assert _CALC_SORT_ROUTING not in CALC_WORKFLOW
     assert _CALC_HAS_HEADER not in CALC_WORKFLOW

--- a/tests/scripts/test_eval_worlds.py
+++ b/tests/scripts/test_eval_worlds.py
@@ -99,6 +99,23 @@ def test_sort_two_pass_stable_device_before_widget() -> None:
     assert names == ["Tool", "Device", "Widget", "Gadget", "Aardvark"]
 
 
+def test_calc_write_formula_range_rejects_length_mismatch() -> None:
+    calc = CalcWorld("Item\tAmt\nAnn\t1\nBea\t2\nCal\t3\nDee\t4")
+    res = calc.write_formula_range(range=["C2:C9"], values=["a", "b", "c", "d"])
+    assert res["status"] == "error"
+    assert "4 values" in res["message"]
+    assert "8 cells" in res["message"]
+    # Must not zip-truncate into the extra rows.
+    assert calc.writes == []
+
+
+def test_calc_write_formula_range_accepts_scalar_fill() -> None:
+    calc = CalcWorld("Item\tAmt\nAnn\t1")
+    res = calc.write_formula_range(range=["C2:C5"], values="=B2+1")
+    assert res["status"] == "ok"
+    assert res["written"] == 4
+
+
 def test_sheet_summary_includes_all_rows() -> None:
     calc = CalcWorld("Item\tPrice\nApple\t10\nBanana\t5\nOrange\t8\nPear\t12.5\nNote\tn/a\nTotal\t?")
     summary = calc.get_sheet_summary()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR 610 ended `CALC_CORE_DIRECTIVES` with three adjacent identically-shaped **Do Z because Y** lines (sort routing, `has_header`, per-row formulas). `z-ai/glm-5.3-flash` appears to have merged that blob, attended to one teaching, and dropped routing — it hand-rolled `write_formula_range` instead of `sort_range`.

Separately, `write_formula_range` advertised “JSON array must match range size exactly” but did not enforce it at the tool boundary. A short array into a longer range zip-wrote the prefix and silently left/corrupted the extra cells (solar-pro4: 4 values into an 8-cell range).

## Rebase onto master (after PR 616)

Rebased onto current master so this PR sits on 616. Resolution:

- **Because-clause:** keep 616’s “rewriting values by hand loses the header row” (no `write_formula_range` / `=PY` in the why)
- **Structure:** keep 617’s `FORMULAS:` / `SORT:` headers, `has_header` as a plain constraint under `SORT`, routing last for recency
- **Docs:** keep both Phase G notes (616 oracle/sort forensics + 617 split/length-check)
- Prompt pins assert both the 616 because-clause and the 617 shape

## Structural choice (prompt)

Keep all three teachings. Do **not** restack Don't+Do (duplicates, ~2× prompt). Do **not** move routing into `CALC_WORKFLOW` (that block sits earlier; last tokens get recency).

- `FORMULAS:` — keep the per-row **Do … because** line
- `SORT:` — keep routing as the only **Do … then tool** line
- Under `SORT`, `has_header` is a **plain constraint**, not a third Do-because

Why this should help weak-model attention: three identical adjacent templates collapse into one attended line. Different headers, different syntactic shapes, and recency on the line flash dropped give each teaching its own slot without a Don't stack.

## Length mismatch

`WriteCellRange.execute` now counts JSON/list leaves against the A1 cell count and returns `_tool_error` **before undo**. Column ranges add a per-row hint. Named/unparseable A1 skips this gate (manipulator still checks 1-D). The string `CalcWorld` uses the same contract so eval cannot zip-truncate.

## Out of scope

- Tax oracle (`_tax_formula_ok`) / Tax/Price task wording (shipped in 616)
- Don't stacks, 20b-only prompt fork

## Tests

- Prompt pins: 616 because-clause, no write tools on the sort line, FORMULAS before SORT, `has_header` no longer Do-because
- `write_formula_range` unit tests: 4-into-8 JSON/list reject; matching JSON, scalar fill, and clear still write
- `CalcWorld` rejects the same 4-into-8 case and does not record a write
- After rebase: targeted pytest 164 passed; `make typecheck` clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83c0ce16-ef41-43e6-9326-7dbe1a314748?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83c0ce16-ef41-43e6-9326-7dbe1a314748&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

