### PR TITLE
Use named gettext args in geometric cap-hit message

### DIFF
--- a/plugin/calc/python/geometric_recalc.py
+++ b/plugin/calc/python/geometric_recalc.py
@@ -279,10 +279,10 @@ def rebuild_formula_with_data_args(formula: str, data_args: list[str]) -> str | 
 def geometric_cap_hit_user_message(sheet_name: str) -> str:
     """User-facing text when a sheet is left unchained. Users do not read logfiles."""
     return _(
-        "Geometric Recalc Order skipped sheet '%s': found %s or more Python "
+        "Geometric Recalc Order skipped sheet '%(sheet)s': found %(cap)s or more Python "
         "cells (discovery cap). The sheet was left unchained so a partial "
         "list is not treated as complete."
-    ) % (sheet_name, GEOMETRIC_DISCOVERY_CAP)
+    ) % {"sheet": sheet_name, "cap": GEOMETRIC_DISCOVERY_CAP}
 
 
 def notify_geometric_cap_hit(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Regenerating translation templates (`xgettext`) warned on `plugin/calc/python/geometric_recalc.py`:

```
msgid format string with unnamed arguments cannot be properly localized:
The translator cannot reorder the arguments.
```

`geometric_cap_hit_user_message` used `'%s'` placeholders and a tuple, so translators could not reorder the sheet name and discovery-cap count.

## Change

Switch that one `_()` string to named `%(sheet)s` / `%(cap)s` placeholders and pass a mapping, matching the existing pattern in `plugin/chatbot/web_research_chat.py`.

No other geometric-recalc behavior changes. Existing unit test still checks that the sheet name and cap appear in the interpolated message.

## Testing

- `tests/calc/python/test_geometric_recalc.py`: 78 passed
- `make typecheck`: passed (ruff, basedpyright, bandit, opengrep, pyspector, ty, thread-safety, mypy)
- `xgettext -L Python -k_` on the file: no unnamed-argument warning; msgid is `%(sheet)s` / `%(cap)s`
- Interpolation still reads `…sheet 'Pivots': found 100…`; a reordered `%(cap)s` / `%(sheet)s` mapping works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9605dea1-6faa-4966-bf03-9749f36c0b2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9605dea1-6faa-4966-bf03-9749f36c0b2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

