### PR TITLE
menu icons: log DPI resolve once at INFO

### DIFF
--- a/plugin/framework/menu_icon_dpi.py
+++ b/plugin/framework/menu_icon_dpi.py
@@ -34,12 +34,16 @@ _cached_scale: float | None = None
 _cached_weak: bool = False
 
 
+_logged_strong: bool = False
+
+
 def reset_menu_icon_dpi_cache() -> None:
     """Test hook: clear the one-shot cache."""
-    global _cached_px, _cached_scale, _cached_weak
+    global _cached_px, _cached_scale, _cached_weak, _logged_strong
     _cached_px = None
     _cached_scale = None
     _cached_weak = False
+    _logged_strong = False
 
 
 def _ppm_scale(win: Any) -> float | None:
@@ -135,7 +139,7 @@ def probe_vcl_dpi_scale(ctx: Any = None) -> float | None:
             scale = _ppm_scale(win)
             if scale is not None:
                 return scale
-        log.info("menu_icon_dpi probe_vcl_dpi: no PixelPerMeterX on %s windows", len(_candidate_windows(ctx)))
+        log.debug("menu_icon_dpi probe_vcl_dpi: no PixelPerMeterX on %s windows", len(_candidate_windows(ctx)))
         return None
     except Exception:
         log.debug("probe_vcl_dpi_scale failed", exc_info=True)
@@ -239,7 +243,7 @@ def interpolate_menu_icon_px(scale: float, *, one_x: int = _ONE_X_PX) -> int:
 
 def resolve_menu_icon_pixel_size(ctx: Any = None) -> int:
     """One-shot: probe, interpolate, cache. Probe-miss prefers HiDPI large assets."""
-    global _cached_px, _cached_scale, _cached_weak
+    global _cached_px, _cached_scale, _cached_weak, _logged_strong
     if _cached_px is not None and not _cached_weak:
         return _cached_px
 
@@ -262,9 +266,8 @@ def resolve_menu_icon_pixel_size(ctx: Any = None) -> int:
         _cached_scale = 2.0
         _cached_px = _HIDPI_PX
         _cached_weak = True  # retry when a real window exists
-        log.info(
-            "menu_icon_dpi source=default_hidpi_large scale=n/a px=%s "
-            "(probe miss — prefer highres assets on HiDPI)",
+        log.debug(
+            "menu_icon_dpi source=default_hidpi_large scale=n/a px=%s (weak; will retry)",
             _cached_px,
         )
         return _cached_px
@@ -273,12 +276,21 @@ def resolve_menu_icon_pixel_size(ctx: Any = None) -> int:
     _cached_scale = float(scale)
     _cached_px = px
     _cached_weak = False
-    log.info(
-        "menu_icon_dpi source=%s scale=%.3f px=%s",
-        source,
-        scale,
-        px,
-    )
+    if not _logged_strong:
+        log.info(
+            "menu_icon_dpi source=%s scale=%.3f px=%s",
+            source,
+            scale,
+            px,
+        )
+        _logged_strong = True
+    else:
+        log.debug(
+            "menu_icon_dpi source=%s scale=%.3f px=%s (cache refresh)",
+            source,
+            scale,
+            px,
+        )
     return px
 
 

--- a/tests/framework/test_menu_icon_dpi.py
+++ b/tests/framework/test_menu_icon_dpi.py
@@ -36,3 +36,16 @@ def test_probe_env_scale_gdk(monkeypatch):
     m.reset_menu_icon_dpi_cache()
     monkeypatch.setenv("GDK_SCALE", "2")
     assert m.probe_env_scale() == 2.0
+
+
+def test_strong_cache_logs_info_once(monkeypatch, caplog):
+    import logging
+    from plugin.framework import menu_icon_dpi as m
+
+    m.reset_menu_icon_dpi_cache()
+    monkeypatch.setattr(m, "probe_vcl_dpi_scale", lambda ctx=None: 1.0)
+    with caplog.at_level(logging.INFO, logger="writeragent.menu_icon_dpi"):
+        assert m.resolve_menu_icon_pixel_size() == 16
+        assert m.resolve_menu_icon_pixel_size() == 16
+    infos = [r for r in caplog.records if r.levelno == logging.INFO and "menu_icon_dpi source=" in r.getMessage()]
+    assert len(infos) == 1


### PR DESCRIPTION
## Summary
- One INFO when the strong DPI cache sticks (`source=… scale=… px=…`)
- Probe-miss / weak-retry and `no PixelPerMeterX` → DEBUG
- Unit test: two resolves → one INFO

## Test plan
- [x] `pytest tests/framework/test_menu_icon_dpi.py`
- [ ] Optional: headed — confirm writeragent_debug has a single `menu_icon_dpi source=` INFO after startup settle