### PR TITLE
Unify path→file: URL helpers in url_utils.path_to_file_url

### DIFF
--- a/docs/framework/uno-utilities.md
+++ b/docs/framework/uno-utilities.md
@@ -1,6 +1,6 @@
 # UNO utility helpers — inventory, overlaps, and future-work plan
 
-**Status:** analysis, plus two landed P1 unifies (public `normalize_doc_url`; shared `normalize_file_url` / `get_document_path` `file:/` repair). Remaining recommendations below are deferred.
+**Status:** analysis, plus three landed P1 unifies (public `normalize_doc_url`; shared `normalize_file_url` / `get_document_path` `file:/` repair; shared UNO-free `url_utils.path_to_file_url`). Remaining recommendations below are deferred.
 
 This is the catalog of **shared UNO utility helpers** — component context, document identity, LibrePy-safe text/path helpers, chat `DocumentService`, type guards, user-defined properties, dialog accessors, listener bases, visual property helpers, and UNO error wrappers. It is **not** a catalog of domain tools (`plugin/writer/`, `plugin/calc/`, `plugin/draw/` feature modules).
 
@@ -19,7 +19,7 @@ Related catalogs (do not duplicate here):
 - **No monolithic `uno_helpers.py`.** Helpers stay split: `uno_context`, `text_helpers` / `doc_type` / `udprops`, `document_helpers`, `dialogs`. That split is an AGENTS.md rule.
 - **LibrePy must not import `document_helpers`.** Light helpers only (`text_helpers`, `doc_type`, `udprops`). Do not re-export the light helpers from `document_helpers`.
 - **Use the extension’s `self.ctx`**, stored via `set_fallback_ctx` / `get_ctx()`. Do not prefer `uno.getComponentContext()` (wrong context in test runners; can segfault on Desktop).
-- **HTTP / LLM URL policy stays in `url_utils`.** Document `file:` URLs and PathSettings are a different problem.
+- **HTTP / LLM URL policy stays in `url_utils`.** One stdlib `path_to_file_url` lives in a separate filesystem / document `file:` section; do not fold it into `normalize_endpoint_url`. PathSettings stay out of `url_utils`.
 
 ---
 
@@ -247,9 +247,7 @@ There is **no** single shared converter. Live implementations:
 
 | Helper | Module | Direction | Mechanism |
 |--------|--------|-----------|-----------|
-| `_path_to_file_url` | `document_research` | path → URL | `Path(abspath).as_uri()` (forces `file:///` on POSIX). |
-| `path_to_file_url` | `embeddings_fs` | path → URL | Same `Path.as_uri()`; **no UNO** (embeddings extract is disk-only). |
-| `_file_url` | `writer/format.py` | path → URL | Same `Path.as_uri()`. |
+| `path_to_file_url` | `url_utils` (filesystem / document `file:` section) | path → URL | `Path(abspath).as_uri()` (forces `file:///` on POSIX). **Landed.** UNO-free; used by `document_research`, `embeddings_fs`, and `format`. |
 | `_to_file_url` | `writer/specialized/mail_merge.py` | path or URL → URL | Prefer `uno.systemPathToFileUrl`; fallback `Path.as_uri()`. |
 | `_file_url_for_path` | `writer/images/image_tools.py` | path → URL | `uno.systemPathToFileUrl(abspath)`. |
 | `_file_url` | `writer/math/math_mml_convert.py` | path → URL | `uno.systemPathToFileUrl(abspath)`. |
@@ -263,7 +261,7 @@ There is **no** single shared converter. Live implementations:
 
 **Why two conversion styles exist**
 
-- `urljoin("file:", path)` produced `file:/home/...` (two slashes). `loadComponentFromURL` needs `file:///home/...`. `Path.as_uri()` is the documented fix (`document_research._path_to_file_url`, tests in `tests/doc/test_document_research.py`).
+- `urljoin("file:", path)` produced `file:/home/...` (two slashes). `loadComponentFromURL` needs `file:///home/...`. `Path.as_uri()` is the documented fix (`url_utils.path_to_file_url`, tests in `tests/framework/test_url_utils.py` and `tests/doc/test_document_research.py`).
 - `uno.systemPathToFileUrl` / `fileUrlToSystemPath` are OS-correct **when UNO is available on the main thread**.
 - Sandbox and Calc session-id parsing **must not** call UNO (off-main / stdlib-only). They reimplement a subset with explicit Windows branches.
 
@@ -271,7 +269,7 @@ There is **no** single shared converter. Live implementations:
 
 | Cluster | Share? |
 |---------|--------|
-| `Path.as_uri()` sites (`document_research`, `embeddings_fs`, `format._file_url`) | **Candidate unify** — same stdlib, no UNO. Keep the helper UNO-free so embeddings can import it. |
+| `Path.as_uri()` sites (`document_research`, `embeddings_fs`, `format`) | **Landed** as `url_utils.path_to_file_url` (filesystem section). Same stdlib, no UNO, no `@deal`. |
 | `uno.systemPathToFileUrl` at GraphicProvider / `loadComponentFromURL` image/math sites | Optional later; behavior matches `Path.as_uri()` on POSIX. Leave until a Windows mismatch is proven. |
 | `get_document_path` vs `_system_path_from_url` | **Landed the `file:/` repair** on `get_document_path` via shared `text_helpers.normalize_file_url`. Research still adds `abspath`. |
 | sandbox / session_manager stdlib parsers | **Stay separate** — no UNO, Windows UNC/drive, off-main. |
@@ -327,7 +325,7 @@ Three **different** PathSettings properties; do not collapse the meanings.
 
 ### 2.5 HTTP / API URL helpers vs document URLs
 
-[`plugin/framework/url_utils.py`](../../plugin/framework/url_utils.py) is **not** a document-URL module.
+[`plugin/framework/url_utils.py`](../../plugin/framework/url_utils.py) is primarily an HTTP / dispatch module. One stdlib filesystem helper lives in a **separate** section.
 
 | Symbol | Purpose |
 |--------|---------|
@@ -335,8 +333,9 @@ Three **different** PathSettings properties; do not collapse the meanings.
 | `get_url_hostname` / `get_url_domain` / `get_url_path` / `get_url_query_dict` / `get_url_path_and_query` | Safe `urllib.parse` for HTTP endpoints. |
 | `is_pdf_url` | HTTP path ends with `.pdf`. |
 | `matches_librepy_dispatch_url` / `dispatch_command_from_url` | LibreOffice **dispatch** URLs (`org.extension.librepy:…`), not `file:`. |
+| `path_to_file_url` | Filesystem path → document `file:` URL (`Path.as_uri()`). No `@deal`. |
 
-Do not add `file:` conversion or document identity here. Tests: `tests/framework/test_url_utils.py`.
+Do not fold document identity or PathSettings into the HTTP helpers. Tests: `tests/framework/test_url_utils.py`.
 
 ### 2.6 Extension and dispatch URLs
 
@@ -399,7 +398,7 @@ Classification: **intentional split** (keep) / **accidental copy** (unify later)
 | Pair | What’s duplicated | Notes |
 |------|-------------------|-------|
 | `uno_context.normalize_doc_url` vs `document_scripts._normalize_doc_url` | Trailing-slash strip | **Landed.** Script identity imports `normalize_doc_url`; the document_scripts copy is gone. |
-| `document_research._path_to_file_url` vs `embeddings_fs.path_to_file_url` vs `format._file_url` | `Path(abspath).as_uri()` | Same stdlib. embeddings **cannot** import `text_helpers` (UNO). Needs a UNO-free home if unified. Deferred (P1 path→URL). |
+| `document_research._path_to_file_url` vs `embeddings_fs.path_to_file_url` vs `format._file_url` | `Path(abspath).as_uri()` | **Landed.** Shared `url_utils.path_to_file_url` (filesystem section). Old copies deleted; no aliases. |
 | `text_helpers.normalize_file_url` vs sandbox vs session_manager `file:/` repair | `file:/` → `file://` + rest | **Landed for UNO callers** (`get_document_path` + research). Sandbox / session_manager stay stdlib. |
 | Desktop component walks | `resolve_document_by_url`, `get_open_documents`, `_collect_open_file_urls` | All enumerate `desktop.getComponents()`. Research already has `_office_model_from_desktop_element`; resolve has a slightly different frame-vs-model walk. |
 
@@ -408,7 +407,7 @@ Classification: **intentional split** (keep) / **accidental copy** (unify later)
 | Split | Why it is intentional |
 |-------|------------------------|
 | `text_helpers` / `doc_type` / `udprops` vs `document_helpers` | LibrePy import graph. Chat context / `SheetAnalyzer` must not load in LibrePy. |
-| `url_utils` (HTTP + LibrePy dispatch) vs document `file:` | Different schemes, different failure modes, `@deal` contracts on HTTP strings. |
+| `url_utils` HTTP helpers vs document `file:` identity | Different schemes and `@deal` contracts. The one exception is stdlib `path_to_file_url` in the filesystem section. |
 | `visual_helpers` vs `doc_type` | Visual adds `WebDocument` (checked first) and unknown→`"writer"`; research uses `impress_as_draw`. |
 | `visual_helpers` vs `image_tools` | Lookup/properties vs insert/gallery/GraphicProvider. Wrappers already delegate. |
 | `get_document_from_frame` vs `get_active_document` | Sidebar must bind the **frame’s** document, not Desktop current (wrong-doc bug). |
@@ -482,7 +481,7 @@ Do **not** re-merge a monolithic `uno_helpers.py`. Prefer the smallest existing 
 ### Leave as-is / invariant
 
 1. LibrePy vs `document_helpers` import split.
-2. HTTP `url_utils` vs document `file:` URLs.
+2. HTTP `url_utils` policy vs document identity (except the one stdlib `path_to_file_url` in the filesystem section).
 3. `get_document_from_frame` for sidebars vs `get_active_document` for menus/MCP.
 4. `visual_helpers` vs `image_tools` (wrappers already delegate).
 5. sandbox / session_manager stdlib file-URL parsers (no UNO, Windows).
@@ -494,7 +493,7 @@ Do **not** re-merge a monolithic `uno_helpers.py`. Prefer the smallest existing 
 ### P1 — candidate unify (small, real duplication)
 
 1. **Delete `document_scripts._normalize_doc_url`.** **Landed.** Callers import public `uno_context.normalize_doc_url`. Tests: `tests/doc/test_document.py`, `tests/scripting/test_document_scripts.py`.
-2. **UNO-free `path_to_file_url`.** Still deferred. One `Path(abspath).as_uri()` helper imported by `document_research`, `embeddings_fs`, and `format._file_url`. Do **not** put it in `url_utils`. Do **not** put it in `text_helpers` (UNO import). A tiny `plugin/doc/file_urls.py` (stdlib only) or a function next to `embeddings_fs` that research can import are both fine; pick the one that does not pull embeddings into LibrePy.
+2. **UNO-free `path_to_file_url`.** **Landed** in `url_utils` filesystem / document `file:` section (not HTTP helpers, not `text_helpers`, not a new `file_urls.py`). `document_research`, `embeddings_fs`, and `format` import it; old copies deleted; no aliases. Tests: `tests/framework/test_url_utils.py`, `tests/doc/test_document_research.py`, `tests/embeddings/test_embeddings_fs.py`.
 3. **Document URL→path: teach `get_document_path` the `file:/` repair.** **Landed.** Shared `text_helpers.normalize_file_url`; `get_document_path` and `_system_path_from_url` both use it. Sandbox / session_manager stdlib copies stay. Tests: `tests/doc/test_text_helpers.py`, `tests/doc/test_document_research.py`.
 
 ### P2 — candidate unify after documenting behavior
@@ -530,7 +529,7 @@ Do **not** re-merge a monolithic `uno_helpers.py`. Prefer the smallest existing 
 | resolve by URL or RuntimeUID | `tests/doc/test_resolve_document_by_url.py` |
 | `file:///` + `file:/` repair, work directory | `tests/doc/test_document_research.py` |
 | `get_open_documents` untitled / Start Center | `tests/mcp/test_list_open_documents.py` |
-| HTTP `url_utils` | `tests/framework/test_url_utils.py` |
+| HTTP `url_utils` + `path_to_file_url` | `tests/framework/test_url_utils.py` |
 | `uno_context` getters | `tests/framework/test_uno_context.py` |
 | listeners | `tests/framework/test_uno_listeners.py` |
 | type guards | `tests/doc/test_doc_type.py` |

--- a/plugin/doc/document_research.py
+++ b/plugin/doc/document_research.py
@@ -11,15 +11,15 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 import uno
 
 from plugin.doc.doc_type import DocumentType, doc_type_label_for_enum, get_document_type
 from plugin.doc.text_helpers import get_document_path, normalize_file_url
-from plugin.framework.uno_context import resolve_document_by_url
 from plugin.embeddings.embeddings_fs import ALL_INDEXABLE_EXTENSIONS
+from plugin.framework.uno_context import resolve_document_by_url
+from plugin.framework.url_utils import path_to_file_url
 
 if TYPE_CHECKING:
     from plugin.framework.tool import ToolBase
@@ -159,16 +159,6 @@ def _normalize_path(path: str) -> str:
 
 def _is_absolute_or_posix_absolute(path: str) -> bool:
     return os.path.isabs(path) or path.startswith("/")
-
-
-def _path_to_file_url(path: str) -> str:
-    """Build a LO-compatible file URL (file:/// on Unix).
-
-    urljoin('file:', ...) wrongly yields file:/home/... (two slashes);
-    loadComponentFromURL and open_document_for_read require file:///home/...
-    """
-    norm = _normalize_path(path)
-    return Path(norm).as_uri()
 
 
 def _system_path_from_url(url: str) -> str | None:
@@ -383,7 +373,7 @@ def _scan_directory(
             truncated = True
             break
         norm = _normalize_path(full)
-        url = open_paths.get(norm) or _path_to_file_url(full)
+        url = open_paths.get(norm) or path_to_file_url(full)
         entries.append(
             FileEntry(
                 path=norm,
@@ -503,7 +493,7 @@ def resolve_path_or_name(
 
     if os.path.isabs(raw) and os.path.isfile(raw):
         norm = _normalize_path(raw)
-        return norm, _path_to_file_url(norm)
+        return norm, path_to_file_url(norm)
 
     listing = list_nearby_files(
         ctx, active_model, filter=filter or raw, file_kind=file_kind, max_entries=_DEFAULT_MAX_ENTRIES
@@ -552,7 +542,7 @@ def open_document_for_read(ctx: Any, path_or_url: str) -> tuple[Any | None, str 
         path = _system_path_from_url(url)
     elif _is_absolute_or_posix_absolute(raw) and os.path.isfile(raw):
         path = _normalize_path(raw)
-        url = _path_to_file_url(path)
+        url = path_to_file_url(path)
     else:
         return None, None, f"Invalid path or URL: {raw!r}", False
 

--- a/plugin/embeddings/embeddings_fs.py
+++ b/plugin/embeddings/embeddings_fs.py
@@ -12,8 +12,9 @@ import dataclasses
 import hashlib
 import logging
 import os
-from pathlib import Path
 from typing import Any
+
+from plugin.framework import url_utils
 
 log = logging.getLogger(__name__)
 
@@ -71,13 +72,6 @@ def content_hash(text: str) -> str:
 
 def _normalize_path(path: str) -> str:
     return os.path.normpath(os.path.abspath(path))
-
-
-def path_to_file_url(path: str) -> str:
-    """Build a LO-compatible file URL (file:/// on Unix)."""
-    norm = _normalize_path(path)
-    return Path(norm).as_uri()
-
 
 
 def extract_writer_paragraph_runs(path: str) -> list[tuple[str, list[LocaleTextRun]]]:
@@ -193,7 +187,7 @@ def guess_indexable_paths(directory: str) -> list[WriterFileEntry]:
         entries.append(
             WriterFileEntry(
                 path=norm,
-                url=path_to_file_url(norm),
+                url=url_utils.path_to_file_url(norm),
                 modified=mtime,
                 name=name,
             )
@@ -219,7 +213,7 @@ def indexable_chunks_from_path(
     from plugin.embeddings.embeddings_split import split_passage_locale_runs_to_chunk_meta, split_passage_to_chunk_meta
 
     norm = _normalize_path(path)
-    url = doc_url if doc_url else path_to_file_url(norm)
+    url = doc_url if doc_url else url_utils.path_to_file_url(norm)
     try:
         mtime = float(file_mtime if file_mtime is not None else os.path.getmtime(norm))
     except OSError:

--- a/plugin/framework/url_utils.py
+++ b/plugin/framework/url_utils.py
@@ -5,12 +5,17 @@
 
 """
 URL parsing utilities for WriterAgent.
+
+HTTP / LLM endpoint helpers live below. Filesystem ``file:`` conversion is a
+separate section — do not fold it into ``normalize_endpoint_url``.
 """
 
 # crosshair: off
 from __future__ import annotations
 
+import os
 import urllib.parse
+from pathlib import Path
 from typing import Any
 
 from plugin.framework.constants import EXTENSION_ID_LIBREPY
@@ -211,3 +216,19 @@ def is_pdf_url(url):
         return (parsed.path or "").lower().endswith(".pdf")
     except (ValueError, TypeError, AttributeError):
         return False
+
+
+# ---------------------------------------------------------------------------
+# Filesystem / document file: URLs (UNO-free; not HTTP endpoints)
+# ---------------------------------------------------------------------------
+
+
+def path_to_file_url(path: str) -> str:
+    """Build a document / ``loadComponentFromURL`` / GraphicProvider-style ``file:`` URL.
+
+    Normalize with ``os.path.abspath`` then ``Path.as_uri()`` so Unix yields
+    ``file:///…`` (three slashes). ``urljoin('file:', …)`` wrongly produces
+    ``file:/…``. Not an LLM endpoint helper; no ``@deal`` (those contracts are
+    for HTTP strings). UNO-free so embeddings extract can import this module.
+    """
+    return Path(os.path.abspath(path)).as_uri()

--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -19,7 +19,6 @@
 import contextlib
 import logging
 import os
-from pathlib import Path
 import re
 import sys
 import tempfile
@@ -27,6 +26,7 @@ from typing import Any, cast
 
 import uno
 from plugin.doc.text_helpers import get_string_without_tracked_deletions as _get_str  # noqa: F401  # pyright: ignore[reportUnusedImport]
+from plugin.framework.url_utils import path_to_file_url
 from .math.html_math_segment import html_fragment_contains_mixed_math  # noqa: F401  # pyright: ignore[reportUnusedImport]
 from .math.math_mml_convert import convert_latex_to_starmath as convert_latex_to_starmath  # noqa: F401  # pyright: ignore[reportUnusedImport]
 from .math.math_mml_convert import convert_mathml_to_starmath as convert_mathml_to_starmath  # noqa: F401  # pyright: ignore[reportUnusedImport]
@@ -116,11 +116,6 @@ def _get_format_props(config_svc=None):
 # ---------------------------------------------------------------------------
 
 
-def _file_url(path):
-    """Return a ``file://`` URL for *path*."""
-    return Path(os.path.abspath(path)).as_uri()
-
-
 def create_property_value(name, value):
     """Create a ``com.sun.star.beans.PropertyValue``."""
     p = cast("Any", uno.createUnoStruct("com.sun.star.beans.PropertyValue"))
@@ -149,7 +144,7 @@ def _with_temp_buffer(content=None, config_svc=None, ext=None):  # pyright: igno
                 f.write(content)
         else:
             os.close(fd)
-        yield (path, _file_url(path))
+        yield (path, path_to_file_url(path))
     finally:
         try:
             os.unlink(path)

--- a/tests/doc/test_document_research.py
+++ b/tests/doc/test_document_research.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, patch
 from plugin.doc.document_research import (
     NEARBY_FILE_EXTENSIONS,
     NEARBY_IMAGE_EXTENSIONS,
-    _path_to_file_url,
     _system_path_from_url,
     close_document_research_document,
     guess_doc_type_from_path,
@@ -24,6 +23,7 @@ from plugin.doc.document_research import (
     resolve_listing_directory,
 )
 from plugin.doc.text_helpers import normalize_file_url
+from plugin.framework.url_utils import path_to_file_url
 
 
 def test_guess_doc_type_from_path():
@@ -39,7 +39,7 @@ def test_guess_doc_type_from_path():
 
 
 def test_path_to_file_url_uses_three_slashes_on_unix():
-    url = _path_to_file_url("/home/user/Writing/Test.odt")
+    url = path_to_file_url("/home/user/Writing/Test.odt")
     assert url.startswith("file:///")
     assert url.endswith("/home/user/Writing/Test.odt") or "Writing" in url
 
@@ -163,7 +163,7 @@ def test_get_work_directory_file_url():
     with tempfile.TemporaryDirectory() as tmp:
         ctx = MagicMock()
         path_settings = MagicMock()
-        path_settings.getPropertyValue.return_value = _path_to_file_url(tmp)
+        path_settings.getPropertyValue.return_value = path_to_file_url(tmp)
         ctx.getValueByName.side_effect = lambda name: path_settings if name == "/singletons/com.sun.star.util.thePathSettings" else None
         norm = os.path.normpath(tmp)
         with patch("plugin.doc.document_research._system_path_from_url", return_value=norm):

--- a/tests/embeddings/test_embeddings_fs.py
+++ b/tests/embeddings/test_embeddings_fs.py
@@ -12,6 +12,29 @@ from pathlib import Path
 import pytest
 
 from plugin.embeddings import embeddings_fs
+from plugin.framework.url_utils import path_to_file_url
+
+
+def test_path_to_file_url_uses_three_slashes_on_unix():
+    url = path_to_file_url("/home/user/Writing/Test.odt")
+    assert url.startswith("file:///")
+    assert url.endswith("/home/user/Writing/Test.odt") or "Writing" in url
+
+
+def test_embeddings_fs_does_not_reexport_path_to_file_url():
+    assert not hasattr(embeddings_fs, "path_to_file_url")
+
+
+def test_embeddings_fs_import_stays_uno_free():
+    """url_utils must stay UNO-free so embeddings extract can import it."""
+    import subprocess
+    import sys
+
+    code = (
+        "import plugin.embeddings.embeddings_fs, plugin.framework.url_utils, sys; "
+        "assert 'uno' not in sys.modules"
+    )
+    subprocess.check_call([sys.executable, "-c", code])
 
 
 def test_content_hash_stable():
@@ -72,7 +95,7 @@ def test_paragraph_chunks_from_path(tmp_path: Path):
     assert len(chunks) == 1
     assert chunks[0].text == "Body"
     assert chunks[0].para_index == 0
-    assert chunks[0].doc_url.startswith("file:")
+    assert chunks[0].doc_url.startswith("file:///")
 
 
 def test_paragraph_chunks_from_path_without_styles(tmp_path: Path):
@@ -88,7 +111,7 @@ def test_paragraph_chunks_from_path_without_styles(tmp_path: Path):
     assert len(chunks) == 1
     assert chunks[0].text == "Body"
     assert chunks[0].para_index == 0
-    assert chunks[0].doc_url.startswith("file:")
+    assert chunks[0].doc_url.startswith("file:///")
 
 
 def test_path_uses_prose_chunking_by_extension():

--- a/tests/embeddings/venv/test_embeddings_folder_maintain.py
+++ b/tests/embeddings/venv/test_embeddings_folder_maintain.py
@@ -61,7 +61,8 @@ def test_maintain_incremental_skips_fresh_file(tmp_path: Path):
     )
 
     from plugin.embeddings.embeddings_cache import mark_file_indexed
-    from plugin.embeddings.embeddings_fs import content_hash, path_to_file_url
+    from plugin.embeddings.embeddings_fs import content_hash
+    from plugin.framework.url_utils import path_to_file_url
     from plugin.embeddings.venv.embeddings_sqlite import connect_corpus_db, ensure_schema, upsert_chunk_with_vector
 
     doc_url = path_to_file_url(str(doc))

--- a/tests/framework/test_url_utils.py
+++ b/tests/framework/test_url_utils.py
@@ -6,6 +6,7 @@ from plugin.framework.url_utils import (
     get_url_query_dict,
     matches_librepy_dispatch_url,
     normalize_endpoint_url,
+    path_to_file_url,
 )
 
 class TestNormalizeEndpointUrl():
@@ -133,3 +134,10 @@ class TestLibrePyDispatchUrl(unittest.TestCase):
         assert matches_librepy_dispatch_url(self._Url(protocol="org.extension.librepy:", path="main.settings"))
         assert matches_librepy_dispatch_url(self._Url(complete="org.extension.librepy:main.settings"))
         assert not matches_librepy_dispatch_url(self._Url(protocol="org.extension.writeragent:", path="main.settings"))
+
+
+class TestPathToFileUrl:
+    def test_posix_absolute_uses_three_slashes(self):
+        url = path_to_file_url("/home/user/Writing/Test.odt")
+        assert url.startswith("file:///")
+        assert url.endswith("/home/user/Writing/Test.odt") or "Writing" in url

--- a/tests/writer/test_format.py
+++ b/tests/writer/test_format.py
@@ -14,7 +14,17 @@ import tempfile as tempfile_mod
 
 import pytest
 
-from plugin.writer.format import _resolve_temp_dir, strip_embedded_image_data, _apply_image_export_options
+from plugin.writer.format import (
+    _apply_image_export_options,
+    _resolve_temp_dir,
+    _with_temp_buffer,
+    strip_embedded_image_data,
+)
+
+
+def test_with_temp_buffer_yields_three_slash_file_url():
+    with _with_temp_buffer(content="x", ext=".html") as (_path, url):
+        assert url.startswith("file:///")
 
 
 def test_resolve_temp_dir_avoids_gettempdir_under_crosshair(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
P1.3 from `docs/framework/uno-utilities.md` §4: one shared UNO-free `path_to_file_url` in the `url_utils` filesystem / document `file:` section.

**What changed**
- Add `plugin.framework.url_utils.path_to_file_url` (`os.path.abspath` + `Path.as_uri()`, no `@deal`).
- Delete `document_research._path_to_file_url`, `embeddings_fs.path_to_file_url`, and `format._file_url`. No aliases.
- Retarget those call sites plus tests. Left `uno.systemPathToFileUrl` sites alone (P3).

**Verify**
- The three copies were the same algorithm (`abspath` already includes `normpath`).
- `mail_merge._to_file_url` and GraphicProvider/math helpers are not this algorithm.
- Embeddings import graph stays UNO-free (`url_utils` → stdlib / `constants` / `deal_shim` only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69bf1409-4411-4780-a00e-02c6a808831d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69bf1409-4411-4780-a00e-02c6a808831d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

