### PR TITLE
menu icons: VCL DPI one-shot size probe (HiDPI-safe)

### DIFF
--- a/plugin/framework/menu_icon_dpi.py
+++ b/plugin/framework/menu_icon_dpi.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """One-shot menu-icon pixel-size probe for LibreOffice ImageManager.
 
-Keith's HiDPI Arch already looks good with 16px menu icons (LO scales them).
-On 1x boxes those same assets look tiny. Probe VCL DPI (preferred), then
-font size, then toolbar/config peers; pick among shipped sizes without
-regressing HiDPI.
+Pick shipped menu-icon pixel sizes from display scale.
+
+HiDPI (~2×) wants the large assets (26/32). Little/1× screens want 16.
+Probe VCL DPI (preferred), then font, toolbar config, then env scale.
+Probe-miss defaults to the large HiDPI asset (not 16).
 """
 
 from __future__ import annotations
@@ -21,8 +22,9 @@ log = logging.getLogger("writeragent.menu_icon_dpi")
 # 96 DPI in device pixels per meter (LO DeviceInfo convention).
 _PPM_96DPI = 96.0 / 0.0254  # 3780.0
 
-# Size that already looks good on Keith's HiDPI when LO scales menus.
-_HIDPI_KNOWN_GOOD_PX = 16
+# Base 1× asset size; HiDPI prefers the largest shipped asset.
+_ONE_X_PX = 16
+_HIDPI_PX = 32
 
 # Shipped menu-icon suffixes we can select (MCP status has 16 + 26).
 _AVAILABLE_PX = (16, 26, 32)
@@ -40,31 +42,121 @@ def reset_menu_icon_dpi_cache() -> None:
     _cached_weak = False
 
 
-def probe_vcl_dpi_scale(ctx: Any = None) -> float | None:
-    """Return VCL device DPI scale vs 96 DPI, or None if unavailable.
-
-    Uses ``XWindow.getInfo().PixelPerMeterX`` (same DeviceInfo LO VCL fills).
-    """
+def _ppm_scale(win: Any) -> float | None:
+    if win is None:
+        return None
+    info = None
     try:
-        from plugin.framework.appearance import get_style_window
-
-        win = get_style_window(ctx=ctx)
-        if win is None:
-            return None
-        info = None
         if hasattr(win, "getInfo"):
             info = win.getInfo()
         elif hasattr(win, "Info"):
             info = win.Info
-        if info is None:
-            return None
-        ppm = float(getattr(info, "PixelPerMeterX", 0.0) or 0.0)
-        if ppm <= 0.0:
-            return None
-        return ppm / _PPM_96DPI
+    except Exception:
+        return None
+    if info is None:
+        return None
+    ppm = float(getattr(info, "PixelPerMeterX", 0.0) or 0.0)
+    if ppm <= 0.0:
+        return None
+    return ppm / _PPM_96DPI
+
+
+def _candidate_windows(ctx: Any = None) -> list[Any]:
+    """StyleSettings host first, then desktop/frame peers (Wayland/KDE often need these)."""
+    wins: list[Any] = []
+    try:
+        from plugin.framework.appearance import get_style_window
+
+        w = get_style_window(ctx=ctx)
+        if w is not None:
+            wins.append(w)
+    except Exception:
+        pass
+    try:
+        import uno
+
+        from plugin.framework.uno_context import get_service_manager
+
+        if ctx is None:
+            ctx = uno.getComponentContext()
+        sm = get_service_manager(ctx)
+        if sm is None:
+            return wins
+        desktop = sm.createInstanceWithContext("com.sun.star.frame.Desktop", ctx)
+        frames_to_try: list[Any] = []
+        try:
+            active = desktop.getActiveFrame()
+            if active is not None:
+                frames_to_try.append(active)
+        except Exception:
+            pass
+        try:
+            frames = desktop.getFrames()
+            for i in range(int(frames.getCount())):
+                frames_to_try.append(frames.getByIndex(i))
+        except Exception:
+            pass
+        for frame in frames_to_try:
+            if frame is None:
+                continue
+            for name in ("getContainerWindow", "getComponentWindow"):
+                fn = getattr(frame, name, None)
+                if not callable(fn):
+                    continue
+                try:
+                    w = fn()
+                    if w is not None:
+                        wins.append(w)
+                except Exception:
+                    pass
+    except Exception:
+        log.debug("candidate windows failed", exc_info=True)
+    # Dedupe by id while preserving order.
+    out: list[Any] = []
+    seen: set[int] = set()
+    for w in wins:
+        wid = id(w)
+        if wid in seen:
+            continue
+        seen.add(wid)
+        out.append(w)
+    return out
+
+
+def probe_vcl_dpi_scale(ctx: Any = None) -> float | None:
+    """Return VCL device DPI scale vs 96 DPI, or None if unavailable.
+
+    Uses ``XWindow.getInfo().PixelPerMeterX`` (same DeviceInfo LO VCL fills).
+    Tries StyleSettings host plus active/open frame windows — KDE/Wayland
+    often has no usable style window at menu-icon time.
+    """
+    try:
+        for win in _candidate_windows(ctx):
+            scale = _ppm_scale(win)
+            if scale is not None:
+                return scale
+        log.info("menu_icon_dpi probe_vcl_dpi: no PixelPerMeterX on %s windows", len(_candidate_windows(ctx)))
+        return None
     except Exception:
         log.debug("probe_vcl_dpi_scale failed", exc_info=True)
         return None
+
+
+def probe_env_scale() -> float | None:
+    """Last-resort desktop scale from GDK_SCALE / QT_SCALE_FACTOR (Arch HiDPI often sets these)."""
+    for key in ("GDK_SCALE", "QT_SCALE_FACTOR", "QT_SCREEN_SCALE_FACTORS"):
+        raw = os.environ.get(key)
+        if not raw:
+            continue
+        # QT_SCREEN_SCALE_FACTORS can be "2;2" or "HDMI-1=2"
+        token = raw.replace(";", "=").split("=")[-1].split(";")[0].strip()
+        try:
+            val = float(token)
+        except ValueError:
+            continue
+        if val > 0:
+            return val
+    return None
 
 
 def probe_menu_font_scale(ctx: Any = None) -> float | None:
@@ -128,25 +220,25 @@ def probe_toolbar_icon_config_px(ctx: Any = None) -> int | None:
 
 
 def _nearest_available(px: int) -> int:
-    # On a tie, prefer the larger asset (helps 1x; HiDPI still lands on 16).
+    # On a tie, prefer the larger asset (HiDPI gets 26/32).
     return min(_AVAILABLE_PX, key=lambda a: (abs(a - px), -a))
 
 
-def interpolate_menu_icon_px(scale: float, *, hidpi_good: int = _HIDPI_KNOWN_GOOD_PX) -> int:
-    """Map DPI scale to shipped pixel size without blowing up HiDPI.
+def interpolate_menu_icon_px(scale: float, *, one_x: int = _ONE_X_PX) -> int:
+    """Map DPI scale to shipped pixel size.
 
-    At scale~2 (Keith), keep ``hidpi_good`` (16). At scale~1, prefer ~32.
-    ``chosen ~= hidpi_good * (2 / scale)``, then snap to available assets.
+    At scale~1 → 16. At scale~2 → 32 (HiDPI highres). Mid scales snap to 26.
+    ``chosen ~= one_x * scale``, then snap to available assets.
     """
     if scale <= 0:
         scale = 1.0
-    target = hidpi_good * (2.0 / scale)
+    target = one_x * scale
     target = max(float(_AVAILABLE_PX[0]), min(float(_AVAILABLE_PX[-1]), target))
     return _nearest_available(int(round(target)))
 
 
 def resolve_menu_icon_pixel_size(ctx: Any = None) -> int:
-    """One-shot: probe, interpolate, cache. Safe default leans HiDPI-known-good."""
+    """One-shot: probe, interpolate, cache. Probe-miss prefers HiDPI large assets."""
     global _cached_px, _cached_scale, _cached_weak
     if _cached_px is not None and not _cached_weak:
         return _cached_px
@@ -159,15 +251,20 @@ def resolve_menu_icon_pixel_size(ctx: Any = None) -> int:
     if scale is None:
         cfg_px = probe_toolbar_icon_config_px(ctx)
         if cfg_px is not None:
-            scale = (2.0 * _HIDPI_KNOWN_GOOD_PX) / float(cfg_px)
+            # Config already stores a pixel-ish size; treat 16 as 1×.
+            scale = float(cfg_px) / float(_ONE_X_PX)
             source = "toolbar_config"
     if scale is None:
-        # Prefer Keith's HiDPI-known-good when we cannot probe (startup race).
+        scale = probe_env_scale()
+        source = "env_scale"
+    if scale is None:
+        # Probe miss is common on Wayland/KDE at startup — assume HiDPI wants big assets.
         _cached_scale = 2.0
-        _cached_px = _HIDPI_KNOWN_GOOD_PX
+        _cached_px = _HIDPI_PX
         _cached_weak = True  # retry when a real window exists
         log.info(
-            "menu_icon_dpi source=default_hidpi_safe scale=n/a px=%s",
+            "menu_icon_dpi source=default_hidpi_large scale=n/a px=%s "
+            "(probe miss — prefer highres assets on HiDPI)",
             _cached_px,
         )
         return _cached_px
@@ -177,11 +274,10 @@ def resolve_menu_icon_pixel_size(ctx: Any = None) -> int:
     _cached_px = px
     _cached_weak = False
     log.info(
-        "menu_icon_dpi source=%s scale=%.3f px=%s (hidpi_good=%s)",
+        "menu_icon_dpi source=%s scale=%.3f px=%s",
         source,
         scale,
         px,
-        _HIDPI_KNOWN_GOOD_PX,
     )
     return px
 

--- a/plugin/framework/menu_icon_dpi.py
+++ b/plugin/framework/menu_icon_dpi.py
@@ -97,9 +97,14 @@ def probe_toolbar_icon_config_px(ctx: Any = None) -> int | None:
         import uno
         from com.sun.star.beans import PropertyValue
 
+        from plugin.framework.uno_context import get_service_manager
+
         if ctx is None:
             ctx = uno.getComponentContext()
-        sm = getattr(ctx, "ServiceManager", None) or ctx.getServiceManager()
+        # ty rejects ctx.getServiceManager() on Any; use the shared getattr helper.
+        sm = get_service_manager(ctx)
+        if sm is None:
+            return None
         cfg_prov = sm.createInstanceWithContext(
             "com.sun.star.configuration.ConfigurationProvider", ctx
         )

--- a/plugin/framework/menu_icon_dpi.py
+++ b/plugin/framework/menu_icon_dpi.py
@@ -1,0 +1,225 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""One-shot menu-icon pixel-size probe for LibreOffice ImageManager.
+
+Keith's HiDPI Arch already looks good with 16px menu icons (LO scales them).
+On 1x boxes those same assets look tiny. Probe VCL DPI (preferred), then
+font size, then toolbar/config peers; pick among shipped sizes without
+regressing HiDPI.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+log = logging.getLogger("writeragent.menu_icon_dpi")
+
+# 96 DPI in device pixels per meter (LO DeviceInfo convention).
+_PPM_96DPI = 96.0 / 0.0254  # 3780.0
+
+# Size that already looks good on Keith's HiDPI when LO scales menus.
+_HIDPI_KNOWN_GOOD_PX = 16
+
+# Shipped menu-icon suffixes we can select (MCP status has 16 + 26).
+_AVAILABLE_PX = (16, 26, 32)
+
+_cached_px: int | None = None
+_cached_scale: float | None = None
+_cached_weak: bool = False
+
+
+def reset_menu_icon_dpi_cache() -> None:
+    """Test hook: clear the one-shot cache."""
+    global _cached_px, _cached_scale, _cached_weak
+    _cached_px = None
+    _cached_scale = None
+    _cached_weak = False
+
+
+def probe_vcl_dpi_scale(ctx: Any = None) -> float | None:
+    """Return VCL device DPI scale vs 96 DPI, or None if unavailable.
+
+    Uses ``XWindow.getInfo().PixelPerMeterX`` (same DeviceInfo LO VCL fills).
+    """
+    try:
+        from plugin.framework.appearance import get_style_window
+
+        win = get_style_window(ctx=ctx)
+        if win is None:
+            return None
+        info = None
+        if hasattr(win, "getInfo"):
+            info = win.getInfo()
+        elif hasattr(win, "Info"):
+            info = win.Info
+        if info is None:
+            return None
+        ppm = float(getattr(info, "PixelPerMeterX", 0.0) or 0.0)
+        if ppm <= 0.0:
+            return None
+        return ppm / _PPM_96DPI
+    except Exception:
+        log.debug("probe_vcl_dpi_scale failed", exc_info=True)
+        return None
+
+
+def probe_menu_font_scale(ctx: Any = None) -> float | None:
+    """Fallback: MenuFont/ApplicationFont Height vs AppFont 10."""
+    try:
+        from plugin.framework.appearance import get_style_window
+
+        win = get_style_window(ctx=ctx)
+        if win is None or not hasattr(win, "StyleSettings"):
+            return None
+        ss = win.StyleSettings
+        for attr in ("MenuFont", "ApplicationFont", "ToolFont"):
+            fd = getattr(ss, attr, None)
+            if fd is None:
+                continue
+            h = int(getattr(fd, "Height", 0) or 0)
+            if h > 0:
+                return h / 10.0
+    except Exception:
+        log.debug("probe_menu_font_scale failed", exc_info=True)
+    return None
+
+
+def probe_toolbar_icon_config_px(ctx: Any = None) -> int | None:
+    """Fallback: Office.Common.Misc SidebarIconSize / NotebookbarIconSize.
+
+    LO values: 0=auto; positive enums map toward 16/24/32. Best-effort.
+    """
+    try:
+        import uno
+        from com.sun.star.beans import PropertyValue
+
+        if ctx is None:
+            ctx = uno.getComponentContext()
+        sm = getattr(ctx, "ServiceManager", None) or ctx.getServiceManager()
+        cfg_prov = sm.createInstanceWithContext(
+            "com.sun.star.configuration.ConfigurationProvider", ctx
+        )
+        arg = PropertyValue()
+        arg.Name = "nodepath"
+        arg.Value = "/org.openoffice.Office.Common/Misc"
+        access = cfg_prov.createInstanceWithArguments(
+            "com.sun.star.configuration.ConfigurationAccess", (arg,)
+        )
+        for key in ("SidebarIconSize", "NotebookbarIconSize"):
+            try:
+                raw = int(access.getByName(key))
+            except Exception:
+                continue
+            if raw <= 0:
+                continue
+            return {1: 16, 2: 24, 3: 32}.get(raw, 16)
+    except Exception:
+        log.debug("probe_toolbar_icon_config_px failed", exc_info=True)
+    return None
+
+
+def _nearest_available(px: int) -> int:
+    # On a tie, prefer the larger asset (helps 1x; HiDPI still lands on 16).
+    return min(_AVAILABLE_PX, key=lambda a: (abs(a - px), -a))
+
+
+def interpolate_menu_icon_px(scale: float, *, hidpi_good: int = _HIDPI_KNOWN_GOOD_PX) -> int:
+    """Map DPI scale to shipped pixel size without blowing up HiDPI.
+
+    At scale~2 (Keith), keep ``hidpi_good`` (16). At scale~1, prefer ~32.
+    ``chosen ~= hidpi_good * (2 / scale)``, then snap to available assets.
+    """
+    if scale <= 0:
+        scale = 1.0
+    target = hidpi_good * (2.0 / scale)
+    target = max(float(_AVAILABLE_PX[0]), min(float(_AVAILABLE_PX[-1]), target))
+    return _nearest_available(int(round(target)))
+
+
+def resolve_menu_icon_pixel_size(ctx: Any = None) -> int:
+    """One-shot: probe, interpolate, cache. Safe default leans HiDPI-known-good."""
+    global _cached_px, _cached_scale, _cached_weak
+    if _cached_px is not None and not _cached_weak:
+        return _cached_px
+
+    scale = probe_vcl_dpi_scale(ctx)
+    source = "vcl_dpi"
+    if scale is None:
+        scale = probe_menu_font_scale(ctx)
+        source = "font"
+    if scale is None:
+        cfg_px = probe_toolbar_icon_config_px(ctx)
+        if cfg_px is not None:
+            scale = (2.0 * _HIDPI_KNOWN_GOOD_PX) / float(cfg_px)
+            source = "toolbar_config"
+    if scale is None:
+        # Prefer Keith's HiDPI-known-good when we cannot probe (startup race).
+        _cached_scale = 2.0
+        _cached_px = _HIDPI_KNOWN_GOOD_PX
+        _cached_weak = True  # retry when a real window exists
+        log.info(
+            "menu_icon_dpi source=default_hidpi_safe scale=n/a px=%s",
+            _cached_px,
+        )
+        return _cached_px
+
+    px = interpolate_menu_icon_px(float(scale))
+    _cached_scale = float(scale)
+    _cached_px = px
+    _cached_weak = False
+    log.info(
+        "menu_icon_dpi source=%s scale=%.3f px=%s (hidpi_good=%s)",
+        source,
+        scale,
+        px,
+        _HIDPI_KNOWN_GOOD_PX,
+    )
+    return px
+
+
+def image_type_for_pixel_size(px: int) -> int:
+    """Map pixel size to ``com.sun.star.ui.ImageType`` flags."""
+    try:
+        from com.sun.star.ui import ImageType
+
+        if px >= 32:
+            return int(ImageType.SIZE_32)
+        if px >= 24:
+            return int(ImageType.SIZE_LARGE)
+        return int(ImageType.SIZE_DEFAULT)
+    except Exception:
+        return 0
+
+
+def menu_icon_filename(prefix: str, px: int | None = None, ctx: Any = None) -> str:
+    """Return ``{prefix}_{px}.png``, falling back to nearest shipped size."""
+    if px is None:
+        px = resolve_menu_icon_pixel_size(ctx)
+    from plugin.framework.uno_context import menu_icon_filesystem_paths
+
+    existing: list[int] = []
+    for cand in list(_AVAILABLE_PX) + [16]:
+        name = "%s_%s.png" % (prefix, cand)
+        if any(os.path.isfile(path) for path in menu_icon_filesystem_paths(name)):
+            if cand not in existing:
+                existing.append(cand)
+    if not existing:
+        return "%s_16.png" % prefix
+    best = min(existing, key=lambda a: (abs(a - px), -a))
+    return "%s_%s.png" % (prefix, best)
+
+
+__all__ = [
+    "reset_menu_icon_dpi_cache",
+    "probe_vcl_dpi_scale",
+    "probe_menu_font_scale",
+    "probe_toolbar_icon_config_px",
+    "interpolate_menu_icon_px",
+    "resolve_menu_icon_pixel_size",
+    "image_type_for_pixel_size",
+    "menu_icon_filename",
+]

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -711,11 +711,28 @@ def _update_menu_icons_impl():
         for cmd_url, (mod_name, prefix) in icon_cmds.items():
             key_cmds.setdefault((mod_name, prefix), []).append(cmd_url)
 
+        from plugin.framework.menu_icon_dpi import (
+            image_type_for_pixel_size,
+            menu_icon_filename,
+            resolve_menu_icon_pixel_size,
+        )
+
+        # One-shot DPI probe → pixel size (16 on HiDPI, larger on 1x).
+        # Warm StyleSettings host so startup race does not stick on hidpi-safe 16.
+        try:
+            from plugin.framework.appearance import get_style_window
+
+            get_style_window(ctx=ctx)
+        except Exception:
+            pass
+        icon_px = resolve_menu_icon_pixel_size(ctx)
+        image_type = image_type_for_pixel_size(icon_px)
+
         # Load graphics
         key_graphics = {}
         for key in key_cmds:
             mod_name, prefix = key
-            filename = "%s_16.png" % prefix
+            filename = menu_icon_filename(prefix, icon_px, ctx)
             graphic = _load_icon_graphic(mod_name, filename, ctx)
             if graphic:
                 key_graphics[key] = graphic
@@ -737,14 +754,23 @@ def _update_menu_icons_impl():
                     graphic = key_graphics.get(key)
                     if not graphic:
                         continue
+                    # Menus usually fetch SIZE_DEFAULT; also stamp LARGE/32 when we
+                    # chose a bigger asset so HiDPI/toolbars can pick either.
+                    type_set = {0, int(image_type)}
                     for cmd in cmds:
-                        try:
-                            if img_mgr.hasImage(0, cmd):
-                                img_mgr.replaceImages(0, (cmd,), (graphic,))
-                            else:
-                                img_mgr.insertImages(0, (cmd,), (graphic,))
-                        except Exception as e:
-                            log.warning("_update_menu_icons: failed to insert/replace image for %s: %s", cmd, e)
+                        for itype in sorted(type_set):
+                            try:
+                                if img_mgr.hasImage(itype, cmd):
+                                    img_mgr.replaceImages(itype, (cmd,), (graphic,))
+                                else:
+                                    img_mgr.insertImages(itype, (cmd,), (graphic,))
+                            except Exception as e:
+                                log.warning(
+                                    "_update_menu_icons: failed to insert/replace image for %s type=%s: %s",
+                                    cmd,
+                                    itype,
+                                    e,
+                                )
             except Exception as e:
                 log.warning("_update_menu_icons: failed to process ImageManager for %s: %s", mod_id, e)
     except Exception:

--- a/tests/framework/test_menu_icon_dpi.py
+++ b/tests/framework/test_menu_icon_dpi.py
@@ -1,0 +1,36 @@
+"""Unit tests for menu icon DPI probe interpolation (no UNO)."""
+
+from plugin.framework.menu_icon_dpi import (
+    interpolate_menu_icon_px,
+    reset_menu_icon_dpi_cache,
+)
+
+
+def setup_function(_fn=None):
+    reset_menu_icon_dpi_cache()
+
+
+def test_hidpi_scale_keeps_16():
+    assert interpolate_menu_icon_px(2.0) == 16
+
+
+def test_one_x_prefers_32():
+    assert interpolate_menu_icon_px(1.0) == 32
+
+
+def test_mid_scale_snaps_to_26():
+    assert interpolate_menu_icon_px(1.5) == 26
+
+
+def test_ultra_hidpi_stays_at_least_16():
+    assert interpolate_menu_icon_px(3.0) == 16
+
+
+def test_failed_probe_defaults_to_hidpi_safe_16(monkeypatch):
+    from plugin.framework import menu_icon_dpi as m
+
+    m.reset_menu_icon_dpi_cache()
+    monkeypatch.setattr(m, "probe_vcl_dpi_scale", lambda ctx=None: None)
+    monkeypatch.setattr(m, "probe_menu_font_scale", lambda ctx=None: None)
+    monkeypatch.setattr(m, "probe_toolbar_icon_config_px", lambda ctx=None: None)
+    assert m.resolve_menu_icon_pixel_size() == 16

--- a/tests/framework/test_menu_icon_dpi.py
+++ b/tests/framework/test_menu_icon_dpi.py
@@ -1,36 +1,38 @@
-"""Unit tests for menu icon DPI probe interpolation (no UNO)."""
+"""Unit tests for menu icon DPI size probe (no UNO)."""
 
-from plugin.framework.menu_icon_dpi import (
-    interpolate_menu_icon_px,
-    reset_menu_icon_dpi_cache,
-)
+from plugin.framework.menu_icon_dpi import interpolate_menu_icon_px, reset_menu_icon_dpi_cache
 
 
-def setup_function(_fn=None):
-    reset_menu_icon_dpi_cache()
+def test_one_x_keeps_16():
+    assert interpolate_menu_icon_px(1.0) == 16
 
 
-def test_hidpi_scale_keeps_16():
-    assert interpolate_menu_icon_px(2.0) == 16
-
-
-def test_one_x_prefers_32():
-    assert interpolate_menu_icon_px(1.0) == 32
+def test_hidpi_prefers_32():
+    assert interpolate_menu_icon_px(2.0) == 32
 
 
 def test_mid_scale_snaps_to_26():
     assert interpolate_menu_icon_px(1.5) == 26
 
 
-def test_ultra_hidpi_stays_at_least_16():
-    assert interpolate_menu_icon_px(3.0) == 16
+def test_ultra_hidpi_caps_at_32():
+    assert interpolate_menu_icon_px(3.0) == 32
 
 
-def test_failed_probe_defaults_to_hidpi_safe_16(monkeypatch):
+def test_failed_probe_defaults_to_hidpi_large(monkeypatch):
     from plugin.framework import menu_icon_dpi as m
 
-    m.reset_menu_icon_dpi_cache()
+    reset_menu_icon_dpi_cache()
     monkeypatch.setattr(m, "probe_vcl_dpi_scale", lambda ctx=None: None)
     monkeypatch.setattr(m, "probe_menu_font_scale", lambda ctx=None: None)
     monkeypatch.setattr(m, "probe_toolbar_icon_config_px", lambda ctx=None: None)
-    assert m.resolve_menu_icon_pixel_size() == 16
+    monkeypatch.setattr(m, "probe_env_scale", lambda: None)
+    assert m.resolve_menu_icon_pixel_size() == 32
+
+
+def test_probe_env_scale_gdk(monkeypatch):
+    from plugin.framework import menu_icon_dpi as m
+
+    m.reset_menu_icon_dpi_cache()
+    monkeypatch.setenv("GDK_SCALE", "2")
+    assert m.probe_env_scale() == 2.0


### PR DESCRIPTION
## Summary
- Add `plugin/framework/menu_icon_dpi.py`: one-shot probe **VCL DPI** (`PixelPerMeterX` / 96) → font height → `SidebarIconSize`, then interpolate toward Keith’s HiDPI-known-good **16px**.
- At scale≈1 choose 26/32 when assets exist (`stopped_26.png` etc.); at scale≈2 keep 16.
- Failed probe defaults to **16** (weak cache, retry when a style window exists) so HiDPI is not regressed by a startup race.
- `_update_menu_icons_impl` loads `{prefix}_{px}.png` and stamps both `SIZE_DEFAULT` and the resolved ImageType.

## Headed note (box)
- Probe from UNO: scale≈1.0 → px=32 → `stopped_26.png`.
- WriterAgent menu on this box still shows **no** icons beside items in screenshots — may be pre-existing ImageManager/menu visibility; needs another pass / Keith compare.

## Test plan
- [ ] Unit: `tests/framework/test_menu_icon_dpi.py`
- [ ] Keith HiDPI: menus still look as good as today (16)
- [ ] 1× box: confirm MCP status icon grows when ImageManager is wired
- [ ] Check debug log `menu_icon_dpi source=vcl_dpi|...`