### PR TITLE
mcp: keep the two tool-exposure modes showing the same capabilities

### DIFF
--- a/plugin/doc/find_tools_tool.py
+++ b/plugin/doc/find_tools_tool.py
@@ -164,7 +164,11 @@ class FindTools(ToolBase):
 
         doc = getattr(ctx, "doc", None)
         agent_label = _agent_label_for_doc_type(getattr(ctx, "doc_type", None)) if doc is not None else None
-        catalog = get_specialized_domain_catalog(agent_label=agent_label, ctx=getattr(ctx, "ctx", None))
+        # for_discovery: this catalog is what a direct_discovery client uses to find tools, so it
+        # must cover everything the flat tool list exposes. Exclusions that only shape a chat
+        # prompt would otherwise make a listed, callable tool impossible to discover.
+        catalog = get_specialized_domain_catalog(agent_label=agent_label, ctx=getattr(ctx, "ctx", None),
+                                                 for_discovery=True)
 
         if not domain:
             out: dict[str, Any] = {

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -555,47 +555,59 @@ def get_core_directives(model) -> str:
         return WRITER_CORE_DIRECTIVES
 
 
-def _catalog_entries_from_base(base_cls, *, agent_label: str | None = None, ctx=None) -> list[dict[str, str]]:
-    """Build ``[{domain, description}, …]`` for one specialized base class (delegate/MCP catalog)."""
+def _catalog_entries_from_base(base_cls, *, agent_label: str | None = None, ctx=None,
+                               for_discovery: bool = False) -> list[dict[str, str]]:
+    """Build ``[{domain, description}, …]`` for one specialized base class (delegate/MCP catalog).
+
+    ``for_discovery`` skips the exclusions that only shape a chat prompt. CALC_HIDDEN_SPECIALIZED_
+    DOMAINS keeps Python delegation out of the Calc sidebar's suggestions, but the MCP tool list
+    exposes those tools regardless — so applying it to find_tools made them callable and
+    undiscoverable at once. The sidebar-only domains stay excluded either way: the flat tool list
+    drops them too, so both modes agree without help.
+    """
     entries: list[dict[str, str]] = []
     for cls in base_cls.__subclasses__():
         domain = getattr(cls, "specialized_domain", None)
         desc = getattr(cls, "specialized_domain_description", None)
         if not domain:
             continue
-        if agent_label == "Calc" and domain in CALC_HIDDEN_SPECIALIZED_DOMAINS:
+        if agent_label == "Calc" and domain in CALC_HIDDEN_SPECIALIZED_DOMAINS and not for_discovery:
             continue
         if agent_label == "Writer" and domain in WRITER_SIDEBAR_ONLY_DOMAINS:
             continue
         if agent_label == "Draw" and domain in IMPRESS_DRAW_SIDEBAR_ONLY_DOMAINS:
             continue
-        if domain == "vision" and ctx is not None:
-            from plugin.vision.vision_availability import vision_venv_configured
+        if ctx is not None:
+            from plugin.vision.vision_availability import specialized_domain_available
 
-            if not vision_venv_configured(ctx):
+            if not specialized_domain_available(str(domain), ctx):
                 continue
         entries.append({"domain": str(domain), "description": str(desc or "")})
     return entries
 
 
-def get_specialized_domain_catalog(*, agent_label: str | None, ctx=None) -> list[dict[str, str]]:
+def get_specialized_domain_catalog(*, agent_label: str | None, ctx=None,
+                                   for_discovery: bool = False) -> list[dict[str, str]]:
     """Full specialized domain catalog — same entries as sidebar/delegate domain hints.
 
     ``agent_label`` is ``Writer`` / ``Calc`` / ``Draw`` for one app, or ``None`` to merge
     all three (e.g. MCP ``find_tools`` with no document open).
+
+    ``for_discovery`` is set by MCP ``find_tools``: it keeps the domains whose exclusion only
+    shapes a chat prompt, so discovery covers everything the flat tool list exposes.
     """
     if agent_label == "Calc":
         from plugin.calc.base import ToolCalcSpecialBase
 
-        entries = _catalog_entries_from_base(ToolCalcSpecialBase, agent_label="Calc", ctx=ctx)
+        entries = _catalog_entries_from_base(ToolCalcSpecialBase, agent_label="Calc", ctx=ctx, for_discovery=for_discovery)
     elif agent_label == "Draw":
         from plugin.draw.base import ToolDrawSpecialBase
 
-        entries = _catalog_entries_from_base(ToolDrawSpecialBase, agent_label="Draw", ctx=ctx)
+        entries = _catalog_entries_from_base(ToolDrawSpecialBase, agent_label="Draw", ctx=ctx, for_discovery=for_discovery)
     elif agent_label == "Writer":
         from plugin.writer.specialized_base import ToolWriterSpecialBase
 
-        entries = _catalog_entries_from_base(ToolWriterSpecialBase, agent_label="Writer", ctx=ctx)
+        entries = _catalog_entries_from_base(ToolWriterSpecialBase, agent_label="Writer", ctx=ctx, for_discovery=for_discovery)
     else:
         from plugin.calc.base import ToolCalcSpecialBase
         from plugin.draw.base import ToolDrawSpecialBase

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -68,6 +68,30 @@ MCP_DELEGATE_EXCLUDE_TIERS = frozenset({"specialized", "specialized_control"})
 MCP_DIRECT_FLAT_EXCLUDE_TIERS = frozenset({"specialized_control"})
 
 
+def drop_unavailable_domains(schemas, registry, ctx):
+    """Remove tools whose specialized domain cannot run on this install.
+
+    The discovery catalog has always hidden such a domain; without this the flat tool list
+    advertised its tools anyway, so the same install offered a capability in one exposure mode and
+    not the other. Only domains with a known prerequisite are affected — everything else passes
+    through untouched.
+    """
+    if ctx is None:
+        return schemas
+    from plugin.vision.vision_availability import specialized_domain_available
+    kept = []
+    for schema in schemas:
+        name = schema.get("name") if isinstance(schema, dict) else None
+        domain = None
+        if name:
+            tool = registry.get(name)
+            domain = getattr(tool, "specialized_domain", None) if tool is not None else None
+        if domain and not specialized_domain_available(str(domain), ctx):
+            continue
+        kept.append(schema)
+    return kept
+
+
 @dataclass
 class _PreparedMcpCall:
     """Main-thread document resolve + ToolContext. Safe to hand to a worker with precomputed echo."""
@@ -591,6 +615,18 @@ class MCPProtocolHandler:
                 exclude_tiers=exclude_tiers,
                 **doc_filter,
             )
+
+            # A domain whose backend is not configured is hidden from the discovery catalog; the
+            # flat list has to agree, or the same install advertises a capability in one exposure
+            # mode and not the other. This block already runs on the main thread, which get_ctx
+            # requires.
+            from plugin.framework.uno_context import get_ctx
+
+            try:
+                uno_ctx = get_ctx()
+            except Exception:
+                uno_ctx = None  # no context to ask -> advertise, same as the catalog does
+            schemas = drop_unavailable_domains(schemas, self.tool_registry, uno_ctx)
 
             if mode == "direct_flat":
                 # Keep Writer sidebar-only flows (brainstorming, writing_plan) out of the flat

--- a/plugin/vision/vision_availability.py
+++ b/plugin/vision/vision_availability.py
@@ -64,6 +64,22 @@ def _probe_ready(python_exe: str) -> bool:
     return ready
 
 
+def specialized_domain_available(domain: str, ctx: Any) -> bool:
+    """Whether a specialized domain can actually run, for the exposure layers that advertise it.
+
+    Some domains need a backend the install may not have. The discovery catalog has always hidden
+    such a domain, but the MCP tool list advertised its tools anyway, so the same install offered
+    a capability in one exposure mode and not the other — and a direct_discovery client could not
+    reach a tool it had no way to learn about. One rule, consulted by both.
+
+    Unknown domains are available: the default is to advertise, and only a domain with a known
+    prerequisite opts into being gated.
+    """
+    if domain == "vision":
+        return vision_venv_configured(ctx)
+    return True
+
+
 def vision_venv_configured(ctx: Any) -> bool:
     """True when Settings venv path is set and a python executable resolves (no import probe).
 

--- a/tests/mcp/test_tool_exposure_parity.py
+++ b/tests/mcp/test_tool_exposure_parity.py
@@ -1,0 +1,181 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""direct_flat and direct_discovery must expose the same capabilities.
+
+The two MCP exposure modes reach the specialized tools by different routes: direct_flat lists
+them straight from the registry, direct_discovery advertises a domain catalog that find_tools
+expands. Nothing kept the two in agreement, and they drifted — extract_structure_from_image was
+listed and callable in direct_flat while no catalog domain mentioned it, so a model driving
+direct_discovery could not know it existed.
+
+The invariant tested here: every tool direct_flat lists belongs to a domain the discovery catalog
+offers. Not "every declared domain is catalogued" — some are hidden from both on purpose — but
+that the two modes hide the same things.
+"""
+import pytest
+
+from plugin.framework.prompts import get_specialized_domain_catalog
+from plugin.framework.tool import ToolBase
+from plugin.mcp.mcp_protocol import MCP_DIRECT_FLAT_EXCLUDE_TIERS
+
+
+def _all_tool_classes():
+    """Every concrete tool class, however deep the base hierarchy goes."""
+    seen, stack, out = set(), list(ToolBase.__subclasses__()), []
+    while stack:
+        cls = stack.pop()
+        if id(cls) in seen:
+            continue
+        seen.add(id(cls))
+        stack.extend(cls.__subclasses__())
+        # An abstract base declares no name of its own; only registered tools have one.
+        if not (isinstance(getattr(cls, "name", None), str) and cls.name):
+            continue
+        # Tool classes defined by other test modules are in memory too once the whole suite has
+        # imported them. This is an invariant about the shipped tools, not about fixtures.
+        if str(getattr(cls, "__module__", "")).startswith(("tests.", "test_")):
+            continue
+        out.append(cls)
+    return out
+
+
+def _app_bases():
+    import plugin.calc  # noqa: F401
+    import plugin.draw  # noqa: F401
+    import plugin.writer  # noqa: F401
+    from plugin.calc.base import ToolCalcSpecialBase
+    from plugin.draw.base import ToolDrawSpecialBase
+    from plugin.writer.specialized_base import ToolWriterSpecialBase
+
+    return {"Writer": ToolWriterSpecialBase, "Calc": ToolCalcSpecialBase, "Draw": ToolDrawSpecialBase}
+
+
+def _direct_flat_tools(label):
+    """``{name: specialized_domain}`` for one app's specialized tools that direct_flat lists.
+
+    Read off the classes rather than a live registry: the registry is populated by module
+    discovery at start-up, and this invariant is about what the code declares, not about what one
+    session happened to load.
+    """
+    from plugin.framework.prompts import (
+        IMPRESS_DRAW_SIDEBAR_ONLY_DOMAINS,
+        WRITER_SIDEBAR_ONLY_DOMAINS,
+    )
+
+    bases = _app_bases()
+    wanted = tuple(bases.values()) if label is None else (bases[label],)
+    # direct_flat drops the sidebar-only flows itself (sidebar_only_tool_names): they need session
+    # orchestration the direct modes do not provide, so they are absent from BOTH modes by design
+    # and are not a parity gap.
+    sidebar_only = WRITER_SIDEBAR_ONLY_DOMAINS | IMPRESS_DRAW_SIDEBAR_ONLY_DOMAINS
+    return {cls.name: getattr(cls, "specialized_domain", None)
+            for cls in _all_tool_classes()
+            if issubclass(cls, wanted)
+            and getattr(cls, "tier", None) not in MCP_DIRECT_FLAT_EXCLUDE_TIERS
+            and getattr(cls, "specialized_domain", None) not in sidebar_only}
+
+
+@pytest.mark.parametrize("label", ["Writer", "Calc", "Draw", None])
+def test_every_listed_specialized_tool_has_a_catalogued_domain(label):
+    listed = _direct_flat_tools(label)
+    offered = {e["domain"] for e in get_specialized_domain_catalog(agent_label=label, ctx=None, for_discovery=True)}
+
+    # Guard against the check passing because it found nothing to check.
+    assert listed, "no specialized tools were found for %s" % label
+    assert any(domain for domain in listed.values()), (
+        "no listed tool reported a specialized_domain for %s — the domain lookup is broken, not "
+        "the catalog" % label)
+
+    stranded = sorted(name for name, domain in listed.items() if domain and domain not in offered)
+
+    assert not stranded, (
+        "%s: direct_flat lists these tools but no discovery domain mentions them, so a "
+        "direct_discovery client cannot find them: %s" % (label, stranded))
+
+
+@pytest.mark.parametrize("label", ["Writer", "Calc"])
+def test_parity_holds_when_a_domains_backend_is_not_configured(label, monkeypatch):
+    """The drift that prompted this file. The catalog drops the vision domain when its venv does
+    not resolve — most installs — while the MCP tool list advertised extract_structure_from_image
+    anyway. Whatever the availability rule is, one exposure mode must not apply it alone."""
+    import plugin.framework.prompts as prompts
+    from plugin.mcp.mcp_protocol import drop_unavailable_domains
+
+    ctx = object()  # any non-None ctx makes the catalog consult the availability gate
+    monkeypatch.setattr("plugin.vision.vision_availability.vision_venv_configured",
+                        lambda _ctx: False)
+
+    offered = {e["domain"] for e in prompts.get_specialized_domain_catalog(agent_label=label, ctx=ctx, for_discovery=True)}
+
+    # Run the app's specialized tools through the same filter the MCP tool list applies, so the
+    # check exercises the production path rather than restating the rule.
+    registry = _FakeRegistry(_direct_flat_tools(label))
+    schemas = [{"name": name} for name in registry.domains]
+    kept = drop_unavailable_domains(schemas, registry, ctx)
+    listed = {s["name"]: registry.domains[s["name"]] for s in kept}
+
+    stranded = sorted(name for name, domain in listed.items() if domain and domain not in offered)
+
+    assert not stranded, (
+        "%s: with the vision venv unconfigured, direct_flat still lists %s while the discovery "
+        "catalog hides the domain" % (label, stranded))
+
+
+class _FakeRegistry:
+    """Answers ``get(name)`` with an object carrying just the specialized_domain."""
+
+    def __init__(self, domains):
+        self.domains = domains
+
+    def get(self, name):
+        return type("_Tool", (), {"specialized_domain": self.domains.get(name)})
+
+
+def test_an_unavailable_domains_tools_are_dropped_from_the_list(monkeypatch):
+    """The concrete bug: extract_structure_from_image stayed in tools/list on an install whose
+    vision venv does not resolve, while the discovery catalog hid the domain."""
+    from plugin.mcp.mcp_protocol import drop_unavailable_domains
+
+    monkeypatch.setattr("plugin.vision.vision_availability.vision_venv_configured",
+                        lambda _ctx: False)
+    registry = _FakeRegistry({"extract_structure_from_image": "vision", "style_list": "styles"})
+    schemas = [{"name": "extract_structure_from_image"}, {"name": "style_list"}]
+
+    kept = drop_unavailable_domains(schemas, registry, object())
+
+    assert [s["name"] for s in kept] == ["style_list"]
+
+
+def test_a_configured_domain_stays_listed(monkeypatch):
+    from plugin.mcp.mcp_protocol import drop_unavailable_domains
+
+    monkeypatch.setattr("plugin.vision.vision_availability.vision_venv_configured",
+                        lambda _ctx: True)
+    registry = _FakeRegistry({"extract_structure_from_image": "vision"})
+    schemas = [{"name": "extract_structure_from_image"}]
+
+    assert drop_unavailable_domains(schemas, registry, object()) == schemas
+
+
+def test_tools_without_a_domain_are_never_dropped(monkeypatch):
+    """Core tools have no specialized domain and must pass through whatever the gate says."""
+    from plugin.mcp.mcp_protocol import drop_unavailable_domains
+
+    monkeypatch.setattr("plugin.vision.vision_availability.vision_venv_configured",
+                        lambda _ctx: False)
+    registry = _FakeRegistry({"get_document_content": None})
+    schemas = [{"name": "get_document_content"}]
+
+    assert drop_unavailable_domains(schemas, registry, object()) == schemas
+
+
+def test_no_context_means_no_filtering():
+    """tools/list before a document resolves has no ctx to ask; advertising is the safe default."""
+    from plugin.mcp.mcp_protocol import drop_unavailable_domains
+
+    registry = _FakeRegistry({"extract_structure_from_image": "vision"})
+    schemas = [{"name": "extract_structure_from_image"}]
+
+    assert drop_unavailable_domains(schemas, registry, None) == schemas


### PR DESCRIPTION
Went to check whether the two MCP exposure modes agree and found they do not. A tool listed and callable in `direct_flat` can be impossible to discover in `direct_discovery`, so a model driving discovery cannot know it exists.

| What breaks | Why | Fix |
|---|---|---|
| `extract_structure_from_image` is invisible to discovery | The catalog hides the `vision` domain when its venv does not resolve, which is most installs, while the tool list advertised the tool regardless | The availability rule moves into one function (`specialized_domain_available`) that both the catalog and the tool list consult |
| `run_venv_python_script` and `symbolic_math` are invisible with a Calc document open | `CALC_HIDDEN_SPECIALIZED_DOMAINS` keeps Python delegation out of the Calc sidebar's suggestions. Applying it to `find_tools` made those tools callable and undiscoverable at once | `get_specialized_domain_catalog` takes `for_discovery`, which keeps the exclusions that only shape a chat prompt. The sidebar-only domains stay excluded either way, because the flat list drops them too |

The point of the test file is that this cannot drift again: for each app, every specialized tool the flat list exposes must belong to a domain the discovery catalog offers. It runs against the production filters rather than restating them, and it guards against passing because it found nothing to check.

**Compatibility:** a domain whose backend is not configured now disappears from `tools/list` as well, instead of only from discovery. Tools with no specialized domain are untouched, and with no UNO context to consult nothing is filtered.
