### PR TITLE
docs: rewrite Phase G as current sort/tax state after 616–618

### DIFF
--- a/docs/eval/eval-dev-plan.md
+++ b/docs/eval/eval-dev-plan.md
@@ -90,191 +90,93 @@ Calc chat no longer delegates `domain="python"`; models must `write_formula_rang
 
 Scoring: dest vs parsed data range on `--backend string` (`CalcWorld` records dest + formula). LO later for spill. Next ranking run is live `--backend string` (do not regenerate golds first). Optimize output if needed: `optimized_calc_py_prompt.json`.
 
-### G. Calc sort/tax prompt lift (Sep 2026 — PR 610 / selective re-rank)
+### G. Calc sort/tax prompt lift (current — PRs 616 / 617 / 618)
 
-Retrospective for the shared Calc prompt work that came out of
-[`oss-20b-eval.md`](oss-20b-eval.md). Keith may keep [PR 610](https://github.com/KeithCu/writeragent/pull/610)
-despite some catalog regressions; this section is the durable record of what
-shipped, what the factorial and selective re-measure actually showed, and
-what to do next. Product prompts and ranking JSON are **not** edited here.
+Shared Calc prompts and the tax oracle are better after this sequence.
+Ranking dropped full `glm-5.3` and selectively remeasured sort+tax.
+Production still ships **one** Calc prompt for all models — there is no
+20b-only fork. The full 17-task pack was **not** re-run.
 
-Source plan: [`oss-20b-eval.md`](oss-20b-eval.md) (gpt-oss-20b lift ideas from
-the Sep 1 ranking). Production still ships **one** Calc prompt for all
-models — there is no 20b-only fork.
+Source plan: [`oss-20b-eval.md`](oss-20b-eval.md). Scores:
+[`benchmarks.md`](benchmarks.md).
 
-#### Starting point (Sep 1 catalog)
+#### What is true now
 
-17-task `--backend string` ranking in `benchmark_results*.json` (see
-[`benchmarks.md`](benchmarks.md)). The 20b failures called out in
-`oss-20b-eval.md` included:
+- Sort goes specialized Calc `domain="ranges"` then `sort_range`, not
+  in-place `=PY`. `sort_range` **requires** `has_header`.
+- `CALC_CORE_DIRECTIVES` is structured: `FORMULAS:` (per-row relative
+  Do-because) then `SORT:` last (routing + plain `has_header`
+  constraint). The sort because-clause does **not** name
+  `write_formula_range` / `=PY`.
+- Tax oracle `_tax_formula_ok` accepts equivalent relative 8% forms
+  (`B2*0.08`, `0.08*B2`, `B2*8%`, `8/100`, `$` / spaces / decimal comma)
+  without loosening wrong-row, wrong-factor, or Price-column junk.
+- `write_formula_range` fails loud when a JSON leaf count does not match
+  the A1 cell count (string `CalcWorld` too).
+- Ranking catalog: `z-ai/glm-5.3-flash` only.
 
-| Task | What 20b did | Kind |
-|------|--------------|------|
-| `data_sorting` | In-place `=PY` over the range; header destroyed | tool routing |
-| `tax_column` | Absolute `=B2*0.08` on every row instead of a relative per-row formula | per-row formulas |
+#### What shipped
 
-The same source plan also suggested Draw flowchart routing (#3) and Writer
-needle-token lines (#5). Those were **not** part of the 610 ship.
+| PR | What landed |
+|----|-------------|
+| [610](https://github.com/KeithCu/writeragent/pull/610) | Sort routing + relative tax formulas + required `has_header` + Do-because lines (shared prompt). |
+| [616](https://github.com/KeithCu/writeragent/pull/616) | `_tax_formula_ok` equivalents; sort Do-line because-clause no longer names `write_formula_range` / `=PY`. |
+| [617](https://github.com/KeithCu/writeragent/pull/617) | `FORMULAS:` / `SORT:` headers; `has_header` as a plain constraint; SORT routing last; `write_formula_range` fails on length mismatch. |
+| [618](https://github.com/KeithCu/writeragent/pull/618) | Dropped `z-ai/glm-5.3` from the ranking catalog (keep flash). Selective re-run of **only** `data_sorting` + `tax_column`; Pareto + [`benchmarks.md`](benchmarks.md) refreshed. |
 
-#### What shipped in PR 610 (Calc patches kept)
+**Method.** k=3 factorial on 20b+120b locked the 610 cell (`both` =
+prompt + schema). Factorial sensitivity is not a single-shot catalog
+`hard_pass` bit. Later scores are selective merges ([613](https://github.com/KeithCu/writeragent/pull/613)
+then 618) via `merge_benchmark_results.py`.
 
-From the oss-20b-eval suggestions, Keith locked Calc patches **1+2+4** and
-dropped Draw #3 and Writer needle #5:
+#### Latest selective help/hurt vs prior (613) snapshot
 
-1. **Sort routing.** Models should use specialized Calc `domain="ranges"` /
-   `sort_range`, not in-place `=PY` for sort.
-2. **Relative per-row formulas** for tax-style writes (Banana → `=B3*0.08`,
-   not a copied `B2`).
-4. **Tool-description** improvements for `sort_range` (and related).
+Per-model **hard_pass** on the two Calc tasks after 616/617 vs the
+[PR 613](https://github.com/KeithCu/writeragent/pull/613) snapshot.
+Remaining catalog only.
 
-Also after factorial learning:
-
-- `sort_range` schema **always requires** `has_header`. Runtime already
-  defaulted `True` when the arg was omitted; models often passed
-  `has_header=false` **explicitly**, which bypassed that default.
-- Calc directives split into short **Do Z because Y** lines (sort routing +
-  `has_header`), not a mashed Don't+Do pair. Don't+Do was ~2× prompt; small
-  models parse DO+why better.
-- Shared prompt for all models. Nemotron-specific sort experiments stay
-  parked until the 20b/120b story is settled (see
-  [`nemotron-35-eval.md`](nemotron-35-eval.md)).
-
-#### Factorial A/B (method)
-
-- **k=3**, `data_sorting` only, `openai/gpt-oss-20b` and
-  `openai/gpt-oss-120b` via OpenRouter `:nitro`.
-- 8-variant grid on prompt/schema cells (routing / tool-desc /
-  `has_header` required / DO lines / combinations), with instrumented
-  `has_header` call logging.
-- Locked winner cell for the shared ship: **`both`** (prompt + schema
-  together). No further master prompt churn after that lock.
-- Factorial headline vs the master-like `neither` cell: **120b** sort
-  `1/3 → 3/3`; **20b** sort unchanged `1/3` in that cell (ties elsewhere
-  at `2/3`). Across calls, more explicit `has_header=false` than
-  `true`; fails often correlated with explicit false — hence required
-  `has_header` + DO lines.
-- Factorial k=3 sensitivity is **not** the same thing as a single-shot
-  catalog `hard_pass` bit. The later catalog re-run (below) is the
-  single-shot measure.
-
-#### Selective catalog re-run (PR 613)
-
-**Not** a full 17-task re-rank (spend-limited OpenRouter key). Re-ran only
-`data_sorting` + `tax_column` across the catalog, merged into the Sep 1
-summaries via `merge_benchmark_results.py`, and refreshed Pareto /
-[`benchmarks.md`](benchmarks.md). Comparison metric: per-model **hard_pass**
-vs the Sep 1 details for those two tasks.
-
-##### `data_sorting` vs Sep 1
+**`data_sorting`**
 
 | Outcome | Models |
 |---------|--------|
-| **Helped (F→P)** | `deepseek/deepseek-v4-flash-0731`, `inception/mercury-2.5-preview`, `meta/muse-spark-1.3-contributor`, `openai/gpt-oss-20b` |
-| **Hurt (P→F)** | `z-ai/glm-5.3-flash` |
-| Unchanged pass | `google/gemma-4-31b-it`, `ibm-granite/granite-4.2-8b`, `meta/muse-glimmer-30b`, `openai/gpt-5.6-luna`, `openai/gpt-oss-120b`, `poolside/laguna-s-2.1`, `qwen/qwen3.8-27b`, `x-ai/grok-4.6`, `z-ai/glm-5.3` |
-| Unchanged fail | `bytedance-seed/seed-2.0-mini`, `google/gemini-3.5-flash-lite`, `minimax/minimax-m3`, `mistralai/mistral-small-2603`, `upstage/solar-pro4` |
-| Error / incomplete (no fair compare) | `google/gemma-4-26b-a4b-it`, `poolside/laguna-xs-2.1` |
-| New catalog rows (no Sep 1) | `qwen/qwen3.8-flash` pass; `nvidia/nemotron-3.5-lightning` fail |
+| HELP (F→P) | `z-ai/glm-5.3-flash`, `upstage/solar-pro4`, `bytedance-seed/seed-2.0-mini`, `google/gemini-3.5-flash-lite`, `google/gemma-4-26b-a4b-it`, `minimax/minimax-m3` |
+| HURT (P→F) | **`openai/gpt-oss-20b`** |
 
-Headline: **net help on sort**. 20b helped (F→P). 120b unchanged pass
-(already green on Sep 1 — the factorial gain was vs `neither` under k=3,
-not vs the Sep 1 catalog bit).
-
-##### `tax_column` vs Sep 1
+**`tax_column`**
 
 | Outcome | Models |
 |---------|--------|
-| **Helped (F→P)** | `google/gemini-3.5-flash-lite`, `openai/gpt-oss-20b`, `poolside/laguna-s-2.1` |
-| **Hurt (P→F)** | `qwen/qwen3.8-27b`, `upstage/solar-pro4`, `z-ai/glm-5.3` |
-| Unchanged pass | `deepseek/deepseek-v4-flash-0731`, `google/gemma-4-31b-it`, `inception/mercury-2.5-preview`, `meta/muse-spark-1.3-contributor`, `minimax/minimax-m3`, `openai/gpt-oss-120b`, `x-ai/grok-4.6`, `z-ai/glm-5.3-flash` |
-| Unchanged fail | `bytedance-seed/seed-2.0-mini`, `google/gemma-4-26b-a4b-it`, `ibm-granite/granite-4.2-8b`, `meta/muse-glimmer-30b`, `mistralai/mistral-small-2603`, `nvidia/nemotron-3.5-lightning`, `openai/gpt-5.6-luna` |
-| Error / incomplete (no fair compare) | `poolside/laguna-xs-2.1` |
-| New catalog rows (no Sep 1) | `qwen/qwen3.8-flash` pass |
+| HELP (F→P) | `qwen/qwen3.8-27b`, `upstage/solar-pro4`, `bytedance-seed/seed-2.0-mini`, `meta/muse-glimmer-30b`, `mistralai/mistral-small-2603`, `openai/gpt-5.6-luna`, `poolside/laguna-xs-2.1` |
+| HURT (P→F) | **`openai/gpt-oss-20b`**, `inception/mercury-2.5-preview` |
 
-##### Combined take
+Two of the old 610/613 tax “hurts” (`qwen3.8-27b`, `glm-5.3`) were
+oracle FNs — fixed by 616. `solar-pro4` tax helped after the 617
+length-harden path. `glm-5.3-flash` sort helped after the 616
+because-clause + 617 structure.
 
-Worth keeping 610 for the catalog needle move (especially 20b on **both**
-tasks). Regressions to work down:
+#### Next watches
 
-| Task | Hurt models |
-|------|-------------|
-| `data_sorting` | `z-ai/glm-5.3-flash` |
-| `tax_column` | `qwen/qwen3.8-27b`, `upstage/solar-pro4`, `z-ai/glm-5.3` |
-
-Catalog note: `z-ai/glm-5.3` was **dropped** from the ranking catalog in the
-post-#616/#617 selective refresh (expensive/overkill); `z-ai/glm-5.3-flash`
-remains as the more likely-used model. Historical 613 snapshot prose above
-still mentions full `glm-5.3` where it ran.
-
-#### Next steps
-
-1. Do per-regression failure forensics on the four hurt models
-   (`glm-5.3-flash` sort; `qwen3.8-27b` / `solar-pro4` / `glm-5.3` tax) —
-   read tool traces and args from the details JSON — **before** more prompt
-   churn, because shared prompts need surgical fixes, not another global
-   rewrite.
-2. Do a targeted A/B on `has_header` wording vs schema-only for
-   `z-ai/glm-5.3-flash` sort (it hurt on sort while tax stayed pass) to
-   isolate whether required bool + DO line over-constrained header
-   detection.
-3. Do a tax-only micro A/B for `qwen/qwen3.8-27b` / `upstage/solar-pro4` /
-   `z-ai/glm-5.3` on relative-formula wording **without** touching sort
-   lines, because the tax hurts did not all co-occur with sort hurts.
-4. Do keep factorial discipline: k≥3 on 20b+120b gate models before
-   shipping shared Calc prompt changes. Single-shot catalog `hard_pass` is
-   noisy (factorial k=3 sensitivity ≠ one catalog bit).
-5. Do selective re-measure (`data_sorting` + `tax_column` only) after the
-   next prompt tweak rather than a full 17-task catalog until spend allows
-   — merge into the prior snapshot the same way as [PR 613](https://github.com/KeithCu/writeragent/pull/613)
-   (`merge_benchmark_results.py`).
-6. Do park Nemotron-specific sort forks until the shared-prompt
-   regressions above are understood.
-7. Do optionally re-run the incomplete models (`google/gemma-4-26b-a4b-it`,
-   `poolside/laguna-xs-2.1`) when key budget allows so Pareto is not
-   carrying stale Sep 1 bits for those ids.
-
-#### Follow-up (oracle FN + sort because-clause)
-
-Forensics on the four catalog "hurts" (item 1 above):
-
-- Two tax `P→F` rows (`qwen/qwen3.8-27b`, `z-ai/glm-5.3`) were **oracle
-  false-negatives**: models wrote semantically correct relative 8% forms
-  (`=0.08*B{n}`, `=B{n}*8%`) that `_tax_formula_ok` rejected as a
-  string-literal `=B{n}*0.08`. Parser now accepts those equivalents
-  (and `8/100`, `$` / spaces / decimal comma) without loosening wrong
-  row, wrong factor, or Price-column junk. Shared-prompt tax lines stay
-  put so the real tax helps (20b, gemini-3.5-flash-lite, laguna-s-2.1)
-  are not undone.
-- `z-ai/glm-5.3-flash` sort `P→F` was **tool-naming priming**: the sort
-  Do-line because-clause named `write_formula_range` / `=PY`, and the
-  model sorted in its head then hand-rolled that write into A2:B6.
-  Because-clause is now "rewriting values by hand loses the header
-  row" — still `domain="ranges"` then `sort_range`, no tool names in
-  the why.
-
-#### Follow-on: split Do-lines + `write_formula_range` length check
-
-Optional later bucket after the 610/613 retrospective (not a tax-oracle
-change; keeps the PR 616 because-clause above):
-
-- **Prompt shape.** The three Calc teachings stay in
-  `CALC_CORE_DIRECTIVES`, but are no longer three adjacent identical
-  Do-because lines. `FORMULAS:` keeps the per-row Do-because; `SORT:`
-  (last, recency) keeps the only “Do … then tool” routing line; `has_header`
-  is a plain constraint under `SORT`. Hypothesis: identically-shaped
-  adjacent lines blur together for flash models, which then attend to one
-  and drop routing.
-- **Length mismatch.** `write_formula_range` now fails loud when a JSON
-  array’s leaf count does not match the A1 cell count (the schema already
-  said “exactly”; solar-pro4 still passed 4 values into an 8-cell range and
-  zip-style writes silently corrupted the extra cells). Same gate in the
-  string `CalcWorld`.
+1. Do forensic `gpt-oss-20b` sort+tax fails from the 618 details
+   **before** more shared-prompt churn — it helped under 610 then hurt
+   under 616/617; gate models matter.
+2. Do k≥3 factorial on 20b+120b before the next Calc directive edit
+   (single-shot catalog bits are noisy).
+3. Do selective-only remeasure (sort+tax) after prompt tweaks; merge
+   into the snapshot (`merge_benchmark_results.py`); avoid a full
+   17-task pack until spend allows.
+4. Do keep the catalog without full `glm-5.3`; flash only.
+5. Do watch `mercury-2.5-preview` tax hurt and incomplete/429 models
+   (`laguna-xs` sort; carried `qwen3.8-flash` / `nemotron-3.5-lightning`
+   rows).
+6. Optional: does required `has_header` still earn keep? Re-check only
+   after 20b routing is understood.
 
 Cross-links: [`oss-20b-eval.md`](oss-20b-eval.md),
-[PR 610](https://github.com/KeithCu/writeragent/pull/610),
-[PR 613](https://github.com/KeithCu/writeragent/pull/613),
 [`benchmarks.md`](benchmarks.md),
-[`nemotron-35-eval.md`](nemotron-35-eval.md).
+[PR 610](https://github.com/KeithCu/writeragent/pull/610),
+[PR 616](https://github.com/KeithCu/writeragent/pull/616),
+[PR 617](https://github.com/KeithCu/writeragent/pull/617),
+[PR 618](https://github.com/KeithCu/writeragent/pull/618).
 
 ---
-*Updated Dev Plan v2.3 — Phase G retrospective (Sep 2026; PR 610 / PR 613); oracle/sort follow-up; Do-line split + length check*
+*Updated Dev Plan v2.4 — Phase G current state (Sep 2026; PRs 610 / 616 / 617 / 618)*

--- a/docs/eval/oss-20b-eval.md
+++ b/docs/eval/oss-20b-eval.md
@@ -14,7 +14,7 @@ when omitted). `sort_range` now **requires** `has_header`. Calc directives
 are two short **Do Z because Y** lines (sort routing + `has_header`), not
 a mashed one-liner. Tax relative rule stayed helpful for 120b. Shared
 prompt; no 20b fork. Selective catalog re-measure (PR 613) and next
-steps: [eval-dev-plan.md § G](eval-dev-plan.md#g-calc-sorttax-prompt-lift-sep-2026--pr-610--selective-re-rank).
+steps: [eval-dev-plan.md § G](eval-dev-plan.md#g-calc-sorttax-prompt-lift-current--prs-616--617--618).
 
 ## Snapshot
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrite `docs/eval/eval-dev-plan.md` Phase G so it describes the **current** post-618 Calc sort/tax state instead of the long 610/613 retrospective.

- What is true now (routing, `FORMULAS:`/`SORT:`, tax oracle equivalents, length-mismatch fail, flash-only catalog).
- What shipped in PRs 610 / 616 / 617 / 618.
- Compact HELP/HURT tables vs the 613 snapshot (latest selective pass).
- Do-shaped next watches, especially forensic `gpt-oss-20b` sort+tax hurts.
- Footer bumped to v2.4. One-line heading-anchor update in `docs/eval/oss-20b-eval.md`.

Docs only. No product or ranking JSON changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fe8e320-54bc-4cf7-9c4a-a5fdea555306?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fe8e320-54bc-4cf7-9c4a-a5fdea555306&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

