### PR TITLE
Keep Char* paint when Para* copy fails in HTML range export

### DIFF
--- a/docs/writer/pr634-first-principles-analysis.md
+++ b/docs/writer/pr634-first-principles-analysis.md
@@ -357,13 +357,9 @@ In-process dispatch to the same implementation `page_get_style_properties` uses 
 
 ### 2.11 `_paint_direct_formatting` aborts Char* if Para* fails
 
-**Today (`html_export.py`)**
+**Fixed (`html_export.py`)**
 
-Para property copy in try/except; on failure **`return`** before the portion Char* loop. A single refused `Para*` drops the entire reason the temp-doc path exists (bold/indent visibility on range read).
-
-**Recommended approach**
-
-Catch Para* failures, log, **continue** to portion painting. Char* failures already `continue` per portion.
+Para* copy is isolated from obtaining `para_start`. A refused Para* is logged and the portion Char* loop still runs. Char* failures already `continue` per portion. Without `para_start` the function still returns (nothing to paint onto).
 
 **Tests**
 

--- a/plugin/writer/html_export.py
+++ b/plugin/writer/html_export.py
@@ -206,11 +206,17 @@ def _paint_direct_formatting(para, portions, temp_text, trim_start, trim_end, st
         para_cursor.gotoEnd(False)
         para_cursor.gotoStartOfParagraph(False)
         para_start = para_cursor.getStart()
+    except Exception:
+        log.debug("_paint_direct_formatting: paragraph start skipped", exc_info=True)
+        return
+
+    try:
         para_cursor.gotoEndOfParagraph(True)
         _copy_properties(para, para_cursor, _COPIED_PARA_PROPERTIES, style)
     except Exception:
+        # A refused Para* used to return here and skip the Char* loop, dropping bold/colour
+        # for the whole range — the reason the temp-doc path exists. Log and keep painting.
         log.debug("_paint_direct_formatting: paragraph properties skipped", exc_info=True)
-        return
 
     offset = 0  # position within the visible (tracked-deletions removed) paragraph text
     for portion, chunk in portions:

--- a/tests/writer/test_format.py
+++ b/tests/writer/test_format.py
@@ -535,6 +535,36 @@ def test_copy_properties_continues_past_one_the_target_refuses():
     assert [c.args[0] for c in dst.setPropertyValue.call_args_list] == ["CharPosture", "CharWeight"]
 
 
+def test_paint_direct_formatting_still_paints_char_when_para_copy_raises():
+    """A refused Para* must not skip the portion Char* loop — that paint is why the
+    temp-doc path exists (bold/colour on a range read)."""
+    from unittest.mock import MagicMock, patch
+    from plugin.writer import html_export as hx
+
+    portion = MagicMock()
+    para = MagicMock()
+    para_start = MagicMock(name="para_start")
+    para_cursor = MagicMock()
+    para_cursor.getStart.return_value = para_start
+    run = MagicMock()
+    temp_text = MagicMock()
+    temp_text.createTextCursor.return_value = para_cursor
+    temp_text.createTextCursorByRange.return_value = run
+
+    def copy_side_effect(src, dst, names, style=None):
+        if names is hx._COPIED_PARA_PROPERTIES:
+            raise RuntimeError("refused Para*")
+
+    with patch.object(hx, "_copy_properties", side_effect=copy_side_effect) as copy:
+        hx._paint_direct_formatting(para, [(portion, "bold")], temp_text, 0, 4)
+
+    names_seen = [c.args[2] for c in copy.call_args_list]
+    assert hx._COPIED_PARA_PROPERTIES in names_seen
+    assert hx._COPIED_CHAR_PROPERTIES in names_seen
+    char_call = next(c for c in copy.call_args_list if c.args[2] is hx._COPIED_CHAR_PROPERTIES)
+    assert char_call.args[0] is portion
+
+
 def test_source_style_is_cached_and_tolerates_a_missing_style():
     from unittest.mock import MagicMock
     from plugin.writer import html_export as hx

--- a/tests/writer/test_html_export_uno.py
+++ b/tests/writer/test_html_export_uno.py
@@ -1,0 +1,47 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""UNO tests for Writer HTML range export (html_export)."""
+
+from typing import Any
+
+import uno  # noqa: F401
+
+from plugin.testing_runner import native_test
+from plugin.tests.testing_utils import with_native_doc
+
+
+@native_test
+@with_native_doc("writer")
+def test_range_export_keeps_bold_inside_odd_para_uno(ctx: Any, doc: Any) -> None:
+    """Range export must still show emphasis when the source paragraph carries
+    unusual Para* values. A refused Para* used to skip Char* paint entirely."""
+    text = doc.getText()
+    text.setString("")
+    cur = text.createTextCursor()
+    text.insertString(cur, "plain ", False)
+    cur.setPropertyValue("CharWeight", 150.0)
+    text.insertString(cur, "BOLD", False)
+    cur.setPropertyValue("CharWeight", 100.0)
+    text.insertString(cur, " tail", False)
+
+    para = text.createTextCursor()
+    para.gotoStart(False)
+    para.gotoEndOfParagraph(True)
+    para.setPropertyValue("ParaLeftMargin", 5000)
+    para.setPropertyValue("ParaFirstLineIndent", -2000)
+    para.setPropertyValue("ParaBackColor", 0xFFE4C4)
+
+    from plugin.writer.html_export import _range_to_content_via_temp_doc
+
+    html = _range_to_content_via_temp_doc(doc, ctx, 0, 16, None, None)
+    assert "BOLD" in html, html
+    compact = html.lower().replace(" ", "")
+    has_emphasis = (
+        "<strong>" in compact
+        or "<b>" in compact
+        or "font-weight:bold" in compact
+        or "font-weight:700" in compact
+    )
+    assert has_emphasis, html


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`_paint_direct_formatting` wrapped Para* property copy and cursor setup in one `try`/`except` and **`return`ed** on any failure. A single refused `Para*` skipped the portion Char* loop, so bold/colour vanished from the range export — the reason the temp-doc path exists.

## Change

Obtain `para_start` first. Catch Para* copy failures, log, and **continue** to portion Char* painting. Char* failures still `continue` per portion. If `para_start` cannot be obtained, return as before (nothing to paint onto).

## Tests

- Unit stub: Para copy raises → Char copy is still invoked.
- UNO: range read of bold inside a paragraph with odd Para* still shows emphasis when export can represent it.

No new tool API.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2cc0c80-2b4e-43f2-953c-27cc2c14d1f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2cc0c80-2b4e-43f2-953c-27cc2c14d1f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

