### PR TITLE
Shared uno_same for header/footer XText identity

### DIFF
--- a/docs/framework/uno-utilities.md
+++ b/docs/framework/uno-utilities.md
@@ -59,6 +59,7 @@ Still [`uno_context.py`](../../plugin/framework/uno_context.py), plus the resear
 |--------|--------|---------|
 | `normalize_doc_url` | `uno_context` | Strip + drop a trailing `/` so URL identity compares. |
 | `get_runtime_uid` | `uno_context` | Per-session id (`getRuntimeUID` / attribute / property); works for untitled docs. |
+| `uno_same` | `uno_context` | UNO object identity: `is` → `==` → `uno.isSame` (unwrap viral proxy first). PyUNO wrappers, not a thread-proxy requirement. |
 | `resolve_document_by_url` | `uno_context` | Walk desktop components; match normalized URL **or** RuntimeUID; return `(model, doc_type)`. |
 | `get_open_documents` | `document_research` | List open OfficeDocuments with name/url/uid/path/type/active/modified (untitled kept). |
 | `_office_model_from_desktop_element` | `document_research` | Frame-or-model → `guard_uno(model)` for desktop walks. |

--- a/docs/writer/page-api-reference.md
+++ b/docs/writer/page-api-reference.md
@@ -52,6 +52,8 @@ These variants are exposed as the `region` values of `page_get_header_footer_tex
 
 Images in a header/footer must be anchored **`AS_CHARACTER`** (in the text flow). A floating `AT_CHARACTER` image does not contribute to line height, so even with dynamic height the region may not grow.
 
+Region membership (is this draw-page shape or search hit in *this* header `XText`?) uses [`uno_same`](../framework/uno-utilities.md) (`is` → `==` → `uno.isSame`). PyUNO often returns distinct Python wrappers for the same UNO object, so bare `==` / `!=` can miss a letterhead logo in `page_get_header_footer_text` metadata. That is a LibreOffice / PyUNO wrapper issue, not the debug UNO thread proxy. A false miss is still wrong for get/scan; historically it also made a wipe look safe.
+
 ### Reading and writing: shared body HTML pipeline
 
 `getString()` cannot represent a letterhead — a logo is an empty line and a page-number field is its rendered digits. `page_get_header_footer_text` therefore exports the region's `XText` through the same XHTML + postprocess stack as `get_document_content` (`xtext_to_content` in `html_export.py`): copy the region into a hidden Writer body, then `document_to_content`. Fields appear as `<span title="page-number"/>` (and `page-count` / `date` / `time`); tables and `<img>` logos are in the HTML. `include_images` defaults to **true** so a letterhead is visible. The result still lists `images` / `fields` / `paragraph_count` as machine-readable extras.

--- a/plugin/draw/bridge.py
+++ b/plugin/draw/bridge.py
@@ -274,13 +274,13 @@ class DrawBridge:
                     except Exception:
                         pass
                 
-                # Fallback: compare pages by identity or index
-                import uno
+                # Fallback: compare pages by UNO identity (PyUNO wrappers can differ).
+                from plugin.framework.uno_context import uno_same
+
                 pages = self.get_pages()
                 count = pages.getCount()
                 for i in range(count):
-                    p = pages.getByIndex(i)
-                    if p == page or (hasattr(uno, "areSame") and getattr(uno, "areSame")(p, page)):
+                    if uno_same(pages.getByIndex(i), page):
                         return i
         except Exception:
             log.debug("get_active_page_index failed", exc_info=True)

--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -297,33 +297,15 @@ def _log_create_shape_page_context(doc, bridge, page) -> None:
 def _page_index_for(bridge, page):
     """Index of ``page`` in the document's draw pages collection.
 
-    ``uno.isSame`` is not available in all LibreOffice Python-UNO builds; fall back to
-    identity and ``==`` (many UNO bindings implement equality for the same underlying object).
+    Uses ``uno_same`` (``is`` → ``==`` → ``uno.isSame``). PyUNO can hand distinct
+    wrappers for one draw page; ``uno.isSame`` is also missing on some builds.
     """
+    from plugin.framework.uno_context import uno_same
+
     pages = bridge.get_pages()
-    is_same = None
-    try:
-        import uno
-
-        is_same = getattr(uno, "isSame", None)
-    except ImportError:
-        pass
-
     for i in range(pages.getCount()):
-        p = pages.getByIndex(i)
-        if p is page:
+        if uno_same(pages.getByIndex(i), page):
             return i
-        try:
-            if p == page:
-                return i
-        except Exception:
-            pass
-        if callable(is_same):
-            try:
-                if is_same(p, page):
-                    return i
-            except Exception:
-                pass
     return 0
 
 

--- a/plugin/framework/uno_context.py
+++ b/plugin/framework/uno_context.py
@@ -602,6 +602,59 @@ def get_runtime_uid(model):
     return ""
 
 
+def uno_same(a: Any, b: Any) -> bool:
+    """True when *a* and *b* are the same underlying UNO object.
+
+    PyUNO often hands out **distinct Python wrappers** for one UNO identity.
+    Bare ``is`` / ``==`` / ``!=`` can then miss that a draw shape's
+    ``shape.getAnchor().getText()`` is the same header ``XText`` as
+    ``style.getPropertyValue("HeaderText")``. That false miss hid logos from
+    ``_scan_region_content`` (get/metadata wrong; historically a wipe could
+    look "safe").
+
+    This is **not** a requirement of the debug viral UNO thread proxy
+    (``_UnoThreadGuardProxy`` in ``thread_guard.py``). That proxy is a
+    separate GUARD_ON tool; release OXTs stub it off. The flaky identity is a
+    LibreOffice / PyUNO wrapper issue and exists with the proxy stripped.
+
+    It still works when proxying is on: ``_UnoThreadGuardProxy.__eq__``
+    unwraps ``_target`` and compares ``self._target == _unwrap_uno(other)``
+    (see ``thread_guard.py``), so step 2 (``==``) succeeds for
+    proxy↔unwrapped. ``uno.isSame`` is a UNO/C++ identity test and must see
+    real PyUNO objects, so step 3 unwraps via ``_unwrap_uno`` first.
+
+    Ladder (a false miss is still wrong for get/metadata, and was the
+    disaster when wipe used this scan as a refuse gate):
+
+    1. ``a is b``
+    2. try ``a == b`` (covers viral-proxy ``__eq__`` unwrap when GUARD_ON)
+    3. try ``uno.isSame`` on unwrapped objects when the function exists
+       (not all LibreOffice Python-UNO builds ship it; same fallback as
+       ``_page_index_for`` historically)
+    4. else False
+    """
+    if a is b:
+        return True
+    try:
+        if a == b:
+            return True
+    except Exception:
+        pass
+    try:
+        import uno
+
+        is_same = getattr(uno, "isSame", None)
+        if not callable(is_same):
+            return False
+        from plugin.framework.thread_guard import _unwrap_uno
+
+        # ``is True``: mocked ``uno.isSame`` (unit tests) returns a MagicMock,
+        # which is truthy. Real PyUNO returns a bool.
+        return is_same(_unwrap_uno(a), _unwrap_uno(b)) is True
+    except Exception:
+        return False
+
+
 @main_thread_only
 def resolve_document_by_url(ctx, url):
     """Resolve an open document by URL or RuntimeUID. Must be called on the UNO main thread.

--- a/plugin/writer/html_import.py
+++ b/plugin/writer/html_import.py
@@ -17,7 +17,7 @@ from html.parser import HTMLParser
 
 from plugin.doc.text_helpers import normalize_linebreaks as _normalize
 from plugin.framework.errors import ToolExecutionError
-from plugin.framework.uno_context import get_desktop
+from plugin.framework.uno_context import get_desktop, uno_same
 from . import xhtml_style_postprocess as xhtml_post
 from . import format as format_mod
 from .math.html_math_segment import html_fragment_contains_mixed_math, segment_html_with_mixed_math
@@ -731,7 +731,7 @@ def _restore_field_placeholders(model, text_obj=None):
             in_region = True
             if text_obj is not None:
                 try:
-                    in_region = found.getText() == text_obj
+                    in_region = uno_same(found.getText(), text_obj)
                 except Exception:
                     in_region = True
             nxt = None

--- a/plugin/writer/inline_review.py
+++ b/plugin/writer/inline_review.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 from typing import Any, NamedTuple
 
+from plugin.framework.uno_context import uno_same
 from plugin.writer import review_scan as _review_scan
 
 log = logging.getLogger(__name__)
@@ -597,7 +598,7 @@ def _span_has_redline(model: Any, text: Any, span: Any, consider) -> bool:
             rl_span.gotoRange(e, True)
         except Exception:
             try:
-                in_other_text = (s.getText() != text)
+                in_other_text = not uno_same(s.getText(), text)
             except Exception:
                 in_other_text = False
             if in_other_text:

--- a/plugin/writer/page.py
+++ b/plugin/writer/page.py
@@ -22,6 +22,7 @@ Page styles, margins, headers/footers, columns, and page breaks.
 from typing import Any
 
 from plugin.framework.errors import make_tool_error
+from plugin.framework.uno_context import uno_same
 
 from .specialized_base import ToolWriterPageBase
 
@@ -187,7 +188,11 @@ def _scan_region_content(doc, text_obj) -> dict[str, Any]:
         for i in range(min(int(draw_page.getCount()), _SCAN_SHAPE_LIMIT)):
             shape = draw_page.getByIndex(i)
             try:
-                if shape.getAnchor().getText() != text_obj:
+                # Distinct PyUNO wrappers for the same header XText used to make
+                # ``!=`` skip the logo (false miss). uno_same is the identity
+                # ladder; a miss here is still wrong for get/metadata (and was
+                # the disaster when wipe used this scan as a refuse gate).
+                if not uno_same(shape.getAnchor().getText(), text_obj):
                     continue
             except Exception:
                 continue

--- a/plugin/writer/search.py
+++ b/plugin/writer/search.py
@@ -22,6 +22,7 @@ from typing import Any, Literal, overload
 
 from plugin.doc.text_helpers import get_string_without_tracked_deletions, normalize_linebreaks
 from plugin.framework.tool import ToolBase, ToolBaseDummy
+from plugin.framework.uno_context import uno_same
 
 
 log = logging.getLogger("writeragent.writer")
@@ -438,7 +439,7 @@ def _header_footer_label(text_obj, doc=None, label_cache=None):
                     ("FooterTextFirst", "first-page footer"),
                 ):
                     try:
-                        if getattr(st, attr, None) == text_obj:
+                        if uno_same(getattr(st, attr, None), text_obj):
                             name = _safe_name(st)
                             result = "%s (page style '%s')" % (region, name) if name else region
                             break

--- a/tests/draw/test_bridge.py
+++ b/tests/draw/test_bridge.py
@@ -154,6 +154,23 @@ def test_get_slide_for_tool_reraises_disposed():
             DrawBridge.get_slide_for_tool("doc", 0)
 
 
+def test_get_active_page_index_matches_via_uno_same():
+    from plugin.draw.bridge import DrawBridge
+
+    pages = MagicMock()
+    pages.getCount.return_value = 2
+    first, second = object(), object()
+    pages.getByIndex.side_effect = lambda i: (first, second)[i]
+
+    class Doc:
+        def getDrawPages(self):
+            return pages
+
+    bridge = DrawBridge(Doc())
+    with patch.object(bridge, "get_active_page", return_value=second):
+        assert bridge.get_active_page_index() == 1
+
+
 def test_get_slide_for_tool_wraps_other_errors():
     from plugin.draw.bridge import DrawBridge
     from plugin.framework.errors import ToolExecutionError

--- a/tests/draw/test_shapes.py
+++ b/tests/draw/test_shapes.py
@@ -139,3 +139,17 @@ def test_shape_upsert_octagon_sets_geometry_before_page_add():
     # Double-apply after add is the crashy swap; fill/line may still set after add.
     assert not any(i > add_idx for i in engine_idxs), events
     assert not any(i > add_idx for i in geom_idxs), events
+
+
+def test_page_index_for_uses_uno_same_ladder():
+    from plugin.draw.shapes import _page_index_for
+
+    first, second = object(), object()
+    pages = MagicMock()
+    pages.getCount.return_value = 2
+    pages.getByIndex.side_effect = lambda i: (first, second)[i]
+    bridge = MagicMock()
+    bridge.get_pages.return_value = pages
+    assert _page_index_for(bridge, second) == 1
+    assert _page_index_for(bridge, first) == 0
+    assert _page_index_for(bridge, object()) == 0

--- a/tests/framework/test_uno_context.py
+++ b/tests/framework/test_uno_context.py
@@ -362,3 +362,99 @@ def test_install_attaches_leave_controls_when_trackers_already_exist():
         query.addFocusListener.assert_not_called()
     finally:
         uc._stream_focus_trackers[:] = saved
+
+
+# ---- uno_same --------------------------------------------------------------
+
+
+class _NeverEq:
+    """Two instances compare unequal so the helper must fall through ``is`` / ``==``."""
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+
+def test_uno_same_identity():
+    from plugin.framework.uno_context import uno_same
+
+    obj = object()
+    assert uno_same(obj, obj) is True
+    assert uno_same(None, None) is True
+    assert uno_same(None, object()) is False
+
+
+def test_uno_same_eq_when_not_same_ref():
+    from plugin.framework.uno_context import uno_same
+
+    class AlwaysEq:
+        def __eq__(self, other: object) -> bool:
+            return True
+
+        def __hash__(self) -> int:
+            return 0
+
+    assert uno_same(AlwaysEq(), AlwaysEq()) is True
+
+
+def test_uno_same_issame_when_is_and_eq_fail():
+    from plugin.framework.uno_context import uno_same
+
+    a, b = _NeverEq(), _NeverEq()
+    with patch.object(sys.modules["uno"], "isSame", return_value=True, create=True):
+        assert uno_same(a, b) is True
+
+
+def test_uno_same_false_when_all_paths_differ():
+    from plugin.framework.uno_context import uno_same
+
+    a, b = _NeverEq(), _NeverEq()
+    with patch.object(sys.modules["uno"], "isSame", return_value=False, create=True):
+        assert uno_same(a, b) is False
+
+
+def test_uno_same_false_when_issame_missing():
+    from plugin.framework.uno_context import uno_same
+
+    a, b = _NeverEq(), _NeverEq()
+    with patch.object(sys.modules["uno"], "isSame", None, create=True):
+        assert uno_same(a, b) is False
+
+
+def test_uno_same_mocked_issame_is_not_treated_as_true():
+    """A session-wide MagicMock ``uno.isSame`` is truthy; must not collapse every pair to same."""
+    from plugin.framework.uno_context import uno_same
+
+    a, b = _NeverEq(), _NeverEq()
+    with patch.object(sys.modules["uno"], "isSame", MagicMock(), create=True):
+        assert uno_same(a, b) is False
+
+
+def test_uno_same_proxy_eq_unwraps_target():
+    """GUARD_ON proxy ``__eq__`` unwraps ``_target`` so proxy↔unwrapped is same (step 2)."""
+    from plugin.framework import thread_guard as tg
+    from plugin.framework.uno_context import uno_same
+
+    real = object()
+    proxy = tg._UnoThreadGuardProxy(real)
+    assert proxy is not real
+    assert uno_same(proxy, real) is True
+    assert uno_same(real, proxy) is True
+
+
+def test_uno_same_issame_unwraps_proxy_first():
+    """``uno.isSame`` must see the real PyUNO target, not the viral proxy wrapper."""
+    from plugin.framework import thread_guard as tg
+    from plugin.framework.uno_context import uno_same
+
+    real_a, real_b = object(), object()
+    proxy_a = tg._UnoThreadGuardProxy(real_a)
+    seen: list[tuple[object, object]] = []
+
+    def _issame(left: object, right: object) -> bool:
+        seen.append((left, right))
+        return left is real_a and right is real_b
+
+    with patch.object(sys.modules["uno"], "isSame", _issame, create=True):
+        # ``==`` is False (distinct objects / proxy target ≠ other), so ladder hits isSame.
+        assert uno_same(proxy_a, real_b) is True
+    assert seen == [(real_a, real_b)]

--- a/tests/writer/test_html_fragment_import.py
+++ b/tests/writer/test_html_fragment_import.py
@@ -138,3 +138,31 @@ def test_rewrite_exported_field_spans_matches_body_xhtml():
 def test_rewrite_exported_field_spans_leaves_plain_html():
     assert rewrite_exported_field_spans("<p>Hello</p>") == "<p>Hello</p>"
     assert rewrite_exported_field_spans("") == ""
+
+
+def test_restore_field_placeholders_scopes_region_with_uno_same():
+    """Header field restore must use UNO identity, not bare ``==`` on XText wrappers."""
+    from plugin.writer import html_import as hi
+
+    header = object()
+    found = MagicMock()
+    found.getText.return_value = object()
+    found.getEnd.return_value = MagicMock()
+    model = MagicMock()
+    model.createSearchDescriptor.return_value = MagicMock()
+    model.findFirst.return_value = found
+    model.findNext.return_value = None
+
+    with (
+        patch.object(hi, "uno_same", return_value=True),
+        patch.object(hi, "_insert_restored_field", return_value=True) as insert,
+    ):
+        assert hi._restore_field_placeholders(model, header) >= 1
+        assert insert.called
+
+    with (
+        patch.object(hi, "uno_same", return_value=False),
+        patch.object(hi, "_insert_restored_field", return_value=True) as insert,
+    ):
+        assert hi._restore_field_placeholders(model, header) == 0
+        insert.assert_not_called()

--- a/tests/writer/test_page.py
+++ b/tests/writer/test_page.py
@@ -18,6 +18,7 @@ from plugin.writer.page import (
     PageInsertBreak,
     _disable_blocked_by_content,
     _region_holds_content,
+    _scan_region_content,
 )
 
 
@@ -368,6 +369,41 @@ def test_first_page_region_uses_the_header_height_properties():
 
     assert _height_props("header_first")[0] == "HeaderIsDynamicHeight"
     assert _height_props("footer_left")[0] == "FooterIsDynamicHeight"
+
+
+def test_scan_sees_logo_when_pyuno_wrappers_differ():
+    """Distinct wrappers for the same header XText: bare ``!=`` would skip the logo."""
+    from unittest.mock import patch
+
+    header = MagicMock()
+    header.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Frame")])])
+    other = MagicMock()
+    assert header is not other
+    assert header != other
+    doc, _style = _page_style_doc(header, shapes=[_logo_anchored_in(other)])
+
+    with patch.object(sys.modules["uno"], "isSame", side_effect=lambda a, b: {a, b} == {header, other}, create=True):
+        scan = _scan_region_content(doc, header)
+
+    assert scan["images"] == ["TIMBRE"]
+
+
+def test_get_header_reports_logo_when_anchor_text_wrapper_differs():
+    """page_get metadata must list the image even when ``==`` on XText would miss it."""
+    from unittest.mock import patch
+
+    text_obj = MagicMock()
+    text_obj.getString.return_value = "\n"
+    text_obj.createEnumeration.side_effect = lambda: _enum_of([_paragraph([_portion("Frame")])])
+    other = MagicMock()
+    doc, _style = _page_style_doc(text_obj, shapes=[_logo_anchored_in(other)])
+
+    with patch.object(sys.modules["uno"], "isSame", side_effect=lambda a, b: {a, b} == {text_obj, other}, create=True):
+        res = PageGetHeaderFooterText().execute(
+            TestingFactory.create_context(doc=doc, doc_type="writer"), style="Standard", region="header")
+
+    assert res["status"] == "ok"
+    assert res["images"] == ["TIMBRE"]
 
 
 def test_set_page_style_properties_writes_first_is_shared():

--- a/tests/writer/test_page_header_html_uno.py
+++ b/tests/writer/test_page_header_html_uno.py
@@ -262,4 +262,6 @@ def test_search_still_reaches_header_after_html_set(ctx, doc):
     found = doc.findFirst(sd)
     assert found is not None, "findFirst must still see header text"
     header = _region_text(doc, "header")
-    assert found.getText() == header or token in header.getString()
+    from plugin.framework.uno_context import uno_same
+
+    assert uno_same(found.getText(), header) or token in header.getString()

--- a/tests/writer/test_page_uno.py
+++ b/tests/writer/test_page_uno.py
@@ -2,16 +2,40 @@
 # Copyright (c) 2026 KeithCu
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Live UNO: page_set_style_properties refuses header/footer off while content remains."""
+"""Live UNO: header/footer region membership and refuse-off-while-content-remains.
+
+Missing XText identity (bare ``!=`` on distinct PyUNO wrappers) was the disaster
+for wipe: ``_scan_region_content`` skipped the logo and ``setString`` looked
+safe. The logo test locks get/scan metadata — a false miss is still wrong — and
+does not require refuse-on-set. The remaining tests pin
+``page_set_style_properties`` refusing header/footer off while content remains.
+"""
 
 from __future__ import annotations
 
+import os
+
+from plugin.framework.uno_context import uno_same
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import with_native_doc
+from plugin.tests.testing_utils import TestingFactory, with_native_doc
+from plugin.writer.images.image_tools import insert_image_into_header_footer
 from plugin.writer.page import (
+    PageGetHeaderFooterText,
     PageSetHeaderFooterText,
     PageSetStyleProperties,
+    _scan_region_content,
+    resolve_page_style,
 )
+
+
+def _header_logo_path() -> str:
+    """Return logo_32.png in the dev tree or a remapped release bundle."""
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    for rel in ("extension/assets/logo_32.png", "assets/logo_32.png"):
+        path = os.path.join(root, *rel.split("/"))
+        if os.path.isfile(path):
+            return path
+    return os.path.join(root, "extension", "assets", "logo_32.png")
 
 
 def _tool_ctx(doc, ctx):
@@ -48,6 +72,57 @@ def _set_text(doc, ctx, region, content, **kwargs):
 def _set_props(doc, ctx, **kwargs):
     return PageSetStyleProperties().execute(
         _tool_ctx(doc, ctx), style=_style_name(doc), **kwargs,
+    )
+
+
+@native_test
+@with_native_doc("writer")
+def test_header_logo_visible_to_scan_and_get(ctx, doc):
+    path = _header_logo_path()
+    assert os.path.isfile(path), "fixture image missing: %s" % path
+
+    placed = insert_image_into_header_footer(
+        doc, path, "header", width_mm=15, height_mm=15, title="HEADER_LOGO", ctx=ctx)
+    graphic = placed["graphic"]
+    assert graphic is not None, "failed to insert AS_CHARACTER graphic into the header"
+    try:
+        graphic.setName("HEADER_LOGO")
+    except Exception:
+        pass
+    try:
+        expected_name = str(graphic.getName()) or None
+    except Exception:
+        expected_name = None
+
+    style, _resolved = resolve_page_style(doc, "Standard")
+    header_text = style.getPropertyValue("HeaderText")
+    scan = _scan_region_content(doc, header_text)
+    draw_count = 0
+    try:
+        draw_count = int(doc.getDrawPage().getCount())
+    except Exception:
+        pass
+    assert scan["images"], (
+        "scan missed the header logo (XText identity). images=%r draw_page_count=%s. "
+        "A false miss is wrong for get/metadata; historically it also made wipe look safe."
+        % (scan["images"], draw_count)
+    )
+    if expected_name:
+        assert expected_name in scan["images"], scan["images"]
+
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
+    res = PageGetHeaderFooterText().execute(tool_ctx, region="header")
+    assert res["status"] == "ok", res
+    assert res.get("images"), "page_get missed the header logo: %r" % (res,)
+    if expected_name:
+        assert expected_name in res["images"], res["images"]
+
+    # Membership: the shape's anchor text is the header XText even when wrappers differ.
+    shape = doc.getDrawPage().getByIndex(0)
+    anchor_text = shape.getAnchor().getText()
+    assert uno_same(anchor_text, header_text), (
+        "uno_same must treat the shape anchor XText as the page-style HeaderText "
+        "(is=%s ===%s)" % (anchor_text is header_text, anchor_text == header_text)
     )
 
 

--- a/tests/writer/test_search_reach.py
+++ b/tests/writer/test_search_reach.py
@@ -8,7 +8,8 @@ Pure control-flow tests with fakes (no LibreOffice). The UNO behavior itself (fi
 header/footer text, comments being invisible to it) was verified live; what is testable here is
 the labeling logic of _header_footer_label / describe_match_location and the matching plus
 defensiveness of comment_matches."""
-from unittest.mock import MagicMock
+import sys
+from unittest.mock import MagicMock, patch
 
 from plugin.tests.testing_utils import setup_uno_mocks
 setup_uno_mocks()
@@ -159,6 +160,29 @@ def test_unused_styles_are_skipped():
     used = FakePageStyle("Standard", footer=hf)
     doc = FakeDoc(styles=[unused, used])
     assert _header_footer_label(hf, doc) == "footer (page style 'Standard')"
+
+
+def test_header_label_when_style_text_is_a_distinct_wrapper():
+    """Page-style HeaderText can be a different PyUNO wrapper than the match's XText."""
+    class DistinctHeadFoot:
+        ImplementationName = "SwXHeadFootText"
+
+        def __eq__(self, other):
+            return False
+
+        def __hash__(self):
+            return id(self)
+
+    match_text = DistinctHeadFoot()
+    style_text = DistinctHeadFoot()
+    doc = FakeDoc(styles=[FakePageStyle("Standard", header=style_text)])
+    with patch.object(
+        sys.modules["uno"],
+        "isSame",
+        side_effect=lambda a, b: {a, b} == {match_text, style_text},
+        create=True,
+    ):
+        assert _header_footer_label(match_text, doc) == "header (page style 'Standard')"
 
 
 def test_style_walk_failure_still_labels_generically():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Shared `uno_same(a, b)` (`is` → `==` → `uno.isSame`) so header/footer region membership does not miss a letterhead logo when PyUNO hands out distinct Python wrappers for the same UNO `XText`.

## Sites switched
- `plugin/writer/page.py` `_scan_region_content` — was `shape.getAnchor().getText() != text_obj`
- `plugin/writer/search.py` `_header_footer_label` — was `getattr(st, attr, None) == text_obj`
- `plugin/writer/inline_review.py` foreign-redline other-`XText` check
- `plugin/writer/html_import.py` `_restore_field_placeholders` — was `found.getText() == text_obj` (landed on master with #638; wired after rebase)
- `plugin/draw/shapes.py` `_page_index_for` and `plugin/draw/bridge.py` `get_active_page_index` now call the same helper (Draw already had this ladder)

Get/scan extras (`images` / `fields`) stay informational. The live UNO test asserts an AS_CHARACTER header logo is **visible** to `_scan_region_content` and `page_get`; it does not require refuse-on-set.

## Why this is not a thread-proxy fix
The viral UNO thread proxy (`_UnoThreadGuardProxy` in `thread_guard.py`) is a separate GUARD_ON debug tool. Release OXTs stub it off. The flaky identity is LibreOffice / PyUNO returning different wrappers for one UNO object.

## How proxy-on still works
`_UnoThreadGuardProxy.__eq__` unwraps `_target` (`self._target == _unwrap_uno(other)`), so step 2 (`==`) succeeds for proxy↔unwrapped. Step 3 unwraps via `_unwrap_uno` before `uno.isSame`, because `isSame` must see real PyUNO objects.

## Tests
- Unit: helper ladder (`is` / `==` / `isSame` / proxy unwrap) plus page scan, search label, draw page index, HTML field-restore region filter
- Live UNO: AS_CHARACTER graphic in a header is listed by `_scan_region_content` and `page_get_header_footer_text`
- `make typecheck` green locally

No issue-closing keywords; Keith merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fdf0d76-50ba-4e15-9469-1cb0f97421e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fdf0d76-50ba-4e15-9469-1cb0f97421e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

