### PR TITLE
Default apply_style to style_props so house font wins on first apply

### DIFF
--- a/docs/writer/html-style-model-plan.md
+++ b/docs/writer/html-style-model-plan.md
@@ -254,11 +254,14 @@ reads back with the bold in place.
 `data-lo-para` is **read-only**: the write path still cannot restore `Para*` when applying a named
 style, which is why it is not emitted as `style=""` — that would round-trip back and be swallowed.
 To make a style win over hand-set values, `apply_style` takes `clear_direct`
-(`none` | `style_props` | `all`), which resets the style-governed `Char*` and the paragraph
-properties to default so the style shows. It is refused on `target='full_document'`: clearing the
-whole document erases the very formatting that distinguishes body text from quotes and headings.
-With `clear_direct='none'` the result echoes `preserved_char_overrides` — the overrides that kept
-the style invisible — so a no-op apply is no longer indistinguishable from a successful one.
+(`none` | `style_props` | `all`). **Default is `style_props`**: house font name + size win
+(via `STYLE_GOVERNED_CHAR_PROPERTIES` + `_reset_properties_to_default`), bold/italic/colour stay,
+and `CLEARABLE_PARA_PROPERTIES` (indents/alignment) are cleared so the style shows. `none` is an
+explicit opt-in that keeps a hand-set font (historical “masking Times” behaviour). `all` is
+Ctrl+M-ish and is refused on `target='full_document'` (that would flatten emphasis across the
+whole document). With `clear_direct='none'` the result still echoes `preserved_char_overrides`.
+**Re-applying a style does not keep a quote indent** — LibreOffice drops direct `Para*`
+(margins/alignment) when `ParaStyleName` is set, even on `none`.
 
 ## v1 limitations (shipped)
 
@@ -266,7 +269,7 @@ These are intentional trade-offs in v1. Tests document the behavior ([`test_xhtm
 
 | Limitation | v1 behavior | Workaround for agents/users | Post-v1 direction |
 |------------|-------------|----------------------------|-------------------|
-| **Whole-paragraph direct overrides** (center, para colour, margins, whole-paragraph font) | Do not round-trip on **write**. Read REPORTS them as read-only `data-lo-para`, taken from the FODT automatic style (see [Direct formatting on read](#direct-formatting-on-read)) | Read `data-lo-para` to tell an indented quote from body text; apply a named style per range with `apply_style(clear_direct='style_props')` so the style wins over the hand-set values | Make `data-lo-para` writable |
+| **Whole-paragraph direct overrides** (center, para colour, margins, whole-paragraph font) | Do not round-trip on **write**. Read REPORTS them as read-only `data-lo-para`, taken from the FODT automatic style (see [Direct formatting on read](#direct-formatting-on-read)) | Read `data-lo-para` to tell an indented quote from body text; `apply_style` defaults to `clear_direct='style_props'` so the house font/size and style indents show (bold/italic stay). Pass `clear_direct='none'` only to keep a hand-set font. Re-applying a style does **not** keep a quote indent — LO drops direct `Para*` | Make `data-lo-para` writable |
 | **Table cell paragraph styles** | `paragraph-*` stripped inside `<table>`; no `data-lo-style` on cell blocks | `apply_style` on cell text; don't rely on agent HTML for table styling | Table-aware style index or cell-level tokens |
 | **Partial edits** (`end` / `search` / `selection` / `beginning`) | Content inserted; `data-lo-style` **not** applied (would restyle merged adjacent text) | `target='full_document'` for styled rewrites; `apply_style` to restyle existing text | Apply only to genuinely new paragraphs after import |
 | **Dual export cost** | Every full read (and range read via temp doc) runs XHTML + FODT `storeToURL` | `scope=range`, `get_document_tree`, `search_in_document` before full reads | Cached UNO paragraph-style index; drop FODT on `scope=full` |

--- a/docs/writer/llm-styles.md
+++ b/docs/writer/llm-styles.md
@@ -55,7 +55,7 @@ Full design notes: [html-style-model-plan.md](html-style-model-plan.md#v1-limita
 
 | Situation | What v1 does | What to do instead |
 |-----------|--------------|-------------------|
-| Whole-paragraph alignment, colour, or margins (not a named style) | Not preserved on read; only the **base style name** may be recovered after an edit | Use a named paragraph style; use inline `style` on **spans** for character-level exceptions |
+| Whole-paragraph alignment, colour, or margins (not a named style) | Not preserved on write; read reports them as read-only `data-lo-para`. Re-applying a style does **not** keep a quote indent (LibreOffice drops direct `Para*`) | Use a named paragraph style (`apply_style` defaults to house font/size winning; pass `clear_direct='none'` only to keep a hand-set font); use inline `style` on **spans** for character-level exceptions |
 | Styling content you insert at `end` / `search` / `selection` | `data-lo-style` is **not** applied (would restyle text already in the document) | Use `target='full_document'` for styled rewrites, or `apply_style` on existing text |
 | Table cell paragraph styles | Not exposed in agent HTML | Use `apply_style` on the cell text |
 | Large documents | Every full read exports twice (XHTML + flat ODF) | Prefer `scope=range`, `get_document_tree`, and `search_in_document` before `scope=full` |

--- a/docs/writer/pr634-first-principles-analysis.md
+++ b/docs/writer/pr634-first-principles-analysis.md
@@ -4,6 +4,8 @@
 **Inputs:** `/workspace/pr634-followups/initial-plan.md`, merged PR [#634](https://github.com/KeithCu/writeragent/pull/634) on `master`  
 **Scope:** Research only — no product PR. Goal: proper fixes that stay **simple, robust, and easy for models**.
 
+> **Later product decision:** `apply_style` now defaults to `clear_direct='style_props'` (house font/size win, bold/italic/colour stay). `none` is an explicit opt-in. The same-style-only special case discussed in §2.7 was **not** implemented. Treat sections below that say “default is `none`” as historical.
+
 Symbols and paths below are current `master` unless noted.
 
 ---

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -299,8 +299,8 @@ WRITER_APPLY_DOCUMENT_HTML_RULES = f"""APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL
   data-lo-style applies only on target='full_document' — on 'beginning'/'end'/'selection'/'search' it is ignored because it would restyle adjacent text (use apply_style or a full_document rewrite).
   v1: whole-paragraph alignment/colour/margins and table-cell styles do not round-trip on write.
 - Hand-set formatting: `data-lo-para` (e.g. `data-lo-para="margin-left:3.25cm; font-size:12pt"`) reports what a paragraph has set directly. READ-ONLY — send it back and the result says it was ignored; it is how you tell a block quote from body text in a document formatted by hand. Reported on both scope='full' and scope='range'.
-  Direct formatting OVERRIDES styles, so there apply_style/style_update alone change nothing on screen; apply_style then echoes `preserved_char_overrides`.
-  Re-apply that range with clear_direct='style_props' to let the style's font, size and indent show (bold/italic survive). One range at a time — it is refused on target='full_document', which would erase the very formatting that tells the paragraphs apart.
+  apply_style defaults to clear_direct='style_props': the style's font name/size and paragraph indents show; bold/italic/colour stay. Pass clear_direct='none' only to keep a hand-set font. clear_direct='all' is Ctrl+M (refused on target='full_document').
+  Re-applying a style does not keep a quote indent — LibreOffice drops direct Para* (margins/alignment) when ParaStyleName is set.
 
 EXAMPLES:
 - Good: ["<h1>Title</h1>", "<p>Paragraph with <strong>bold</strong> text and \\"quotes\\".</p>"]

--- a/plugin/writer/content.py
+++ b/plugin/writer/content.py
@@ -170,8 +170,8 @@ def _note_read_only_attrs(result, content):
     result["ignored_attributes"] = [_READ_ONLY_ATTR]
     result["message"] = (result.get("message") or "") + (
         " Note: %s in the content was ignored — it is a read-only report of a paragraph's hand-set"
-        " formatting. To change an indent or a font, apply a named style (apply_style, with"
-        " clear_direct when the paragraph is formatted by hand)." % _READ_ONLY_ATTR)
+        " formatting. To change an indent or a font, apply a named style (apply_style;"
+        " default clear_direct lets the style's font and size show)." % _READ_ONLY_ATTR)
     return result
 
 

--- a/plugin/writer/format.py
+++ b/plugin/writer/format.py
@@ -209,10 +209,15 @@ def _strip_html_boilerplate(html_string):  # pyright: ignore[reportUnusedFunctio
 #   plugin/writer/format.py   — replace_single_range_with_content style restore (~595)
 #   plugin/notebook/writer_importer.py — resolved paragraph style on import (~621)
 #   plugin/notebook/notebook_runner.py — output cell paragraph style (~177)
-# Char properties a paragraph style is expected to govern. With clear_direct="style_props" these
-# are the ONLY captured overrides not restored after the style is applied, so the style's font and
-# size finally show while hand-set bold/italic/colour survive. See CLEARABLE_PARA_PROPERTIES for
-# the paragraph half (indents/alignment), which setting ParaStyleName does NOT reset on its own.
+# Char properties a paragraph style is expected to govern. apply_style defaults to
+# clear_direct="style_props": these are the ONLY captured overrides not restored after the style
+# is applied, so the house font and size show while hand-set bold/italic/colour survive.
+# See CLEARABLE_PARA_PROPERTIES for the paragraph half (indents/alignment).
+#
+# Future idea — not now: clear whatever the *target style* actually defines (PropertyState /
+# inheritance), instead of this fixed list. Hard because a Normal weight or an inherited default
+# looks the same as "the style does not set this", so it is easy to wipe emphasis the style
+# never claimed.
 STYLE_GOVERNED_CHAR_PROPERTIES = (
     "CharFontName", "CharFontNameAsian", "CharFontNameComplex",
     "CharHeight", "CharHeightAsian", "CharHeightComplex",
@@ -277,21 +282,23 @@ def apply_paragraph_style_preserving_direct_char(doc, cursor, style_name, clear_
 
     Setting ParaStyleName to a DIFFERENT style resets hand-set Char* properties to that style's
     defaults — across the WHOLE paragraph, even for a sub-range cursor — which is what the capture
-    below exists to undo. Re-applying the style a paragraph already has does not reset them (it
-    does still drop the paragraph's direct Para*), so clearing an override is never a side effect
-    to rely on; see _reset_properties_to_default.
+    below exists to undo. Re-applying the style a paragraph already has does not reset Char*
+    (LibreOffice 26.2). It *does* drop the paragraph's direct Para* (margins, alignment, first-line
+    indent) — so re-applying Standard does not keep a hand-set quote indent. Clearing a Char*
+    override is never a side effect to rely on; see _reset_properties_to_default.
     ``getPropertyState`` is unreliable at the text-portion level, so overrides are
     detected by VALUE (Char* differs from the paragraph's current style default).
 
-    *clear_direct* decides what happens to those captured overrides:
-      ``"none"`` (default) restores all of them — the historical behaviour, which keeps a
-      document's hand-set font but also means an updated style is invisible on screen;
+    *clear_direct* decides what happens to those captured overrides. The helper default is
+    ``"none"`` so HTML import / style-restore callers keep inline fonts; ``apply_style``
+    defaults to ``"style_props"`` so a house-font update is visible without a retry:
       ``"style_props"`` restores everything except STYLE_GOVERNED_CHAR_PROPERTIES and clears
-      CLEARABLE_PARA_PROPERTIES, so font/size/indent obey the style and bold/italic survive;
+      CLEARABLE_PARA_PROPERTIES, so font/size/indent obey the style and bold/italic/colour survive;
+      ``"none"`` restores all captured Char* — keeps a hand-set font (the style can look like a
+      no-op). Does not restore Para*; LibreOffice already dropped those when ParaStyleName was set;
       ``"all"`` restores nothing and clears the paragraph properties too (Ctrl+M semantics).
 
-    Returns a report dict so callers can tell the agent what actually happened — a style apply
-    that silently kept the old font used to be indistinguishable from success.
+    Returns a report dict so callers can tell the agent what actually happened.
 
     KNOWN LIMITATION: a direct override whose value equals the old style default is not
     captured; applying a style with a different default can change that property visibly.

--- a/plugin/writer/styles.py
+++ b/plugin/writer/styles.py
@@ -279,8 +279,10 @@ class ApplyStyle(FrameworkToolBase):
         "with family='CharacterStyles' to remove a character style. "
         "Use target='selection' (default), 'beginning', 'end', 'full_document', "
         "or 'search' with old_content. "
-        "If the result reports preserved_char_overrides, the target had hand-set formatting that "
-        "overrides the style and nothing changed on screen — re-apply with clear_direct='style_props'."
+        "Paragraph styles default to clear_direct='style_props': the style's font name and size "
+        "show (house font wins) and paragraph indents/alignment follow the style; bold, italic "
+        "and colour stay. Pass clear_direct='none' only to keep a hand-set font. "
+        "Re-applying a style does not keep a quote indent — LibreOffice drops direct Para*."
     )
     parameters = {
         "type": "object",
@@ -291,14 +293,16 @@ class ApplyStyle(FrameworkToolBase):
             "old_content": {"type": "string", "description": "Text to find and apply style to if target = 'search'."},
             "all_matches": {"type": "boolean", "description": "For target='search': apply to EVERY occurrence of old_content (default false = first only)."},
             "occurrence": {"type": "integer", "description": "For target='search': apply to this single 0-based occurrence instead of the first."},
-            "clear_direct": {"type": "string", "enum": ["none", "style_props", "all"], "description": (
+            "clear_direct": {"type": "string", "enum": ["none", "style_props", "all"], "default": "style_props", "description": (
                 "What to do with direct (hand-set) formatting on the target, ParagraphStyles only. "
-                "'none' (default) keeps it — but direct formatting OVERRIDES the style, so on a document "
-                "formatted by hand the style will have no visible effect. 'style_props' drops the font "
-                "name/size override and the paragraph indents/alignment so the style's own values show, "
-                "keeping bold/italic/colour. 'all' drops every direct override (Ctrl+M). "
-                "Not allowed with target='full_document' — clearing the whole document flattens the "
-                "formatting that tells one kind of paragraph from another; style each range instead.")},
+                "'style_props' (default) drops the font name/size override and the paragraph "
+                "indents/alignment so the style's own values show, keeping bold/italic/colour. "
+                "The name means 'let the style's properties win' for the font/size/indent the "
+                "style governs — not 'clear only what this style defines'. "
+                "'none' keeps a hand-set font (historical; the style can look unchanged). "
+                "'all' drops every direct override (Ctrl+M). "
+                "'all' is not allowed with target='full_document' — that would flatten emphasis "
+                "across the whole document; style each range instead.")},
         },
         "required": ["style"],
     }
@@ -308,7 +312,7 @@ class ApplyStyle(FrameworkToolBase):
     # Maps family to the UNO property that holds the style name.
     _PROPERTY_MAP = {"ParagraphStyles": "ParaStyleName", "CharacterStyles": "CharStyleName"}
 
-    def _apply_one(self, ctx, family, uno_prop, uno_value, cursor, clear_direct="none"):
+    def _apply_one(self, ctx, family, uno_prop, uno_value, cursor, clear_direct="style_props"):
         """Apply the style to one cursor. Returns the direct-formatting report (or None)."""
         if family == "ParagraphStyles":
             return apply_paragraph_style_preserving_direct_char(ctx.doc, cursor, uno_value, clear_direct)
@@ -330,13 +334,19 @@ class ApplyStyle(FrameworkToolBase):
             for key in ("cleared_char_properties", "cleared_paragraph_properties"):
                 if rep.get(key):
                     out[key] = rep[key]  # same list for every range; last one wins
-        if out.get("preserved_char_overrides"):
-            # The whole point of the echo: a style apply that changed nothing visible used to be
-            # indistinguishable from one that worked.
-            out["hint"] = ("Direct formatting on the target overrides this style, so the document "
-                           "may look unchanged. Re-apply with clear_direct='style_props' to let the "
-                           "style's font, size and indents show.")
+        # No retry hint: default is already style_props (house font shows). preserved_char_overrides
+        # is only set on the explicit none path, which the caller asked for.
         return out
+
+    @staticmethod
+    def _resolve_clear_direct(family, raw):
+        """Paragraph styles default to style_props so the house font shows without a retry.
+
+        Character styles ignore the flag (it is not implemented for them); omitted there is none.
+        """
+        if raw is None or (isinstance(raw, str) and not str(raw).strip()):
+            return "style_props" if family == "ParagraphStyles" else "none"
+        return str(raw).strip()
 
     def execute(self, ctx, **kwargs):
         style_name = str(kwargs.get("style") or "").strip()
@@ -377,20 +387,20 @@ class ApplyStyle(FrameworkToolBase):
         target = kwargs.get("target", "selection")
         old_content = kwargs.get("old_content")
 
-        clear_direct = str(kwargs.get("clear_direct") or "none").strip()
+        clear_direct = self._resolve_clear_direct(family, kwargs.get("clear_direct"))
         if clear_direct not in ("none", "style_props", "all"):
             return self._tool_error("clear_direct must be one of: none, style_props, all.")
         if clear_direct != "none":
             if family != "ParagraphStyles":
                 return self._tool_error("clear_direct only applies to family='ParagraphStyles'.")
-            if target == "full_document":
-                # Clearing the whole document erases the direct formatting that distinguishes a
-                # block quote from body text — and the caller needs that distinction to pick which
-                # style each range gets. Force the per-range path instead.
+            if clear_direct == "all" and target == "full_document":
+                # Ctrl+M on the whole document wipes emphasis as well as fonts — force the
+                # per-range path. style_props (the default) is allowed: house font/size win
+                # and bold/italic/colour stay.
                 return self._tool_error(
-                    "clear_direct is not allowed with target='full_document': it would flatten the "
-                    "whole document, including the formatting that tells body text from quotes and "
-                    "headings. Style each range separately (target='search') instead.")
+                    "clear_direct='all' is not allowed with target='full_document': it would "
+                    "flatten emphasis across the whole document. Style each range separately "
+                    "(target='search') instead, or omit clear_direct to use style_props.")
 
         # Multi-occurrence styling (target='search' only). resolve_target_cursor styles only the
         # first match; all_matches / occurrence let a defined term or repeated quote lead be

--- a/tests/writer/test_apply_style_preserve_inline_uno.py
+++ b/tests/writer/test_apply_style_preserve_inline_uno.py
@@ -7,14 +7,18 @@
 # (at your option) any later version.
 #
 # Regression test: applying a paragraph style via apply_style must not wipe DIRECT
-# character formatting (color/bold/highlight) already set on the target text. The fix
-# captures the direct char overrides (values that differ from the old style's defaults)
-# and restores them after setting ParaStyleName.
+# character emphasis (color/bold/highlight) already set on the target text. Default
+# clear_direct is style_props: house font/size win, bold/italic/colour stay. The
+# helper captures Char* that differ from the old style default and restores
+# everything except STYLE_GOVERNED_CHAR_PROPERTIES (font name/size).
 import uno  # noqa: F401
 
 from plugin.testing_runner import native_test
-from plugin.writer.styles import ApplyStyle
+from plugin.writer.styles import ApplyStyle, StyleUpdate
 from plugin.tests.testing_utils import TestingFactory, with_native_doc
+
+_HOUSE_FONT = "Liberation Sans"
+_DIRECT_FONT = "Times New Roman"
 
 
 @native_test
@@ -216,6 +220,114 @@ def test_apply_paragraph_style_multi_paragraph_selection_uno(ctx, doc):
     p2.goRight(len("First paragraph here.") + 1 + 6, True)
     assert int(p2.getPropertyValue("CharColor")) == 0xFF0000, \
         "direct COLOR lost in second paragraph"
+
+
+@native_test
+@with_native_doc("writer")
+def test_apply_style_default_shows_house_font_keeps_bold_uno(ctx, doc):
+    """Lawyer path: Times + bold → update Standard house font → apply Standard with
+    no clear_direct arg → house font shows, bold survives. Small models must not
+    need a retry-with-style_props dance."""
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    text.insertString(cur, "Lawyer clause in Times.", False)
+
+    fmt = text.createTextCursorByRange(text.getStart())
+    fmt.gotoEnd(True)
+    fmt.setPropertyValue("CharFontName", _DIRECT_FONT)
+    fmt.setPropertyValue("CharWeight", 150.0)
+    assert fmt.getPropertyValue("CharFontName") == _DIRECT_FONT
+    assert fmt.getPropertyValue("CharWeight") == 150.0
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
+    upd = StyleUpdate().execute(
+        tool_ctx, style="Standard", family="ParagraphStyles",
+        property_updates={"CharFontName": _HOUSE_FONT},
+    )
+    assert upd.get("status") == "ok", upd
+
+    res = ApplyStyle().execute(
+        tool_ctx, style="Standard", family="ParagraphStyles",
+        target="search", old_content="Lawyer clause in Times.",
+    )
+    assert res.get("status") == "ok", f"apply_style failed: {res}"
+    assert "hint" not in res
+    assert res.get("removed_char_overrides", {}).get("CharFontName") == _DIRECT_FONT
+
+    chk = text.createTextCursorByRange(text.getStart())
+    chk.gotoEnd(True)
+    assert chk.getPropertyValue("CharFontName") == _HOUSE_FONT, (
+        "default apply_style left the direct font standing (house font should win): %r"
+        % chk.getPropertyValue("CharFontName"))
+    assert chk.getPropertyValue("CharWeight") == 150.0, (
+        "default apply_style wiped bold; style_props must keep emphasis")
+
+
+@native_test
+@with_native_doc("writer")
+def test_apply_style_explicit_none_keeps_direct_font_uno(ctx, doc):
+    """clear_direct='none' is the opt-in that still masks Times over the house font."""
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    text.insertString(cur, "Keep Times on this clause.", False)
+
+    fmt = text.createTextCursorByRange(text.getStart())
+    fmt.gotoEnd(True)
+    fmt.setPropertyValue("CharFontName", _DIRECT_FONT)
+    fmt.setPropertyValue("CharWeight", 150.0)
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
+    upd = StyleUpdate().execute(
+        tool_ctx, style="Standard", family="ParagraphStyles",
+        property_updates={"CharFontName": _HOUSE_FONT},
+    )
+    assert upd.get("status") == "ok", upd
+
+    res = ApplyStyle().execute(
+        tool_ctx, style="Standard", family="ParagraphStyles",
+        target="search", old_content="Keep Times on this clause.",
+        clear_direct="none",
+    )
+    assert res.get("status") == "ok", f"apply_style failed: {res}"
+    assert "hint" not in res
+    assert res.get("preserved_char_overrides", {}).get("CharFontName") == _DIRECT_FONT
+
+    chk = text.createTextCursorByRange(text.getStart())
+    chk.gotoEnd(True)
+    assert chk.getPropertyValue("CharFontName") == _DIRECT_FONT, (
+        "explicit none must keep the direct font, got %r" % chk.getPropertyValue("CharFontName"))
+    assert chk.getPropertyValue("CharWeight") == 150.0
+
+
+@native_test
+@with_native_doc("writer")
+def test_apply_style_reapply_drops_direct_para_indent_uno(ctx, doc):
+    """Honest pin: setting ParaStyleName drops direct Para* (quote indents). Keith's F1
+    probe — do not promise that re-applying a style keeps a hand-set margin, even on none."""
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    text.insertString(cur, "Indented quote lookalike.", False)
+
+    fmt = text.createTextCursorByRange(text.getStart())
+    fmt.gotoEnd(True)
+    fmt.setPropertyValue("ParaLeftMargin", 3251)  # ~3.25 cm
+    assert int(fmt.getPropertyValue("ParaLeftMargin")) == 3251
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
+    res = ApplyStyle().execute(
+        tool_ctx, style="Standard", family="ParagraphStyles",
+        target="search", old_content="Indented quote lookalike.",
+        clear_direct="none",
+    )
+    assert res.get("status") == "ok", f"apply_style failed: {res}"
+
+    chk = text.createTextCursorByRange(text.getStart())
+    chk.gotoEnd(True)
+    assert int(chk.getPropertyValue("ParaLeftMargin")) != 3251, (
+        "if this fails, re-apply started keeping direct Para* — update the docs")
 
 
 @native_test

--- a/tests/writer/test_styles.py
+++ b/tests/writer/test_styles.py
@@ -141,6 +141,21 @@ def test_get_style_info():
     assert res["is_in_use"] is True
 
 
+def test_apply_style_clear_direct_schema_default_is_style_props():
+    """Small models read the schema; default must be the house-font-wins value."""
+    schema = ApplyStyle.parameters["properties"]["clear_direct"]
+    assert schema["default"] == "style_props"
+    assert schema["enum"] == ["none", "style_props", "all"]
+
+
+def test_resolve_clear_direct_defaults():
+    assert ApplyStyle._resolve_clear_direct("ParagraphStyles", None) == "style_props"
+    assert ApplyStyle._resolve_clear_direct("ParagraphStyles", "") == "style_props"
+    assert ApplyStyle._resolve_clear_direct("ParagraphStyles", "none") == "none"
+    assert ApplyStyle._resolve_clear_direct("CharacterStyles", None) == "none"
+    assert ApplyStyle._resolve_clear_direct("CharacterStyles", "all") == "all"
+
+
 @patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char")
 @patch("plugin.writer.styles.resolve_target_cursor")
 def test_apply_style_paragraph(mock_resolve, mock_preserve, mock_ctx):
@@ -152,7 +167,7 @@ def test_apply_style_paragraph(mock_resolve, mock_preserve, mock_ctx):
 
     assert res["status"] == "ok"
     assert res["family"] == "ParagraphStyles"
-    mock_preserve.assert_called_once_with(mock_ctx.doc, cursor, "Heading 1", "none")
+    mock_preserve.assert_called_once_with(mock_ctx.doc, cursor, "Heading 1", "style_props")
     cursor.setPropertyValue.assert_not_called()
 
 
@@ -178,26 +193,39 @@ def test_apply_style_clear_direct_is_forwarded(mock_resolve, mock_preserve, mock
 
 @patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char")
 @patch("plugin.writer.styles.resolve_target_cursor")
-def test_apply_style_reports_preserved_overrides_with_hint(mock_resolve, mock_preserve, mock_ctx):
-    """The default path echoes the direct formatting that overrode the style — otherwise a style
-    apply that changed nothing on screen is indistinguishable from one that worked."""
+def test_apply_style_explicit_none_reports_overrides_without_retry_hint(mock_resolve, mock_preserve, mock_ctx):
+    """clear_direct='none' still echoes what was kept. No retry-with-style_props hint: that
+    dance was for the old default=none no-op; default already shows the house font."""
     mock_resolve.return_value = MagicMock()
     mock_preserve.return_value = {"direct_formatting": "preserved", "clear_direct": "none",
                                   "preserved_char_overrides": {"CharFontName": "Times New Roman", "CharHeight": 12.0}}
 
-    res = ApplyStyle().execute(mock_ctx, style="Standard", target="selection")
+    res = ApplyStyle().execute(mock_ctx, style="Standard", target="selection", clear_direct="none")
 
     assert res["preserved_char_overrides"]["CharHeight"] == 12.0
-    assert "clear_direct='style_props'" in res["hint"]
+    assert "hint" not in res
 
 
 @patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char")
 @patch("plugin.writer.styles.resolve_target_cursor")
-def test_apply_style_clear_direct_rejected_on_full_document(mock_resolve, mock_preserve, mock_ctx):
-    """Clearing the whole document erases the very formatting used to tell paragraph kinds apart."""
+def test_apply_style_default_allowed_on_full_document(mock_resolve, mock_preserve, mock_ctx):
+    """Default style_props is allowed on full_document so house font shows without a flag."""
+    mock_resolve.return_value = MagicMock()
+    mock_preserve.return_value = {"direct_formatting": "cleared", "clear_direct": "style_props"}
+
+    res = ApplyStyle().execute(mock_ctx, style="Standard", target="full_document")
+
+    assert res["status"] == "ok"
+    assert mock_preserve.call_args[0][3] == "style_props"
+
+
+@patch("plugin.writer.styles.apply_paragraph_style_preserving_direct_char")
+@patch("plugin.writer.styles.resolve_target_cursor")
+def test_apply_style_clear_direct_all_rejected_on_full_document(mock_resolve, mock_preserve, mock_ctx):
+    """Ctrl+M on the whole document would wipe emphasis; force the per-range path."""
     mock_resolve.return_value = MagicMock()
 
-    res = ApplyStyle().execute(mock_ctx, style="Standard", target="full_document", clear_direct="style_props")
+    res = ApplyStyle().execute(mock_ctx, style="Standard", target="full_document", clear_direct="all")
 
     assert res["status"] == "error"
     assert "full_document" in res["message"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Small models calling `apply_style` after a house-font `style_update` used to see **no visual change**. Default `clear_direct` was `none`, which restores a hand-set Times/size over the style. The tool then hinted “retry with `style_props`” — a dance small models miss.

## What changed

**Default `clear_direct` is now `style_props`** (name kept; it means “let the style’s governed properties win”, not “clear whatever this style defines”):

- House **font name + size** show (`STYLE_GOVERNED_CHAR_PROPERTIES` + `_reset_properties_to_default`)
- **Bold / italic / colour stay**
- Paragraph indents/alignment (`CLEARABLE_PARA_PROPERTIES`) are cleared, as `style_props` already did

| Value | Meaning |
|---|---|
| `style_props` (default) | House font/size win; emphasis kept |
| `none` | Explicit opt-in: keep the direct font (old “masking Times” behaviour) |
| `all` | Ctrl+M-ish; still refused on `target='full_document'` |

`style_props` (the default) is allowed on `full_document` so a no-arg apply still works. `all` on `full_document` stays refused.

No same-style-only special case. No PropertyState “clear whatever the style defines” engine (short comment in `format.py`: inheritance / Normal-weight makes that hard).

The retry-with-`style_props` hint is gone — default already shows the house font. `preserved_char_overrides` still echoes on explicit `none`.

**Honest limitation:** re-applying a style does **not** keep a quote indent. LibreOffice drops direct `Para*` when `ParaStyleName` is set (Keith’s F1 probe), even on `none`.

HTML import still calls the helper without a flag (helper default stays `none`) so inline CSS fonts survive on write.

## Tests (green)

- Unit: 72 passed (`test_styles.py`, `test_format.py`, related apply-content / all_matches)
- UNO: 11/11 in `test_apply_style_preserve_inline_uno.py`
  - Lawyer path: Times + bold → update Standard to Liberation Sans → `apply_style("Standard")` with **no** `clear_direct` → house font shows, bold survives
  - Explicit `none` still keeps Times
  - Re-apply drops `ParaLeftMargin`
  - Existing color/bold/highlight/char-style preserve tests still green under the new default
- `make typecheck` passed

## How to verify

```bash
make manifest
.venv/bin/python -m pytest tests/writer/test_styles.py tests/writer/test_format.py -q
.venv/bin/python plugin/testing_runner.py tests/writer/test_apply_style_preserve_inline_uno.py
make typecheck
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f79368bc-360d-4424-9425-b9cb7409cbf6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f79368bc-360d-4424-9425-b9cb7409cbf6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

