### PR TITLE
Fix paragraph tracked-deletion reads injecting newlines between portions

### DIFF
--- a/docs/framework/uno-utilities.md
+++ b/docs/framework/uno-utilities.md
@@ -77,7 +77,7 @@ LibrePy Run Python Script, text analytics, Excel auto-open, and Writer selection
 | Symbol | Purpose |
 |--------|---------|
 | `normalize_linebreaks` | `\r\n` / `\r` → `\n` so offsets match (Windows UNO/clipboard). |
-| `get_string_without_tracked_deletions` | Skip redline Delete portions when reading a text range. |
+| `get_string_without_tracked_deletions` | Skip redline Delete portions. A paragraph concatenates visible portions without a mid-`\n`; a document or multi-para range still joins with `\n`. Shares `_visible_portions` with html_export paint (paint aborts on portion-enum failure to avoid offset drift; the helper continues). |
 | `normalize_file_url` | Repair `file:/path` → `file:///path` (legacy `urljoin`). Shared with research. |
 | `get_document_path` | `file:` URL → repair then `uno.fileUrlToSystemPath`; `None` if untitled / non-file. |
 | `get_selection_range` | Writer `(start, end)` character offsets (cursor = equal ends). |

--- a/plugin/doc/text_helpers.py
+++ b/plugin/doc/text_helpers.py
@@ -15,7 +15,6 @@ load ``document_helpers`` → chat context / ``DocumentService``.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
 from typing import TypedDict
 
 import uno
@@ -194,7 +193,7 @@ def _visible_portions(
     *,
     abort_on_portion_error: bool = False,
     limit: int | None = None,
-) -> Iterator[tuple[object, str]]:
+):
     """Yield ``(portion, text)`` for visible text, skipping tracked deletions.
 
     Shared by ``get_string_without_tracked_deletions`` and html_export paint so

--- a/plugin/doc/text_helpers.py
+++ b/plugin/doc/text_helpers.py
@@ -15,6 +15,7 @@ load ``document_helpers`` → chat context / ``DocumentService``.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from typing import TypedDict
 
 import uno
@@ -22,6 +23,8 @@ import uno
 from plugin.doc import doc_type as _doc_type
 from plugin.framework.errors import UnoObjectError, check_disposed, safe_call
 from plugin.framework.thread_guard import main_thread_only
+
+_PARAGRAPH_SERVICE = "com.sun.star.text.Paragraph"
 
 
 def normalize_linebreaks(text: str | None) -> str:
@@ -155,12 +158,124 @@ class HeadingTreeNode(TypedDict):
     body_paragraphs: int
 
 
+def _portion_type(portion) -> str | None:
+    try:
+        return portion.getPropertyValue("TextPortionType")
+    except Exception:
+        try:
+            return portion.TextPortionType
+        except Exception:
+            return None
+
+
+def _range_is_paragraph(text_range) -> bool:
+    """True when *text_range* is a paragraph: children are portions, not paragraphs.
+
+    ``createEnumeration()`` on a document or multi-para cursor yields paragraphs.
+    On a paragraph ``XTextRange`` it yields text portions (bold runs, redlines).
+    Treating those portions as paragraphs used to inject a ``\\n`` between runs.
+    """
+    try:
+        if text_range.supportsService(_PARAGRAPH_SERVICE):
+            return True
+    except Exception:
+        pass
+    try:
+        enum = text_range.createEnumeration()
+        if not enum.hasMoreElements():
+            return False
+        return _portion_type(enum.nextElement()) is not None
+    except Exception:
+        return False
+
+
+def _visible_portions(
+    para,
+    *,
+    abort_on_portion_error: bool = False,
+    limit: int | None = None,
+) -> Iterator[tuple[object, str]]:
+    """Yield ``(portion, text)`` for visible text, skipping tracked deletions.
+
+    Shared by ``get_string_without_tracked_deletions`` and html_export paint so
+    an offset taken from the helper string indexes these chunks without drift.
+
+    Paint (``html_export._paint_direct_formatting``) passes
+    ``abort_on_portion_error=True``: a failed ``nextElement`` / portion type
+    would desync character offsets, so the walk stops. The helper continues
+    past a bad portion so later runs can still contribute text.
+    """
+    try:
+        portion_enum = para.createEnumeration()
+    except Exception:
+        return
+    in_delete = False
+    seen = 0
+    while portion_enum.hasMoreElements():
+        if limit is not None and seen >= limit:
+            return
+        seen += 1
+        try:
+            portion = portion_enum.nextElement()
+        except Exception:
+            if abort_on_portion_error:
+                return
+            continue
+        portion_type = _portion_type(portion)
+        if portion_type is None:
+            if abort_on_portion_error:
+                return
+            continue
+        if portion_type == "Redline":
+            try:
+                if str(portion.getPropertyValue("RedlineType")) == "Delete":
+                    in_delete = not in_delete
+            except Exception:
+                pass
+            continue
+        if in_delete:
+            continue
+        try:
+            chunk = portion.getString()
+        except Exception:
+            continue
+        if chunk:
+            yield portion, chunk
+
+
+def _paragraph_visible_text(para) -> str:
+    """Visible text of one paragraph via ``_visible_portions``.
+
+    Falls back to ``getString()`` only when the portion enum cannot be opened
+    (same as the old helper). An empty walk after a successful enum is kept
+    empty so tracked-only paragraphs do not re-include deleted text.
+    """
+    chunks = list(_visible_portions(para))
+    if chunks:
+        return "".join(chunk for _unused, chunk in chunks)
+    try:
+        para.createEnumeration()
+    except Exception:
+        try:
+            return para.getString()
+        except Exception:
+            return ""
+    return ""
+
+
 @main_thread_only
 def get_string_without_tracked_deletions(text_range) -> str:
-    """Return text_range text while skipping tracked deletions when possible."""
+    """Return *text_range* text while skipping tracked deletions when possible.
+
+    A paragraph (``com.sun.star.text.Paragraph``, or first child has
+    ``TextPortionType``) concatenates visible portions without a mid-``\\n``.
+    A document or multi-paragraph range still joins paragraphs with ``\\n``.
+    """
     if hasattr(text_range, "_mock_return_value") or type(text_range).__name__ in ("Mock", "MagicMock"):
         return text_range.getString()
     try:
+        if _range_is_paragraph(text_range):
+            return _paragraph_visible_text(text_range)
         para_enum = text_range.createEnumeration()
     except Exception:
         return text_range.getString()
@@ -173,43 +288,10 @@ def get_string_without_tracked_deletions(text_range) -> str:
             if not first_para:
                 parts.append("\n")
             first_para = False
-
-            try:
-                portion_enum = para.createEnumeration()
-            except Exception:
-                parts.append(para.getString())
-                continue
-
             # Each paragraph's portion enum is independent; Delete start/end
-            # markers for this walk live in that para. Reset here matches UNO.
-            in_delete = False
-            while portion_enum.hasMoreElements():
-                portion = portion_enum.nextElement()
-                try:
-                    try:
-                        portion_type = portion.getPropertyValue("TextPortionType")
-                    except Exception:
-                        portion_type = portion.TextPortionType
-                except Exception:
-                    continue
-
-                if portion_type == "Redline":
-                    try:
-                        if str(portion.getPropertyValue("RedlineType")) == "Delete":
-                            in_delete = not in_delete
-                    except Exception:
-                        pass
-                    continue
-
-                if in_delete:
-                    continue
-
-                try:
-                    chunk = portion.getString()
-                except Exception:
-                    continue
-                if chunk:
-                    parts.append(chunk)
+            # markers for this walk live in that para. Reset is inside
+            # _visible_portions (same as UNO per-paragraph redline markers).
+            parts.append(_paragraph_visible_text(para))
     except Exception:
         return text_range.getString()
 

--- a/plugin/writer/html_export.py
+++ b/plugin/writer/html_export.py
@@ -12,7 +12,10 @@ import logging
 import re
 import time
 
-from plugin.doc.text_helpers import get_string_without_tracked_deletions
+from plugin.doc.text_helpers import (
+    get_string_without_tracked_deletions,
+    _visible_portions as _shared_visible_portions,
+)
 from plugin.framework.uno_context import get_desktop
 from . import xhtml_style_postprocess as xhtml_post
 from . import format as format_mod
@@ -155,40 +158,15 @@ def _source_style(model, style_name, cache):
 
 
 def _visible_portions(para):
-    """Yield ``(portion, text)`` for a paragraph's visible text, skipping tracked deletions.
+    """Visible portions for offset paint. Same walk as the text helper.
 
-    Mirrors the walk in ``get_string_without_tracked_deletions`` exactly — same Redline/Delete
-    toggle, same skips — so an offset taken from that string indexes into these chunks without
-    drift. Any divergence here would paint one run's formatting onto another's characters.
+    Aborts on portion enum / type failure so later runs are not painted at a
+    drifted offset. ``get_string_without_tracked_deletions`` continues past a
+    bad portion instead — that is the only intentional divergence.
     """
-    try:
-        portion_enum = para.createEnumeration()
-    except Exception:
-        return
-    in_delete = False
-    seen = 0
-    while portion_enum.hasMoreElements() is True and seen < _COPY_PORTION_LIMIT:
-        seen += 1
-        try:
-            portion = portion_enum.nextElement()
-            portion_type = portion.getPropertyValue("TextPortionType")
-        except Exception:
-            return
-        if portion_type == "Redline":
-            try:
-                if str(portion.getPropertyValue("RedlineType")) == "Delete":
-                    in_delete = not in_delete
-            except Exception:
-                pass
-            continue
-        if in_delete:
-            continue
-        try:
-            chunk = portion.getString()
-        except Exception:
-            continue
-        if chunk:
-            yield portion, chunk
+    yield from _shared_visible_portions(
+        para, abort_on_portion_error=True, limit=_COPY_PORTION_LIMIT
+    )
 
 
 def _paint_direct_formatting(para, portions, temp_text, trim_start, trim_end, style=None):
@@ -256,11 +234,9 @@ def _range_to_content_via_temp_doc(model, ctx, start, end, max_chars, config_svc
                 style = el.getPropertyValue("ParaStyleName")
             except Exception:
                 style = ""
-            # Built from the portion walk rather than get_string_without_tracked_deletions: that
-            # helper enumerates a paragraph's PORTIONS as if they were paragraphs and joins them
-            # with "\n", so a bold run mid-sentence used to come back as "text\nbold\ntext" —
-            # spurious <br/> in the output, and offsets that no longer match the portions the
-            # formatting has to be painted onto.
+            # Same _visible_portions walk as get_string_without_tracked_deletions so
+            # paint offsets match the helper string. Still walk here (not just the
+            # helper) because we need the portion objects to copy Char* properties.
             portions = list(_visible_portions(el))
             para_text = "".join(chunk for _unused, chunk in portions)
             style = style or ""

--- a/tests/doc/test_text_helpers.py
+++ b/tests/doc/test_text_helpers.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from plugin.doc.text_helpers import (
+    _visible_portions,
     get_document_path,
     get_full_writer_text,
     get_string_without_tracked_deletions,
@@ -127,6 +128,63 @@ def test_get_string_without_tracked_deletions_skips_deleted_portions():
     )
 
     assert get_string_without_tracked_deletions(text_range) == "Keep text\nNext line"
+
+
+class _ParagraphService(_Paragraph):
+    def supportsService(self, name):
+        return name == "com.sun.star.text.Paragraph"
+
+
+def test_get_string_without_tracked_deletions_paragraph_no_mid_newline():
+    """A paragraph's children are portions (e.g. a bold run), not paragraphs."""
+    para = _Paragraph(
+        [
+            _Portion("Paragraph "),
+            _Portion("with n"),
+            _Portion("ormal and bold text"),
+        ],
+        fallback_text="Paragraph with normal and bold text",
+    )
+
+    got = get_string_without_tracked_deletions(para)
+    assert got == "Paragraph with normal and bold text"
+    assert "\n" not in got
+    assert got == "".join(chunk for _unused, chunk in _visible_portions(para))
+
+
+def test_get_string_without_tracked_deletions_paragraph_service():
+    para = _ParagraphService(
+        [_Portion("Hello "), _Portion("bold")],
+        fallback_text="Hello bold",
+    )
+    assert get_string_without_tracked_deletions(para) == "Hello bold"
+
+
+def test_visible_portions_helper_continues_paint_aborts():
+    """Paint stops on a bad portion (offset drift); the helper continues."""
+
+    class _BoomEnum:
+        def __init__(self, items):
+            self._items = list(items)
+            self._idx = 0
+
+        def hasMoreElements(self):
+            return self._idx < len(self._items)
+
+        def nextElement(self):
+            item = self._items[self._idx]
+            self._idx += 1
+            if item == "boom":
+                raise RuntimeError("portion gone")
+            return item
+
+    class _BoomPara:
+        def createEnumeration(self):
+            return _BoomEnum(["boom", _Portion("later")])
+
+    para = _BoomPara()
+    assert list(_visible_portions(para, abort_on_portion_error=True)) == []
+    assert "".join(chunk for _unused, chunk in _visible_portions(para)) == "later"
 
 
 def test_get_full_writer_text_truncates_and_reads_prefix():

--- a/tests/doc/test_text_helpers_uno.py
+++ b/tests/doc/test_text_helpers_uno.py
@@ -1,0 +1,66 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""UNO tests for get_string_without_tracked_deletions paragraph vs multi-para walks."""
+
+from plugin.doc.text_helpers import _visible_portions, get_string_without_tracked_deletions
+from plugin.testing_runner import native_test
+from plugin.tests.testing_utils import TestingFactory
+from plugin.writer.html_export import _visible_portions as html_visible_portions
+
+
+# com.sun.star.text.ControlCharacter.PARAGRAPH_BREAK
+_PARAGRAPH_BREAK = 0
+_BOLD = 150.0
+
+
+def _first_paragraph(doc):
+    return doc.getText().createEnumeration().nextElement()
+
+
+@native_test
+def test_get_string_without_tracked_deletions_paragraph_bold_run_no_newline(ctx):
+    """A paragraph with a bold run must stay one line (portions are not paragraphs)."""
+    with TestingFactory.native_doc(ctx, "writer") as doc:
+        text = doc.getText()
+        cursor = text.createTextCursor()
+        text.insertString(cursor, "Paragraph with normal and bold text", False)
+        cursor.gotoStart(False)
+        cursor.goRight(len("Paragraph with "), False)
+        cursor.goRight(len("normal and bold"), True)
+        cursor.setPropertyValue("CharWeight", _BOLD)
+
+        para = _first_paragraph(doc)
+        assert para.supportsService("com.sun.star.text.Paragraph")
+        visible = para.getString()
+        got = get_string_without_tracked_deletions(para)
+        assert got == visible
+        assert "\n" not in got
+        assert got == "".join(chunk for _unused, chunk in _visible_portions(para))
+        assert got == "".join(chunk for _unused, chunk in html_visible_portions(para))
+
+        # A cursor covering that single paragraph is document-mode (one child)
+        # and must still match the visible string.
+        full = text.createTextCursor()
+        full.gotoStart(False)
+        full.gotoEnd(True)
+        assert get_string_without_tracked_deletions(full) == visible
+
+
+@native_test
+def test_get_string_without_tracked_deletions_multi_para_joins_with_newline(ctx):
+    with TestingFactory.native_doc(ctx, "writer") as doc:
+        text = doc.getText()
+        cursor = text.createTextCursor()
+        text.insertString(cursor, "First para", False)
+        text.insertControlCharacter(cursor, _PARAGRAPH_BREAK, False)
+        text.insertString(cursor, "Second para", False)
+
+        expected = "First para\nSecond para"
+        assert get_string_without_tracked_deletions(text) == expected
+
+        full = text.createTextCursor()
+        full.gotoStart(False)
+        full.gotoEnd(True)
+        assert get_string_without_tracked_deletions(full) == expected

--- a/tests/writer/test_format.py
+++ b/tests/writer/test_format.py
@@ -463,7 +463,7 @@ def _para_of(portions):
 
 
 def test_visible_portions_skips_tracked_deletions():
-    """Must match get_string_without_tracked_deletions exactly — a divergence would paint one
+    """Shared walk with get_string_without_tracked_deletions — a divergence would paint one
     run's formatting onto another run's characters."""
     from plugin.writer import html_export as hx
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`get_string_without_tracked_deletions` treated every `createEnumeration()` child as a paragraph and joined with `\n`. On a paragraph `XTextRange`, those children are text portions, so a bold run became `'Paragraph \nwith n\normal and bold text\n'`.

**Change**
- Detect a paragraph via `com.sun.star.text.Paragraph` or a first child with `TextPortionType`.
- Portion mode concatenates visible text with no mid-`\n` (same Redline/Delete skip rules).
- Document / multi-para mode still joins paragraphs with `\n`.
- Move `_visible_portions` next to the helper and reuse it from `html_export` paint. Paint still **aborts** on portion-enum failure (offset drift); the helper **continues**. No new public tool API.

**Tests**
- Unit: paragraph portions stay one line; paint abort vs helper continue (`39 passed`).
- UNO: bold run on one paragraph equals visible `getString()`; multi-para still uses `\n`; html_export walk matches the helper (`2 passed`).
- `make typecheck` green.

Base: `master`. No issue close.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f0b88d1-55ca-4f12-805f-bfedbd1fa9d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f0b88d1-55ca-4f12-805f-bfedbd1fa9d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

