### PR TITLE
Unify document URL helpers (normalize_doc_url + file:/ repair)

### DIFF
--- a/docs/framework/uno-utilities.md
+++ b/docs/framework/uno-utilities.md
@@ -1,6 +1,6 @@
 # UNO utility helpers — inventory, overlaps, and future-work plan
 
-**Status:** analysis only. No helper moves, renames, or new shared path/URL API in this document’s originating goal. Recommendations below are deferred work.
+**Status:** analysis, plus two landed P1 unifies (public `normalize_doc_url`; shared `normalize_file_url` / `get_document_path` `file:/` repair). Remaining recommendations below are deferred.
 
 This is the catalog of **shared UNO utility helpers** — component context, document identity, LibrePy-safe text/path helpers, chat `DocumentService`, type guards, user-defined properties, dialog accessors, listener bases, visual property helpers, and UNO error wrappers. It is **not** a catalog of domain tools (`plugin/writer/`, `plugin/calc/`, `plugin/draw/` feature modules).
 
@@ -57,7 +57,7 @@ Still [`uno_context.py`](../../plugin/framework/uno_context.py), plus the resear
 
 | Symbol | Module | Purpose |
 |--------|--------|---------|
-| `_normalize_doc_url` | `uno_context` | Strip + drop a trailing `/` so URL identity compares. |
+| `normalize_doc_url` | `uno_context` | Strip + drop a trailing `/` so URL identity compares. |
 | `get_runtime_uid` | `uno_context` | Per-session id (`getRuntimeUID` / attribute / property); works for untitled docs. |
 | `resolve_document_by_url` | `uno_context` | Walk desktop components; match normalized URL **or** RuntimeUID; return `(model, doc_type)`. |
 | `get_open_documents` | `document_research` | List open OfficeDocuments with name/url/uid/path/type/active/modified (untitled kept). |
@@ -66,7 +66,7 @@ Still [`uno_context.py`](../../plugin/framework/uno_context.py), plus the resear
 | `close_document_research_document` | `document_research` | Close only if this call loaded a hidden sibling (not a user-visible doc). |
 | `list_open_documents` (tool) | `document_research_tools` | Tool facade over `get_open_documents` (not a second resolver). |
 
-`DocumentService.resolve_document_by_url` / `get_active_document` are thin wrappers (see §1.4). MCP mutation-gate keys import `_normalize_doc_url` + `get_runtime_uid` from `uno_context`.
+`DocumentService.resolve_document_by_url` / `get_active_document` are thin wrappers (see §1.4). MCP mutation-gate keys import `normalize_doc_url` + `get_runtime_uid` from `uno_context`.
 
 ### 1.3 LibrePy-safe text / path / selection
 
@@ -78,7 +78,8 @@ LibrePy Run Python Script, text analytics, Excel auto-open, and Writer selection
 |--------|---------|
 | `normalize_linebreaks` | `\r\n` / `\r` → `\n` so offsets match (Windows UNO/clipboard). |
 | `get_string_without_tracked_deletions` | Skip redline Delete portions when reading a text range. |
-| `get_document_path` | `file://` URL → `uno.fileUrlToSystemPath`; `None` if untitled / non-file. |
+| `normalize_file_url` | Repair `file:/path` → `file:///path` (legacy `urljoin`). Shared with research. |
+| `get_document_path` | `file:` URL → repair then `uno.fileUrlToSystemPath`; `None` if untitled / non-file. |
 | `get_selection_range` | Writer `(start, end)` character offsets (cursor = equal ends). |
 | `get_selection_text` | Selected string for Writer / Calc / Draw; `None` if empty. |
 | `build_heading_tree` | Single-pass outline tree (`HeadingTreeNode`). |
@@ -253,8 +254,9 @@ There is **no** single shared converter. Live implementations:
 | `_file_url_for_path` | `writer/images/image_tools.py` | path → URL | `uno.systemPathToFileUrl(abspath)`. |
 | `_file_url` | `writer/math/math_mml_convert.py` | path → URL | `uno.systemPathToFileUrl(abspath)`. |
 | (inline) | `styles.py`, `get_image.py`, `duckdb_tools.py`, `calc/python/image_egress.py`, `librepy/sidebar_menus.py` | path → URL | Raw `uno.systemPathToFileUrl`. |
-| `get_document_path` | `text_helpers` | URL → path | `file://` prefix required; `uno.fileUrlToSystemPath`. |
-| `_system_path_from_url` | `document_research` | URL → path | Accepts `file:`; repairs `file:/`; then `fileUrlToSystemPath` + `abspath`. |
+| `normalize_file_url` | `text_helpers` | URL repair | `file:/path` → `file:///path`. Shared by `get_document_path` and research. **Landed.** |
+| `get_document_path` | `text_helpers` | URL → path | Repair then `file://` prefix; `uno.fileUrlToSystemPath`. |
+| `_system_path_from_url` | `document_research` | URL → path | Accepts `file:`; uses shared `normalize_file_url`; then `fileUrlToSystemPath` + `abspath`. |
 | `get_extension_path` | `uno_context` | URL → path | `file://` → `fileUrlToSystemPath`; else returns the URL string (`vnd.sun.star.extension://…`). |
 | `_path_from_file_url` | `scripting/sandbox.py` | URL → path | **stdlib only** (`urlparse`/`unquote`); Windows drive + UNC. |
 | `_system_dir_from_file_url` | `scripting/session_manager.py` | URL → parent dir | **stdlib, no UNO** (off-main `=PY()`); Windows drive letter. |
@@ -271,7 +273,7 @@ There is **no** single shared converter. Live implementations:
 |---------|--------|
 | `Path.as_uri()` sites (`document_research`, `embeddings_fs`, `format._file_url`) | **Candidate unify** — same stdlib, no UNO. Keep the helper UNO-free so embeddings can import it. |
 | `uno.systemPathToFileUrl` at GraphicProvider / `loadComponentFromURL` image/math sites | Optional later; behavior matches `Path.as_uri()` on POSIX. Leave until a Windows mismatch is proven. |
-| `get_document_path` vs `_system_path_from_url` | **Candidate unify the URL→path direction** for document models (`file:/` repair is missing from `get_document_path`). |
+| `get_document_path` vs `_system_path_from_url` | **Landed the `file:/` repair** on `get_document_path` via shared `text_helpers.normalize_file_url`. Research still adds `abspath`. |
 | sandbox / session_manager stdlib parsers | **Stay separate** — no UNO, Windows UNC/drive, off-main. |
 | `mail_merge._to_file_url` | Domain helper; can call a shared path→URL once one exists. |
 
@@ -279,14 +281,14 @@ There is **no** single shared converter. Live implementations:
 
 | Helper | What it normalizes | What it does **not** |
 |--------|--------------------|----------------------|
-| `uno_context._normalize_doc_url` | strip; drop trailing `/` | Does not repair `file:/` vs `file:///`. |
-| `document_scripts._normalize_doc_url` | **byte-identical copy** | Same. Used only for script stale-detection identity. |
-| `document_research._normalize_file_url` | `file:/path` → `file:///path` | Does not strip trailing slash. |
-| sandbox / session_manager | same `file:/` → `file://` + rest | Then stdlib parse. |
+| `uno_context.normalize_doc_url` | strip; drop trailing `/` | Does not repair `file:/` vs `file:///`. |
+| `document_scripts_identity` | imports `normalize_doc_url` | URL-only; empty if untitled. |
+| `text_helpers.normalize_file_url` | `file:/path` → `file:///path` | Does not strip trailing slash. |
+| sandbox / session_manager | same `file:/` → `file://` + rest | Then stdlib parse. Stay local (no UNO). |
 
-`resolve_document_by_url` compares `_normalize_doc_url(model.getURL())` to the request. A request of `file:/home/a.odt` will **not** match an open `file:///home/a.odt` unless something else repaired it first. `open_document_for_read` **does** run `_normalize_file_url` before resolve.
+`resolve_document_by_url` compares `normalize_doc_url(model.getURL())` to the request. A request of `file:/home/a.odt` will **not** match an open `file:///home/a.odt` unless something else repaired it first. `open_document_for_read` **does** run `normalize_file_url` before resolve. `get_document_path` now repairs before `fileUrlToSystemPath`.
 
-Tests: `tests/doc/test_document.py` (`_normalize_doc_url` trailing slash), `tests/doc/test_document_research.py` (`file:/` repair).
+Tests: `tests/doc/test_document.py` (`normalize_doc_url` trailing slash), `tests/doc/test_text_helpers.py` (`file:/` repair + `get_document_path`).
 
 ### 2.3 Untitled / empty URL / RuntimeUID
 
@@ -297,7 +299,7 @@ Untitled documents have `getURL() == ""`. Identity then **must** use RuntimeUID.
 | `get_runtime_uid` | Returns uid string or `""`. Accepts only `str`/`int` (mocks cannot fake it). |
 | `resolve_document_by_url` | `url` argument may be a RuntimeUID; matches unsaved docs. |
 | `get_open_documents` | Keeps untitled rows (`url=""`, `path=""`, `name="Untitled"`, `uid=…`). Never drops them on type-lookup failure. |
-| `get_document_path` | Returns `None` (not a `file://` URL). |
+| `get_document_path` | Returns `None` (not a `file:` URL after repair). |
 | `document_scripts_identity` | Empty string for untitled (URL-only; **no** uid). |
 | MCP `_resolve_mcp_doc_key` | Prefers `uid:<RuntimeUID>`; else `url:<normalized>`; else active-document sentinel. Survives Save As. |
 | `DocumentService.doc_key` | `id(doc)` — proxy-unsafe; **not** uid. |
@@ -396,9 +398,9 @@ Classification: **intentional split** (keep) / **accidental copy** (unify later)
 
 | Pair | What’s duplicated | Notes |
 |------|-------------------|-------|
-| `uno_context._normalize_doc_url` vs `document_scripts._normalize_doc_url` | Trailing-slash strip | Byte-identical. MCP already imports the `uno_context` copy. **Highest-value unify.** |
-| `document_research._path_to_file_url` vs `embeddings_fs.path_to_file_url` vs `format._file_url` | `Path(abspath).as_uri()` | Same stdlib. embeddings **cannot** import `text_helpers` (UNO). Needs a UNO-free home if unified. |
-| `document_research._normalize_file_url` vs sandbox vs session_manager `file:/` repair | `file:/` → `file://` + rest | Research uses UNO after repair; the other two stay stdlib. Share the **repair string** only, or leave the stdlib pair local. |
+| `uno_context.normalize_doc_url` vs `document_scripts._normalize_doc_url` | Trailing-slash strip | **Landed.** Script identity imports `normalize_doc_url`; the document_scripts copy is gone. |
+| `document_research._path_to_file_url` vs `embeddings_fs.path_to_file_url` vs `format._file_url` | `Path(abspath).as_uri()` | Same stdlib. embeddings **cannot** import `text_helpers` (UNO). Needs a UNO-free home if unified. Deferred (P1 path→URL). |
+| `text_helpers.normalize_file_url` vs sandbox vs session_manager `file:/` repair | `file:/` → `file://` + rest | **Landed for UNO callers** (`get_document_path` + research). Sandbox / session_manager stay stdlib. |
 | Desktop component walks | `resolve_document_by_url`, `get_open_documents`, `_collect_open_file_urls` | All enumerate `desktop.getComponents()`. Research already has `_office_model_from_desktop_element`; resolve has a slightly different frame-vs-model walk. |
 
 ### 3.2 Intentional splits (do not collapse)
@@ -438,7 +440,7 @@ Unifying `detect_doc_type` onto `doc_type_label_for_enum` would change unknown �
 
 **URL → path**
 
-`get_document_path` requires `startswith("file://")` and does not repair `file:/`. `_system_path_from_url` accepts `file:`, repairs, then `abspath`. A document whose URL is the legacy two-slash form would be “unsaved” to `get_document_path` / `get_document_directory` but openable via `open_document_for_read`.
+`get_document_path` and `_system_path_from_url` both repair `file:/` via `text_helpers.normalize_file_url`. Research still applies `abspath` after conversion. Untitled / non-file URLs still return `None`.
 
 **Active document**
 
@@ -491,9 +493,9 @@ Do **not** re-merge a monolithic `uno_helpers.py`. Prefer the smallest existing 
 
 ### P1 — candidate unify (small, real duplication)
 
-1. **Delete `document_scripts._normalize_doc_url`.** Import `uno_context._normalize_doc_url` (or promote it to a public `normalize_doc_url`). Same tests as `tests/doc/test_document.py`.
-2. **UNO-free `path_to_file_url`.** One `Path(abspath).as_uri()` helper imported by `document_research`, `embeddings_fs`, and `format._file_url`. Do **not** put it in `url_utils`. Do **not** put it in `text_helpers` (UNO import). A tiny `plugin/doc/file_urls.py` (stdlib only) or a function next to `embeddings_fs` that research can import are both fine; pick the one that does not pull embeddings into LibrePy.
-3. **Document URL→path: teach `get_document_path` the `file:/` repair** (or have it call a shared `_system_path_from_url`). Today research and text_helpers disagree on legacy two-slash URLs.
+1. **Delete `document_scripts._normalize_doc_url`.** **Landed.** Callers import public `uno_context.normalize_doc_url`. Tests: `tests/doc/test_document.py`, `tests/scripting/test_document_scripts.py`.
+2. **UNO-free `path_to_file_url`.** Still deferred. One `Path(abspath).as_uri()` helper imported by `document_research`, `embeddings_fs`, and `format._file_url`. Do **not** put it in `url_utils`. Do **not** put it in `text_helpers` (UNO import). A tiny `plugin/doc/file_urls.py` (stdlib only) or a function next to `embeddings_fs` that research can import are both fine; pick the one that does not pull embeddings into LibrePy.
+3. **Document URL→path: teach `get_document_path` the `file:/` repair.** **Landed.** Shared `text_helpers.normalize_file_url`; `get_document_path` and `_system_path_from_url` both use it. Sandbox / session_manager stdlib copies stay. Tests: `tests/doc/test_text_helpers.py`, `tests/doc/test_document_research.py`.
 
 ### P2 — candidate unify after documenting behavior
 
@@ -510,7 +512,7 @@ Do **not** re-merge a monolithic `uno_helpers.py`. Prefer the smallest existing 
 11. Point remaining `uno.systemPathToFileUrl` image/math sites at the P1 helper **after** a Windows smoke check.
 12. Notebook `file://` strip fallback → same URL→path helper.
 13. `DocumentService.doc_key` → `get_runtime_uid` (or uid-or-url like MCP). This is a behavior change for any cache keyed on `id(doc)`.
-14. Promote `uno_context._normalize_doc_url` to public name when P1 lands (callers already treat it as shared).
+14. Promote `uno_context._normalize_doc_url` to public name when P1 lands. **Landed** as `normalize_doc_url`.
 
 ### Explicit non-goals for later refactors
 
@@ -524,7 +526,7 @@ Do **not** re-merge a monolithic `uno_helpers.py`. Prefer the smallest existing 
 
 | Area | Tests |
 |------|-------|
-| `_normalize_doc_url` | `tests/doc/test_document.py` |
+| `normalize_doc_url` | `tests/doc/test_document.py` |
 | resolve by URL or RuntimeUID | `tests/doc/test_resolve_document_by_url.py` |
 | `file:///` + `file:/` repair, work directory | `tests/doc/test_document_research.py` |
 | `get_open_documents` untitled / Start Center | `tests/mcp/test_list_open_documents.py` |

--- a/plugin/doc/document_research.py
+++ b/plugin/doc/document_research.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict
 import uno
 
 from plugin.doc.doc_type import DocumentType, doc_type_label_for_enum, get_document_type
-from plugin.doc.text_helpers import get_document_path
+from plugin.doc.text_helpers import get_document_path, normalize_file_url
 from plugin.framework.uno_context import resolve_document_by_url
 from plugin.embeddings.embeddings_fs import ALL_INDEXABLE_EXTENSIONS
 
@@ -171,20 +171,10 @@ def _path_to_file_url(path: str) -> str:
     return Path(norm).as_uri()
 
 
-def _normalize_file_url(url: str) -> str:
-    """Repair file:/path URLs from the old urljoin-based _path_to_file_url."""
-    raw = str(url).strip()
-    if raw.startswith("file:///"):
-        return raw
-    if raw.startswith("file:/") and not raw.startswith("file://"):
-        return "file://" + raw[len("file:") :]
-    return raw
-
-
 def _system_path_from_url(url: str) -> str | None:
     if not url or not str(url).startswith("file:"):
         return None
-    url = _normalize_file_url(str(url))
+    url = normalize_file_url(str(url))
     if not url.startswith("file://"):
         return None
     try:
@@ -558,7 +548,7 @@ def open_document_for_read(ctx: Any, path_or_url: str) -> tuple[Any | None, str 
     url: str | None = None
     raw = str(path_or_url).strip()
     if raw.startswith("file:"):
-        url = _normalize_file_url(raw)
+        url = normalize_file_url(raw)
         path = _system_path_from_url(url)
     elif _is_absolute_or_posix_absolute(raw) and os.path.isfile(raw):
         path = _normalize_path(raw)

--- a/plugin/doc/text_helpers.py
+++ b/plugin/doc/text_helpers.py
@@ -216,12 +216,32 @@ def get_string_without_tracked_deletions(text_range) -> str:
     return "".join(parts)
 
 
+def normalize_file_url(url: str) -> str:
+    """Repair ``file:/path`` URLs from the old ``urljoin('file:', ...)`` form.
+
+    That join wrongly yields ``file:/home/...`` (two slashes).
+    ``loadComponentFromURL`` and ``fileUrlToSystemPath`` need ``file:///home/...``.
+    Shared by ``get_document_path`` and document-research URL→path.
+    Sandbox / session_manager keep their own stdlib copies (no UNO, Windows).
+    """
+    raw = str(url).strip()
+    if raw.startswith("file:///"):
+        return raw
+    if raw.startswith("file:/") and not raw.startswith("file://"):
+        return "file://" + raw[len("file:") :]
+    return raw
+
+
 @main_thread_only
 def get_document_path(model):
     """Return the local filesystem path for the document, or None if not a file URL (e.g. untitled)."""
     try:
         url = model.getURL()
-        if not url or not str(url).startswith("file://"):
+        if not url:
+            return None
+        # Legacy urljoin produced file:/path; require file:// after that repair.
+        url = normalize_file_url(str(url))
+        if not url.startswith("file://"):
             return None
         return str(uno.fileUrlToSystemPath(url))
     except Exception as e:

--- a/plugin/framework/uno_context.py
+++ b/plugin/framework/uno_context.py
@@ -558,8 +558,12 @@ def process_events_to_idle(ctx, rounds: int = 1, force: bool = False) -> bool:
     return pumped
 
 
-def _normalize_doc_url(url):
-    """Normalize document URL for comparison (strip, optional trailing slash)."""
+def normalize_doc_url(url):
+    """Normalize document URL for comparison (strip, optional trailing slash).
+
+    Shared by resolve-by-URL, MCP doc keys, and document-script stale detection.
+    Does not repair ``file:/`` vs ``file:///`` — that is ``text_helpers.normalize_file_url``.
+    """
     if not url:
         return ""
     s = str(url).strip()
@@ -612,7 +616,7 @@ def resolve_document_by_url(ctx, url):
         return (None, None)
     from plugin.doc import doc_type as _doc_type
 
-    target = _normalize_doc_url(url)
+    target = normalize_doc_url(url)
     try:
         desktop = get_desktop(ctx)
         comps = desktop.getComponents()
@@ -634,7 +638,7 @@ def resolve_document_by_url(ctx, url):
                     if controller is not None and hasattr(controller, "getModel"):
                         model = controller.getModel()
                 if model is not None:
-                    doc_url = _normalize_doc_url(model.getURL()) if hasattr(model, "getURL") else ""
+                    doc_url = normalize_doc_url(model.getURL()) if hasattr(model, "getURL") else ""
                     uid = get_runtime_uid(model)
                     if (doc_url and doc_url == target) or (uid and uid == target):
                         doc_type_enum = _doc_type.get_document_type(model)

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -31,7 +31,7 @@ import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 
-from plugin.framework.uno_context import _normalize_doc_url, get_runtime_uid
+from plugin.framework.uno_context import get_runtime_uid, normalize_doc_url
 from plugin.framework.queue_executor import QueueExecutor
 from plugin.framework.errors import WriterAgentException, safe_json_loads
 from plugin.mcp.cors import send_cors_headers
@@ -238,7 +238,7 @@ def _resolve_mcp_doc_key(document_url, doc):
             uid = get_runtime_uid(doc)
             if uid:
                 return "uid:%s" % uid
-            url = _normalize_doc_url(doc.getURL())
+            url = normalize_doc_url(doc.getURL())
             if url:
                 return "url:%s" % url
         except Exception:
@@ -247,7 +247,7 @@ def _resolve_mcp_doc_key(document_url, doc):
     # namespaced ("url:") so it can never collide with a resolved "uid:"/"url:" key; else the
     # active-document sentinel.
     if document_url:
-        return "url:%s" % _normalize_doc_url(document_url)
+        return "url:%s" % normalize_doc_url(document_url)
     return _ACTIVE_DOCUMENT_SENTINEL
 
 

--- a/plugin/scripting/document_scripts.py
+++ b/plugin/scripting/document_scripts.py
@@ -30,7 +30,7 @@ from plugin.doc.udprops import get_document_property, set_document_property
 from plugin.framework.errors import UnoObjectError
 from plugin.framework.i18n import _
 from plugin.framework.json_utils import safe_json_loads
-from plugin.framework.uno_context import get_desktop
+from plugin.framework.uno_context import get_desktop, normalize_doc_url
 from plugin.scripting.domain_registry import (
     ANALYSIS_SCRIPT_DISPLAY_PREFIX,
     DOC_SCRIPT_DISPLAY_PREFIX,
@@ -58,20 +58,11 @@ _SOFT_WARN_SCRIPT_BYTES = 200_000
 _ENVELOPE_VERSION = 1
 
 
-def _normalize_doc_url(url: Any) -> str:
-    if not url:
-        return ""
-    s = str(url).strip()
-    if s.endswith("/") and len(s) > 1:
-        s = s[:-1]
-    return s
-
-
 def document_scripts_identity(doc: Any) -> str:
     """Stable identity for stale detection (normalized URL or empty for untitled)."""
     try:
         if hasattr(doc, "getURL"):
-            return _normalize_doc_url(doc.getURL() or "")
+            return normalize_doc_url(doc.getURL() or "")
     except Exception:
         log.debug("document_scripts_identity failed", exc_info=True)
     return ""

--- a/tests/doc/test_document.py
+++ b/tests/doc/test_document.py
@@ -1,13 +1,13 @@
 """Headless unit tests for document URL/excerpt helpers (not a native UNO suite)."""
 
 from plugin.doc.document_helpers import _inject_markers_into_excerpt
-from plugin.framework.uno_context import _normalize_doc_url
+from plugin.framework.uno_context import normalize_doc_url
 
 def test_normalize_doc_url():
-    assert _normalize_doc_url("file:///test/") == "file:///test"
-    assert _normalize_doc_url("file:///test") == "file:///test"
-    assert _normalize_doc_url("") == ""
-    assert _normalize_doc_url(None) == ""
+    assert normalize_doc_url("file:///test/") == "file:///test"
+    assert normalize_doc_url("file:///test") == "file:///test"
+    assert normalize_doc_url("") == ""
+    assert normalize_doc_url(None) == ""
 
 def test_inject_markers_into_excerpt():
     text = "0123456789"

--- a/tests/doc/test_document_research.py
+++ b/tests/doc/test_document_research.py
@@ -13,8 +13,8 @@ from unittest.mock import MagicMock, patch
 from plugin.doc.document_research import (
     NEARBY_FILE_EXTENSIONS,
     NEARBY_IMAGE_EXTENSIONS,
-    _normalize_file_url,
     _path_to_file_url,
+    _system_path_from_url,
     close_document_research_document,
     guess_doc_type_from_path,
     get_document_directory,
@@ -23,6 +23,7 @@ from plugin.doc.document_research import (
     open_document_for_read,
     resolve_listing_directory,
 )
+from plugin.doc.text_helpers import normalize_file_url
 
 
 def test_guess_doc_type_from_path():
@@ -45,7 +46,17 @@ def test_path_to_file_url_uses_three_slashes_on_unix():
 
 def test_normalize_file_url_repairs_legacy_urljoin_form():
     legacy = "file:/home/user/Writing/Test.odt"
-    assert _normalize_file_url(legacy) == "file:///home/user/Writing/Test.odt"
+    assert normalize_file_url(legacy) == "file:///home/user/Writing/Test.odt"
+
+
+def test_system_path_from_url_uses_shared_file_url_repair():
+    with patch(
+        "plugin.doc.document_research.uno.fileUrlToSystemPath",
+        return_value="/home/user/Writing/Test.odt",
+    ), patch("plugin.doc.document_research._normalize_path", side_effect=lambda path: path):
+        assert _system_path_from_url("file:/home/user/Writing/Test.odt") == "/home/user/Writing/Test.odt"
+        assert _system_path_from_url("") is None
+        assert _system_path_from_url("private:factory/swriter") is None
 
 
 def test_get_document_directory():

--- a/tests/doc/test_text_helpers.py
+++ b/tests/doc/test_text_helpers.py
@@ -1,6 +1,12 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from plugin.doc.text_helpers import get_full_writer_text, get_string_without_tracked_deletions, normalize_linebreaks
+from plugin.doc.text_helpers import (
+    get_document_path,
+    get_full_writer_text,
+    get_string_without_tracked_deletions,
+    normalize_file_url,
+    normalize_linebreaks,
+)
 
 
 def test_normalize_linebreaks():
@@ -17,6 +23,34 @@ def test_normalize_linebreaks():
     assert normalize_linebreaks("\r\r") == "\n\n"
     assert normalize_linebreaks("") == ""
     assert normalize_linebreaks(None) == ""
+
+
+def test_normalize_file_url_repairs_legacy_urljoin_form():
+    assert normalize_file_url("file:/home/user/Writing/Test.odt") == "file:///home/user/Writing/Test.odt"
+    assert normalize_file_url("file:///home/user/Writing/Test.odt") == "file:///home/user/Writing/Test.odt"
+    assert normalize_file_url("  file:/tmp/a.odt  ") == "file:///tmp/a.odt"
+    assert normalize_file_url("private:factory/swriter") == "private:factory/swriter"
+    assert normalize_file_url("") == ""
+
+
+def test_get_document_path_repairs_legacy_file_url_and_rejects_non_file():
+    def to_system_path(url):
+        assert url.startswith("file://")
+        return url[len("file://") :]
+
+    with patch("plugin.doc.text_helpers.uno.fileUrlToSystemPath", side_effect=to_system_path):
+        model = MagicMock()
+        model.getURL.return_value = "file:/tmp/legacy.odt"
+        assert get_document_path(model) == "/tmp/legacy.odt"
+
+        model.getURL.return_value = "file:///tmp/ok.odt"
+        assert get_document_path(model) == "/tmp/ok.odt"
+
+        model.getURL.return_value = ""
+        assert get_document_path(model) is None
+
+        model.getURL.return_value = "private:factory/swriter"
+        assert get_document_path(model) is None
 
 
 class _Enum:

--- a/tests/mcp/test_mcp_doc_key.py
+++ b/tests/mcp/test_mcp_doc_key.py
@@ -8,7 +8,7 @@ The per-document mutation gate must give the SAME key whether a document is addr
 URL or by its RuntimeUID, so two concurrent mutating MCP calls on that document serialize on one
 lock instead of racing on two.
 """
-from plugin.framework.uno_context import _normalize_doc_url
+from plugin.framework.uno_context import normalize_doc_url
 from plugin.mcp.mcp_protocol import _ACTIVE_DOCUMENT_SENTINEL, _resolve_mcp_doc_key
 
 
@@ -35,7 +35,7 @@ def test_same_doc_by_url_and_by_uid_map_to_one_key():
 
 def test_saved_doc_without_uid_keys_on_url():
     doc = Doc(uid="", url="file:///docs/a.odt")
-    assert _resolve_mcp_doc_key("file:///docs/a.odt", doc) == "url:" + _normalize_doc_url("file:///docs/a.odt")
+    assert _resolve_mcp_doc_key("file:///docs/a.odt", doc) == "url:" + normalize_doc_url("file:///docs/a.odt")
 
 
 def test_unsaved_active_doc_keys_on_uid_not_sentinel():
@@ -45,7 +45,7 @@ def test_unsaved_active_doc_keys_on_uid_not_sentinel():
 
 
 def test_unresolved_doc_falls_back_to_request_url():
-    assert _resolve_mcp_doc_key("file:///docs/x.odt", None) == "url:" + _normalize_doc_url("file:///docs/x.odt")
+    assert _resolve_mcp_doc_key("file:///docs/x.odt", None) == "url:" + normalize_doc_url("file:///docs/x.odt")
 
 
 def test_unresolved_uid_request_cannot_collide_with_resolved_uid_key():

--- a/tests/scripting/test_document_scripts.py
+++ b/tests/scripting/test_document_scripts.py
@@ -20,6 +20,7 @@ from plugin.scripting.document_scripts import (
     delete_document_script,
     delete_user_script,
     document_script_display_name,
+    document_scripts_identity,
     get_document_scripts,
     handle_editor_script_message,
     has_document_scripts,
@@ -41,6 +42,14 @@ from plugin.tests.testing_utils import setup_uno_mocks
 from tests.writer.test_document_helpers import _DocWithUserDefinedProperties, _UserDefinedProperties
 
 setup_uno_mocks()
+
+
+def test_document_scripts_identity_uses_shared_trailing_slash_normalize():
+    doc = MagicMock()
+    doc.getURL.return_value = "file:///tmp/doc.odt/"
+    assert document_scripts_identity(doc) == "file:///tmp/doc.odt"
+    doc.getURL.return_value = ""
+    assert document_scripts_identity(doc) == ""
 
 
 def test_get_document_scripts_empty():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Two P1 items from `docs/framework/uno-utilities.md` §4, as one PR:

1. Unify `_normalize_doc_url` (delete the `document_scripts` copy).
2. Teach `get_document_path` the `file:/` repair via one shared helper.

P1 path→URL (`path_to_file_url` / `Path.as_uri`) and P2/P3 are **not** in this PR.

## Verified on the tree (before coding)

- `uno_context._normalize_doc_url` and `document_scripts._normalize_doc_url` were the same algorithm: `str(url).strip()`, drop a trailing `/` when `len > 1`. No drift.
- Callers of the `uno_context` copy: `resolve_document_by_url`, `mcp_protocol`, `tests/doc/test_document.py`, `tests/mcp/test_mcp_doc_key.py`.
- Callers of the `document_scripts` copy: only `document_scripts_identity`.
- `get_document_path` required `startswith("file://")` and skipped legacy `file:/path`.
- `document_research._normalize_file_url` / `_system_path_from_url` repaired `file:/` → `file:///` then `fileUrlToSystemPath` (+ `abspath` in research). Empty / non-file → `None`.
- Sandbox / `session_manager` have their own stdlib `file:/` parsers (left alone: no UNO, Windows).
- `text_helpers` is already LibrePy-safe; `document_research` already imported `get_document_path` from it. Embeddings do not import these helpers.

## What changed

- Promoted `uno_context.normalize_doc_url` (public; no `_` alias). Updated every call site.
- Deleted `document_scripts._normalize_doc_url`. `document_scripts_identity` imports the shared helper.
- Moved the `file:/` repair to `text_helpers.normalize_file_url`. `get_document_path` repairs then still returns `None` for untitled / non-file.
- Deleted `document_research._normalize_file_url`. `_system_path_from_url` and `open_document_for_read` import the shared helper. No re-exports or compat aliases.
- Docs: brief landed notes in §2.1 / §3.1 / §4 P1 items 1 and 3 (user items 1–2). Path→URL unify remains deferred.

## Tests

Extended matching files only. Local results:

- `pytest tests/doc/test_document.py tests/doc/test_text_helpers.py tests/doc/test_document_research.py tests/scripting/test_document_scripts.py tests/mcp/test_mcp_doc_key.py -q --tb=short` → **77 passed**
- `make typecheck` → ruff, basedpyright, bandit, opengrep, pyspector, ty, thread-safety, mypy **passed**

Coverage added:

- Trailing-slash normalize from the shared home (`tests/doc/test_document.py`).
- `get_document_path` accepts repaired `file:/`; still `None` for untitled / non-file (`tests/doc/test_text_helpers.py`).
- Research still uses the shared repair (`tests/doc/test_document_research.py`).
- Script identity uses shared trailing-slash normalize (`tests/scripting/test_document_scripts.py`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b5b36f9-e85c-40be-a3a3-247c64c6aec3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b5b36f9-e85c-40be-a3a3-247c64c6aec3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

