### PR TITLE
add_comment: optional parent_name for threaded replies (#636)

### DIFF
--- a/docs/mcp-protocol.md
+++ b/docs/mcp-protocol.md
@@ -691,7 +691,7 @@ The mutating edit tools return **structured, machine-readable fields** alongside
 
 **`apply_style`** — `applied` (bool), `target`, and `matched` (only when `target="search"`; a search miss returns `status:"error"`, `applied:false`, `matched:false`).
 
-**`add_comment`** — `matched` (anchor found) and `comment_added`; an anchor miss returns `status:"error"`. `anchor_text` is echoed on success.
+**`add_comment`** — `matched` (anchor found) and `comment_added`; an anchor miss returns `status:"error"`. `anchor_text` is echoed on success. Success also returns `name` (LibreOffice annotation Name) so a later call can reply. Optional `parent_name` (the `name` from `comment_list`) creates a threaded reply at that **immediate** parent — not coerced to the thread root — and skips `search` / `occurrence`. The parent stays unresolved; `comment_resolve` is the reply-and-resolve path. A reply success payload includes `parent_name`.
 
 These fields are intended for clients to avoid parsing message strings; branch on `replaced_count` / `applied` / `comment_added`. Search no-ops now return `status:"error"` so clients do not treat missed edits as successful mutations.
 

--- a/plugin/scripting/writeragent_api.py
+++ b/plugin/scripting/writeragent_api.py
@@ -1174,9 +1174,9 @@ vision = _VisionProxy()
 class _WriterProxy:
     """Proxy for writer tools."""
 
-    def add_comment(self, content: str, search: str, *, occurrence: int | None = None, author: str | None = None) -> dict:
-        """Add a comment/annotation anchored to text matching search."""
-        return _rpc_call("add_comment", content=content, search=search, occurrence=occurrence, author=author)
+    def add_comment(self, content: str, *, search: str | None = None, occurrence: int | None = None, author: str | None = None, parent_name: str | None = None) -> dict:
+        """Add a comment/annotation."""
+        return _rpc_call("add_comment", content=content, search=search, occurrence=occurrence, author=author, parent_name=parent_name)
 
     def apply_document_content(self, content: list, *, target: str | None = None, old_content: str | None = None, all_matches: bool | None = None, position: str | None = None, dry_run: bool | None = None, regex: bool | None = None, case_sensitive: bool | None = None) -> dict:
         """Insert or replace content."""

--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -69,29 +69,51 @@ class CommentList(ToolWriterCommentBase):
 
 
 class AddComment(ToolBase):
-    """Add a comment anchored to a search string."""
+    """Add a comment anchored to a search string, or reply via parent_name."""
 
     name = "add_comment"
     intent = "review"
     description = (
-        "Add a comment/annotation anchored to text matching search. The comment SPANS the "
-        "matched passage (the user sees which text it covers). Use occurrence to target a later "
-        "match and author to sign it."
+        "Add a comment/annotation. For a new root comment, pass search (and optional occurrence) "
+        "so the comment SPANS the matched passage. To reply without resolving, pass parent_name "
+        "(the 'name' from comment_list); search is not required. Replies nest under that immediate "
+        "parent (including other replies) and do not mark it resolved — use comment_resolve for "
+        "reply-and-resolve. Use author to sign the comment."
     )
     parameters = {"type": "object", "properties": {
         "content": {"type": "string", "description": "The comment text."},
-        "search": {"type": "string", "description": "Anchor the comment to text matching this string."},
-        "occurrence": {"type": "integer", "description": "0-based match to comment on when search repeats (default 0)."},
+        "search": {"type": "string", "description": "Anchor a new root comment to text matching this string. Not required when parent_name is set."},
+        "occurrence": {"type": "integer", "description": "0-based match to comment on when search repeats (default 0). Ignored when parent_name is set."},
         "author": {"type": "string", "description": "Comment author (default 'WriterAgent')."},
-    }, "required": ["content", "search"]}
+        "parent_name": {"type": "string", "description": "Reply to this comment (the 'name' from comment_list). Immediate parent — not coerced to the thread root. When set, search/occurrence are skipped."},
+    }, "required": ["content"]}
     uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True
 
     def execute(self, ctx, **kwargs):
         content = kwargs.get("content", "")
-        search_text = kwargs.get("search")
+        parent_name = (kwargs.get("parent_name") or "").strip()
         author = (kwargs.get("author") or "WriterAgent").strip() or "WriterAgent"
 
+        # Reply path: look up the immediate parent by Name and insert at its anchor
+        # (same shape as CommentResolve) without setting Resolved. Do not walk to the
+        # thread root — nesting under a reply matches LO's Reply button (#636).
+        if parent_name:
+            if not content:
+                return self._tool_error("Provide content.")
+            parent = _find_annotation_by_name(ctx.doc, parent_name)
+            if parent is None:
+                # Top-level comment_added (not _tool_error details) matches the
+                # search-miss payload so clients can branch on one field.
+                return {
+                    "status": "error",
+                    "code": "COMMENT_NOT_FOUND",
+                    "message": "Comment '%s' not found. Call comment_list to see the current names." % parent_name,
+                    "comment_added": False,
+                }
+            return self._insert_reply(ctx.doc, parent, parent_name, content, author)
+
+        search_text = kwargs.get("search")
         if not search_text:
             return self._tool_error("Provide search.")
         try:
@@ -148,7 +170,45 @@ class AddComment(ToolBase):
                 "anchor_text": anchor_text or search_text,
             }
 
-        return {"status": "ok", "message": "Comment added.", "author": author, "matched": True, "comment_added": True, "anchor_text": anchor_text or search_text}
+        return {
+            "status": "ok",
+            "message": "Comment added.",
+            "author": author,
+            "matched": True,
+            "comment_added": True,
+            "anchor_text": anchor_text or search_text,
+            "name": _annotation_name(annotation),
+        }
+
+    def _insert_reply(self, doc, parent, parent_name, content, author):
+        """Insert a threaded reply at the parent's anchor. Does not set Resolved."""
+        reply = doc.createInstance("com.sun.star.text.textfield.Annotation")
+        reply.setPropertyValue("ParentName", parent_name)
+        reply.setPropertyValue("Content", content)
+        reply.setPropertyValue("Author", author)
+        _set_annotation_date(reply)
+        # Same insert as CommentResolve.execute (point insert at parent anchor,
+        # absorb=False). That path also sets Resolved; this one must not.
+        doc_text = doc.getText()
+        anchor = parent.getAnchor()
+        cursor = doc_text.createTextCursorByRange(anchor.getStart())
+        before = _count_annotations(doc)
+        doc_text.insertTextContent(cursor, reply, False)
+        if _count_annotations(doc) <= before:
+            return {
+                "status": "error",
+                "message": "Reply insert did not register an annotation.",
+                "comment_added": False,
+                "parent_name": parent_name,
+            }
+        return {
+            "status": "ok",
+            "message": "Reply added.",
+            "author": author,
+            "comment_added": True,
+            "name": _annotation_name(reply),
+            "parent_name": parent_name,
+        }
 
 
 class CommentDelete(ToolWriterCommentBase):
@@ -463,6 +523,37 @@ class CommentCheckStop(ToolWriterCommentBase):
 # ------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------
+
+
+def _find_annotation_by_name(doc, comment_name):
+    """Return the Annotation field whose Name matches *comment_name*, or None."""
+    try:
+        enum = doc.getTextFields().createEnumeration()
+    except Exception:
+        return None
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            field = enum.nextElement()
+        except Exception:
+            break
+        try:
+            if not field.supportsService("com.sun.star.text.textfield.Annotation"):
+                continue
+            if field.getPropertyValue("Name") == comment_name:
+                return field
+        except Exception:
+            continue
+    return None
+
+
+def _annotation_name(field):
+    """LibreOffice-assigned Name after insert (empty if the property is unreadable)."""
+    try:
+        return field.getPropertyValue("Name") or ""
+    except Exception:
+        return ""
 
 
 def _count_annotations(doc):

--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -187,6 +187,10 @@ class AddComment(ToolBase):
         reply.setPropertyValue("ParentName", parent_name)
         reply.setPropertyValue("Content", content)
         reply.setPropertyValue("Author", author)
+        # Point-insert replies (ParentName set) do not get an auto Name from Writer;
+        # the pre-insert instance and the document enumeration both stay empty.
+        # Setting Name before insert sticks (LO probe: listed ParentName + Name).
+        assigned_name = _ensure_annotation_name(reply, doc)
         _set_annotation_date(reply)
         # Same insert as CommentResolve.execute (point insert at parent anchor,
         # absorb=False). That path also sets Resolved; this one must not.
@@ -208,7 +212,7 @@ class AddComment(ToolBase):
             "message": "Reply added.",
             "author": author,
             "comment_added": True,
-            "name": _name_of_new_annotation(doc, reply, names_before),
+            "name": _annotation_name(reply) or assigned_name or _name_of_new_annotation(doc, reply, names_before),
             "parent_name": parent_name,
         }
 
@@ -582,6 +586,25 @@ def _annotation_field_names(doc):
         except Exception:
             names.append("")
     return names
+
+
+def _ensure_annotation_name(field, doc):
+    """Return *field*'s Name, assigning a unique one if Writer left it empty."""
+    name = _annotation_name(field)
+    if name:
+        return name
+    existing = set(n for n in _annotation_field_names(doc) if n)
+    stamp = int(now_aware().timestamp())
+    n = len(existing) + 1
+    candidate = "__Annotation__%d_%d" % (n, stamp)
+    while candidate in existing:
+        n += 1
+        candidate = "__Annotation__%d_%d" % (n, stamp)
+    try:
+        field.setPropertyValue("Name", candidate)
+    except Exception:
+        return ""
+    return _annotation_name(field) or candidate
 
 
 def _name_of_new_annotation(doc, field, names_before):

--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -156,12 +156,13 @@ class AddComment(ToolBase):
             anchor_text = found.getString()
         except Exception:
             pass
-        before = _count_annotations(doc)
+        names_before = _annotation_field_names(doc)
         match_text = found.getText()
         cursor = match_text.createTextCursorByRange(found.getStart())
         cursor.gotoRange(found.getEnd(), True)
         match_text.insertTextContent(cursor, annotation, True)
-        if _count_annotations(doc) <= before:
+        names_after = _annotation_field_names(doc)
+        if len(names_after) <= len(names_before):
             return {
                 "status": "error",
                 "message": "Comment insert did not register an annotation.",
@@ -177,7 +178,7 @@ class AddComment(ToolBase):
             "matched": True,
             "comment_added": True,
             "anchor_text": anchor_text or search_text,
-            "name": _annotation_name(annotation),
+            "name": _name_of_new_annotation(doc, annotation, names_before),
         }
 
     def _insert_reply(self, doc, parent, parent_name, content, author):
@@ -192,9 +193,10 @@ class AddComment(ToolBase):
         doc_text = doc.getText()
         anchor = parent.getAnchor()
         cursor = doc_text.createTextCursorByRange(anchor.getStart())
-        before = _count_annotations(doc)
+        names_before = _annotation_field_names(doc)
         doc_text.insertTextContent(cursor, reply, False)
-        if _count_annotations(doc) <= before:
+        names_after = _annotation_field_names(doc)
+        if len(names_after) <= len(names_before):
             return {
                 "status": "error",
                 "message": "Reply insert did not register an annotation.",
@@ -206,7 +208,7 @@ class AddComment(ToolBase):
             "message": "Reply added.",
             "author": author,
             "comment_added": True,
-            "name": _annotation_name(reply),
+            "name": _name_of_new_annotation(doc, reply, names_before),
             "parent_name": parent_name,
         }
 
@@ -556,13 +558,13 @@ def _annotation_name(field):
         return ""
 
 
-def _count_annotations(doc):
-    """How many Annotation text fields are on *doc* (0 if the enumeration is unusable)."""
-    n = 0
+def _annotation_field_names(doc):
+    """Name of each Annotation on *doc* (empty string when Name is unreadable)."""
+    names = []
     try:
         enum = doc.getTextFields().createEnumeration()
     except Exception:
-        return 0
+        return names
     while True:
         try:
             if not enum.hasMoreElements():
@@ -571,11 +573,36 @@ def _count_annotations(doc):
         except Exception:
             break
         try:
-            if field.supportsService("com.sun.star.text.textfield.Annotation"):
-                n += 1
+            if not field.supportsService("com.sun.star.text.textfield.Annotation"):
+                continue
         except Exception:
             continue
-    return n
+        try:
+            names.append(field.getPropertyValue("Name") or "")
+        except Exception:
+            names.append("")
+    return names
+
+
+def _name_of_new_annotation(doc, field, names_before):
+    """Name on *field*, or the new Name that appeared on *doc* after insert.
+
+    Point-insert replies (CommentResolve shape) often leave Name empty on the
+    pre-insert instance; the document field enumeration has the assigned id.
+    """
+    name = _annotation_name(field)
+    if name:
+        return name
+    prior = set(n for n in names_before if n)
+    for n in _annotation_field_names(doc):
+        if n and n not in prior:
+            return n
+    return ""
+
+
+def _count_annotations(doc):
+    """How many Annotation text fields are on *doc* (0 if the enumeration is unusable)."""
+    return len(_annotation_field_names(doc))
 
 
 def _set_annotation_date(annotation):

--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -623,11 +623,6 @@ def _name_of_new_annotation(doc, field, names_before):
     return ""
 
 
-def _count_annotations(doc):
-    """How many Annotation text fields are on *doc* (0 if the enumeration is unusable)."""
-    return len(_annotation_field_names(doc))
-
-
 def _set_annotation_date(annotation):
     """Set DateTimeValue (and Date) to now for a new annotation."""
     now = now_aware()

--- a/tests/writer/specialized/test_comments.py
+++ b/tests/writer/specialized/test_comments.py
@@ -107,3 +107,104 @@ def test_comment_scan_tasks_with_prefixes():
     assert res_filtered["count"] == 1
     assert res_filtered["tasks"][0]["prefix"] == "NOTE"
 
+
+def test_add_comment_schema_parent_name_optional():
+    from plugin.writer.specialized.comments import AddComment
+
+    params = AddComment.parameters
+    assert "parent_name" in params["properties"]
+    assert params["required"] == ["content"]
+    assert "search" not in params["required"]
+    assert "parent_name" not in params["required"]
+
+
+def test_add_comment_reply_requires_content():
+    from plugin.writer.specialized.comments import AddComment
+
+    ctx = MagicMock()
+    res = AddComment().execute(ctx, parent_name="some-parent")
+    assert res["status"] == "error"
+    assert "content" in res["message"].lower()
+    ctx.doc.getTextFields.assert_not_called()
+
+
+def test_add_comment_reply_unknown_parent():
+    from plugin.writer.specialized.comments import AddComment
+
+    class FakeEnum:
+        def __init__(self, items):
+            self._items = list(items)
+        def hasMoreElements(self):
+            return bool(self._items)
+        def nextElement(self):
+            return self._items.pop(0)
+
+    doc = MagicMock()
+    doc.getTextFields.return_value.createEnumeration.side_effect = lambda: FakeEnum([])
+    res = AddComment().execute(MagicMock(doc=doc), content="a reply", parent_name="no-such-comment")
+    assert res["status"] == "error"
+    assert res.get("comment_added") is False
+    assert "no-such-comment" in res["message"]
+
+
+def test_add_comment_reply_via_parent_name_skips_search():
+    """parent_name is the reply path: no text search, ParentName = immediate parent, not Resolved."""
+    from plugin.writer.specialized.comments import AddComment
+
+    class FakeEnum:
+        def __init__(self, items):
+            self._items = list(items)
+        def hasMoreElements(self):
+            return bool(self._items)
+        def nextElement(self):
+            return self._items.pop(0)
+
+    parent = MagicMock()
+    parent.supportsService.return_value = True
+    # B is itself a reply to A — we must parent the new comment to B, not walk to A.
+    parent.getPropertyValue.side_effect = lambda p: {
+        "Name": "B",
+        "ParentName": "A",
+        "Resolved": False,
+    }.get(p, "")
+
+    reply = MagicMock()
+    reply.supportsService.return_value = True
+    reply.getPropertyValue.side_effect = lambda p: {
+        "Name": "C",
+        "ParentName": "B",
+    }.get(p, "")
+
+    doc = MagicMock()
+    doc.createInstance.return_value = reply
+    calls = {"n": 0}
+
+    def _enum():
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            return FakeEnum([parent])
+        return FakeEnum([parent, reply])
+
+    doc.getTextFields.return_value.createEnumeration.side_effect = _enum
+    doc_text = MagicMock()
+    doc.getText.return_value = doc_text
+
+    with patch("plugin.writer.specialized.comments._set_annotation_date"):
+        res = AddComment().execute(
+            MagicMock(doc=doc),
+            content="approved",
+            parent_name="B",
+            search="should-be-ignored",
+        )
+    assert res["status"] == "ok", res
+    assert res["name"] == "C"
+    assert res["parent_name"] == "B"
+    assert res["comment_added"] is True
+    doc.findFirst.assert_not_called()
+    reply.setPropertyValue.assert_any_call("ParentName", "B")
+    assert not any(c[0][0] == "Resolved" for c in reply.setPropertyValue.call_args_list)
+    parent.setPropertyValue.assert_not_called()
+    doc_text.insertTextContent.assert_called_once()
+    _cursor, _field, absorb = doc_text.insertTextContent.call_args[0]
+    assert absorb is False
+

--- a/tests/writer/specialized/test_comments.py
+++ b/tests/writer/specialized/test_comments.py
@@ -209,6 +209,30 @@ def test_add_comment_reply_via_parent_name_skips_search():
     assert absorb is False
 
 
+def test_ensure_annotation_name_assigns_when_empty():
+    from plugin.writer.specialized.comments import _ensure_annotation_name
+
+    class FakeEnum:
+        def __init__(self, items):
+            self._items = list(items)
+        def hasMoreElements(self):
+            return bool(self._items)
+        def nextElement(self):
+            return self._items.pop(0)
+
+    existing = MagicMock()
+    existing.supportsService.return_value = True
+    existing.getPropertyValue.return_value = "__Annotation__1_1"
+    field = MagicMock()
+    field.getPropertyValue.return_value = ""
+    doc = MagicMock()
+    doc.getTextFields.return_value.createEnumeration.side_effect = lambda: FakeEnum([existing])
+    name = _ensure_annotation_name(field, doc)
+    assert name.startswith("__Annotation__")
+    assert name != "__Annotation__1_1"
+    field.setPropertyValue.assert_called_once_with("Name", name)
+
+
 def test_name_of_new_annotation_reads_back_from_doc():
     """Point-insert replies leave Name empty on the instance; read the new Name from the doc."""
     from plugin.writer.specialized.comments import _name_of_new_annotation

--- a/tests/writer/specialized/test_comments.py
+++ b/tests/writer/specialized/test_comments.py
@@ -208,3 +208,25 @@ def test_add_comment_reply_via_parent_name_skips_search():
     _cursor, _field, absorb = doc_text.insertTextContent.call_args[0]
     assert absorb is False
 
+
+def test_name_of_new_annotation_reads_back_from_doc():
+    """Point-insert replies leave Name empty on the instance; read the new Name from the doc."""
+    from plugin.writer.specialized.comments import _name_of_new_annotation
+
+    class FakeEnum:
+        def __init__(self, items):
+            self._items = list(items)
+        def hasMoreElements(self):
+            return bool(self._items)
+        def nextElement(self):
+            return self._items.pop(0)
+
+    field = MagicMock()
+    field.getPropertyValue.return_value = ""
+    listed = MagicMock()
+    listed.supportsService.return_value = True
+    listed.getPropertyValue.return_value = "__Annotation__9_1"
+    doc = MagicMock()
+    doc.getTextFields.return_value.createEnumeration.side_effect = lambda: FakeEnum([listed])
+    assert _name_of_new_annotation(doc, field, names_before=[]) == "__Annotation__9_1"
+

--- a/tests/writer/test_add_comment_uno.py
+++ b/tests/writer/test_add_comment_uno.py
@@ -13,7 +13,7 @@
 import uno  # noqa: F401
 
 from plugin.testing_runner import native_test
-from plugin.writer.specialized.comments import AddComment
+from plugin.writer.specialized.comments import AddComment, CommentList
 from plugin.tests.testing_utils import TestingFactory, with_native_doc
 
 
@@ -37,6 +37,29 @@ def _annotation_contents(doc):
     return out
 
 
+def _annotations(doc):
+    out = []
+    enum = doc.getTextFields().createEnumeration()
+    while enum.hasMoreElements():
+        field = enum.nextElement()
+        if not field.supportsService("com.sun.star.text.textfield.Annotation"):
+            continue
+        out.append({
+            "content": field.getPropertyValue("Content"),
+            "name": field.getPropertyValue("Name"),
+            "parent_name": field.getPropertyValue("ParentName") or "",
+            "resolved": bool(field.getPropertyValue("Resolved")),
+        })
+    return out
+
+
+def _by_name(comments, name):
+    for item in comments:
+        if item.get("name") == name:
+            return item
+    return None
+
+
 @native_test
 @with_native_doc("writer")
 def test_add_comment_reports_anchor_found_uno(ctx, doc):
@@ -50,6 +73,11 @@ def test_add_comment_reports_anchor_found_uno(ctx, doc):
     assert "a note" in _annotation_contents(doc), _annotation_contents(doc)
     # Spanning insert: Annotation registered as a TextField; matched passage stays in the body.
     assert "Anchor here please" in doc.getText().getString()
+    assert res.get("name"), res
+    listed = CommentList().execute(tool_ctx)
+    assert listed.get("status") == "ok", listed
+    listed_names = [c.get("name") for c in listed.get("comments") or []]
+    assert res["name"] in listed_names, listed
 
 
 @native_test
@@ -63,3 +91,66 @@ def test_add_comment_reports_anchor_not_found_uno(ctx, doc):
     assert res.get("status") == "error", res
     assert res.get("matched") is False, res
     assert res.get("comment_added") is False, res
+
+
+@native_test
+@with_native_doc("writer")
+def test_add_comment_reply_via_parent_name_uno(ctx, doc):
+    """Reply with parent_name only (no search). Parent stays unresolved."""
+    _set_body(doc, "Passage under review")
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
+    root = AddComment().execute(tool_ctx, content="please revise", search="Passage")
+    assert root.get("status") == "ok" and root.get("name"), root
+
+    reply = AddComment().execute(tool_ctx, content="Approved, thank you", parent_name=root["name"])
+    assert reply.get("status") == "ok", reply
+    assert reply.get("comment_added") is True, reply
+    assert reply.get("name"), reply
+    assert reply.get("parent_name") == root["name"], reply
+    assert reply["name"] != root["name"], reply
+
+    listed = CommentList().execute(tool_ctx)
+    assert listed.get("status") == "ok", listed
+    parent = _by_name(listed["comments"], root["name"])
+    child = _by_name(listed["comments"], reply["name"])
+    assert parent is not None and child is not None, listed
+    assert child["parent_name"] == root["name"], child
+    assert child["content"] == "Approved, thank you", child
+    assert parent["resolved"] is False, parent
+    fields = _annotations(doc)
+    assert _by_name(fields, root["name"])["resolved"] is False, fields
+
+
+@native_test
+@with_native_doc("writer")
+def test_add_comment_reply_to_reply_nests_uno(ctx, doc):
+    """C parented to B, B parented to A — do not flatten to the thread root."""
+    _set_body(doc, "Title sentence")
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
+    a = AddComment().execute(tool_ctx, content="root A", search="Title")
+    assert a.get("status") == "ok" and a.get("name"), a
+    b = AddComment().execute(tool_ctx, content="reply B", parent_name=a["name"])
+    assert b.get("status") == "ok" and b.get("name"), b
+    assert b.get("parent_name") == a["name"], b
+    c = AddComment().execute(tool_ctx, content="reply C", parent_name=b["name"])
+    assert c.get("status") == "ok" and c.get("name"), c
+    assert c.get("parent_name") == b["name"], c
+    assert c["parent_name"] != a["name"], c
+
+    listed = CommentList().execute(tool_ctx)
+    listed_b = _by_name(listed["comments"], b["name"])
+    listed_c = _by_name(listed["comments"], c["name"])
+    assert listed_b["parent_name"] == a["name"], listed
+    assert listed_c["parent_name"] == b["name"], listed
+
+
+@native_test
+@with_native_doc("writer")
+def test_add_comment_reply_unknown_parent_uno(ctx, doc):
+    _set_body(doc, "Some body text")
+    tool_ctx = TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
+    res = AddComment().execute(tool_ctx, content="orphan reply", parent_name="no-such-annotation")
+    assert res.get("status") == "error", res
+    assert res.get("comment_added") is False, res
+    assert "no-such-annotation" in (res.get("message") or ""), res
+    assert _annotation_contents(doc) == []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Optional `parent_name` on existing `add_comment` (Option A — no new tool). References #636.

## What changed

`add_comment` can now create a **threaded reply** without resolving the parent.

- **Root (unchanged):** `content` + `search`, optional `occurrence` / `author`.
- **Reply:** pass `parent_name` (the `name` string already returned by `comment_list`). `search` / `occurrence` are not required and are skipped.
- Replies nest under the **immediate parent**, including another reply. They are **not** coerced to the thread root (matches LibreOffice’s Reply button).
- `comment_resolve` stays the reply-and-mark-`Resolved` path.

Success returns the new annotation’s `name` (and `parent_name` on a reply) so an agent can chain further replies.

## Implementation

In `plugin/writer/specialized/comments.py`, the reply path looks up the parent Annotation by `Name`, sets `ParentName` on the new field, and inserts at the parent’s anchor using the same insert shape as `CommentResolve` — without setting `Resolved`.

Writer does not auto-assign `Name` on those point-insert replies (the pre-insert instance and the field enumeration stay empty). We set a unique `Name` before insert so `comment_list` and chained `parent_name` calls work.

## Tests

- Root `add_comment` still works and returns `name`.
- Reply with `parent_name` only appears in `comment_list` with matching `parent_name`; parent stays unresolved.
- Reply-to-reply (C → B → A) is not flattened to the root.
- Bad `parent_name` → clear error.
- Validation: missing content with `parent_name` errors; search is not required when `parent_name` is set.

Unit: `tests/writer/specialized/test_comments.py` (26 passed with existing add_comment unit tests). UNO: `tests/writer/test_add_comment_uno.py` (5 passed). `make typecheck` green.

## Docs

`docs/mcp-protocol.md` documents `name` / `parent_name` on the structured return. Scripting proxy `writer.add_comment` accepts optional `parent_name`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93159de5-7164-4a82-9dfb-e13b999ed552?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93159de5-7164-4a82-9dfb-e13b999ed552&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

