### PR TITLE
Remove leftover force/refuse-on-held header-footer teaching

### DIFF
--- a/docs/writer/page-api-reference.md
+++ b/docs/writer/page-api-reference.md
@@ -56,9 +56,7 @@ Images in a header/footer must be anchored **`AS_CHARACTER`** (in the text flow)
 
 `getString()` cannot represent a letterhead — a logo is an empty line and a page-number field is its rendered digits. `page_get_header_footer_text` therefore exports the region's `XText` through the same XHTML + postprocess stack as `get_document_content` (`xtext_to_content` in `html_export.py`): copy the region into a hidden Writer body, then `document_to_content`. Fields appear as `<span title="page-number"/>` (and `page-count` / `date` / `time`); tables and `<img>` logos are in the HTML. `include_images` defaults to **true** so a letterhead is visible. The result still lists `images` / `fields` / `paragraph_count` as machine-readable extras.
 
-`page_set_header_footer_text` imports that HTML into the same `XText` via `replace_xtext_with_html` (`html_import.py`) — StarWriter `insertDocumentFromURL`, not `setString`. Field spans are restored as live UNO fields after import (the HTML filter drops the empty span). Plain text is wrapped as a paragraph and still goes through import.
-
-There is no `force` parameter. It existed because get lied and set wiped; honest HTML get + HTML set is the edit path. `apply_document_content(target='search')` still reaches headers and footers for a surgical substring edit (document-wide `findFirst`); that reach is unchanged.
+`page_set_header_footer_text` imports that HTML into the same `XText` via `replace_xtext_with_html` (`html_import.py`) — StarWriter `insertDocumentFromURL`. Field spans are restored as live UNO fields after import (the HTML filter drops the empty span). Plain text is wrapped as a paragraph and still goes through import. Get the HTML, edit it, set it back — logos, tables, and fields stay live.
 
 ### Python Example: Enabling and Writing to a Header
 ```python
@@ -69,7 +67,7 @@ There is no `force` parameter. It existed because get lied and set wiped; honest
 # Low-level UNO equivalent of enabling the region (the tool does this):
 default_style.setPropertyValue("HeaderIsOn", True)
 header_text = default_style.getPropertyValue("HeaderText")
-# Do not setString a letterhead — use replace_xtext_with_html / the page set tool.
+# Write via replace_xtext_with_html / page_set so logos, tables, and fields stay live.
 ```
 
 ## 3. Columns (`com.sun.star.text.TextColumns`)

--- a/docs/writer/pr634-first-principles-analysis.md
+++ b/docs/writer/pr634-first-principles-analysis.md
@@ -6,7 +6,9 @@
 
 > **Later product decision:** `apply_style` now defaults to `clear_direct='style_props'` (house font/size win, bold/italic/colour stay). `none` is an explicit opt-in. The same-style-only special case discussed in §2.7 was **not** implemented. Treat sections below that say “default is `none`” as historical.
 
-Symbols and paths below are current `master` unless noted.
+> **Header/footer write path (after #638):** HTML get + HTML import replaced refuse-on-held, `force`, and “use search instead of `page_set`.” Sections below that prescribe refuse, `force=true` wipe, or search-as-escape are historical. Get still reports `images` / `fields` / `paragraph_count` as optional scan extras — not as a write refuse gate. Do not add refuse-on-table. `page_set_style_properties` refuse-when-`header_is_on=false` while content remains is a separate feature if it lands.
+
+Symbols and paths below describe the #634-era API unless a later banner says otherwise.
 
 ---
 

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -284,10 +284,9 @@ WRITER_APPLY_DOCUMENT_HTML_RULES = f"""APPLY_DOCUMENT_CONTENT AND HTML (CRITICAL
   Floating drawing-shape text: in place only when review is off — in record/wait it cannot become a tracked change, so the tool routes you to the shapes domain.
   Rich/block HTML in a table cell is not supported (clear error, document untouched); use plain text or inline tags.
 - Headers/footers: edit the region with page_get_header_footer_text then page_set_header_footer_text.
-  Get returns the same XHTML as get_document_content (fields as <span title="page-number"/>, tables, logos).
-  Set imports that HTML into the region's XText — not setString wipe.
+  Get returns the same XHTML as get_document_content (fields as <span title="page-number"/>, tables, logos) plus images/fields lists.
+  Set imports that HTML into the region's XText so logos, tables, and page-number fields survive.
   page_set_style_properties header_is_on=false / footer_is_on=false refuses while the region still has content; clear with page_set_header_footer_text first, then disable. Enabling is always allowed.
-  target='search' still reaches headers and footers for a surgical substring edit.
   A "different first page" letterhead lives in header_first / footer_first (page_get_style_properties reports first_is_shared); style_list(family='PageStyles') gives the page-style names, and style_get_info(family='PageStyles') returns the same margins/header/footer payload.
 - `content` is a JSON array of HTML strings (one fragment per heading/paragraph).
   We wrap in <html>/<body>.

--- a/plugin/writer/page.py
+++ b/plugin/writer/page.py
@@ -139,11 +139,11 @@ def _disable_blocked_by_content(doc, style, kwargs: dict[str, Any]) -> str | Non
 
 
 def _scan_region_content(doc, text_obj) -> dict[str, Any]:
-    """Report what a header/footer holds beyond plain text: fields and anchored images.
+    """Report fields and anchored images in a header/footer as get-side extras.
 
-    ``getString()`` flattens both away — a letterhead logo reads back as an empty line and a
-    page-number field as the literal digit — so a caller cannot see what a plain-text overwrite
-    is about to delete. Returns ``{"fields": [...], "images": [...], "paragraph_count": int}``.
+    HTML ``content`` already carries structure; these lists are machine-readable so a
+    caller can see logos and live fields without parsing the markup. Returns
+    ``{"fields": [...], "images": [...], "paragraph_count": int}``.
     """
     out = _empty_scan()
     try:
@@ -483,8 +483,8 @@ class PageGetHeaderFooterText(ToolWriterPageBase):
         "Get this page-style header or footer as HTML so you can edit structure "
         "(fields, tables, logos) and send it back to page_set_header_footer_text. "
         "Uses the same XHTML export as get_document_content, pointed at the region's "
-        "XText — getString() hid images and flattened fields. "
-        "Use header_first / footer_first when first_is_shared is false."
+        "XText. Also lists images, fields, and paragraph_count so structure is visible "
+        "without parsing the HTML. Use header_first / footer_first when first_is_shared is false."
     )
     parameters = {
         "type": "object",
@@ -552,6 +552,7 @@ class PageGetHeaderFooterText(ToolWriterPageBase):
                 "format": "html",
             }
             if text_obj is not None:
+                # Machine-readable extras; HTML already has the structure. Not a write refuse gate.
                 scan = _scan_region_content(ctx.doc, text_obj)
                 result["paragraph_count"] = scan["paragraph_count"]
                 if scan["fields"]:
@@ -584,7 +585,7 @@ class PageSetHeaderFooterText(ToolWriterPageBase):
         "pointed at the region's XText. Call page_get_header_footer_text first and edit "
         "that HTML. Enables the region if it is off. Pass auto_height=true so a taller "
         "letterhead grows instead of overlapping the body. Plain text is wrapped as a "
-        "paragraph; it still goes through import, not setString wipe."
+        "paragraph and still goes through import."
     )
     parameters = {
         "type": "object",
@@ -636,8 +637,6 @@ class PageSetHeaderFooterText(ToolWriterPageBase):
 
         try:
             is_on_prop, text_prop = _REGION_PROPS[region]
-            # force= was a refuse/wipe hatch when getString lied and set used setString.
-            # HTML get+import is the edit path now; ignore a leftover force kwarg.
             style.setPropertyValue(is_on_prop, True)
             auto_height = kwargs.get("auto_height")
             if auto_height is not None:

--- a/tests/framework/test_constants.py
+++ b/tests/framework/test_constants.py
@@ -210,6 +210,11 @@ def test_writer_apply_document_math_latex_rules_document_only():
     assert "Math (CRITICAL)" not in HTML_FRAGMENT_RULES
     assert "Local edits use target='search'" in WRITER_APPLY_DOCUMENT_HTML_RULES
     assert "target='full_document' is rewrite/translation only" in WRITER_APPLY_DOCUMENT_HTML_RULES
+    assert "page_get_header_footer_text" in WRITER_APPLY_DOCUMENT_HTML_RULES
+    assert "page_set_header_footer_text" in WRITER_APPLY_DOCUMENT_HTML_RULES
+    assert "setString wipe" not in WRITER_APPLY_DOCUMENT_HTML_RULES
+    assert "force=true" not in WRITER_APPLY_DOCUMENT_HTML_RULES
+    assert "target='search' still reaches headers" not in WRITER_APPLY_DOCUMENT_HTML_RULES
 
     model = MagicMock()
     model.supportsService.return_value = False

--- a/tests/writer/test_page.py
+++ b/tests/writer/test_page.py
@@ -288,7 +288,7 @@ def test_get_header_footer_returns_html_and_still_lists_logo_and_field():
 
 
 def test_set_header_footer_imports_html_even_when_a_logo_is_present():
-    """force/refuse was the getString-lie hatch; HTML set is the edit path now."""
+    """HTML set with a logo must succeed — no force, no refuse-on-held."""
     from unittest.mock import patch
 
     text_obj = MagicMock()
@@ -305,6 +305,48 @@ def test_set_header_footer_imports_html_even_when_a_logo_is_present():
     replace_html.assert_called_once()
     text_obj.setString.assert_not_called()
     style.setPropertyValue.assert_any_call("HeaderIsOn", True)
+
+
+def test_set_header_footer_imports_field_html_without_force():
+    """A footer with a page-number field is a normal HTML set, not a refuse."""
+    from unittest.mock import patch
+
+    text_obj = MagicMock()
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([
+        _paragraph([_portion("Text"), _portion("TextField", _page_number_field())]),
+    ])
+    doc, _style = _page_style_doc(text_obj)
+    html = '<p>Confidential | <span title="page-number"/></p>'
+
+    with patch("plugin.writer.html_import.replace_xtext_with_html") as replace_html:
+        res = PageSetHeaderFooterText().execute(
+            TestingFactory.create_context(doc=doc, doc_type="writer"),
+            style="Standard", region="footer", content=html)
+
+    assert res["status"] == "ok"
+    replace_html.assert_called_once()
+    assert replace_html.call_args[0][1] == html
+    text_obj.setString.assert_not_called()
+
+
+def test_set_header_footer_imports_table_html_without_force():
+    """Letterhead tables go through HTML import; do not add refuse-on-table."""
+    from unittest.mock import patch
+
+    text_obj = MagicMock()
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Text")])])
+    doc, _style = _page_style_doc(text_obj)
+    html = "<table><tr><td>Logo cell</td><td>Address cell</td></tr></table>"
+
+    with patch("plugin.writer.html_import.replace_xtext_with_html") as replace_html:
+        res = PageSetHeaderFooterText().execute(
+            TestingFactory.create_context(doc=doc, doc_type="writer"),
+            style="Standard", region="header", content=html)
+
+    assert res["status"] == "ok"
+    replace_html.assert_called_once()
+    assert replace_html.call_args[0][1] == html
+    text_obj.setString.assert_not_called()
 
 
 def test_set_header_footer_enables_a_region_that_is_off():
@@ -326,30 +368,19 @@ def test_set_header_footer_enables_a_region_that_is_off():
     text_obj.setString.assert_not_called()
 
 
-def test_set_header_footer_ignores_legacy_force_kwarg():
-    from unittest.mock import patch
-
-    text_obj = MagicMock()
-    text_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Frame")])])
-    doc, _style = _page_style_doc(text_obj, shapes=[_logo_anchored_in(text_obj)])
-
-    with patch("plugin.writer.html_import.replace_xtext_with_html") as replace_html:
-        res = PageSetHeaderFooterText().execute(
-            TestingFactory.create_context(doc=doc, doc_type="writer"),
-            style="Standard", region="header", content="<p>plain</p>", force=True)
-
-    assert res["status"] == "ok"
-    replace_html.assert_called_once()
-    assert "force" not in PageSetHeaderFooterText.parameters["properties"]
-
-
-def test_page_header_footer_descriptions_say_html_not_wipe():
+def test_page_header_footer_schema_has_no_force_and_descriptions_say_html():
+    """force/refuse-on-held is gone: schema omits force; copy says get/set HTML, not wipe."""
     get_desc = PageGetHeaderFooterText.description.lower()
     set_desc = PageSetHeaderFooterText.description.lower()
     assert "html" in get_desc
     assert "html" in set_desc
-    assert "setstring" in set_desc
+    assert "images" in get_desc and "fields" in get_desc
+    assert "force" not in PageSetHeaderFooterText.parameters["properties"]
     assert "force" not in set_desc
+    assert "force" not in get_desc
+    assert "wipe" not in set_desc
+    assert "refuse" not in set_desc
+    assert "setstring" not in set_desc
 
 
 def test_first_page_region_targets_its_own_text_object():

--- a/tests/writer/test_page_header_html_uno.py
+++ b/tests/writer/test_page_header_html_uno.py
@@ -2,7 +2,10 @@
 # Copyright (c) 2026 KeithCu
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Live UNO: page_get / page_set header-footer HTML roundtrip (API shape B)."""
+"""Live UNO: page_get / page_set header-footer HTML roundtrip.
+
+Logos, fields, and tables set without force; get still lists scan extras.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cleanup after the header/footer HTML roundtrip (#638). `page_set` already imports HTML; this PR deletes the leftover wipe/refuse/search-as-escape teaching so models are not steered back to the old path.

## Error paths that died

- **`force` on `page_set_header_footer_text`** — already gone from the schema in #638; this removes the “ignore leftover `force`” comment and the unit test that still passed `force=True`.
- **Refuse-on-held (images/fields → error unless `force`)** — no remaining set-side scan gate, `deleted` payload, or “pass `force=true` to wipe” branch.
- **Search-as-escape** — prompts and `page-api-reference` no longer tell agents to use `apply_document_content(target='search')` instead of `page_set` to keep logos/fields.
- **Wipe letterhead messaging** — tool descriptions and the apply-HTML prompt no longer mention `setString` wipe.

## Kept

- Get-side `_scan_region_content` extras: `images`, `fields`, `paragraph_count` (honest structure, not a write refuse gate).
- HTML set with logos, page-number fields, or tables succeeds without `force` (unit + existing UNO roundtrips).
- Separate “refuse `header_is_on=false` while content remains” work is untouched (not present on this tree).

No Fixes/Closes. No new tools.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-533b39a4-b8e3-4586-bffc-a253320add55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-533b39a4-b8e3-4586-bffc-a253320add55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

