### PR TITLE
Refuse turning Writer headers/footers off while they still have content

### DIFF
--- a/docs/writer/page-api-reference.md
+++ b/docs/writer/page-api-reference.md
@@ -41,7 +41,7 @@ default_style.setPropertyValue("Height", 21000) # 210mm
 Headers and footers are also controlled via the Page Style properties. Each page style has separate properties for turning headers/footers on and accessing their text objects.
 
 ### Key Properties
-- **`HeaderIsOn`** / **`FooterIsOn`** (`bool`): Enables or disables the header/footer.
+- **`HeaderIsOn`** / **`FooterIsOn`** (`bool`): Enables or disables the header/footer. `page_set_style_properties` with `header_is_on=false` / `footer_is_on=false` **refuses** if any matching region still holds text, fields, images, or tables (LibreOffice’s “delete header?” spirit — no silent disable). Clear first with `page_set_header_footer_text(region=…, content='')`, then disable. Enabling (`true`) is always allowed. There is no force-off flag. Do not assume `IsOn=false` means empty — leftover `HeaderText` can survive an off toggle.
 - **`HeaderIsShared`** / **`FooterIsShared`** (`bool`): If true, the same header/footer is used for left and right pages.
 - **`HeaderText`** / **`FooterText`** (`com.sun.star.text.XText`): The text object representing the header/footer content. This is a full text object, just like the main document body.
 - **`HeaderIsDynamicHeight`** / **`FooterIsDynamicHeight`** (`bool`): When true, the region grows with its content. Needed when inserting a logo via `insert_image(target="header"|"footer")` — without it a taller image keeps the fixed header height and spills into the body. WriterAgent enables this by default for header/footer image inserts (`auto_height`, also on `page_set_header_footer_text`).

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -286,6 +286,7 @@ WRITER_APPLY_DOCUMENT_HTML_RULES = f"""APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL
 - Headers/footers: edit the region with page_get_header_footer_text then page_set_header_footer_text.
   Get returns the same XHTML as get_document_content (fields as <span title="page-number"/>, tables, logos).
   Set imports that HTML into the region's XText — not setString wipe.
+  page_set_style_properties header_is_on=false / footer_is_on=false refuses while the region still has content; clear with page_set_header_footer_text first, then disable. Enabling is always allowed.
   target='search' still reaches headers and footers for a surgical substring edit.
   A "different first page" letterhead lives in header_first / footer_first (page_get_style_properties reports first_is_shared); style_list(family='PageStyles') gives the page-style names.
 - `content` is a JSON array of HTML strings (one fragment per heading/paragraph).

--- a/plugin/writer/page.py
+++ b/plugin/writer/page.py
@@ -58,6 +58,84 @@ def _empty_scan() -> dict[str, Any]:
     return {"fields": [], "images": [], "paragraph_count": 0}
 
 
+def _region_has_table(text_obj) -> bool:
+    """True when the region's enumeration includes a text table (letterhead grid)."""
+    try:
+        enum = text_obj.createEnumeration()
+    except Exception:
+        return False
+    seen = 0
+    while enum.hasMoreElements() is True and seen < _SCAN_PARA_LIMIT:
+        seen += 1
+        try:
+            el = enum.nextElement()
+        except Exception:
+            break
+        try:
+            # `is True`: MagicMock supportsService() is truthy and would false-positive.
+            if el.supportsService("com.sun.star.text.TextTable") is True:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _region_holds_content(doc, text_obj) -> bool:
+    """True if the header/footer XText still holds text, fields, images, or tables.
+
+    Do not treat a missing ``IsOn`` as empty: LibreOffice may keep ``HeaderText``
+    after ``HeaderIsOn=false`` (F5). A ``None`` text object is the only true absence.
+    ``getString()`` misses logos and can hide tables; the #638 region scan plus a
+    table walk covers those.
+    """
+    if text_obj is None:
+        return False
+    try:
+        plain = text_obj.getString()
+    except Exception:
+        plain = ""
+    if isinstance(plain, str) and plain.strip():
+        return True
+    scan = _scan_region_content(doc, text_obj)
+    if scan["fields"] or scan["images"]:
+        return True
+    return _region_has_table(text_obj)
+
+
+def _disable_blocked_by_content(doc, style, kwargs: dict[str, Any]) -> str | None:
+    """Error text if ``header_is_on=false`` / ``footer_is_on=false`` would wipe content.
+
+    ``HeaderIsOn`` / ``FooterIsOn`` are the only toggles (no first/left IsOn props).
+    Turning one off drops every variant of that kind, so all matching regions are
+    scanned. Enabling (``true``) is never blocked. No force-off flag.
+    """
+    for kw, kind in (("header_is_on", "header"), ("footer_is_on", "footer")):
+        if kw not in kwargs or kwargs[kw]:
+            continue
+        held: list[str] = []
+        for region, (_unused_is_on, text_prop) in _REGION_PROPS.items():
+            if _region_kind(region) != kind:
+                continue
+            try:
+                text_obj = style.getPropertyValue(text_prop)
+            except Exception:
+                continue
+            if _region_holds_content(doc, text_obj):
+                held.append(region)
+        if not held:
+            continue
+        clears = "; ".join(
+            "page_set_header_footer_text(region='%s', content='')" % region for region in held
+        )
+        return (
+            "Cannot turn the %s off while it still has content (%s). "
+            "LibreOffice asks before deleting header/footer contents. "
+            "Clear first with %s, then page_set_style_properties(%s=false)."
+            % (kind, ", ".join(held), clears, kw)
+        )
+    return None
+
+
 def _scan_region_content(doc, text_obj) -> dict[str, Any]:
     """Report what a header/footer holds beyond plain text: fields and anchored images.
 
@@ -227,7 +305,12 @@ class PageSetStyleProperties(ToolWriterPageBase):
     """Modify dimensions, margins, and header/footer toggles of a page style."""
 
     name = "page_set_style_properties"
-    description = "Modify dimensions, margins, and header/footer toggles of a page style."
+    description = (
+        "Modify dimensions, margins, and header/footer toggles of a page style. "
+        "header_is_on=false / footer_is_on=false refuse if that region still has "
+        "text, fields, images, or tables — clear with page_set_header_footer_text "
+        "first, then disable. Enabling (true) is always allowed. No force-off."
+    )
     parameters = {
         "type": "object",
         "properties": {
@@ -240,8 +323,23 @@ class PageSetStyleProperties(ToolWriterPageBase):
             "top_margin_mm": {"type": "number", "description": "Top margin in mm."},
             "bottom_margin_mm": {"type": "number", "description": "Bottom margin in mm."},
             "gutter_margin_mm": {"type": "number", "description": "Gutter margin in mm (for binding)."},
-            "header_is_on": {"type": "boolean", "description": "Enable or disable header."},
-            "footer_is_on": {"type": "boolean", "description": "Enable or disable footer."},
+            "header_is_on": {
+                "type": "boolean",
+                "description": (
+                    "Enable the header, or disable it when empty. false refuses while "
+                    "any header region still holds text, fields, images, or tables — "
+                    "clear with page_set_header_footer_text first (LibreOffice asks "
+                    "before deleting header contents)."
+                ),
+            },
+            "footer_is_on": {
+                "type": "boolean",
+                "description": (
+                    "Enable the footer, or disable it when empty. false refuses while "
+                    "any footer region still holds text, fields, images, or tables — "
+                    "clear with page_set_header_footer_text first."
+                ),
+            },
             "header_is_shared": {"type": "boolean", "description": "Share header between left/right pages."},
             "footer_is_shared": {"type": "boolean", "description": "Share footer between left/right pages."},
             "first_is_shared": {"type": "boolean", "description": (
@@ -274,6 +372,12 @@ class PageSetStyleProperties(ToolWriterPageBase):
             style = page_styles.getByName(style_name)
         except Exception as e:
             return self._tool_error(f"Error accessing page style '{style_name}': {e}")
+
+        # Refuse HeaderIsOn/FooterIsOn=false before any write: LO UI asks
+        # "delete header?" rather than silently wiping leftover content.
+        blocked = _disable_blocked_by_content(doc, style, kwargs)
+        if blocked:
+            return self._tool_error(blocked)
 
         updated = []
         try:

--- a/tests/writer/test_page.py
+++ b/tests/writer/test_page.py
@@ -16,6 +16,8 @@ from plugin.writer.page import (
     PageSetHeaderFooterText,
     PageSetColumns,
     PageInsertBreak,
+    _disable_blocked_by_content,
+    _region_holds_content,
 )
 
 
@@ -383,3 +385,119 @@ def test_set_page_style_properties_writes_first_is_shared():
     assert res["status"] == "ok"
     assert "first_is_shared" in res["updated"]
     style.setPropertyValue.assert_any_call("FirstIsShared", False)
+
+
+# --- header/footer off: refuse while the region still holds content ----------------------
+
+
+def _empty_text_obj():
+    text_obj = MagicMock()
+    text_obj.getString.return_value = ""
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([])
+    return text_obj
+
+
+def test_region_holds_content_is_false_for_empty_or_whitespace():
+    doc, _style = _page_style_doc(_empty_text_obj())
+    assert _region_holds_content(doc, None) is False
+    empty = _empty_text_obj()
+    assert _region_holds_content(doc, empty) is False
+    ws = MagicMock()
+    ws.getString.return_value = "  \n"
+    ws.createEnumeration.side_effect = lambda: _enum_of([])
+    assert _region_holds_content(doc, ws) is False
+
+
+def test_region_holds_content_sees_text_fields_images_and_tables():
+    text_obj = MagicMock()
+    text_obj.getString.return_value = "Letterhead"
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([])
+    doc, _style = _page_style_doc(text_obj)
+    assert _region_holds_content(doc, text_obj) is True
+
+    field_obj = MagicMock()
+    field_obj.getString.return_value = ""
+    field_obj.createEnumeration.side_effect = lambda: _enum_of([
+        _paragraph([_portion("TextField", _page_number_field())]),
+    ])
+    doc_f, _style_f = _page_style_doc(field_obj)
+    assert _region_holds_content(doc_f, field_obj) is True
+
+    logo_obj = MagicMock()
+    logo_obj.getString.return_value = ""
+    logo_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Frame")])])
+    doc_i, _style_i = _page_style_doc(logo_obj, shapes=[_logo_anchored_in(logo_obj)])
+    assert _region_holds_content(doc_i, logo_obj) is True
+
+    table = MagicMock()
+    table.supportsService.side_effect = lambda s: s == "com.sun.star.text.TextTable"
+    table_obj = MagicMock()
+    table_obj.getString.return_value = ""
+    table_obj.createEnumeration.side_effect = lambda: _enum_of([table])
+    doc_t, _style_t = _page_style_doc(table_obj)
+    assert _region_holds_content(doc_t, table_obj) is True
+
+
+def test_set_style_properties_refuses_header_off_while_text_remains():
+    text_obj = _empty_text_obj()
+    text_obj.getString.return_value = "Keep this letterhead"
+    doc, style = _page_style_doc(text_obj)
+
+    res = PageSetStyleProperties().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", width_mm=300, header_is_on=False)
+
+    assert res["status"] == "error"
+    assert "page_set_header_footer_text" in res["message"]
+    assert "header_is_on=false" in res["message"]
+    style.setPropertyValue.assert_not_called()
+
+
+def test_set_style_properties_refuses_footer_off_while_logo_remains():
+    text_obj = MagicMock()
+    text_obj.getString.return_value = ""
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Frame")])])
+    doc, style = _page_style_doc(text_obj, shapes=[_logo_anchored_in(text_obj)])
+
+    res = PageSetStyleProperties().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", footer_is_on=False)
+
+    assert res["status"] == "error"
+    assert "footer" in res["message"]
+    style.setPropertyValue.assert_not_called()
+
+
+def test_set_style_properties_allows_header_off_when_empty():
+    doc, style = _page_style_doc(_empty_text_obj())
+
+    res = PageSetStyleProperties().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", header_is_on=False)
+
+    assert res["status"] == "ok"
+    style.setPropertyValue.assert_any_call("HeaderIsOn", False)
+
+
+def test_set_style_properties_allows_enable_while_content_remains():
+    text_obj = _empty_text_obj()
+    text_obj.getString.return_value = "Already there"
+    doc, style = _page_style_doc(text_obj)
+
+    res = PageSetStyleProperties().execute(
+        TestingFactory.create_context(doc=doc, doc_type="writer"),
+        style="Standard", header_is_on=True)
+
+    assert res["status"] == "ok"
+    style.setPropertyValue.assert_any_call("HeaderIsOn", True)
+
+
+def test_disable_blocked_by_content_skips_enable_and_lists_held_regions():
+    text_obj = _empty_text_obj()
+    text_obj.getString.return_value = "First-page letterhead"
+    doc, style = _page_style_doc(text_obj)
+    assert _disable_blocked_by_content(doc, style, {"header_is_on": True}) is None
+    msg = _disable_blocked_by_content(doc, style, {"header_is_on": False})
+    assert msg is not None
+    assert "header" in msg
+    assert "page_set_header_footer_text" in msg

--- a/tests/writer/test_page_uno.py
+++ b/tests/writer/test_page_uno.py
@@ -1,0 +1,156 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Live UNO: page_set_style_properties refuses header/footer off while content remains."""
+
+from __future__ import annotations
+
+from plugin.testing_runner import native_test
+from plugin.tests.testing_utils import with_native_doc
+from plugin.writer.page import (
+    PageSetHeaderFooterText,
+    PageSetStyleProperties,
+)
+
+
+def _tool_ctx(doc, ctx):
+    from plugin.framework.tool import ToolContext
+
+    services = None
+    try:
+        from plugin.main import get_services
+
+        services = get_services()
+    except Exception:
+        services = None
+    return ToolContext(doc, ctx, "writer", services, "test")
+
+
+def _style_name(doc):
+    styles = doc.getStyleFamilies().getByName("PageStyles")
+    if styles.hasByName("Standard"):
+        return "Standard"
+    return styles.getElementNames()[0]
+
+
+def _style(doc):
+    name = _style_name(doc)
+    return doc.getStyleFamilies().getByName("PageStyles").getByName(name), name
+
+
+def _set_text(doc, ctx, region, content, **kwargs):
+    return PageSetHeaderFooterText().execute(
+        _tool_ctx(doc, ctx), style=_style_name(doc), region=region, content=content, **kwargs,
+    )
+
+
+def _set_props(doc, ctx, **kwargs):
+    return PageSetStyleProperties().execute(
+        _tool_ctx(doc, ctx), style=_style_name(doc), **kwargs,
+    )
+
+
+@native_test
+@with_native_doc("writer")
+def test_disable_header_refuses_while_text_remains(ctx, doc):
+    applied = _set_text(doc, ctx, "header", "<p>Keep this header</p>")
+    assert applied["status"] == "ok"
+    style, _name = _style(doc)
+    assert style.getPropertyValue("HeaderIsOn") is True
+    before = style.getPropertyValue("HeaderText").getString()
+
+    res = _set_props(doc, ctx, header_is_on=False)
+    assert res["status"] == "error"
+    assert "page_set_header_footer_text" in res["message"]
+    assert style.getPropertyValue("HeaderIsOn") is True
+    after = style.getPropertyValue("HeaderText").getString()
+    assert "Keep this header" in after
+    assert after == before
+
+
+@native_test
+@with_native_doc("writer")
+def test_disable_header_ok_after_clear(ctx, doc):
+    applied = _set_text(doc, ctx, "header", "<p>Temporary header</p>")
+    assert applied["status"] == "ok"
+    cleared = _set_text(doc, ctx, "header", "")
+    assert cleared["status"] == "ok"
+
+    res = _set_props(doc, ctx, header_is_on=False)
+    assert res["status"] == "ok", res
+    style, _name = _style(doc)
+    assert style.getPropertyValue("HeaderIsOn") is False
+
+
+@native_test
+@with_native_doc("writer")
+def test_disable_footer_refuses_while_text_remains(ctx, doc):
+    applied = _set_text(doc, ctx, "footer", "<p>Keep this footer</p>")
+    assert applied["status"] == "ok"
+    style, _name = _style(doc)
+    res = _set_props(doc, ctx, footer_is_on=False)
+    assert res["status"] == "error"
+    assert "footer" in res["message"]
+    assert style.getPropertyValue("FooterIsOn") is True
+    assert "Keep this footer" in style.getPropertyValue("FooterText").getString()
+
+
+@native_test
+@with_native_doc("writer")
+def test_enable_header_allowed_with_content(ctx, doc):
+    applied = _set_text(doc, ctx, "header", "<p>Already on</p>")
+    assert applied["status"] == "ok"
+    res = _set_props(doc, ctx, header_is_on=True)
+    assert res["status"] == "ok"
+    style, _name = _style(doc)
+    assert style.getPropertyValue("HeaderIsOn") is True
+    assert "Already on" in style.getPropertyValue("HeaderText").getString()
+
+
+@native_test
+@with_native_doc("writer")
+def test_disable_empty_header_allowed(ctx, doc):
+    style, _name = _style(doc)
+    style.setPropertyValue("HeaderIsOn", True)
+    header = style.getPropertyValue("HeaderText")
+    header.setString("")
+    res = _set_props(doc, ctx, header_is_on=False)
+    assert res["status"] == "ok", res
+    assert style.getPropertyValue("HeaderIsOn") is False
+
+
+@native_test
+@with_native_doc("writer")
+def test_disable_header_refuses_while_table_remains(ctx, doc):
+    style, _name = _style(doc)
+    style.setPropertyValue("HeaderIsOn", True)
+    header = style.getPropertyValue("HeaderText")
+    header.setString("")
+    tbl = doc.createInstance("com.sun.star.text.TextTable")
+    tbl.initialize(1, 2)
+    header.insertTextContent(header.createTextCursor(), tbl, False)
+    tbl.getCellByName("A1").setString("Logo cell")
+    tbl.getCellByName("B1").setString("Address cell")
+
+    res = _set_props(doc, ctx, header_is_on=False)
+    assert res["status"] == "error"
+    assert style.getPropertyValue("HeaderIsOn") is True
+    assert "Logo cell" in style.getPropertyValue("HeaderText").getString()
+
+
+@native_test
+@with_native_doc("writer")
+def test_disable_header_refuses_first_page_letterhead(ctx, doc):
+    style, _name = _style(doc)
+    style.setPropertyValue("HeaderIsOn", True)
+    style.setPropertyValue("FirstIsShared", False)
+    shared = _set_text(doc, ctx, "header", "")
+    first = _set_text(doc, ctx, "header_first", "<p>First-page letterhead</p>")
+    assert shared["status"] == "ok" and first["status"] == "ok"
+
+    res = _set_props(doc, ctx, header_is_on=False)
+    assert res["status"] == "error"
+    assert "header_first" in res["message"]
+    assert style.getPropertyValue("HeaderIsOn") is True
+    assert "First-page letterhead" in style.getPropertyValue("HeaderTextFirst").getString()

--- a/tests/writer/test_page_uno.py
+++ b/tests/writer/test_page_uno.py
@@ -136,7 +136,21 @@ def test_disable_header_refuses_while_table_remains(ctx, doc):
     res = _set_props(doc, ctx, header_is_on=False)
     assert res["status"] == "error"
     assert style.getPropertyValue("HeaderIsOn") is True
-    assert "Logo cell" in style.getPropertyValue("HeaderText").getString()
+    # getString() on a header table is empty / not the cell text — the table
+    # itself must still be there (the refuse is what keeps it).
+    header = style.getPropertyValue("HeaderText")
+    found_table = False
+    enum = header.createEnumeration()
+    while enum.hasMoreElements() is True:
+        el = enum.nextElement()
+        try:
+            if el.supportsService("com.sun.star.text.TextTable") is True:
+                assert el.getCellByName("A1").getString() == "Logo cell"
+                found_table = True
+                break
+        except Exception:
+            continue
+    assert found_table, "letterhead table must remain after refused disable"
 
 
 @native_test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`page_set_style_properties` with `header_is_on=false` / `footer_is_on=false` now **errors** if any matching header/footer region still holds text, fields, images, or tables. Same spirit as LibreOffice’s “delete header?” prompt: no silent disable.

Clear first with `page_set_header_footer_text(region=…, content='')`, then disable. Enabling (`true`) stays allowed. No force-off flag. No silent wipe-on-disable.

`HeaderIsOn` / `FooterIsOn` are the only toggles (no first/left IsOn props). Turning one off drops every variant of that kind, so all matching regions are scanned. Does not treat `IsOn=false` as empty (F5: leftover `HeaderText` can survive an off toggle).

## Tests (green locally)

- Unit: `tests/writer/test_page.py` — 21 passed (empty vs text/fields/images/tables; refuse leaves the document untouched; enable with content is allowed).
- UNO: `tests/writer/test_page_uno.py` — 7/7: text refuse (content intact); clear then off; footer analogue; enable with content; empty off; table refuse (table intact); first-page letterhead refuse.
- `make typecheck` green.

## Docs

`docs/writer/page-api-reference.md` and one line in `WRITER_APPLY_DOCUMENT_HTML_RULES`. No new tool.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf074bb-d46c-40f3-af16-8c1ce0f1f53e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf074bb-d46c-40f3-af16-8c1ce0f1f53e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

