### PR TITLE
Improvements inspired by feedback from real users

### DIFF
--- a/docs/writer/html-style-model-plan.md
+++ b/docs/writer/html-style-model-plan.md
@@ -230,13 +230,43 @@ StarWriter HTML import does not understand `data-lo-style`. Write path:
 
 ---
 
+## Direct formatting on read
+
+An autostyle's XHTML rule is flattened — base style and override merged, with no rule emitted for
+the base at all — so the XHTML alone cannot say which values were hand-set. The flat-ODF sidecar
+already exported for the `Pn -> parent` map holds the automatic style's **own** properties, which
+are exactly the direct overrides. `extract_autostyle_overrides_from_fodt()` reads them from that
+same export (no extra `storeToURL`) and `_rewrite_block` emits them as `data-lo-para`, e.g.
+`<p data-lo-style="Standard" data-lo-para="margin-left:3.25cm; font-size:12pt">`.
+
+Geometry (margins, indent, alignment, line height) and the paragraph-level font are both reported:
+a `.docx` reused as a model carries its font as a whole-paragraph override, which is what makes an
+applied style look like it did nothing. Nothing is reported when the sidecar is unavailable, rather
+than guessing from the flattened CSS.
+
+The range read reports it too. `_range_to_content_via_temp_doc` used to copy plain text plus the
+paragraph style name, so every override — `data-lo-para` and character runs alike — was already
+gone before the export. It now carries the source paragraph's direct `Para*` and paints each text
+portion's direct `Char*` onto the copy, skipping anything the paragraph style already provides so
+an inherited value is not reported as hand-set. A range slice that crosses a bold run therefore
+reads back with the bold in place.
+
+`data-lo-para` is **read-only**: the write path still cannot restore `Para*` when applying a named
+style, which is why it is not emitted as `style=""` — that would round-trip back and be swallowed.
+To make a style win over hand-set values, `apply_style` takes `clear_direct`
+(`none` | `style_props` | `all`), which resets the style-governed `Char*` and the paragraph
+properties to default so the style shows. It is refused on `target='full_document'`: clearing the
+whole document erases the very formatting that distinguishes body text from quotes and headings.
+With `clear_direct='none'` the result echoes `preserved_char_overrides` — the overrides that kept
+the style invisible — so a no-op apply is no longer indistinguishable from a successful one.
+
 ## v1 limitations (shipped)
 
 These are intentional trade-offs in v1. Tests document the behavior ([`test_xhtml_style_postprocess.py`](../../tests/writer/test_xhtml_style_postprocess.py), [`test_content_style_model_uno.py`](../../tests/writer/test_content_style_model_uno.py)).
 
 | Limitation | v1 behavior | Workaround for agents/users | Post-v1 direction |
 |------------|-------------|----------------------------|-------------------|
-| **Whole-paragraph direct overrides** (center, para colour, margins baked into autostyle CSS) | Read omits token and drops override CSS; FODT recovers the **base style name** only | Prefer named styles; use inline `style` on **spans** for char exceptions | UNO index + optional Para* snapshot; or dedicated `get_paragraph_metadata` for debugging |
+| **Whole-paragraph direct overrides** (center, para colour, margins, whole-paragraph font) | Do not round-trip on **write**. Read REPORTS them as read-only `data-lo-para`, taken from the FODT automatic style (see [Direct formatting on read](#direct-formatting-on-read)) | Read `data-lo-para` to tell an indented quote from body text; apply a named style per range with `apply_style(clear_direct='style_props')` so the style wins over the hand-set values | Make `data-lo-para` writable |
 | **Table cell paragraph styles** | `paragraph-*` stripped inside `<table>`; no `data-lo-style` on cell blocks | `apply_style` on cell text; don't rely on agent HTML for table styling | Table-aware style index or cell-level tokens |
 | **Partial edits** (`end` / `search` / `selection` / `beginning`) | Content inserted; `data-lo-style` **not** applied (would restyle merged adjacent text) | `target='full_document'` for styled rewrites; `apply_style` to restyle existing text | Apply only to genuinely new paragraphs after import |
 | **Dual export cost** | Every full read (and range read via temp doc) runs XHTML + FODT `storeToURL` | `scope=range`, `get_document_tree`, `search_in_document` before full reads | Cached UNO paragraph-style index; drop FODT on `scope=full` |

--- a/docs/writer/page-api-reference.md
+++ b/docs/writer/page-api-reference.md
@@ -45,9 +45,18 @@ Headers and footers are also controlled via the Page Style properties. Each page
 - **`HeaderIsShared`** / **`FooterIsShared`** (`bool`): If true, the same header/footer is used for left and right pages.
 - **`HeaderText`** / **`FooterText`** (`com.sun.star.text.XText`): The text object representing the header/footer content. This is a full text object, just like the main document body.
 - **`HeaderIsDynamicHeight`** / **`FooterIsDynamicHeight`** (`bool`): When true, the region grows with its content. Needed when inserting a logo via `insert_image(target="header"|"footer")` — without it a taller image keeps the fixed header height and spills into the body. WriterAgent enables this by default for header/footer image inserts (`auto_height`, also on `page_set_header_footer_text`).
-- **`HeaderLeftText`** / **`HeaderRightText`** / **`FooterLeftText`** / **`FooterRightText`**: Used when left and right pages have different headers/footers (i.e., when `HeaderIsShared` is False).
+- **`HeaderTextLeft`** / **`HeaderTextRight`** / **`FooterTextLeft`** / **`FooterTextRight`**: Used when left and right pages have different headers/footers (i.e., when `HeaderIsShared` is False).
+- **`FirstIsShared`** (`bool`): If false, the first page has its own header/footer — the usual setup for a letterhead. Its content then lives in **`HeaderTextFirst`** / **`FooterTextFirst`**, which are separate text objects: `HeaderText` does not reach them.
+
+These variants are exposed as the `region` values of `page_get_header_footer_text` / `page_set_header_footer_text`: `header`, `footer`, `header_first`, `footer_first`, `header_left`, `footer_left`. When the matching `*IsShared` flag is on, the variant mirrors the shared text, so asking for it is always safe. `page_get_style_properties` reports `first_is_shared`, and `page_set_style_properties` writes it.
 
 Images in a header/footer must be anchored **`AS_CHARACTER`** (in the text flow). A floating `AT_CHARACTER` image does not contribute to line height, so even with dynamic height the region may not grow.
+
+### Writing: `setString` is destructive
+
+`XText.setString()` replaces the whole region with unformatted text, so a letterhead logo, a page-number field and every paragraph but the first are deleted with no way back. `getString()` cannot show any of that — an image reads back as an empty line and a field as its rendered digits — so the loss is invisible on both sides.
+
+`page_get_header_footer_text` therefore also reports the region's `images`, `fields` and `paragraph_count`, and `page_set_header_footer_text` refuses when either is present (`force=true` overrides, and the result then lists what it deleted). To change the wording while keeping them, edit with `apply_document_content(target='search')`: `XSearchable.findFirst` on the document reaches header and footer text, so the edit lands in place and keeps the formatting.
 
 ### Python Example: Enabling and Writing to a Header
 ```python

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -280,9 +280,12 @@ WRITER_APPLY_DOCUMENT_HTML_RULES = f"""APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL
 - **Never** pass the entire document as old_content — that is not supported and will fail search.
 - target='search': old_content may span paragraphs, but each interior line must match a WHOLE paragraph.
   position='before'/'after' INSERTS next to the match and leaves it untouched — add a paragraph without re-sending the clause.
-- Reach: body, table cells, text frames.
+- Reach: body, table cells, text frames, headers and footers.
   Floating drawing-shape text: in place only when review is off — in record/wait it cannot become a tracked change, so the tool routes you to the shapes domain.
   Rich/block HTML in a table cell is not supported (clear error, document untouched); use plain text or inline tags.
+- Headers/footers: reword with target='search' — that keeps the letterhead logo, the fields and the formatting.
+  page_set_header_footer_text writes PLAIN TEXT over the whole region and deletes them; it refuses when it would, and page_get_header_footer_text lists the images and fields the text alone hides.
+  A "different first page" letterhead lives in header_first / footer_first (page_get_style_properties reports first_is_shared); style_list(family='PageStyles') gives the page-style names.
 - `content` is a JSON array of HTML strings (one fragment per heading/paragraph).
   We wrap in <html>/<body>.
 {HTML_FRAGMENT_RULES}

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -294,7 +294,10 @@ WRITER_APPLY_DOCUMENT_HTML_RULES = f"""APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL
   Copy tokens exactly. Prefer named styles; unknown token → Standard.
   inline style="" is a character override on top of the named style.
   data-lo-style applies only on target='full_document' — on 'beginning'/'end'/'selection'/'search' it is ignored because it would restyle adjacent text (use apply_style or a full_document rewrite).
-  v1: whole-paragraph alignment/colour/margins and table-cell styles do not round-trip.
+  v1: whole-paragraph alignment/colour/margins and table-cell styles do not round-trip on write.
+- Hand-set formatting: `data-lo-para` (e.g. `data-lo-para="margin-left:3.25cm; font-size:12pt"`) reports what a paragraph has set directly. READ-ONLY — send it back and the result says it was ignored; it is how you tell a block quote from body text in a document formatted by hand. Reported on both scope='full' and scope='range'.
+  Direct formatting OVERRIDES styles, so there apply_style/style_update alone change nothing on screen; apply_style then echoes `preserved_char_overrides`.
+  Re-apply that range with clear_direct='style_props' to let the style's font, size and indent show (bold/italic survive). One range at a time — it is refused on target='full_document', which would erase the very formatting that tells the paragraphs apart.
 
 EXAMPLES:
 - Good: ["<h1>Title</h1>", "<p>Paragraph with <strong>bold</strong> text and \\"quotes\\".</p>"]

--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -152,6 +152,29 @@ class GetDocumentContent(ToolBase):
 # ------------------------------------------------------------------
 
 
+# get_document_content reports a paragraph's hand-set formatting as data-lo-para. It is a read
+# report, not an instruction: the import path cannot restore Para* when applying a named style,
+# so the attribute is dropped. Say so instead of accepting it and doing nothing — a silent no-op
+# is exactly the failure this tool's callers get bitten by.
+_READ_ONLY_ATTR = "data-lo-para"
+
+
+def _note_read_only_attrs(result, content):
+    """Flag a successful write whose content carried the read-only ``data-lo-para``."""
+    if not isinstance(result, dict) or result.get("status") != "ok":
+        return result
+    items = content if isinstance(content, (list, tuple)) else [content]
+    if not any(isinstance(item, str) and _READ_ONLY_ATTR in item for item in items):
+        return result
+    result = dict(result)
+    result["ignored_attributes"] = [_READ_ONLY_ATTR]
+    result["message"] = (result.get("message") or "") + (
+        " Note: %s in the content was ignored — it is a read-only report of a paragraph's hand-set"
+        " formatting. To change an indent or a font, apply a named style (apply_style, with"
+        " clear_direct when the paragraph is formatted by hand)." % _READ_ONLY_ATTR)
+    return result
+
+
 class ApplyDocumentContent(ToolBase):
     """Insert or replace content in the document.
 
@@ -343,6 +366,11 @@ class ApplyDocumentContent(ToolBase):
         }
 
     def execute(self, ctx, **kwargs):
+        # Thin wrapper so every return path gets the read-only-attribute note, including the
+        # review-wait branch that does not go through _annotate_review_status.
+        return _note_read_only_attrs(self._execute(ctx, **kwargs), kwargs.get("content"))
+
+    def _execute(self, ctx, **kwargs):
         if kwargs.get("dry_run"):
             return self._dry_run_preview(ctx, **kwargs)
         wait_seconds = self._review_wait_seconds(ctx.ctx)

--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -209,13 +209,89 @@ def _strip_html_boilerplate(html_string):  # pyright: ignore[reportUnusedFunctio
 #   plugin/writer/format.py   — replace_single_range_with_content style restore (~595)
 #   plugin/notebook/writer_importer.py — resolved paragraph style on import (~621)
 #   plugin/notebook/notebook_runner.py — output cell paragraph style (~177)
-def apply_paragraph_style_preserving_direct_char(doc, cursor, style_name):
-    """Set *cursor*'s ParaStyleName to *style_name* without wiping direct Char* formatting.
+# Char properties a paragraph style is expected to govern. With clear_direct="style_props" these
+# are the ONLY captured overrides not restored after the style is applied, so the style's font and
+# size finally show while hand-set bold/italic/colour survive. See CLEARABLE_PARA_PROPERTIES for
+# the paragraph half (indents/alignment), which setting ParaStyleName does NOT reset on its own.
+STYLE_GOVERNED_CHAR_PROPERTIES = (
+    "CharFontName", "CharFontNameAsian", "CharFontNameComplex",
+    "CharHeight", "CharHeightAsian", "CharHeightComplex",
+)
 
-    LibreOffice resets hand-set Char* properties to the new paragraph style's defaults
-    when ParaStyleName is set — across the WHOLE paragraph, even for a sub-range cursor.
+# Whole-paragraph direct overrides cleared by clear_direct. Mirrors _KNOWN_PARAGRAPH_PROPERTIES in
+# plugin/writer/styles.py (kept here to avoid a styles -> format -> styles import cycle); keep the
+# two in sync. Deliberately NOT setAllPropertiesToDefault — that also wipes numbering, borders and
+# language, which no caller asked to lose.
+CLEARABLE_PARA_PROPERTIES = (
+    "ParaTopMargin", "ParaBottomMargin", "ParaLeftMargin", "ParaRightMargin",
+    "ParaFirstLineIndent", "ParaAdjust", "ParaBackColor", "ParaKeepTogether", "ParaSplit",
+)
+
+# Scalar, JSON-safe subset reported back to the agent. The capture itself still covers every Char*
+# property; only the report is narrowed (CharLocale and friends are UNO structs).
+REPORTED_CHAR_PROPERTIES = ("CharFontName", "CharHeight", "CharWeight", "CharPosture", "CharColor")
+
+
+def _reset_properties_to_default(cursor, names):
+    """Drop *names* as direct attributes on *cursor* so they fall back to the paragraph style.
+
+    This is Format > Clear Direct Formatting, narrowed to the names the caller asks for. It is the
+    only reliable way to remove an override: re-applying a paragraph's existing style leaves its
+    direct Char* standing (LibreOffice 26.2), so imposing a house font on a document whose
+    paragraphs are all already 'Standard' silently keeps the old font without this.
+
+    Returns the names actually cleared.
+    """
+    names = tuple(names)
+    if not names:
+        return []
+    try:
+        cursor.setPropertiesToDefault(names)
+        return list(names)
+    except Exception:
+        pass  # no XMultiPropertyStates on this range — fall back to one at a time
+    cleared = []
+    for name in names:
+        try:
+            cursor.setPropertyToDefault(name)
+            cleared.append(name)
+        except Exception:
+            continue
+    return cleared
+
+
+def _summarize_char_overrides(overrides):
+    """Flat, JSON-safe {prop: value} of the captured direct Char* overrides (first portion wins)."""
+    summary = {}
+    for _pc, props in overrides:
+        for name in REPORTED_CHAR_PROPERTIES:
+            if name in props and name not in summary:
+                val = props[name]
+                if isinstance(val, (str, int, float, bool)):
+                    summary[name] = val
+    return summary
+
+
+def apply_paragraph_style_preserving_direct_char(doc, cursor, style_name, clear_direct="none"):
+    """Set *cursor*'s ParaStyleName to *style_name*, deciding what happens to direct formatting.
+
+    Setting ParaStyleName to a DIFFERENT style resets hand-set Char* properties to that style's
+    defaults — across the WHOLE paragraph, even for a sub-range cursor — which is what the capture
+    below exists to undo. Re-applying the style a paragraph already has does not reset them (it
+    does still drop the paragraph's direct Para*), so clearing an override is never a side effect
+    to rely on; see _reset_properties_to_default.
     ``getPropertyState`` is unreliable at the text-portion level, so overrides are
     detected by VALUE (Char* differs from the paragraph's current style default).
+
+    *clear_direct* decides what happens to those captured overrides:
+      ``"none"`` (default) restores all of them — the historical behaviour, which keeps a
+      document's hand-set font but also means an updated style is invisible on screen;
+      ``"style_props"`` restores everything except STYLE_GOVERNED_CHAR_PROPERTIES and clears
+      CLEARABLE_PARA_PROPERTIES, so font/size/indent obey the style and bold/italic survive;
+      ``"all"`` restores nothing and clears the paragraph properties too (Ctrl+M semantics).
+
+    Returns a report dict so callers can tell the agent what actually happened — a style apply
+    that silently kept the old font used to be indistinguishable from success.
 
     KNOWN LIMITATION: a direct override whose value equals the old style default is not
     captured; applying a style with a different default can change that property visibly.
@@ -307,13 +383,47 @@ def apply_paragraph_style_preserving_direct_char(doc, cursor, style_name):
 
     capture_cursor = _expand_to_full_paragraphs(cursor) or cursor
     overrides = _capture_direct_char_overrides(capture_cursor)
+    found = _summarize_char_overrides(overrides)
     cursor.setPropertyValue("ParaStyleName", style_name)
-    for pc, props in overrides:
-        for name, val in props.items():
-            try:
-                pc.setPropertyValue(name, val)
-            except Exception:
-                pass
+
+    if clear_direct == "all":
+        skip = None  # restore nothing
+    elif clear_direct == "style_props":
+        skip = set(STYLE_GOVERNED_CHAR_PROPERTIES)
+    else:
+        skip = set()  # historical behaviour: restore everything
+
+    if skip is not None:
+        for pc, props in overrides:
+            for name, val in props.items():
+                if name in skip:
+                    continue
+                try:
+                    pc.setPropertyValue(name, val)
+                except Exception:
+                    pass
+
+    report: dict[str, Any] = {"direct_formatting": "preserved" if clear_direct == "none" else "cleared",
+                              "clear_direct": clear_direct}
+    if clear_direct == "none":
+        # What the caller can act on: these overrode the style and are the reason it looks like
+        # the apply did nothing.
+        if found:
+            report["preserved_char_overrides"] = found
+    else:
+        # Only what was really dropped — under "style_props" bold and italic were restored, and
+        # listing them as removed would send the caller chasing a change that never happened.
+        removed = found if skip is None else {k: v for k, v in found.items() if k in skip}
+        if removed:
+            report["removed_char_overrides"] = removed
+        # Clear explicitly rather than leaning on the ParaStyleName side effect, which leaves
+        # direct Char* on the text portions standing. "all" targets exactly the overrides that
+        # were found, so nothing unrelated is touched.
+        char_targets = (STYLE_GOVERNED_CHAR_PROPERTIES if clear_direct == "style_props"
+                        else sorted({n for _pc, props in overrides for n in props}))
+        report["cleared_char_properties"] = _reset_properties_to_default(capture_cursor, char_targets)
+        report["cleared_paragraph_properties"] = _reset_properties_to_default(capture_cursor, CLEARABLE_PARA_PROPERTIES)
+    return report
 
 
 # ---------------------------------------------------------------------------

--- a/plugin/writer/html_export.py
+++ b/plugin/writer/html_export.py
@@ -69,23 +69,164 @@ def _export_xhtml(doc, config_svc):
 
 
 
-def _autostyle_parents(doc, config_svc):
-    """Export *doc* as flat ODF and return the autostyle -> parent-style map (Pn -> base name).
+def _autostyle_maps(doc, config_svc):
+    """Export *doc* as flat ODF once and return ``(parents, overrides)`` for the autostyles.
 
-    Lets the read path recover an autostyle paragraph's real style name when the XHTML CSS
-    fingerprint matches nothing. Returns ``{}`` on any failure (the read still works, just
-    without the autostyle-name recovery)."""
+    ``parents`` (Pn -> base style name) lets the read path recover an autostyle paragraph's real
+    style name when the XHTML CSS fingerprint matches nothing. ``overrides`` (Pn -> CSS text) is
+    the paragraph's DIRECT formatting, which the flattened XHTML cannot distinguish from inherited
+    values. Both come from the same export. Returns ``({}, {})`` on any failure (the read still
+    works, just without autostyle-name recovery and without the direct-formatting report).
+
+    Both scopes report overrides: the range path copies the source paragraphs' direct formatting
+    onto the temp document first (see _paint_direct_formatting)."""
     try:
         with format_mod._with_temp_buffer(None, config_svc, ext=format_mod.FODT_EXTENSION) as (path, file_url):
             props = (format_mod.create_property_value("FilterName", format_mod.FLAT_ODF_FILTER),)
             doc.storeToURL(file_url, props)
             with open(path, "r", encoding="utf-8", errors="replace") as f:
                 fodt = f.read()
-        return xhtml_post.extract_autostyle_parents_from_fodt(fodt)
+        return (xhtml_post.extract_autostyle_parents_from_fodt(fodt),
+                xhtml_post.extract_autostyle_overrides_from_fodt(fodt))
     except Exception:
-        log.debug("_autostyle_parents: flat-ODF export failed", exc_info=True)
-        return {}
+        log.debug("_autostyle_maps: flat-ODF export failed", exc_info=True)
+        return ({}, {})
 
+
+
+# Direct formatting the range copy carries into the temp document. Whitelists rather than "every
+# property": a blanket copy drags UNO structs and page/section properties along, which either fail
+# to set or change the temp document's layout. Char* is painted per text portion so a bold run
+# inside a sentence survives; Para* is set once per paragraph.
+_COPIED_CHAR_PROPERTIES = (
+    "CharStyleName", "CharFontName", "CharHeight", "CharWeight", "CharPosture",
+    "CharUnderline", "CharStrikeout", "CharColor", "CharBackColor", "CharCaseMap",
+    "CharEscapement", "CharEscapementHeight",
+)
+_COPIED_PARA_PROPERTIES = (
+    "ParaLeftMargin", "ParaRightMargin", "ParaTopMargin", "ParaBottomMargin",
+    "ParaFirstLineIndent", "ParaAdjust", "ParaBackColor",
+)
+
+_COPY_PORTION_LIMIT = 50000
+
+
+def _copy_properties(src, dst, names, style=None):
+    """Copy *names* from one range to another, but only where they differ from *style*.
+
+    Copying a value equal to the style's turns an inherited value into a hand-set one on the copy,
+    and the read would then report it as a direct override — margin-right:0cm and text-align:left
+    on every paragraph, drowning the one indent that was actually set. Detection is by VALUE for
+    the same reason as apply_paragraph_style_preserving_direct_char: getPropertyState is not
+    dependable at the text-portion level.
+
+    Per-property rather than all-or-nothing: the temp document is a plain Writer doc and does not
+    necessarily offer every property the source paragraph carries.
+    """
+    for name in names:
+        try:
+            value = src.getPropertyValue(name)
+        except Exception:
+            continue
+        if style is not None:
+            try:
+                if value == style.getPropertyValue(name):
+                    continue
+            except Exception:
+                pass
+        try:
+            dst.setPropertyValue(name, value)
+        except Exception:
+            continue
+
+
+def _source_style(model, style_name, cache):
+    """The source document's paragraph-style object for *style_name*, or None. Cached per read."""
+    if style_name in cache:
+        return cache[style_name]
+    style = None
+    if style_name:
+        try:
+            style = model.getStyleFamilies().getByName("ParagraphStyles").getByName(style_name)
+        except Exception:
+            style = None
+    cache[style_name] = style
+    return style
+
+
+def _visible_portions(para):
+    """Yield ``(portion, text)`` for a paragraph's visible text, skipping tracked deletions.
+
+    Mirrors the walk in ``get_string_without_tracked_deletions`` exactly — same Redline/Delete
+    toggle, same skips — so an offset taken from that string indexes into these chunks without
+    drift. Any divergence here would paint one run's formatting onto another's characters.
+    """
+    try:
+        portion_enum = para.createEnumeration()
+    except Exception:
+        return
+    in_delete = False
+    seen = 0
+    while portion_enum.hasMoreElements() is True and seen < _COPY_PORTION_LIMIT:
+        seen += 1
+        try:
+            portion = portion_enum.nextElement()
+            portion_type = portion.getPropertyValue("TextPortionType")
+        except Exception:
+            return
+        if portion_type == "Redline":
+            try:
+                if str(portion.getPropertyValue("RedlineType")) == "Delete":
+                    in_delete = not in_delete
+            except Exception:
+                pass
+            continue
+        if in_delete:
+            continue
+        try:
+            chunk = portion.getString()
+        except Exception:
+            continue
+        if chunk:
+            yield portion, chunk
+
+
+def _paint_direct_formatting(para, portions, temp_text, trim_start, trim_end, style=None):
+    """Re-apply the source paragraph's direct formatting to the copy just written.
+
+    The copy is made with setString, which carries plain text and nothing else — so a range read
+    used to hand the caller a flattened slice where a block quote was indistinguishable from body
+    text. Done as a second pass over character OFFSETS rather than by inserting run by run: the
+    text is already in place, so there is no insertion-point bookkeeping to get wrong, and a
+    failure here degrades to the old plain-text result instead of corrupting the copy.
+    """
+    try:
+        # The copy always appends, so the paragraph just written is the one at the document end.
+        para_cursor = temp_text.createTextCursor()
+        para_cursor.gotoEnd(False)
+        para_cursor.gotoStartOfParagraph(False)
+        para_start = para_cursor.getStart()
+        para_cursor.gotoEndOfParagraph(True)
+        _copy_properties(para, para_cursor, _COPIED_PARA_PROPERTIES, style)
+    except Exception:
+        log.debug("_paint_direct_formatting: paragraph properties skipped", exc_info=True)
+        return
+
+    offset = 0  # position within the visible (tracked-deletions removed) paragraph text
+    for portion, chunk in portions:
+        chunk_start, chunk_end = offset, offset + len(chunk)
+        offset = chunk_end
+        lo, hi = max(chunk_start, trim_start), min(chunk_end, trim_end)
+        if lo >= hi:
+            continue  # portion lies outside the requested range
+        try:
+            run = temp_text.createTextCursorByRange(para_start)
+            run.goRight(lo - trim_start, False)
+            run.goRight(hi - lo, True)
+            _copy_properties(portion, run, _COPIED_CHAR_PROPERTIES, style)
+        except Exception:
+            log.debug("_paint_direct_formatting: portion skipped", exc_info=True)
+            continue
 
 
 def _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc, *, include_images=False):
@@ -101,6 +242,7 @@ def _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc
 
         temp_text = temp_doc.getText()
         temp_cursor = temp_text.createTextCursor()
+        style_cache = {}
         text = model.getText()
         enum = text.createEnumeration()
         first_para = True
@@ -114,7 +256,13 @@ def _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc
                 style = el.getPropertyValue("ParaStyleName")
             except Exception:
                 style = ""
-            para_text = get_string_without_tracked_deletions(el)
+            # Built from the portion walk rather than get_string_without_tracked_deletions: that
+            # helper enumerates a paragraph's PORTIONS as if they were paragraphs and joins them
+            # with "\n", so a bold run mid-sentence used to come back as "text\nbold\ntext" —
+            # spurious <br/> in the output, and offsets that no longer match the portions the
+            # formatting has to be painted onto.
+            portions = list(_visible_portions(el))
+            para_text = "".join(chunk for _unused, chunk in portions)
             style = style or ""
             # Compute paragraph start offset
             start_cursor = model.getText().createTextCursor()
@@ -126,6 +274,9 @@ def _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc
 
             if para_end <= start or para_start >= end:
                 continue
+            # The window in the paragraph's own (tracked-deletions removed) coordinates. Kept even
+            # when nothing is trimmed: _paint_direct_formatting indexes portions with it.
+            trim_start, trim_end = 0, len(para_text)
             if para_start < start or para_end > end:
                 trim_start = max(0, start - para_start)
                 trim_end = len(para_text) - max(0, para_end - end)
@@ -146,6 +297,8 @@ def _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc
                 temp_cursor.gotoEndOfParagraph(True)
                 temp_cursor.setPropertyValue("ParaStyleName", style)
                 temp_cursor.setString(para_text)
+            _paint_direct_formatting(el, portions, temp_text, trim_start, trim_end,
+                                      _source_style(model, style, style_cache))
             added_any = True
 
         if not added_any:
@@ -153,8 +306,8 @@ def _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc
 
         try:
             xhtml = _export_xhtml(temp_doc, config_svc)
-            parents = _autostyle_parents(temp_doc, config_svc)
-            content = xhtml_post.xhtml_to_semantic_html(xhtml, parents)
+            parents, overrides = _autostyle_maps(temp_doc, config_svc)
+            content = xhtml_post.xhtml_to_semantic_html(xhtml, parents, overrides)
         except Exception:
             log.exception("_range_to_content_via_temp_doc (XHTML) failed; falling back to StarWriter")
             filter_name, _unused = format_mod._get_format_props(config_svc)
@@ -252,14 +405,15 @@ def document_to_content(
             len(xhtml) if isinstance(xhtml, str) else -1,
         )
         t_phase = time.perf_counter()
-        parents = _autostyle_parents(model, config_svc)
+        parents, overrides = _autostyle_maps(model, config_svc)
         log.debug(
-            "document_to_content: phase=_autostyle_parents elapsed_ms=%.1f parents=%d",
+            "document_to_content: phase=_autostyle_maps elapsed_ms=%.1f parents=%d overrides=%d",
             (time.perf_counter() - t_phase) * 1000.0,
             len(parents) if isinstance(parents, dict) else -1,
+            len(overrides) if isinstance(overrides, dict) else -1,
         )
         t_phase = time.perf_counter()
-        content = xhtml_post.xhtml_to_semantic_html(xhtml, parents)
+        content = xhtml_post.xhtml_to_semantic_html(xhtml, parents, overrides)
         content = _apply_image_export_options(content, include_images=include_images)
         content = _inject_exported_math_tex(model, ctx, content)
         if max_chars and len(content) > max_chars:

--- a/plugin/writer/page.py
+++ b/plugin/writer/page.py
@@ -19,18 +19,124 @@
 Page styles, margins, headers/footers, columns, and page breaks.
 """
 
+from typing import Any
+
 from .specialized_base import ToolWriterPageBase
 
 # region name -> (is_on property, text property)
+#
+# The *_first and *_left variants are separate UNO text objects, not views of the same one: a
+# "different first page" letterhead (FirstIsShared=False) lives ONLY in HeaderTextFirst, and with
+# HeaderIsShared=False the plain HeaderText covers right-hand pages alone. Exposing just the
+# shared pair left both cases unreachable — read and write silently hit the wrong page.
+# When the corresponding *IsShared* flag is on, the variant mirrors the shared text, so asking for
+# it is always safe.
 _REGION_PROPS = {
     "header": ("HeaderIsOn", "HeaderText"),
     "footer": ("FooterIsOn", "FooterText"),
+    "header_first": ("HeaderIsOn", "HeaderTextFirst"),
+    "footer_first": ("FooterIsOn", "FooterTextFirst"),
+    "header_left": ("HeaderIsOn", "HeaderTextLeft"),
+    "footer_left": ("FooterIsOn", "FooterTextLeft"),
 }
+
+_REGIONS = tuple(_REGION_PROPS)
+
+# Walk caps for _scan_region_content. A header/footer is small; these only bound a runaway.
+_SCAN_PARA_LIMIT = 5000
+_SCAN_PORTION_LIMIT = 5000
+_SCAN_SHAPE_LIMIT = 5000
+
+
+def _region_kind(region: str) -> str:
+    """'header' or 'footer' for any region name (the shared one or a first/left variant)."""
+    return "header" if region.startswith("header") else "footer"
+
+
+def _empty_scan() -> dict[str, Any]:
+    """The shape _scan_region_content returns, for a region with nothing to scan."""
+    return {"fields": [], "images": [], "paragraph_count": 0}
+
+
+def _describe_region_contents(scan: dict[str, Any]) -> str:
+    """Human-readable summary of a scan, e.g. ``1 image(s): TIMBRE, 1 field(s): Page number``.
+
+    Empty when the region is plain text, so callers can use it as the "is this destructive?" test
+    and as the message in one go.
+    """
+    parts = []
+    if scan["images"]:
+        parts.append("%d image(s): %s" % (len(scan["images"]), ", ".join(scan["images"])))
+    if scan["fields"]:
+        parts.append("%d field(s): %s" % (len(scan["fields"]), ", ".join(f["content"] for f in scan["fields"])))
+    return ", ".join(parts)
+
+
+def _scan_region_content(doc, text_obj) -> dict[str, Any]:
+    """Report what a header/footer holds beyond plain text: fields and anchored images.
+
+    ``getString()`` flattens both away — a letterhead logo reads back as an empty line and a
+    page-number field as the literal digit — so a caller cannot see what a plain-text overwrite
+    is about to delete. Returns ``{"fields": [...], "images": [...], "paragraph_count": int}``.
+    """
+    out = _empty_scan()
+    try:
+        para_enum = text_obj.createEnumeration()
+    except Exception:
+        return out
+    # `is True` and the hard caps match the enumeration walk in format.py: a UNO enumeration that
+    # misbehaves otherwise spins here forever.
+    while para_enum.hasMoreElements() is True and out["paragraph_count"] < _SCAN_PARA_LIMIT:
+        try:
+            para = para_enum.nextElement()
+        except Exception:
+            break
+        out["paragraph_count"] += 1
+        try:
+            portions = para.createEnumeration()
+        except Exception:
+            continue
+        seen_portions = 0
+        while portions.hasMoreElements() is True and seen_portions < _SCAN_PORTION_LIMIT:
+            seen_portions += 1
+            try:
+                portion = portions.nextElement()
+                if portion.getPropertyValue("TextPortionType") != "TextField":
+                    continue
+                field = portion.getPropertyValue("TextField")
+            except Exception:
+                break
+            try:
+                # Same argument sense as fields_list: presentation is what the reader sees
+                # ("1"), content is what the field IS ("Page number"). Swapping them would have
+                # the two tools describe the same field in opposite terms.
+                out["fields"].append({"presentation": field.getPresentation(False),
+                                      "content": field.getPresentation(True)})
+            except Exception:
+                out["fields"].append({"presentation": "", "content": ""})
+    # Images anchored in the region live on the draw page, whatever their anchor type, so they are
+    # found by matching the anchor's text object rather than by walking portions.
+    try:
+        draw_page = doc.getDrawPage()
+        for i in range(min(int(draw_page.getCount()), _SCAN_SHAPE_LIMIT)):
+            shape = draw_page.getByIndex(i)
+            try:
+                if shape.getAnchor().getText() != text_obj:
+                    continue
+            except Exception:
+                continue
+            try:
+                out["images"].append(str(shape.getName()) or "unnamed")
+            except Exception:
+                out["images"].append("unnamed")
+    except Exception:
+        pass
+    return out
 
 
 def _height_props(region: str) -> tuple[str, str, str]:
     """Return the (dynamic-height, dynamic-spacing, height) property names."""
-    prefix = "Header" if region == "header" else "Footer"
+    prefix = "Header" if _region_kind(region) == "header" else "Footer"
     return (prefix + "IsDynamicHeight", prefix + "DynamicSpacing", prefix + "Height")
 
 
@@ -107,6 +213,14 @@ class PageGetStyleProperties(ToolWriterPageBase):
                 "footnote_height_mm": style.getPropertyValue("FootnoteHeight") / 100.0,
                 "register_paragraph_style": style.getPropertyValue("RegisterParagraphStyle"),
             }
+            # False means the first page has its OWN header/footer — the usual setup for a
+            # letterhead — reachable only through the header_first / footer_first regions. Fetched
+            # separately: not every page style offers it, and one missing property must not sink
+            # the whole read.
+            try:
+                props["first_is_shared"] = style.getPropertyValue("FirstIsShared")
+            except Exception:
+                pass
             # Attempt to safely fetch PageStyleLayout enum
             try:
                 psl = style.getPropertyValue("PageStyleLayout")
@@ -144,6 +258,9 @@ class PageSetStyleProperties(ToolWriterPageBase):
             "footer_is_on": {"type": "boolean", "description": "Enable or disable footer."},
             "header_is_shared": {"type": "boolean", "description": "Share header between left/right pages."},
             "footer_is_shared": {"type": "boolean", "description": "Share footer between left/right pages."},
+            "first_is_shared": {"type": "boolean", "description": (
+                "Share the header/footer with the first page. Set false for a 'different first page' "
+                "letterhead; its content then lives in the header_first / footer_first regions.")},
             "header_height_mm": {"type": "number", "description": "Absolute header height in mm."},
             "footer_height_mm": {"type": "number", "description": "Absolute footer height in mm."},
             "header_body_distance_mm": {"type": "number", "description": "Spacing from header to body in mm."},
@@ -210,6 +327,9 @@ class PageSetStyleProperties(ToolWriterPageBase):
             if "footer_is_shared" in kwargs:
                 style.setPropertyValue("FooterIsShared", kwargs["footer_is_shared"])
                 updated.append("footer_is_shared")
+            if "first_is_shared" in kwargs:
+                style.setPropertyValue("FirstIsShared", kwargs["first_is_shared"])
+                updated.append("first_is_shared")
             if "header_height_mm" in kwargs:
                 style.setPropertyValue("HeaderHeight", int(kwargs["header_height_mm"] * 100))
                 updated.append("header_height")
@@ -270,8 +390,12 @@ class PageGetHeaderFooterText(ToolWriterPageBase):
             },
             "region": {
                 "type": "string",
-                "enum": ["header", "footer"],
-                "description": "Whether to get the header or footer text.",
+                "enum": list(_REGIONS),
+                "description": (
+                    "Which region to read. 'header'/'footer' are the shared ones. Use the "
+                    "'_first' variants for a 'different first page' letterhead and the '_left' "
+                    "variants when left/right pages differ (see first_is_shared / header_is_shared "
+                    "in page_get_style_properties)."),
             },
         },
         "required": ["region"],
@@ -281,7 +405,7 @@ class PageGetHeaderFooterText(ToolWriterPageBase):
         style_name = kwargs.get("style", "Standard")
         region = kwargs.get("region")
         if region not in _REGION_PROPS:
-            return self._tool_error("region is required ('header' or 'footer').")
+            return self._tool_error("region is required, one of: %s." % ", ".join(_REGIONS))
 
         try:
             style, style_name = resolve_page_style(ctx.doc, style_name)
@@ -294,13 +418,28 @@ class PageGetHeaderFooterText(ToolWriterPageBase):
                 return {"status": "ok", "style_name": style_name, "region": region, "content": "", "is_on": False}
             text_obj = style.getPropertyValue(text_prop)
             content = text_obj.getString() if text_obj else ""
-            result = {
+            result: dict[str, Any] = {
                 "status": "ok",
                 "style_name": style_name,
                 "region": region,
                 "content": content,
                 "is_on": True,
             }
+            # content is plain text: a logo shows up as an empty line and a page-number field as
+            # its rendered digits. Report both so the caller knows what is really in there before
+            # deciding how to edit it.
+            scan = _scan_region_content(ctx.doc, text_obj)
+            result["paragraph_count"] = scan["paragraph_count"]
+            if scan["fields"]:
+                result["fields"] = scan["fields"]
+            if scan["images"]:
+                result["images"] = scan["images"]
+            held = _describe_region_contents(scan)
+            if held:
+                result["warning"] = (
+                    "This %s holds %s, which plain text cannot represent. page_set_header_footer_text "
+                    "would delete them; change the wording with apply_document_content(target='search') "
+                    "instead — it reaches headers and footers and keeps them." % (_region_kind(region), held))
             dyn_prop, _unused_spacing, height_prop = _height_props(region)
             try:
                 result["auto_height"] = bool(style.getPropertyValue(dyn_prop))
@@ -336,8 +475,10 @@ class PageSetHeaderFooterText(ToolWriterPageBase):
             },
             "region": {
                 "type": "string",
-                "enum": ["header", "footer"],
-                "description": "Whether to set the header or footer text.",
+                "enum": list(_REGIONS),
+                "description": (
+                    "Which region to set. 'header'/'footer' are the shared ones; '_first' targets a "
+                    "'different first page' letterhead and '_left' the left-hand pages."),
             },
             "content": {"type": "string", "description": "The text to insert into the header or footer."},
             "auto_height": {
@@ -346,6 +487,13 @@ class PageSetHeaderFooterText(ToolWriterPageBase):
                     "Let the region grow with its content so taller content is not clipped "
                     "and does not overlap the body. Left unchanged when omitted."
                 ),
+            },
+            "force": {
+                "type": "boolean",
+                "description": (
+                    "Overwrite even when the region holds images or fields that plain text cannot "
+                    "carry. Without it such a call is refused, because the replacement is silent "
+                    "and permanent."),
             },
         },
         "required": ["region", "content"],
@@ -358,7 +506,7 @@ class PageSetHeaderFooterText(ToolWriterPageBase):
         content = kwargs.get("content", "")
 
         if region not in _REGION_PROPS:
-            return self._tool_error("region is required ('header' or 'footer').")
+            return self._tool_error("region is required, one of: %s." % ", ".join(_REGIONS))
 
         try:
             style, style_name = resolve_page_style(ctx.doc, style_name)
@@ -367,6 +515,24 @@ class PageSetHeaderFooterText(ToolWriterPageBase):
 
         try:
             is_on_prop, text_prop = _REGION_PROPS[region]
+
+            # setString replaces the whole region with unformatted text: a letterhead logo and any
+            # field (page number, date) are destroyed with no way back and no sign in the result.
+            # Refuse rather than report ok, and point at the edit that keeps them. Checked BEFORE
+            # the region is enabled or resized, so a refusal leaves the document untouched.
+            scan = _empty_scan()
+            if style.getPropertyValue(is_on_prop):
+                existing = style.getPropertyValue(text_prop)
+                if existing:
+                    scan = _scan_region_content(ctx.doc, existing)
+            held = _describe_region_contents(scan)
+            if held and not kwargs.get("force"):
+                return self._tool_error(
+                    "This %s holds %s. Writing plain text would delete them permanently. To change "
+                    "the wording and keep them, use apply_document_content(target='search') with the "
+                    "existing text as old_content — it reaches headers and footers. Pass force=true "
+                    "only if deleting them is what you want." % (_region_kind(region), held))
+
             style.setPropertyValue(is_on_prop, True)
             auto_height = kwargs.get("auto_height")
             if auto_height is not None:
@@ -375,8 +541,14 @@ class PageSetHeaderFooterText(ToolWriterPageBase):
             text_obj = style.getPropertyValue(text_prop)
             if not text_obj:
                 return self._tool_error(f"Could not retrieve text object for {region} on style '{style_name}'.")
+
             text_obj.setString(content)
-            result = {"status": "ok", "style_name": style_name, "region": region, "updated": True}
+            result: dict[str, Any] = {"status": "ok", "style_name": style_name, "region": region, "updated": True}
+            if held:
+                result["deleted"] = {"images": scan["images"], "fields": [f["content"] for f in scan["fields"]]}
+            dropped = scan["paragraph_count"] - (content.count("\n") + 1)
+            if dropped > 0:
+                result["paragraphs_dropped"] = dropped
             if auto_height is not None:
                 result["auto_height"] = bool(auto_height)
             return result

--- a/plugin/writer/search.py
+++ b/plugin/writer/search.py
@@ -433,7 +433,9 @@ def _header_footer_label(text_obj, doc=None, label_cache=None):
                     pass
                 for attr, region in (
                     ("HeaderText", "header"), ("HeaderTextLeft", "header"), ("HeaderTextRight", "header"),
+                    ("HeaderTextFirst", "first-page header"),
                     ("FooterText", "footer"), ("FooterTextLeft", "footer"), ("FooterTextRight", "footer"),
+                    ("FooterTextFirst", "first-page footer"),
                 ):
                     try:
                         if getattr(st, attr, None) == text_obj:

--- a/plugin/writer/specialized/fields.py
+++ b/plugin/writer/specialized/fields.py
@@ -47,10 +47,15 @@ class FieldsList(ToolWriterFieldBase):
         if not hasattr(doc, "getTextFields"):
             return self._tool_error("Document does not support text fields.")
 
+        # Deferred: plugin.writer.search pulls the UNO document helpers in, and this module is
+        # imported wherever the field tools are registered.
+        from ..search import describe_match_location
+
         fields = doc.getTextFields()
         enum = fields.createEnumeration()
 
         results = []
+        hf_labels = {}
         count = 0
         while enum.hasMoreElements():
             field = enum.nextElement()
@@ -96,7 +101,16 @@ class FieldsList(ToolWriterFieldBase):
                 except Exception:
                     pass
 
-            results.append({"id": count, "presentation": presentation, "content": content, "properties": props})
+            # Where the field lives decides whether deleting it is safe: getTextFields() returns
+            # header and footer fields mixed in with the body's, and a page number in a footer
+            # looks exactly like one in the text. Same labels the search path reports.
+            try:
+                location = describe_match_location(field.getAnchor(), doc, hf_labels)
+            except Exception:
+                location = "unknown"
+
+            results.append({"id": count, "presentation": presentation, "content": content,
+                            "location": location, "properties": props})
 
         return {"status": "ok", "field_count": count, "fields": results}
 
@@ -114,10 +128,13 @@ class FieldsDelete(ToolWriterFieldBase):
         if not hasattr(doc, "getTextFields"):
             return self._tool_error("Document does not support text fields.")
 
+        from ..search import describe_match_location  # deferred, see FieldsList.execute
+
         fields = doc.getTextFields()
         enum = fields.createEnumeration()
 
         fields_to_delete = []
+        hf_labels = {}
         count = 0
         while enum.hasMoreElements():
             field = enum.nextElement()
@@ -129,16 +146,29 @@ class FieldsDelete(ToolWriterFieldBase):
             return {"status": "ok", "deleted_count": 0, "message": "No matching fields found to delete."}
 
         deleted_count = 0
+        deleted = []
         for field in fields_to_delete:
             try:
                 # Text fields can be deleted by removing their anchor content
                 anchor = field.getAnchor()
+                # Report the region before the anchor is emptied: a page number removed from a
+                # footer and one removed from the body read identically afterwards.
+                try:
+                    where = describe_match_location(anchor, doc, hf_labels)
+                except Exception:
+                    where = "unknown"
+                try:
+                    what = field.getPresentation(True)  # the field's identity, not its rendering
+                except Exception:
+                    what = ""
                 anchor.setString("")
                 deleted_count += 1
+                deleted.append({"content": what, "location": where})
             except Exception as e:
                 return self._tool_error(f"Failed to delete field: {str(e)}")
 
-        return {"status": "ok", "message": f"Successfully deleted {deleted_count} field(s).", "deleted_count": deleted_count}
+        return {"status": "ok", "message": f"Successfully deleted {deleted_count} field(s).",
+                "deleted_count": deleted_count, "deleted": deleted}
 
 
 class FieldsInsert(ToolWriterFieldBase):

--- a/plugin/writer/styles.py
+++ b/plugin/writer/styles.py
@@ -53,7 +53,10 @@ from .target_resolver import resolve_target_cursor
 
 log = logging.getLogger("writeragent.writer")
 
-_STYLE_FAMILIES = ["ParagraphStyles", "CharacterStyles"]
+# Families style_list will report and enumerate. PageStyles is listed because the page tools take
+# a page-style NAME and a document converted from .docx rarely uses "Standard" — without it the
+# only way to learn the real names was to guess one and read them off the error.
+_STYLE_FAMILIES = ["ParagraphStyles", "CharacterStyles", "PageStyles"]
 
 _CONDITIONAL_CONTEXTS = [
     "TableHeader", "Table", "Frame", "Section", "Footnote", "Endnote",
@@ -116,7 +119,7 @@ class StyleList(ToolWriterStyleBase):
 
     name = "style_list"
     description = "List available styles in the document. Omit family to list all style family names; set family to list styles in that family."
-    parameters = {"type": "object", "properties": {"family": {"type": "string", "enum": ["ParagraphStyles", "CharacterStyles"], "description": ("Style family (ParagraphStyles or CharacterStyles). Default: ParagraphStyles.")}}, "required": []}
+    parameters = {"type": "object", "properties": {"family": {"type": "string", "enum": _STYLE_FAMILIES, "description": ("Style family. Default: ParagraphStyles. Use PageStyles to find the page-style name the page tools need.")}}, "required": []}
 
     def execute(self, ctx, **kwargs):
         family = kwargs.get("family")
@@ -231,6 +234,13 @@ class StyleGetInfo(ToolWriterStyleBase):
         style_name = kwargs.get("style", "")
         family = kwargs.get("family", "ParagraphStyles")
 
+        # style_list reports PageStyles, but the property set read here is text-style shaped and
+        # would come back empty for one. Send the caller to the tool that does answer.
+        if family == "PageStyles":
+            return self._tool_error(
+                "style_get_info does not read page styles. Use page_get_style_properties(style='%s') "
+                "for margins, size and header/footer state." % (style_name or "Standard"))
+
         doc = ctx.doc
         style_family = self.get_item(doc, "getStyleFamilies", family, missing_msg="Document does not support style families.", not_found_msg="Unknown style family: %s" % family)
         if isinstance(style_family, dict):
@@ -268,7 +278,9 @@ class ApplyStyle(FrameworkToolBase):
         "styles (e.g. Source Text). Use 'No Character Style' "
         "with family='CharacterStyles' to remove a character style. "
         "Use target='selection' (default), 'beginning', 'end', 'full_document', "
-        "or 'search' with old_content."
+        "or 'search' with old_content. "
+        "If the result reports preserved_char_overrides, the target had hand-set formatting that "
+        "overrides the style and nothing changed on screen — re-apply with clear_direct='style_props'."
     )
     parameters = {
         "type": "object",
@@ -279,6 +291,14 @@ class ApplyStyle(FrameworkToolBase):
             "old_content": {"type": "string", "description": "Text to find and apply style to if target = 'search'."},
             "all_matches": {"type": "boolean", "description": "For target='search': apply to EVERY occurrence of old_content (default false = first only)."},
             "occurrence": {"type": "integer", "description": "For target='search': apply to this single 0-based occurrence instead of the first."},
+            "clear_direct": {"type": "string", "enum": ["none", "style_props", "all"], "description": (
+                "What to do with direct (hand-set) formatting on the target, ParagraphStyles only. "
+                "'none' (default) keeps it — but direct formatting OVERRIDES the style, so on a document "
+                "formatted by hand the style will have no visible effect. 'style_props' drops the font "
+                "name/size override and the paragraph indents/alignment so the style's own values show, "
+                "keeping bold/italic/colour. 'all' drops every direct override (Ctrl+M). "
+                "Not allowed with target='full_document' — clearing the whole document flattens the "
+                "formatting that tells one kind of paragraph from another; style each range instead.")},
         },
         "required": ["style"],
     }
@@ -288,11 +308,35 @@ class ApplyStyle(FrameworkToolBase):
     # Maps family to the UNO property that holds the style name.
     _PROPERTY_MAP = {"ParagraphStyles": "ParaStyleName", "CharacterStyles": "CharStyleName"}
 
-    def _apply_one(self, ctx, family, uno_prop, uno_value, cursor):
+    def _apply_one(self, ctx, family, uno_prop, uno_value, cursor, clear_direct="none"):
+        """Apply the style to one cursor. Returns the direct-formatting report (or None)."""
         if family == "ParagraphStyles":
-            apply_paragraph_style_preserving_direct_char(ctx.doc, cursor, uno_value)
-        else:
-            cursor.setPropertyValue(uno_prop, uno_value)
+            return apply_paragraph_style_preserving_direct_char(ctx.doc, cursor, uno_value, clear_direct)
+        cursor.setPropertyValue(uno_prop, uno_value)
+        return None
+
+    @staticmethod
+    def _merge_reports(reports):
+        """Fold per-range reports into the fields echoed on the tool result."""
+        out: dict[str, Any] = {}
+        for rep in reports:
+            if not rep:
+                continue
+            # One value per property across all ranges (last one wins). This is a signal that
+            # direct formatting was in play, not a per-range ledger.
+            for key in ("preserved_char_overrides", "removed_char_overrides"):
+                if rep.get(key):
+                    out.setdefault(key, {}).update(rep[key])
+            for key in ("cleared_char_properties", "cleared_paragraph_properties"):
+                if rep.get(key):
+                    out[key] = rep[key]  # same list for every range; last one wins
+        if out.get("preserved_char_overrides"):
+            # The whole point of the echo: a style apply that changed nothing visible used to be
+            # indistinguishable from one that worked.
+            out["hint"] = ("Direct formatting on the target overrides this style, so the document "
+                           "may look unchanged. Re-apply with clear_direct='style_props' to let the "
+                           "style's font, size and indents show.")
+        return out
 
     def execute(self, ctx, **kwargs):
         style_name = str(kwargs.get("style") or "").strip()
@@ -333,6 +377,21 @@ class ApplyStyle(FrameworkToolBase):
         target = kwargs.get("target", "selection")
         old_content = kwargs.get("old_content")
 
+        clear_direct = str(kwargs.get("clear_direct") or "none").strip()
+        if clear_direct not in ("none", "style_props", "all"):
+            return self._tool_error("clear_direct must be one of: none, style_props, all.")
+        if clear_direct != "none":
+            if family != "ParagraphStyles":
+                return self._tool_error("clear_direct only applies to family='ParagraphStyles'.")
+            if target == "full_document":
+                # Clearing the whole document erases the direct formatting that distinguishes a
+                # block quote from body text — and the caller needs that distinction to pick which
+                # style each range gets. Force the per-range path instead.
+                return self._tool_error(
+                    "clear_direct is not allowed with target='full_document': it would flatten the "
+                    "whole document, including the formatting that tells body text from quotes and "
+                    "headings. Style each range separately (target='search') instead.")
+
         # Multi-occurrence styling (target='search' only). resolve_target_cursor styles only the
         # first match; all_matches / occurrence let a defined term or repeated quote lead be
         # styled everywhere. Each match gets a cursor in its OWN text object (cell/frame safe).
@@ -360,17 +419,19 @@ class ApplyStyle(FrameworkToolBase):
                     return self._tool_error("occurrence %s out of range (found %d match(es), use 0..%d)." % (occ_raw, len(ranges), len(ranges) - 1))
                 ranges = [ranges[occ]]
             applied = 0
+            reports = []
             for found in ranges:
                 try:
                     ftext = found.getText()
                     c = ftext.createTextCursorByRange(found.getStart())
                     c.gotoRange(found.getEnd(), True)
-                    self._apply_one(ctx, family, uno_prop, uno_value, c)
+                    reports.append(self._apply_one(ctx, family, uno_prop, uno_value, c, clear_direct))
                     applied += 1
                 except Exception as e:
                     return self._tool_error("Applied to %d of %d; failed on one match: %s" % (applied, len(ranges), e))
             result = {"status": "ok", "message": "Applied style '%s' (%s) to %d match(es)." % (style_name, family, applied),
                       "style_name": style_name, "family": family, "target": "search", "applied": True, "matched": True, "applied_count": applied}
+            result.update(self._merge_reports(reports))
             from plugin.writer.edit_review import review_recording_enabled
             if review_recording_enabled(ctx.ctx):
                 result["style_unreviewed"] = True
@@ -391,11 +452,12 @@ class ApplyStyle(FrameworkToolBase):
             return self._tool_error("Failed to resolve target location.")
 
         try:
-            self._apply_one(ctx, family, uno_prop, uno_value, cursor)
+            report = self._apply_one(ctx, family, uno_prop, uno_value, cursor, clear_direct)
         except Exception as e:
             return self._tool_error("Could not apply style: %s" % e)
         result = {"status": "ok", "message": "Applied style '%s' (%s) to %s." % (style_name, family, target),
                   "style_name": style_name, "family": family, "target": target, "applied": True}
+        result.update(self._merge_reports([report]))
         if target == "search":
             result["matched"] = True  # a search miss would have errored earlier in resolve_target_cursor
         # A style change is applied directly and does NOT become a tracked change (LibreOffice

--- a/plugin/writer/xhtml_style_postprocess.py
+++ b/plugin/writer/xhtml_style_postprocess.py
@@ -14,8 +14,11 @@
 #     (when supplied), else CSS fingerprint, else omitted
 #
 # v1 limitations (see docs/writer/html-style-model-plan.md#v1-limitations-shipped):
-#   - Whole-paragraph Para* overrides (center, para colour, margins) are dropped on read;
+#   - Whole-paragraph Para* overrides (center, para colour, margins) do not round-trip on WRITE;
 #     FODT recovers the base style NAME only. Char-level overrides via text-* spans survive.
+#     Read REPORTS the hand-set paragraph formatting as read-only data-lo-para, taken from the
+#     flat-ODF sidecar (see extract_autostyle_overrides_from_fodt): the XHTML CSS is flattened
+#     and cannot tell an override from an inherited value.
 #   - Inside <table>: paragraph-* classes stripped; no data-lo-style (cell styles out of scope).
 #   - Colliding compact tokens (two UNO names -> same token): token omitted on read.
 #
@@ -105,6 +108,85 @@ def _normalize_decl(decl):
     return ";".join(sorted(parts))
 
 
+# Direct paragraph overrides surfaced to the agent as read-only ``data-lo-para``. v1 dropped them
+# entirely, so an agent could not tell an indented block quote from body text, nor verify an
+# indent it had just set.
+#
+# Read from the flat-ODF sidecar, NOT from the XHTML CSS: an autostyle's XHTML rule is FLATTENED
+# (base style + override merged, with no rule emitted for the base at all), so it cannot say which
+# values were hand-set — reporting it would present a style's own indent as a direct override. The
+# .fodt automatic style holds exactly the overrides and nothing inherited.
+#
+# Both the geometry and the paragraph-level font are reported: a .docx reused as a model carries
+# its font as a whole-paragraph override, which is precisely what makes an applied style look like
+# it did nothing.
+#
+# INFORMATIONAL only — the write path ignores ``data-lo-para`` (it still cannot restore Para* when
+# applying a named style), which is why it is not emitted as ``style=""``: that would round-trip
+# back and be silently swallowed. ODF attribute -> CSS name, in emit order.
+_FODT_OVERRIDE_ATTRS = (
+    ("fo:margin-left", "margin-left"),
+    ("fo:margin-right", "margin-right"),
+    ("fo:margin-top", "margin-top"),
+    ("fo:margin-bottom", "margin-bottom"),
+    ("fo:text-indent", "text-indent"),
+    ("fo:text-align", "text-align"),
+    ("fo:line-height", "line-height"),
+    ("style:font-name", "font-family"),
+    ("fo:font-family", "font-family"),
+    ("fo:font-size", "font-size"),
+    ("fo:font-weight", "font-weight"),
+    ("fo:font-style", "font-style"),
+)
+
+# ODF writes alignment relative to writing direction; the agent reads CSS.
+_ODF_TEXT_ALIGN = {"start": "left", "end": "right"}
+
+_FODT_PARA_STYLE_RE = re.compile(
+    r'<style:style\b([^>]*?)style:family="paragraph"([^>]*?)(?:/>|>(.*?)</style:style>)',
+    re.IGNORECASE | re.DOTALL)
+
+
+def _fodt_override_css(style_block):
+    """CSS-ish ``prop: value`` list for one flat-ODF automatic paragraph style's own attributes."""
+    parts = []
+    seen = set()
+    for odf_attr, css_name in _FODT_OVERRIDE_ATTRS:
+        if css_name in seen:
+            continue
+        m = re.search(r'\b%s="([^"]*)"' % re.escape(odf_attr), style_block)
+        if not m:
+            continue
+        value = _html.unescape(m.group(1)).strip()
+        if not value:
+            continue
+        if css_name == "text-align":
+            value = _ODF_TEXT_ALIGN.get(value, value)
+        parts.append("%s:%s" % (css_name, value))
+        seen.add(css_name)
+    return "; ".join(parts)
+
+
+def extract_autostyle_overrides_from_fodt(fodt):
+    """Map automatic paragraph style name (``P1``, ...) -> its DIRECT overrides as CSS text.
+
+    Companion to :func:`extract_autostyle_parents_from_fodt`, parsed from the same export. An
+    automatic style in flat ODF lists only what was set on top of its parent, so what comes back
+    is exactly the hand-set formatting — the thing the XHTML projection cannot express.
+    """
+    out = {}
+    text = fodt if type(fodt) is str else ""
+    for m in _FODT_PARA_STYLE_RE.finditer(text):
+        head = (m.group(1) or "") + (m.group(2) or "")
+        name = re.search(r'style:name="([^"]*)"', head)
+        if not name or not _AUTOSTYLE_RE.match(name.group(1)):
+            continue
+        css = _fodt_override_css(head + (m.group(3) or ""))
+        if css:
+            out[name.group(1)] = css
+    return out
+
+
 @deal.post(lambda result: isinstance(result, tuple) and len(result) == 2 and isinstance(result[0], dict) and isinstance(result[1], dict))
 def parse_style_block(xhtml):
     """Return ``(raw_map, norm_map)`` for every class rule in the ``<style>`` block(s).
@@ -166,10 +248,11 @@ class _SemanticTransformer(HTMLParser):
     attributes we change are rewritten with string ops.
     """
 
-    def __init__(self, raw_map, norm_map, autostyle_parents=None):
+    def __init__(self, raw_map, norm_map, autostyle_parents=None, autostyle_overrides=None):
         super().__init__(convert_charrefs=False)
         self._raw = raw_map
         self._autostyle_parents = autostyle_parents or {}
+        self._autostyle_overrides = autostyle_overrides or {}
         # Map a named paragraph rule's fingerprint -> list of its compact tokens.
         self._named_fingerprint = {}
         # Map a compact token -> set of distinct UNO names that compact to it. When more than
@@ -231,13 +314,21 @@ class _SemanticTransformer(HTMLParser):
         classes = _attr_value(attrs, "class")
         para_classes = _PARA_CLASS_RE.findall(classes)
         token = None
+        para_css = ""
         if para_classes and self._table_depth == 0:
             suffix = para_classes[0][len("paragraph-"):]
             token = self._paragraph_token(suffix)
+            # Only an autostyle (Pn) carries direct overrides — a plain named-style class
+            # describes the style itself — and only the flat-ODF sidecar can say which values
+            # those are, so without it nothing is reported rather than a guess.
+            if _AUTOSTYLE_RE.match(suffix):
+                para_css = self._autostyle_overrides.get(suffix, "")
         # Strip every paragraph-* class (top-level or cell) so it never leaks to the agent.
         raw = _strip_class_names(raw, _PARA_CLASS_RE)
         if token:
             raw = _inject_attr(raw, ' data-lo-style="%s"' % token)
+        if para_css:
+            raw = _inject_attr(raw, ' data-lo-para="%s"' % para_css)
         return raw
 
     def _rewrite_span(self, raw, attrs):
@@ -303,7 +394,7 @@ def _strip_class_names(start_tag, name_re):
     return re.sub(r'\s+class=(["\'])(.*?)\1', _sub, start_tag)
 
 
-def xhtml_to_semantic_html(full_xhtml, autostyle_parents=None):
+def xhtml_to_semantic_html(full_xhtml, autostyle_parents=None, autostyle_overrides=None):
     """Convert raw LO ``XHTML Writer File`` output to the agent-facing semantic HTML.
 
     Single entry point: parse the ``<style>`` block, extract the body, inline char overrides,
@@ -318,7 +409,7 @@ def xhtml_to_semantic_html(full_xhtml, autostyle_parents=None):
     # crosshair: off  # HTMLParser over unbounded XHTML (cover-all 33418536119: xhtml_style_postprocess 1141s). Doable later with UNDER_CROSSHAIR dual-profile + DEAL_MAX_HTML_CHUNK (pytest fixtures exceed 512).
     raw_map, norm_map = parse_style_block(full_xhtml)
     body = _strip_body(full_xhtml)
-    tr = _SemanticTransformer(raw_map, norm_map, autostyle_parents)
+    tr = _SemanticTransformer(raw_map, norm_map, autostyle_parents, autostyle_overrides)
     tr.feed(body)
     tr.close()
     out = _drop_trailing_empty_paragraphs(tr.result())

--- a/tests/writer/specialized/test_fields.py
+++ b/tests/writer/specialized/test_fields.py
@@ -125,3 +125,67 @@ def test_fields_delete(mock_ctx):
     assert res["deleted_count"] == 1
     mock_anchor_1.setString.assert_not_called()
     mock_anchor_2.setString.assert_called_with("")
+
+
+# --- where a field lives decides whether deleting it is safe -------------------------------
+
+
+def _one_field_doc(doc, field):
+    fields, enum = MagicMock(), MagicMock()
+    enum.hasMoreElements.side_effect = [True, False]
+    enum.nextElement.return_value = field
+    fields.createEnumeration.return_value = enum
+    doc.getTextFields.return_value = fields
+
+
+def test_fields_list_reports_where_each_field_is(mock_ctx, monkeypatch):
+    """getTextFields() mixes header and footer fields in with the body's, and a page number in a
+    footer is indistinguishable from one in the text without this."""
+    from plugin.writer import search as search_mod
+
+    field = MagicMock()
+    field.getPresentation.side_effect = ["Page 1", "1"]
+    field.getPropertySetInfo.return_value.hasPropertyByName.return_value = False
+    _one_field_doc(mock_ctx.doc, field)
+    monkeypatch.setattr(search_mod, "describe_match_location", lambda *a, **k: "footer (page style 'Standard')")
+
+    res = FieldsList().execute(mock_ctx)
+
+    assert res["fields"][0]["location"] == "footer (page style 'Standard')"
+
+
+def test_fields_list_location_falls_back_when_it_cannot_be_resolved(mock_ctx, monkeypatch):
+    """An unlabelable anchor must not sink the whole listing."""
+    from plugin.writer import search as search_mod
+
+    field = MagicMock()
+    field.getPresentation.side_effect = ["Page 1", "1"]
+    field.getPropertySetInfo.return_value.hasPropertyByName.return_value = False
+    _one_field_doc(mock_ctx.doc, field)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("no anchor")
+
+    monkeypatch.setattr(search_mod, "describe_match_location", boom)
+
+    res = FieldsList().execute(mock_ctx)
+
+    assert res["status"] == "ok"
+    assert res["fields"][0]["location"] == "unknown"
+
+
+def test_fields_delete_says_what_it_removed_and_from_where(mock_ctx, monkeypatch):
+    """Reported before the anchor is emptied — afterwards the two are indistinguishable."""
+    from plugin.writer import search as search_mod
+
+    field = MagicMock()
+    field.getPresentation.return_value = "Page Number"
+    anchor = field.getAnchor.return_value
+    _one_field_doc(mock_ctx.doc, field)
+    monkeypatch.setattr(search_mod, "describe_match_location", lambda *a, **k: "footer (page style 'Standard')")
+
+    res = FieldsDelete().execute(mock_ctx, ids=[1])
+
+    assert res["deleted_count"] == 1
+    assert res["deleted"] == [{"content": "Page Number", "location": "footer (page style 'Standard')"}]
+    anchor.setString.assert_called_with("")

--- a/tests/writer/test_apply_document_content_structured_return.py
+++ b/tests/writer/test_apply_document_content_structured_return.py
@@ -74,3 +74,47 @@ def test_search_all_matches_no_match_errors(monkeypatch):
     assert res["status"] == "error", res
     assert res["replaced_count"] == 0, res
     assert res["message"].startswith("Replaced 0 occurrence"), res
+
+
+# --- data-lo-para is a read report, not an instruction --------------------------------------
+
+
+def test_read_only_attribute_sent_back_is_flagged():
+    """The write path drops data-lo-para. Say so: a silent no-op is the failure this tool's
+    callers already get bitten by."""
+    from plugin.writer.content import _note_read_only_attrs
+
+    res = _note_read_only_attrs(
+        {"status": "ok", "message": "Replaced entire document."},
+        ['<p data-lo-para="margin-left:3.25cm">A quoted clause.</p>'])
+
+    assert res["ignored_attributes"] == ["data-lo-para"]
+    assert "apply_style" in res["message"]
+
+
+def test_content_without_the_attribute_is_untouched():
+    from plugin.writer.content import _note_read_only_attrs
+
+    original = {"status": "ok", "message": "Replaced entire document."}
+    res = _note_read_only_attrs(original, ["<p>A quoted clause.</p>"])
+
+    assert res == original
+    assert "ignored_attributes" not in res
+
+
+def test_failed_write_is_not_annotated():
+    """Nothing was written, so there is nothing to say about what was ignored."""
+    from plugin.writer.content import _note_read_only_attrs
+
+    original = {"status": "error", "message": "old_content not found."}
+
+    assert _note_read_only_attrs(original, ['<p data-lo-para="margin-left:3cm">x</p>']) == original
+
+
+def test_plain_string_content_is_accepted():
+    """content is normally a list, but the checker must not choke on a bare string."""
+    from plugin.writer.content import _note_read_only_attrs
+
+    res = _note_read_only_attrs({"status": "ok"}, '<p data-lo-para="text-align:center">x</p>')
+
+    assert res["ignored_attributes"] == ["data-lo-para"]

--- a/tests/writer/test_format.py
+++ b/tests/writer/test_format.py
@@ -186,7 +186,7 @@ def test_replace_preserving_format_atomic_when_split_author_false_even_in_undo_c
     # Configurable coloring: split_author=False forces the SINGLE atomic setString (one author -> one
     # color) even INSIDE an open undo context, where split_author=True (the default) would use the
     # two-step delete+insert for split-author coloring. The two-step is gated on BOTH flags, so turning
-    # coloring off collapses every recorded replace -- surgical or whole-block -- to one color, still
+    # coloring off collapses every recorded replace — surgical or whole-block — to one color, still
     # all-or-nothing.
     from unittest.mock import patch
 
@@ -254,14 +254,14 @@ def test_document_to_content_full_timing_path_with_mocks():
     xhtml = '<html><body><p class="paragraph-Text_20_body">hello</p></body></html>'
     with (
         patch.object(html_export, "_export_xhtml", return_value=xhtml) as export_xhtml,
-        patch.object(html_export, "_autostyle_parents", return_value={}) as autostyle,
+        patch.object(html_export, "_autostyle_maps", return_value=({}, {})) as autostyle,
         patch.object(fmt.xhtml_post, "xhtml_to_semantic_html", return_value="<p>hello</p>") as post,
     ):
         out = fmt.document_to_content(object(), object(), None, scope="full")
 
     export_xhtml.assert_called_once()
     autostyle.assert_called_once()
-    post.assert_called_once_with(xhtml, {})
+    post.assert_called_once_with(xhtml, {}, {})
     assert out == "<p>hello</p>"
 
 
@@ -319,3 +319,233 @@ def test_resolve_style_name():
     assert fmt._resolve_style_name(model, "heading 1") == "Heading 1"
     # Fallback to input string on unknown style
     assert fmt._resolve_style_name(model, "UnknownStyle") == "UnknownStyle"
+
+
+# --- clear_direct: the paragraph half of Format > Clear Direct Formatting -----------------
+
+
+class _MultiStatesCursor:
+    """Range that supports XMultiPropertyStates (the normal LibreOffice text cursor)."""
+
+    def __init__(self):
+        self.cleared = None
+
+    def setPropertiesToDefault(self, names):
+        self.cleared = tuple(names)
+
+
+class _SingleStateCursor:
+    """Range without the multi variant — exercises the one-at-a-time fallback."""
+
+    def __init__(self, unsupported=()):
+        self.cleared = []
+        self._unsupported = set(unsupported)
+
+    def setPropertyToDefault(self, name):
+        if name in self._unsupported:
+            raise RuntimeError("unsupported property: %s" % name)
+        self.cleared.append(name)
+
+
+def test_clear_direct_paragraph_properties_uses_multi_variant():
+    from plugin.writer import format as fmt
+
+    cursor = _MultiStatesCursor()
+    cleared = fmt._reset_properties_to_default(cursor, fmt.CLEARABLE_PARA_PROPERTIES)
+
+    assert cursor.cleared == fmt.CLEARABLE_PARA_PROPERTIES
+    assert cleared == list(fmt.CLEARABLE_PARA_PROPERTIES)
+
+
+def test_clear_direct_paragraph_properties_falls_back_one_at_a_time():
+    from plugin.writer import format as fmt
+
+    cursor = _SingleStateCursor(unsupported={"ParaSplit"})
+    cleared = fmt._reset_properties_to_default(cursor, fmt.CLEARABLE_PARA_PROPERTIES)
+
+    assert "ParaLeftMargin" in cleared and "ParaFirstLineIndent" in cleared
+    assert "ParaSplit" not in cleared  # reported honestly as not cleared
+
+
+def test_clear_direct_never_touches_non_paragraph_properties():
+    """Deliberately narrower than setAllPropertiesToDefault: numbering, borders and language are
+    not the caller's to lose."""
+    from plugin.writer import format as fmt
+
+    assert all(name.startswith("Para") for name in fmt.CLEARABLE_PARA_PROPERTIES)
+    for unwanted in ("NumberingRules", "ParaStyleName", "CharLocale"):
+        assert unwanted not in fmt.CLEARABLE_PARA_PROPERTIES
+
+
+def test_summarize_char_overrides_is_json_safe_and_first_portion_wins():
+    from plugin.writer import format as fmt
+
+    overrides = [
+        (object(), {"CharFontName": "Times New Roman", "CharHeight": 12.0, "CharLocale": object()}),
+        (object(), {"CharFontName": "Courier"}),
+    ]
+    summary = fmt._summarize_char_overrides(overrides)
+
+    assert summary == {"CharFontName": "Times New Roman", "CharHeight": 12.0}
+    assert "CharLocale" not in summary  # UNO struct -> not serialisable, left out
+
+
+def test_style_governed_char_properties_spare_bold_and_italic():
+    """style_props drops the font the style owns; hand-set emphasis is the user's, not the style's."""
+    from plugin.writer import format as fmt
+
+    assert "CharFontName" in fmt.STYLE_GOVERNED_CHAR_PROPERTIES
+    assert "CharHeight" in fmt.STYLE_GOVERNED_CHAR_PROPERTIES
+    assert "CharWeight" not in fmt.STYLE_GOVERNED_CHAR_PROPERTIES   # bold survives
+    assert "CharPosture" not in fmt.STYLE_GOVERNED_CHAR_PROPERTIES  # italic survives
+
+
+def test_report_lists_only_the_overrides_actually_removed():
+    """Under style_props, bold/italic are restored — listing them as removed would be wrong."""
+    from plugin.writer import format as fmt
+
+    found = {"CharFontName": "Times New Roman", "CharHeight": 12.0, "CharWeight": 150.0}
+    skip = set(fmt.STYLE_GOVERNED_CHAR_PROPERTIES)
+    removed = {k: v for k, v in found.items() if k in skip}
+
+    assert removed == {"CharFontName": "Times New Roman", "CharHeight": 12.0}
+    assert "CharWeight" not in removed
+
+
+def test_reset_properties_to_default_is_a_noop_on_empty_names():
+    from plugin.writer import format as fmt
+
+    cursor = _MultiStatesCursor()
+    assert fmt._reset_properties_to_default(cursor, ()) == []
+    assert cursor.cleared is None  # never call UNO with an empty set
+
+
+def test_reset_properties_to_default_takes_the_caller_s_names():
+    """The clear is scoped by the caller — style_props clears the font, all clears what was found."""
+    from plugin.writer import format as fmt
+
+    cursor = _MultiStatesCursor()
+    fmt._reset_properties_to_default(cursor, fmt.STYLE_GOVERNED_CHAR_PROPERTIES)
+
+    assert cursor.cleared == fmt.STYLE_GOVERNED_CHAR_PROPERTIES
+
+
+# --- range copy: carrying direct formatting into the temp document -------------------------
+
+
+def _enum(items):
+    from unittest.mock import MagicMock
+
+    e = MagicMock()
+    rest = list(items)
+    e.hasMoreElements.side_effect = lambda: True if rest else False
+    e.nextElement.side_effect = lambda: rest.pop(0)
+    return e
+
+
+def _text_portion(text, ptype="Text", **props):
+    from unittest.mock import MagicMock
+
+    p = MagicMock()
+    values = {"TextPortionType": ptype}
+    values.update(props)
+    p.getPropertyValue.side_effect = lambda n: values[n]
+    p.getString.return_value = text
+    return p
+
+
+def _para_of(portions):
+    from unittest.mock import MagicMock
+
+    para = MagicMock()
+    para.createEnumeration.side_effect = lambda: _enum(portions)
+    return para
+
+
+def test_visible_portions_skips_tracked_deletions():
+    """Must match get_string_without_tracked_deletions exactly — a divergence would paint one
+    run's formatting onto another run's characters."""
+    from plugin.writer import html_export as hx
+
+    para = _para_of([
+        _text_portion("kept "),
+        _text_portion("", "Redline", RedlineType="Delete"),
+        _text_portion("deleted"),
+        _text_portion("", "Redline", RedlineType="Delete"),
+        _text_portion(" tail"),
+    ])
+
+    assert "".join(chunk for _p, chunk in hx._visible_portions(para)) == "kept  tail"
+
+
+def test_visible_portions_ignores_non_delete_redlines():
+    from plugin.writer import html_export as hx
+
+    para = _para_of([
+        _text_portion("", "Redline", RedlineType="Insert"),
+        _text_portion("inserted text"),
+    ])
+
+    assert "".join(chunk for _p, chunk in hx._visible_portions(para)) == "inserted text"
+
+
+def test_copy_properties_skips_values_the_style_already_gives():
+    """Copying an inherited value would make it a hand-set one on the copy, and the read would
+    then report margin-right:0cm on every paragraph as if the user had set it."""
+    from unittest.mock import MagicMock
+    from plugin.writer import html_export as hx
+
+    src, dst, style = MagicMock(), MagicMock(), MagicMock()
+    src.getPropertyValue.side_effect = {"ParaLeftMargin": 3251, "ParaRightMargin": 0}.get
+    style.getPropertyValue.side_effect = {"ParaLeftMargin": 0, "ParaRightMargin": 0}.get
+
+    hx._copy_properties(src, dst, ("ParaLeftMargin", "ParaRightMargin"), style)
+
+    dst.setPropertyValue.assert_called_once_with("ParaLeftMargin", 3251)
+
+
+def test_copy_properties_without_a_style_copies_everything_readable():
+    from unittest.mock import MagicMock
+    from plugin.writer import html_export as hx
+
+    src, dst = MagicMock(), MagicMock()
+    src.getPropertyValue.side_effect = {"CharWeight": 150.0}.get
+
+    hx._copy_properties(src, dst, ("CharWeight",))
+
+    dst.setPropertyValue.assert_called_once_with("CharWeight", 150.0)
+
+
+def test_copy_properties_continues_past_one_the_target_refuses():
+    """The temp document is a plain Writer doc and need not offer every source property."""
+    from unittest.mock import MagicMock
+    from plugin.writer import html_export as hx
+
+    src, dst = MagicMock(), MagicMock()
+    src.getPropertyValue.side_effect = {"CharPosture": 1, "CharWeight": 150.0}.get
+
+    def refuse_posture(name, _value):
+        if name == "CharPosture":
+            raise RuntimeError("unsupported")
+
+    dst.setPropertyValue.side_effect = refuse_posture
+
+    hx._copy_properties(src, dst, ("CharPosture", "CharWeight"))
+
+    assert [c.args[0] for c in dst.setPropertyValue.call_args_list] == ["CharPosture", "CharWeight"]
+
+
+def test_source_style_is_cached_and_tolerates_a_missing_style():
+    from unittest.mock import MagicMock
+    from plugin.writer import html_export as hx
+
+    model = MagicMock()
+    families = model.getStyleFamilies.return_value.getByName.return_value
+    families.getByName.side_effect = lambda n: "STYLE" if n == "Standard" else (_ for _ in ()).throw(KeyError(n))
+
+    cache = {}
+    assert hx._source_style(model, "Standard", cache) == "STYLE"
+    assert hx._source_style(model, "Standard", cache) == "STYLE"
+    assert families.getByName.call_count == 1  # second read served from the cache
+    assert hx._source_style(model, "Nope", cache) is None
+    assert hx._source_style(model, "", cache) is None

--- a/tests/writer/test_page.py
+++ b/tests/writer/test_page.py
@@ -10,6 +10,7 @@ import sys
 setattr(sys.modules["com.sun.star.style.BreakType"], "PAGE_BEFORE", 4)
 
 from plugin.writer.page import (
+    PageGetHeaderFooterText,
     PageGetStyleProperties,
     PageSetStyleProperties,
     PageSetHeaderFooterText,
@@ -194,3 +195,200 @@ def test_page_tools_shortened_style_param():
 
     res_set = PageSetStyleProperties().execute(ctx, style="Standard", width_mm=210)
     assert res_set["status"] == "ok"
+
+
+# --- header/footer: what plain text cannot carry ------------------------------------------
+
+
+def _enum_of(items):
+    """UNO-style enumeration over *items* (hasMoreElements/nextElement)."""
+    e = MagicMock()
+    rest = list(items)
+    e.hasMoreElements.side_effect = lambda: True if rest else False
+    e.nextElement.side_effect = lambda: rest.pop(0)
+    return e
+
+
+def _portion(kind, field=None):
+    p = MagicMock()
+    p.getPropertyValue.side_effect = lambda n: kind if n == "TextPortionType" else field
+    return p
+
+
+def _paragraph(portions):
+    para = MagicMock()
+    para.createEnumeration.side_effect = lambda: _enum_of(portions)
+    return para
+
+
+def _page_style_doc(text_obj, shapes=()):
+    doc = MagicMock()
+    families, page_styles, style = MagicMock(), MagicMock(), MagicMock()
+    doc.getStyleFamilies.return_value = families
+    families.getByName.return_value = page_styles
+    page_styles.hasByName.return_value = True
+    page_styles.getByName.return_value = style
+    style.getPropertyValue.side_effect = lambda n: True if n.endswith("IsOn") else text_obj
+    draw_page = MagicMock()
+    draw_page.getCount.return_value = len(shapes)
+    draw_page.getByIndex.side_effect = lambda i: shapes[i]
+    doc.getDrawPage.return_value = draw_page
+    return doc, style
+
+
+def _logo_anchored_in(text_obj, name="TIMBRE"):
+    shape = MagicMock()
+    shape.getName.return_value = name
+    shape.getAnchor.return_value.getText.return_value = text_obj
+    return shape
+
+
+def _page_number_field():
+    field = MagicMock()
+    field.getPresentation.side_effect = lambda cmd: "Page Number" if cmd is True else "1"
+    return field
+
+
+def test_get_header_footer_reports_the_logo_and_field_text_alone_hides():
+    """getString() renders a logo as an empty line and a page-number field as its digits, so a
+    caller reading only `content` cannot see what an overwrite would destroy."""
+    text_obj = MagicMock()
+    text_obj.getString.return_value = "\nESCRITORIO ZOLET"
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([
+        _paragraph([_portion("Frame")]),
+        _paragraph([_portion("Text"), _portion("TextField", _page_number_field())]),
+    ])
+    doc, _style = _page_style_doc(text_obj, shapes=[_logo_anchored_in(text_obj)])
+
+    res = PageGetHeaderFooterText().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"), style="Standard", region="header")
+
+    assert res["status"] == "ok"
+    assert res["images"] == ["TIMBRE"]
+    assert res["fields"] == [{"presentation": "1", "content": "Page Number"}]
+    assert res["paragraph_count"] == 2
+    assert "apply_document_content" in res["warning"]
+
+
+def test_set_header_footer_refuses_to_silently_delete_a_logo():
+    """The old behaviour returned ok and destroyed the letterhead with no way back."""
+    text_obj = MagicMock()
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Frame")])])
+    doc, _style = _page_style_doc(text_obj, shapes=[_logo_anchored_in(text_obj)])
+
+    res = PageSetHeaderFooterText().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", region="header", content="ESCRITORIO ZOLET")
+
+    assert res["status"] == "error"
+    assert "TIMBRE" in res["message"]
+    assert "apply_document_content" in res["message"]
+    text_obj.setString.assert_not_called()
+
+
+def test_set_header_footer_refusal_leaves_the_document_untouched():
+    """A refusal must not have already enabled the region or resized it on the way in."""
+    text_obj = MagicMock()
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Frame")])])
+    doc, style = _page_style_doc(text_obj, shapes=[_logo_anchored_in(text_obj)])
+
+    res = PageSetHeaderFooterText().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", region="header", content="ESCRITORIO ZOLET", auto_height=True)
+
+    assert res["status"] == "error"
+    style.setPropertyValue.assert_not_called()
+
+
+def test_set_header_footer_skips_the_scan_when_the_region_is_off():
+    """Nothing to destroy in a region that is not on yet — enable it and write."""
+    text_obj = MagicMock()
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([])
+    doc, style = _page_style_doc(text_obj)
+    style.getPropertyValue.side_effect = lambda n: False if n.endswith("IsOn") else text_obj
+
+    res = PageSetHeaderFooterText().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", region="footer", content="Rua Exemplo, 123")
+
+    assert res["status"] == "ok"
+    style.setPropertyValue.assert_any_call("FooterIsOn", True)
+    text_obj.setString.assert_called_with("Rua Exemplo, 123")
+
+
+def test_set_header_footer_force_deletes_and_says_what_it_deleted():
+    text_obj = MagicMock()
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Frame")])])
+    doc, _style = _page_style_doc(text_obj, shapes=[_logo_anchored_in(text_obj)])
+
+    res = PageSetHeaderFooterText().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", region="header", content="ESCRITORIO ZOLET", force=True)
+
+    assert res["status"] == "ok"
+    assert res["deleted"]["images"] == ["TIMBRE"]
+    text_obj.setString.assert_called_with("ESCRITORIO ZOLET")
+
+
+def test_set_header_footer_plain_text_still_goes_straight_through():
+    """No images, no fields -> unchanged behaviour, no new friction."""
+    text_obj = MagicMock()
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Text")])])
+    doc, _style = _page_style_doc(text_obj)
+
+    res = PageSetHeaderFooterText().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", region="footer", content="Rua Exemplo, 123")
+
+    assert res["status"] == "ok"
+    assert "deleted" not in res
+    text_obj.setString.assert_called_with("Rua Exemplo, 123")
+
+
+def test_set_header_footer_reports_paragraphs_it_dropped():
+    """setString collapses the region to the content given; say so instead of losing a line quietly."""
+    text_obj = MagicMock()
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([
+        _paragraph([_portion("Text")]), _paragraph([_portion("Text")]), _paragraph([_portion("Text")])])
+    doc, _style = _page_style_doc(text_obj)
+
+    res = PageSetHeaderFooterText().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", region="footer", content="uma linha so")
+
+    assert res["paragraphs_dropped"] == 2
+
+
+def test_first_page_region_targets_its_own_text_object():
+    """A 'different first page' letterhead lives in HeaderTextFirst; the shared HeaderText never
+    reaches it."""
+    from plugin.writer.page import _REGION_PROPS
+
+    assert _REGION_PROPS["header_first"] == ("HeaderIsOn", "HeaderTextFirst")
+    assert _REGION_PROPS["footer_first"] == ("FooterIsOn", "FooterTextFirst")
+    assert _REGION_PROPS["header_left"] == ("HeaderIsOn", "HeaderTextLeft")
+
+
+def test_first_page_region_uses_the_header_height_properties():
+    """_height_props must key off header/footer, not the exact region name."""
+    from plugin.writer.page import _height_props
+
+    assert _height_props("header_first")[0] == "HeaderIsDynamicHeight"
+    assert _height_props("footer_left")[0] == "FooterIsDynamicHeight"
+
+
+def test_set_page_style_properties_writes_first_is_shared():
+    doc = MagicMock()
+    families, page_styles, style = MagicMock(), MagicMock(), MagicMock()
+    doc.getStyleFamilies.return_value = families
+    families.getByName.return_value = page_styles
+    page_styles.hasByName.return_value = True
+    page_styles.getByName.return_value = style
+
+    res = PageSetStyleProperties().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", first_is_shared=False)
+
+    assert res["status"] == "ok"
+    assert "first_is_shared" in res["updated"]
+    style.setPropertyValue.assert_any_call("FirstIsShared", False)

--- a/tests/writer/test_styles.py
+++ b/tests/writer/test_styles.py
@@ -84,7 +84,10 @@ def test_list_styles_filtering():
     res = tool.execute(mock_ctx, family="")
     assert "ParagraphStyles" in res["families"]
     assert "CharacterStyles" in res["families"]
-    assert "PageStyles" not in res["families"]
+    # PageStyles is reported: the page tools take a page-style NAME, and a converted .docx rarely
+    # uses "Standard" — without this the only way to learn the real names was to guess and read
+    # them off the error message.
+    assert "PageStyles" in res["families"]
 
     res = tool.execute(mock_ctx, family="ParagraphStyles")
     assert res["status"] == "ok"
@@ -149,8 +152,78 @@ def test_apply_style_paragraph(mock_resolve, mock_preserve, mock_ctx):
 
     assert res["status"] == "ok"
     assert res["family"] == "ParagraphStyles"
-    mock_preserve.assert_called_once_with(mock_ctx.doc, cursor, "Heading 1")
+    mock_preserve.assert_called_once_with(mock_ctx.doc, cursor, "Heading 1", "none")
     cursor.setPropertyValue.assert_not_called()
+
+
+@patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char")
+@patch("plugin.writer.styles.resolve_target_cursor")
+def test_apply_style_clear_direct_is_forwarded(mock_resolve, mock_preserve, mock_ctx):
+    """clear_direct reaches the apply helper, which decides what happens to direct formatting."""
+    mock_resolve.return_value = MagicMock()
+    mock_preserve.return_value = {"direct_formatting": "cleared", "clear_direct": "style_props",
+                                  "removed_char_overrides": {"CharFontName": "Times New Roman"},
+                                  "cleared_char_properties": ["CharFontName", "CharHeight"],
+                                  "cleared_paragraph_properties": ["ParaLeftMargin"]}
+
+    res = ApplyStyle().execute(mock_ctx, style="Heading 1", target="selection", clear_direct="style_props")
+
+    assert res["status"] == "ok"
+    assert mock_preserve.call_args[0][3] == "style_props"
+    assert res["removed_char_overrides"] == {"CharFontName": "Times New Roman"}
+    assert res["cleared_char_properties"] == ["CharFontName", "CharHeight"]
+    assert res["cleared_paragraph_properties"] == ["ParaLeftMargin"]
+    assert "hint" not in res  # nothing was preserved -> nothing to warn about
+
+
+@patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char")
+@patch("plugin.writer.styles.resolve_target_cursor")
+def test_apply_style_reports_preserved_overrides_with_hint(mock_resolve, mock_preserve, mock_ctx):
+    """The default path echoes the direct formatting that overrode the style — otherwise a style
+    apply that changed nothing on screen is indistinguishable from one that worked."""
+    mock_resolve.return_value = MagicMock()
+    mock_preserve.return_value = {"direct_formatting": "preserved", "clear_direct": "none",
+                                  "preserved_char_overrides": {"CharFontName": "Times New Roman", "CharHeight": 12.0}}
+
+    res = ApplyStyle().execute(mock_ctx, style="Standard", target="selection")
+
+    assert res["preserved_char_overrides"]["CharHeight"] == 12.0
+    assert "clear_direct='style_props'" in res["hint"]
+
+
+@patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char")
+@patch("plugin.writer.styles.resolve_target_cursor")
+def test_apply_style_clear_direct_rejected_on_full_document(mock_resolve, mock_preserve, mock_ctx):
+    """Clearing the whole document erases the very formatting used to tell paragraph kinds apart."""
+    mock_resolve.return_value = MagicMock()
+
+    res = ApplyStyle().execute(mock_ctx, style="Standard", target="full_document", clear_direct="style_props")
+
+    assert res["status"] == "error"
+    assert "full_document" in res["message"]
+    mock_preserve.assert_not_called()
+
+
+@patch("plugin.writer.styles.resolve_target_cursor")
+def test_apply_style_clear_direct_rejected_for_character_styles(mock_resolve, mock_ctx):
+    """Character styles do not go through the paragraph apply path, so the flag would be a no-op."""
+    mock_resolve.return_value = MagicMock()
+
+    res = ApplyStyle().execute(mock_ctx, style="Source Text", family="CharacterStyles",
+                               target="selection", clear_direct="all")
+
+    assert res["status"] == "error"
+    assert "ParagraphStyles" in res["message"]
+
+
+@patch("plugin.writer.styles.resolve_target_cursor")
+def test_apply_style_rejects_unknown_clear_direct(mock_resolve, mock_ctx):
+    mock_resolve.return_value = MagicMock()
+
+    res = ApplyStyle().execute(mock_ctx, style="Standard", target="selection", clear_direct="yes")
+
+    assert res["status"] == "error"
+    assert "clear_direct" in res["message"]
 
 
 @patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char")

--- a/tests/writer/test_writer_diff_and_html_verification.py
+++ b/tests/writer/test_writer_diff_and_html_verification.py
@@ -27,6 +27,7 @@ from tests.strip_bundle import deal_pre_present
 from plugin.writer.xhtml_style_postprocess import (
     compact_lo_style_name,
     decode_lo_css_class_suffix,
+    extract_autostyle_overrides_from_fodt,
     extract_autostyle_parents_from_fodt,
     parse_style_block,
 )
@@ -97,6 +98,16 @@ def test_hypothesis_compact_lo_style_name_removes_spaces(name: str) -> None:
 @settings(max_examples=vhs_max_examples(40, 400), deadline=None)
 def test_hypothesis_extract_autostyle_parents_from_fodt_invariant(fodt: str) -> None:
     res = extract_autostyle_parents_from_fodt(fodt)
+    assert isinstance(res, dict)
+    for k, v in res.items():
+        assert isinstance(k, str)
+        assert isinstance(v, str)
+
+
+@given(fodt=_SHORT_TEXT)
+@settings(max_examples=vhs_max_examples(40, 400), deadline=None)
+def test_hypothesis_extract_autostyle_overrides_from_fodt_invariant(fodt: str) -> None:
+    res = extract_autostyle_overrides_from_fodt(fodt)
     assert isinstance(res, dict)
     for k, v in res.items():
         assert isinstance(k, str)

--- a/tests/writer/test_xhtml_style_postprocess.py
+++ b/tests/writer/test_xhtml_style_postprocess.py
@@ -9,6 +9,7 @@
 # Pure pytest unit tests (no LibreOffice) for the XHTML style post-process pipeline.
 # Fixtures mirror the real "XHTML Writer File" output captured from LibreOffice.
 from plugin.writer.xhtml_style_postprocess import (
+    extract_autostyle_overrides_from_fodt,
     compact_lo_style_name,
     decode_lo_css_class_suffix,
     extract_autostyle_parents_from_fodt,
@@ -159,17 +160,44 @@ def test_autostyle_ambiguous_match_omitted():
     assert "paragraph-" not in out, out
 
 
-# --- Issue 1 characterization: whole-paragraph direct overrides are dropped ---
+# --- Issue 1: whole-paragraph direct overrides are REPORTED (read-only), not applied ---
 
-def test_whole_paragraph_direct_override_is_dropped():
-    """KNOWN LIMITATION: a Standard paragraph with whole-paragraph center+colour (autostyle P2,
-    a superset of the body style) is emitted WITHOUT a token and WITHOUT the override CSS.
-    Alignment/whole-paragraph colour do not round-trip in v1 (documented for the maintainer)."""
-    out = xhtml_to_semantic_html(REFERENCE_XHTML)
+_FODT_OVERRIDES = """<office:document>
+ <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Standard">
+  <style:text-properties fo:font-size="12pt" style:font-name="Times New Roman"/>
+ </style:style>
+ <style:style style:name="P2" style:family="paragraph" style:parent-style-name="Standard">
+  <style:paragraph-properties fo:margin-left="3.25cm" fo:text-indent="0cm" fo:text-align="start"/>
+ </style:style>
+ <style:style style:name="Standard" style:family="paragraph">
+  <style:paragraph-properties fo:margin-left="0cm"/>
+ </style:style>
+</office:document>"""
+
+
+def test_extract_autostyle_overrides_reads_only_the_direct_values():
+    """A flat-ODF automatic style lists exactly what was set on top of its parent."""
+    out = extract_autostyle_overrides_from_fodt(_FODT_OVERRIDES)
+    assert out["P2"] == "margin-left:3.25cm; text-indent:0cm; text-align:left"  # ODF 'start' -> CSS
+    assert out["P1"] == "font-family:Times New Roman; font-size:12pt"
+    assert "Standard" not in out  # named styles are not overrides
+
+
+def test_whole_paragraph_override_is_reported_from_the_fodt_map():
+    """The paragraph geometry AND its hand-set font reach the agent as read-only data-lo-para --
+    without it an indented block quote is indistinguishable from body text."""
+    out = xhtml_to_semantic_html(REFERENCE_XHTML, None, extract_autostyle_overrides_from_fodt(_FODT_OVERRIDES))
     line = next(ln for ln in out.splitlines() if "centered red whole paragraph" in ln)
-    assert "data-lo-style" not in line, line          # base style not recoverable -> omitted
-    assert "text-align" not in line and "center" not in line.replace("centered", ""), line
-    assert "ff0000" not in line.lower() and "color" not in line, line  # the override is dropped
+    assert 'data-lo-para="margin-left:3.25cm; text-indent:0cm; text-align:left"' in line, line
+    body = next(ln for ln in out.splitlines() if "normal " in ln and "BOLD" in ln)
+    assert 'data-lo-para="font-family:Times New Roman; font-size:12pt"' in body, body
+
+
+def test_no_para_override_reported_without_the_fodt_map():
+    """The XHTML rule for an autostyle is FLATTENED (base + override merged, and no rule is emitted
+    for the base at all), so with no sidecar nothing is reported rather than a guess."""
+    out = xhtml_to_semantic_html(REFERENCE_XHTML)
+    assert "data-lo-para" not in out, out
 
 
 # --- Issue 2: token collision (two styles compacting to the same token) -------


### PR DESCRIPTION
This comes from the lawyers using WriterAgent on real casework at our office.

On a document formatted by hand — every document reused as a template model — the tools return `ok` and either change nothing or destroy content.

```
style_update("Standard", {CharFontName: "Arial", CharHeight: 9.5})  -> ok
apply_style("Standard", target="search", old_content="...")          -> ok
```

Text stays Times 12. One of them gave up on the tool over this. Another kept losing the letterhead whenever the agent touched the header.

| What breaks | Why | Fix |
|---|---|---|
| A style apply changes nothing, reports `ok` | direct formatting overrides styles, and `apply_style` restored it after applying | `clear_direct='style_props'` **deletes** the override instead of restoring it, so the value falls back to the style's and the style finally shows. Default stays `none`, which now echoes `preserved_char_overrides` — so the agent can see its apply was a no-op and retry |
| Agent can't tell a block quote from body text | whole-paragraph overrides dropped on read | the FODT sidecar we already export lists each autostyle's **own** properties, i.e. exactly what was hand-set. Emitted as `data-lo-para`, so the agent can classify a paragraph before styling it. Same export, no extra `storeToURL`. Sending it back reports that it was ignored, rather than silently doing nothing |
| `page_set_header_footer_text` deletes the letterhead, reports `ok` | it is `setString()` over the whole region | the region is scanned first; if it holds an image or a field the call is refused and points at `apply_document_content(target='search')`, which edits in place and keeps them. `force=true` still overwrites and lists what it deleted |
| First-page letterhead unreachable | only `HeaderText` was exposed | the `_first` / `_left` region names map to the separate UNO text objects (`HeaderTextFirst`, …) that actually hold that content, and `first_is_shared` lets it be turned on in the first place |
| Deleting a page-number field is blind | `fields_list` never said which region | each field is labelled with the region it lives in, reusing the labeller the search path already had. `fields_delete` also reports what it removed and from where |
| A range read hands back a flattened slice | `_range_to_content_via_temp_doc` copied plain text plus the paragraph style name, so every override was gone before the export | the copy now carries the paragraph's direct `Para*` and paints each portion's direct `Char*`, skipping whatever the style already provides. A slice that crosses a bold run reads back with the bold in place. It also stopped taking the paragraph text from `get_string_without_tracked_deletions`, which enumerates a paragraph's *portions* as if they were paragraphs and joins them with `\n` — spurious `<br/>` in the output, and offsets that no longer matched the portions |
| Page-style names undiscoverable | `PageStyles` hidden from `style_list` | the family is listed and enumerable, so the name every page tool takes can be read instead of guessed; `style_get_info` redirects page styles to `page_get_style_properties` |

The manual also said the edit reach was "body, table cells, text frames" — headers and footers were always reachable via `target='search'`, so the agent skipped the safe path for the destructive one.

**Compatibility:** the new behaviour is opt-in — `clear_direct` only acts when a caller passes it, so `apply_style` is unchanged otherwise. Reads gain fields and the `data-lo-para` attribute, which are additive. The one call that can now fail where it used to succeed is `page_set_header_footer_text`, and only when it would delete an image or a field; `force=true` restores the old behaviour.

**Not covered:** `data-lo-para` can be read but not written back — setting an indent still needs a named style.


