### PR TITLE
Add eval-2 AFC harness ODS oracle (ignore chat Ready)

### DIFF
--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -7,3 +7,11 @@ Each subdirectory is one experiment. First: `afc-sample-83d10b06/` (GDPval audit
 See each task’s `run.md` for how to execute a trial.
 
 Headed GDPval/AFC: run `scripts/eval_2_headed.py` (writes `chatbot.max_tool_rounds` to 50, restores when done). Do not hand-edit `writeragent.json`. Everyday default stays 15.
+
+After a trial, score the saved workbook (not chat Ready):
+
+```bash
+.venv/bin/python scripts/eval_2_headed.py --score docs/eval/eval-2/afc-sample-83d10b06/runs/<stamp>/final_workbook.ods
+```
+
+Oracle: [`scripts/eval_2_ods_oracle.py`](../../scripts/eval_2_ods_oracle.py). Rubric: [`afc-sample-83d10b06/rubric.eval2.md`](afc-sample-83d10b06/rubric.eval2.md).

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -20,3 +20,5 @@ Unified diff of the two prompt files should show only those lines.
 - Gold rubric, `task.json`, `meta.txt`, Population fixture, Sample gold workbook
 
 The gold rubric still describes a separate Excel file named `Sample`. This variant is for iterating WriterAgent/Calc in-workbook behavior; do not treat gold rubric items about a separate deliverable filename as automatically rewritten.
+
+Harness pass/fail for this variant is [`rubric.eval2.md`](rubric.eval2.md) (fixture + in-workbook oracle), not a letter-shift of `rubric_pretty.txt`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/rubric.eval2.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/rubric.eval2.md
@@ -1,0 +1,38 @@
+# rubric.eval2 — fail-closed in-workbook oracle
+
+Derived from the **Population fixture** plus **`prompt.writeragent.txt`**, not by
+letter-shifting gold [`rubric_pretty.txt`](rubric_pretty.txt). Gold is a
+separate `Sample` workbook (variance in I, flags in J, tab named
+`Sample Size`). This variant scores sheets **in the open workbook**.
+
+Leave [`docs/eval/gdpval/`](../../gdpval/) untouched.
+
+## What is scored
+
+The harness opens the saved trial artifact (`final_workbook.ods`, or `.xlsx`
+if that is what was saved). **Chat Ready / STREAM_DONE is ignored.** An empty
+Sample that ended Ready still fails.
+
+| Check | Source | Fail closed |
+|-------|--------|-------------|
+| Sheets named `Sample` and `Sample Size Calculation` exist | Writer prompt step 4 (case-insensitive, surrounding spaces ignored) | Missing either sheet |
+| Sample data rows > 0 | Fixture is a header + data table | Header-only / blank Sample |
+| S = count of flag=`1` on Sample ≥ R, and R ≥ 1 | Writer prompt: flags in **column K**. R is the integer the **Sample Size Calculation** tab reports (`Sample size`, `R`, or `R = N`) — same in-workbook source as the gold rubric, not a recomputed Cochran/FPC | Unparseable or `R < 1` (muse-style FPC→0); `S < R` |
+| Ban dominant husks in Sample data cells | Observed residue on Ready-empty trials | ≥ 50% of non-empty Sample data cells match `#DIV/0!`, `Err:507`, `Error:`, `_deal_*` / `DEAL_*`, or `PYTHONFUNCTION`-shaped text |
+
+`__Anonymous_Sheet_DB__*` is a conversion artifact, not a deliverable sheet.
+
+## Column assumptions (minimal, fixture-aligned)
+
+The Population fixture is A–H (`G` = Q3 2024 KRI, `H` = Q2 2024 KRI). This
+oracle does **not** check variance math in J (prompt §2.6 / fill-down are
+out of scope). It only needs K to count flags.
+
+## What this is not
+
+- Not a full gold-rubric grader (entity coverage, 90%/10% prose, formatting).
+- Not a product Ready predicate and not a repeated-error brake.
+- Not a reason to raise `chatbot.max_tool_rounds` (headed helper stays at 50
+  for live trials only).
+
+CLI: `scripts/eval_2_ods_oracle.py` or `scripts/eval_2_headed.py --score`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/run.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/run.md
@@ -26,4 +26,10 @@ Create `runs/<stamp>-gpt-oss-120b/` (example: `runs/20260906-1530-gpt-oss-120b/`
 | `final_workbook.ods` | Workbook after the agent finished |
 | `notes.txt` | Observer notes: failures, extra files created, rubric mismatches, timing |
 
-Leave gold under `gold/` and this `run.md` unchanged when adding a trial.
+Then score the saved workbook. Ready / STREAM_DONE is ignored — an empty Sample fails:
+
+```bash
+.venv/bin/python scripts/eval_2_headed.py --score runs/<stamp>-gpt-oss-120b/final_workbook.ods
+```
+
+See [`rubric.eval2.md`](rubric.eval2.md). Leave gold under `gold/` and this `run.md` unchanged when adding a trial.

--- a/scripts/eval_2_headed.py
+++ b/scripts/eval_2_headed.py
@@ -8,6 +8,7 @@ Usage:
   .venv/bin/python scripts/eval_2_headed.py
   .venv/bin/python scripts/eval_2_headed.py --launch
   .venv/bin/python scripts/eval_2_headed.py -- soffice --calc workbook.ods
+  .venv/bin/python scripts/eval_2_headed.py --score path/to/final_workbook.ods
 """
 from __future__ import annotations
 
@@ -176,11 +177,21 @@ def main(argv: list[str] | None = None) -> int:
         help="Start soffice --calc with the AFC Population fixture when present",
     )
     parser.add_argument(
+        "--score",
+        type=Path,
+        default=None,
+        help="Score a saved trial workbook (ODS/XLSX). Ignores chat Ready; does not write config.",
+    )
+    parser.add_argument(
         "command",
         nargs=argparse.REMAINDER,
         help="Optional command to run as the session (prefix with --)",
     )
     args = parser.parse_args(argv)
+    if args.score is not None:
+        from eval_2_ods_oracle import main as score_main
+
+        return score_main([str(args.score)])
     command = list(args.command)
     if command and command[0] == "--":
         command = command[1:]

--- a/scripts/eval_2_ods_oracle.py
+++ b/scripts/eval_2_ods_oracle.py
@@ -341,7 +341,12 @@ def score_sheets(sheets: dict[str, list[list[Cell]]]) -> OracleResult:
     s_flags = 0
     if sample is not None:
         s_flags = sum(1 for row in data_rows if is_flag_one(_flag_cell(row)))
-    if r_required is not None and r_required >= 1 and s_flags < r_required:
+    if (
+        sample is not None
+        and r_required is not None
+        and r_required >= 1
+        and s_flags < r_required
+    ):
         failures.append(f"S={s_flags} flag=1 in column K is < R={r_required}")
 
     husk_cells, scored_cells = _count_scored_husks(data_rows)

--- a/scripts/eval_2_ods_oracle.py
+++ b/scripts/eval_2_ods_oracle.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+# WriterAgent - eval-2 / AFC harness ODS oracle
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Fail-closed structural scorer for an eval-2 AFC trial workbook.
+
+Pass/fail is document-local. Chat Ready / STREAM_DONE is never consulted —
+those green-washed empty Sample sheets in the six CLEAN Ready runs.
+
+R comes from the in-workbook ``Sample Size Calculation`` tab (same source as
+the eval-2 / gold rubric: the integer the SSC sheet reports). This module does
+not recompute Cochran/FPC and does not letter-shift gold ``rubric_pretty.txt``.
+Column K is the flag column because ``prompt.writeragent.txt`` says so.
+
+Usage:
+  .venv/bin/python scripts/eval_2_ods_oracle.py path/to/final_workbook.ods
+  .venv/bin/python scripts/eval_2_headed.py --score path/to/final_workbook.ods
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+SAMPLE_SHEET = "Sample"
+SSC_SHEET = "Sample Size Calculation"
+# eval-2 writer prompt step 3: "indicate sampled rows in column K".
+# Gold flags live in J on a different deliverable — do not letter-shift.
+FLAG_COLUMN_INDEX = 10  # A=1 … K=11 → 0-based 10
+# Empty LO padding uses huge number-rows-repeated; never materialize that.
+_MAX_REPEAT = 10_000
+_ANON_DB_SHEET = re.compile(r"^__Anonymous_Sheet_DB__", re.I)
+
+_TABLE_NS = "urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+_OFFICE_NS = "urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+_TEXT_NS = "urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+_TABLE = f"{{{_TABLE_NS}}}table"
+_TABLE_ROW = f"{{{_TABLE_NS}}}table-row"
+_TABLE_CELL = f"{{{_TABLE_NS}}}table-cell"
+_COVERED_CELL = f"{{{_TABLE_NS}}}covered-table-cell"
+_TABLE_NAME = f"{{{_TABLE_NS}}}name"
+_NCOLS_REP = f"{{{_TABLE_NS}}}number-columns-repeated"
+_NROWS_REP = f"{{{_TABLE_NS}}}number-rows-repeated"
+_FORMULA = f"{{{_TABLE_NS}}}formula"
+_OFFICE_VALUE = f"{{{_OFFICE_NS}}}value"
+_OFFICE_STRING = f"{{{_OFFICE_NS}}}string-value"
+_OFFICE_BOOL = f"{{{_OFFICE_NS}}}boolean-value"
+_TEXT_P = f"{{{_TEXT_NS}}}p"
+
+# Dominant husks / residue observed on Ready-but-empty AFC trials.
+_HUSK_RE = re.compile(
+    r"(?:#DIV/0!|Err:507|Error:|_deal_|DEAL_|PYTHONFUNCTION)",
+    re.IGNORECASE,
+)
+# Labels the gold SSC uses ("Sample size") plus explicit R / required size.
+_R_LABEL_RE = re.compile(
+    r"(?i)^\s*(?:required\s+|final\s+(?:required\s+)?)?sample\s+size\s*$|^\s*r\s*$"
+)
+_R_INLINE_RE = re.compile(r"(?i)\bR\s*=\s*(\d+)\b")
+_INT_RE = re.compile(r"^[+-]?\d+(?:\.0+)?$")
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One stored cell: displayed/office value plus any formula text."""
+
+    value: object = None
+    formula: str = ""
+
+    def texts(self) -> tuple[str, ...]:
+        parts = [self.formula]
+        if self.value is not None:
+            parts.append(str(self.value))
+        return tuple(p for p in parts if p)
+
+
+@dataclass
+class OracleResult:
+    """Fail-closed trial score. ``passed`` is true only when ``failures`` is empty."""
+
+    passed: bool
+    failures: list[str] = field(default_factory=list)
+    sheet_names: list[str] = field(default_factory=list)
+    sample_data_rows: int = 0
+    s_flags: int = 0
+    r_required: int | None = None
+    husk_cells: int = 0
+    scored_cells: int = 0
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _norm_sheet(name: str) -> str:
+    return " ".join((name or "").split()).casefold()
+
+
+def _is_anon_db_sheet(name: str) -> bool:
+    return bool(_ANON_DB_SHEET.match((name or "").strip()))
+
+
+def _find_sheet(sheets: dict[str, list[list[Cell]]], wanted: str) -> list[list[Cell]] | None:
+    target = _norm_sheet(wanted)
+    for name, rows in sheets.items():
+        if _is_anon_db_sheet(name):
+            continue
+        if _norm_sheet(name) == target:
+            return rows
+    return None
+
+
+def _cell_is_empty(cell: Cell) -> bool:
+    if cell.formula.strip():
+        return False
+    value = cell.value
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
+def _row_is_empty(row: list[Cell]) -> bool:
+    return all(_cell_is_empty(cell) for cell in row)
+
+
+def is_husk_text(text: str) -> bool:
+    return bool(text) and bool(_HUSK_RE.search(text))
+
+
+def cell_is_husk(cell: Cell) -> bool:
+    return any(is_husk_text(part) for part in cell.texts())
+
+
+def _as_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        return None
+    if isinstance(value, str):
+        raw = value.strip().replace(",", "")
+        if _INT_RE.match(raw):
+            return int(float(raw))
+    return None
+
+
+def is_flag_one(cell: Cell) -> bool:
+    """True for numeric/string 1. Husks that happen to contain '1' do not count."""
+    if cell_is_husk(cell):
+        return False
+    if _as_int(cell.value) == 1:
+        return True
+    if isinstance(cell.value, str) and cell.value.strip() == "1":
+        return True
+    return False
+
+
+def parse_required_sample_size(ssc_rows: list[list[Cell]]) -> int | None:
+    """R from the SSC tab. Fail-closed caller requires R >= 1.
+
+    Picks labeled values only (``Sample size``, ``R``, ``R = N``) so the
+    population N sitting next to ``Dataset`` is not treated as R.
+    """
+    found: list[int] = []
+    for row in ssc_rows:
+        for idx, cell in enumerate(row):
+            for text in cell.texts():
+                inline = _R_INLINE_RE.search(text)
+                if inline:
+                    found.append(int(inline.group(1)))
+                if _R_LABEL_RE.match(text.strip()):
+                    for other in row[idx + 1 :]:
+                        parsed = _as_int(other.value)
+                        if parsed is not None:
+                            found.append(parsed)
+                            break
+    if not found:
+        return None
+    return found[-1]
+
+
+def _text_p_join(cell_el: ET.Element) -> str:
+    texts = ["".join(paragraph.itertext()) for paragraph in cell_el.findall(_TEXT_P)]
+    if texts:
+        return "\n".join(texts)
+    return "".join(cell_el.itertext())
+
+
+def _ods_cell_from_el(el: ET.Element) -> Cell:
+    formula = el.get(_FORMULA) or ""
+    raw_value: object
+    if el.get(_OFFICE_VALUE) is not None:
+        try:
+            raw_value = float(el.get(_OFFICE_VALUE) or "")
+        except ValueError:
+            raw_value = el.get(_OFFICE_VALUE)
+    elif el.get(_OFFICE_STRING) is not None:
+        raw_value = el.get(_OFFICE_STRING)
+    elif el.get(_OFFICE_BOOL) is not None:
+        raw_value = (el.get(_OFFICE_BOOL) or "").casefold() in {"true", "1"}
+    else:
+        raw_value = _text_p_join(el)
+        if raw_value == "":
+            raw_value = None
+    return Cell(value=raw_value, formula=formula)
+
+
+def _repeat(count_raw: str | None, *, empty: bool) -> int:
+    try:
+        count = int(count_raw or "1")
+    except ValueError:
+        count = 1
+    if count < 1:
+        return 1
+    if empty:
+        # Trailing LO padding (often 1e6 empty rows) is not Sample data.
+        return 1 if count == 1 else 0
+    return min(count, _MAX_REPEAT)
+
+
+def _read_ods_rows(table: ET.Element) -> list[list[Cell]]:
+    rows: list[list[Cell]] = []
+    for row_el in table.findall(_TABLE_ROW):
+        cells: list[Cell] = []
+        for child in row_el:
+            if child.tag not in (_TABLE_CELL, _COVERED_CELL):
+                continue
+            cell = Cell() if child.tag == _COVERED_CELL else _ods_cell_from_el(child)
+            col_repeat = _repeat(child.get(_NCOLS_REP), empty=_cell_is_empty(cell))
+            cells.extend([cell] * col_repeat)
+        row_repeat = _repeat(row_el.get(_NROWS_REP), empty=_row_is_empty(cells))
+        if row_repeat <= 0:
+            continue
+        rows.extend([list(cells) for _unused in range(row_repeat)])
+    return rows
+
+
+def read_ods(path: Path) -> dict[str, list[list[Cell]]]:
+    """Read sheet → rows from an ODS via stdlib zip/XML. No soffice."""
+    with zipfile.ZipFile(path) as zf:
+        root = ET.fromstring(zf.read("content.xml"))
+    sheets: dict[str, list[list[Cell]]] = {}
+    for table in root.findall(f".//{_TABLE}"):
+        name = table.get(_TABLE_NAME) or ""
+        if _is_anon_db_sheet(name):
+            continue
+        sheets[name] = _read_ods_rows(table)
+    return sheets
+
+
+def read_xlsx(path: Path) -> dict[str, list[list[Cell]]]:
+    from openpyxl import load_workbook
+
+    # data_only=False: we need formula text to ban PYTHONFUNCTION husks
+    # without a LibreOffice calc pass.
+    wb = load_workbook(path, data_only=False, read_only=True)
+    try:
+        sheets: dict[str, list[list[Cell]]] = {}
+        for name in wb.sheetnames:
+            if _is_anon_db_sheet(name):
+                continue
+            rows: list[list[Cell]] = []
+            for row in wb[name].iter_rows(values_only=False):
+                cells: list[Cell] = []
+                for cell in row:
+                    formula = ""
+                    value: object = cell.value
+                    if isinstance(value, str) and value.startswith("="):
+                        formula = value
+                    cells.append(Cell(value=value, formula=formula))
+                rows.append(cells)
+            sheets[name] = rows
+        return sheets
+    finally:
+        wb.close()
+
+
+def read_workbook(path: Path) -> dict[str, list[list[Cell]]]:
+    suffix = path.suffix.lower()
+    if suffix == ".ods":
+        return read_ods(path)
+    if suffix in {".xlsx", ".xlsm", ".xltx", ".xltm"}:
+        return read_xlsx(path)
+    raise ValueError(f"unsupported workbook type: {path.suffix}")
+
+
+def _sample_data_rows(sample: list[list[Cell]]) -> list[list[Cell]]:
+    if not sample:
+        return []
+    return [row for row in sample[1:] if not _row_is_empty(row)]
+
+
+def _flag_cell(row: list[Cell]) -> Cell:
+    if len(row) > FLAG_COLUMN_INDEX:
+        return row[FLAG_COLUMN_INDEX]
+    return Cell()
+
+
+def _count_scored_husks(data_rows: list[list[Cell]]) -> tuple[int, int]:
+    scored = 0
+    husks = 0
+    for row in data_rows:
+        for cell in row:
+            if _cell_is_empty(cell):
+                continue
+            scored += 1
+            if cell_is_husk(cell):
+                husks += 1
+    return husks, scored
+
+
+def score_sheets(sheets: dict[str, list[list[Cell]]]) -> OracleResult:
+    """Apply the four fail-closed checks. Does not take a Ready/status argument."""
+    failures: list[str] = []
+    names = [name for name in sheets if not _is_anon_db_sheet(name)]
+    sample = _find_sheet(sheets, SAMPLE_SHEET)
+    ssc = _find_sheet(sheets, SSC_SHEET)
+    if sample is None:
+        failures.append(f"missing sheet {SAMPLE_SHEET!r}")
+    if ssc is None:
+        failures.append(f"missing sheet {SSC_SHEET!r}")
+
+    data_rows = _sample_data_rows(sample) if sample is not None else []
+    if sample is not None and not data_rows:
+        # Empty Sample + Ready was the greenwash; fail closed here.
+        failures.append("Sample has no data rows")
+
+    r_required = parse_required_sample_size(ssc) if ssc is not None else None
+    if ssc is not None and (r_required is None or r_required < 1):
+        failures.append("R from Sample Size Calculation is missing or < 1")
+
+    s_flags = 0
+    if sample is not None:
+        s_flags = sum(1 for row in data_rows if is_flag_one(_flag_cell(row)))
+    if r_required is not None and r_required >= 1 and s_flags < r_required:
+        failures.append(f"S={s_flags} flag=1 in column K is < R={r_required}")
+
+    husk_cells, scored_cells = _count_scored_husks(data_rows)
+    if scored_cells and husk_cells * 2 >= scored_cells:
+        failures.append(
+            f"husk-dominated Sample ({husk_cells}/{scored_cells} scored cells)"
+        )
+
+    return OracleResult(
+        passed=not failures,
+        failures=failures,
+        sheet_names=names,
+        sample_data_rows=len(data_rows),
+        s_flags=s_flags,
+        r_required=r_required,
+        husk_cells=husk_cells,
+        scored_cells=scored_cells,
+    )
+
+
+def score_workbook(path: Path | str) -> OracleResult:
+    workbook = Path(path)
+    if not workbook.is_file():
+        return OracleResult(passed=False, failures=[f"workbook not found: {workbook}"])
+    try:
+        sheets = read_workbook(workbook)
+    except Exception as exc:
+        # Fail closed: a workbook we cannot parse is not a pass, including
+        # openpyxl/ODS XML surprises. Ready is still not consulted.
+        return OracleResult(passed=False, failures=[f"cannot read workbook: {exc}"])
+    return score_sheets(sheets)
+
+
+def format_result(result: OracleResult) -> str:
+    status = "PASS" if result.passed else "FAIL"
+    lines = [
+        status,
+        f"  sheets: {', '.join(result.sheet_names) or '(none)'}",
+        f"  sample_data_rows: {result.sample_data_rows}",
+        f"  S={result.s_flags} R={result.r_required}",
+        f"  husks: {result.husk_cells}/{result.scored_cells} scored cells",
+    ]
+    for item in result.failures:
+        lines.append(f"  - {item}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workbook", type=Path, help="Saved trial .ods (or .xlsx)")
+    parser.add_argument("--json", action="store_true", help="Print the result as JSON")
+    args = parser.parse_args(argv)
+    result = score_workbook(args.workbook)
+    if args.json:
+        print(json.dumps(result.to_json(), indent=2))
+    else:
+        print(format_result(result))
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval_2_ods_oracle.py
+++ b/scripts/eval_2_ods_oracle.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
 import zipfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path

--- a/tests/scripts/test_eval_2_ods_oracle.py
+++ b/tests/scripts/test_eval_2_ods_oracle.py
@@ -1,0 +1,341 @@
+# WriterAgent tests for scripts/eval_2_ods_oracle.py
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from odf.opendocument import OpenDocumentSpreadsheet
+from odf.table import Table, TableCell, TableRow
+from odf.text import P
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from eval_2_headed import main as headed_main  # noqa: E402
+from eval_2_ods_oracle import (  # noqa: E402
+    FLAG_COLUMN_INDEX,
+    Cell,
+    is_husk_text,
+    main as oracle_main,
+    parse_required_sample_size,
+    score_sheets,
+    score_workbook,
+)
+
+# Population A–H headers from the eval-2 fixture (not gold I/J).
+_SAMPLE_HEADERS = (
+    "No",
+    "Division",
+    "Sub-Division",
+    "Country",
+    "Legal Entity",
+    "KRIs",
+    "Q3 2024 KRI",
+    "Q2 2024 KRI",
+    "Variance",
+    "",
+    "Sample flag",
+)
+
+
+def _cell(val: Any) -> TableCell:
+    if val is None or val == "":
+        return TableCell()
+    if isinstance(val, dict):
+        formula = val.get("formula")
+        text = val.get("text", "")
+        cell = TableCell(valuetype="string", formula=formula) if formula else TableCell(valuetype="string")
+        if text != "":
+            cell.addElement(P(text=str(text)))
+        return cell
+    if isinstance(val, bool):
+        cell = TableCell(valuetype="boolean", boolean=val)
+        cell.addElement(P(text="true" if val else "false"))
+        return cell
+    if isinstance(val, int):
+        cell = TableCell(valuetype="float", value=float(val))
+        cell.addElement(P(text=str(val)))
+        return cell
+    if isinstance(val, float):
+        cell = TableCell(valuetype="float", value=val)
+        cell.addElement(P(text=str(val)))
+        return cell
+    cell = TableCell(valuetype="string")
+    cell.addElement(P(text=str(val)))
+    return cell
+
+
+def _pad_to_k(values: tuple[Any, ...]) -> tuple[Any, ...]:
+    """Pad a short row so index 10 is column K (eval-2 flag column)."""
+    padded = list(values)
+    while len(padded) < FLAG_COLUMN_INDEX + 1:
+        padded.append("")
+    return tuple(padded)
+
+
+def write_ods(path: Path, sheets: dict[str, list[tuple[Any, ...]]]) -> Path:
+    doc = OpenDocumentSpreadsheet()
+    for name, rows in sheets.items():
+        table = Table(name=name)
+        for rec in rows:
+            row = TableRow()
+            for val in rec:
+                row.addElement(_cell(val))
+            table.addElement(row)
+        doc.spreadsheet.addElement(table)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(path))
+    return path
+
+
+def _ssc(*, r: int | str = 1, extra: tuple[tuple[Any, ...], ...] = ()) -> list[tuple[Any, ...]]:
+    rows: list[tuple[Any, ...]] = [
+        ("Sample size", r),
+        ("confidence", "90%"),
+        ("tolerable error", "10%"),
+    ]
+    rows.extend(extra)
+    return rows
+
+
+def _good_sample_row(*, flag: int | str | None = 1) -> tuple[Any, ...]:
+    return _pad_to_k((1, "AM", "Asset Management", "Italy", "Entity", "A1", 20, 10, 1.0, "", flag))
+
+
+def write_pass_ods(path: Path) -> Path:
+    return write_ods(
+        path,
+        {
+            "Sample": [_SAMPLE_HEADERS, _good_sample_row()],
+            "Sample Size Calculation": _ssc(r=1),
+        },
+    )
+
+
+def write_missing_sample_ods(path: Path) -> Path:
+    return write_ods(path, {"Sample Size Calculation": _ssc(r=1), "Sheet1": [("No",), (1,)]})
+
+
+def write_empty_sample_ods(path: Path) -> Path:
+    return write_ods(
+        path,
+        {
+            "Sample": [_SAMPLE_HEADERS],
+            "Sample Size Calculation": _ssc(r=1),
+        },
+    )
+
+
+def write_husk_dominated_ods(path: Path) -> Path:
+    # Flag=1 would satisfy S≥R if husks were ignored. Residue must still fail.
+    husk_row = _pad_to_k(
+        (
+            "#DIV/0!",
+            "Err:507",
+            "Error: PreContractError",
+            "_deal_grid_ok",
+            "DEAL_MAX_SHAPE_DIM",
+            {"text": "COM.SUN.STAR.SHEET.ADDIN.PYTHONFUNCTION", "formula": "of:=PYTHONFUNCTION()"},
+            "",
+            "",
+            "",
+            "",
+            1,
+        )
+    )
+    return write_ods(
+        path,
+        {
+            "Sample": [_SAMPLE_HEADERS, husk_row],
+            "Sample Size Calculation": _ssc(r=1),
+        },
+    )
+
+
+def write_ready_looking_no_flags_ods(path: Path) -> Path:
+    # Both deliverable sheets + data + a Ready/STREAM_DONE note — no K flags.
+    row = _pad_to_k((1, "AM", "Asset Management", "Italy", "Entity", "A1", 20, 10, 1.0, "STREAM_DONE", ""))
+    return write_ods(
+        path,
+        {
+            "Sample": [_SAMPLE_HEADERS, row, _pad_to_k(("Ready", "chat idle", "", "", "", "", "", "", "", "", ""))],
+            "Sample Size Calculation": _ssc(r=1, extra=(("status", "Ready"),)),
+        },
+    )
+
+
+def test_pass_minimal_good_sample(tmp_path: Path) -> None:
+    path = write_pass_ods(tmp_path / "pass.ods")
+    result = score_workbook(path)
+    assert result.passed, result.failures
+    assert result.sample_data_rows == 1
+    assert result.s_flags == 1
+    assert result.r_required == 1
+    assert result.husk_cells == 0
+
+
+def test_fail_missing_sample(tmp_path: Path) -> None:
+    path = write_missing_sample_ods(tmp_path / "missing-sample.ods")
+    result = score_workbook(path)
+    assert not result.passed
+    assert any("missing sheet 'Sample'" in item for item in result.failures)
+
+
+def test_fail_empty_sample(tmp_path: Path) -> None:
+    path = write_empty_sample_ods(tmp_path / "empty-sample.ods")
+    result = score_workbook(path)
+    assert not result.passed
+    assert result.sample_data_rows == 0
+    assert any("no data rows" in item for item in result.failures)
+
+
+def test_fail_husk_dominated(tmp_path: Path) -> None:
+    path = write_husk_dominated_ods(tmp_path / "husks.ods")
+    result = score_workbook(path)
+    assert not result.passed
+    assert any("husk-dominated" in item for item in result.failures)
+
+
+def test_fail_ready_looking_but_no_flags(tmp_path: Path) -> None:
+    path = write_ready_looking_no_flags_ods(tmp_path / "ready-looking.ods")
+    result = score_workbook(path)
+    assert not result.passed
+    assert result.sample_data_rows == 2
+    assert result.s_flags == 0
+    assert any(item.startswith("S=0") for item in result.failures)
+    # Chat chrome must not greenwash.
+    assert "Ready" not in result.failures
+    assert "STREAM_DONE" not in result.failures
+
+
+def test_sheet_names_case_and_spaces(tmp_path: Path) -> None:
+    path = write_ods(
+        tmp_path / "case.ods",
+        {
+            " sample ": [_SAMPLE_HEADERS, _good_sample_row()],
+            "Sample Size Calculation ": _ssc(r=1),
+        },
+    )
+    assert score_workbook(path).passed
+
+
+def test_r_zero_fails_even_with_flags(tmp_path: Path) -> None:
+    path = write_ods(
+        tmp_path / "r0.ods",
+        {
+            "Sample": [_SAMPLE_HEADERS, _good_sample_row()],
+            "Sample Size Calculation": _ssc(r=0),
+        },
+    )
+    result = score_workbook(path)
+    assert not result.passed
+    assert any("R from Sample Size Calculation" in item for item in result.failures)
+
+
+def test_s_less_than_r_fails(tmp_path: Path) -> None:
+    path = write_ods(
+        tmp_path / "short.ods",
+        {
+            "Sample": [_SAMPLE_HEADERS, _good_sample_row()],
+            "Sample Size Calculation": _ssc(r=2),
+        },
+    )
+    result = score_workbook(path)
+    assert not result.passed
+    assert any("S=1" in item and "R=2" in item for item in result.failures)
+
+
+def test_anon_db_sheet_is_not_sample(tmp_path: Path) -> None:
+    path = write_ods(
+        tmp_path / "anon.ods",
+        {
+            "__Anonymous_Sheet_DB__0": [_SAMPLE_HEADERS, _good_sample_row()],
+            "Sample Size Calculation": _ssc(r=1),
+        },
+    )
+    result = score_workbook(path)
+    assert not result.passed
+    assert any("missing sheet 'Sample'" in item for item in result.failures)
+    assert "__Anonymous_Sheet_DB__0" not in result.sheet_names
+
+
+def test_missing_file_fails_closed(tmp_path: Path) -> None:
+    result = score_workbook(tmp_path / "nope.ods")
+    assert not result.passed
+    assert result.failures[0].startswith("workbook not found")
+
+
+def test_parse_r_ignores_population_n() -> None:
+    rows = [
+        [Cell("Dataset"), Cell(1516)],
+        [Cell("Sample size"), Cell(65)],
+    ]
+    assert parse_required_sample_size(rows) == 65
+    assert parse_required_sample_size([[Cell("R = 1")]]) == 1
+    assert parse_required_sample_size([[Cell("Dataset"), Cell(1516)]]) is None
+
+
+def test_husk_tokens() -> None:
+    assert is_husk_text("#DIV/0!")
+    assert is_husk_text("Err:507")
+    assert is_husk_text("Error: boom")
+    assert is_husk_text("_deal_grid_ok")
+    assert is_husk_text("DEAL_MAX_SHAPE_DIM")
+    assert is_husk_text("=COM.SUN.STAR.SHEET.ADDIN.PYTHONFUNCTION()")
+    assert not is_husk_text("1")
+    assert not is_husk_text("Ready")
+
+
+def test_score_sheets_has_no_ready_parameter() -> None:
+    # Structural only — a Ready-looking workbook without flags still fails.
+    sheets = {
+        "Sample": [
+            [Cell("No")],
+            [Cell("Ready")],
+        ],
+        "Sample Size Calculation": [[Cell("Sample size"), Cell(1)]],
+    }
+    result = score_sheets(sheets)
+    assert not result.passed
+    assert result.s_flags == 0
+
+
+def test_cli_pass_and_fail_exit_codes(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    good = write_pass_ods(tmp_path / "pass.ods")
+    bad = write_empty_sample_ods(tmp_path / "empty.ods")
+    assert oracle_main([str(good)]) == 0
+    assert "PASS" in capsys.readouterr().out
+    assert oracle_main([str(bad), "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] is False
+
+
+def test_gold_sample_workbook_is_not_eval2_pass() -> None:
+    """Gold is a separate file (tab ``Sample Size``, flags in J). Do not letter-shift it."""
+    gold = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "eval"
+        / "eval-2"
+        / "afc-sample-83d10b06"
+        / "gold"
+        / "Sample v2.xlsx"
+    )
+    if not gold.is_file():
+        pytest.skip("gold Sample v2.xlsx not checked out")
+    result = score_workbook(gold)
+    assert not result.passed
+    assert any("Sample Size Calculation" in item for item in result.failures)
+
+
+def test_headed_score_does_not_write_config(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    workbook = write_pass_ods(tmp_path / "pass.ods")
+    config = tmp_path / "writeragent.json"
+    assert headed_main(["--score", str(workbook), "--config", str(config)]) == 0
+    assert not config.exists()
+    assert "PASS" in capsys.readouterr().out
+    assert headed_main(["--score", str(write_empty_sample_ods(tmp_path / "empty.ods"))]) == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Harness oracle only. When an eval-2 / AFC trial ends, score the saved workbook fail-closed:

- Sheets `Sample` and `Sample Size Calculation` exist
- Sample has data rows
- S = flag=`1` count on Sample column K ≥ R, with R ≥ 1 from the in-workbook Sample Size Calculation tab (same R source as the existing rubric; not a letter-shift of gold `rubric_pretty.txt`)
- Ban dominant husks (`#DIV/0!`, `Err:507`, `Error:`, `_deal_*` / `DEAL_*`, `PYTHONFUNCTION`)

Chat Ready / STREAM_DONE is ignored and cannot greenwash an empty Sample.

**Unchanged / parked**
- Product Ready and FSM `next_state` are not touched
- Repeated-error brake stays parked
- `chatbot.max_tool_rounds` is not raised here (headed helper still writes 50 for live trials only)

CLI: `scripts/eval_2_ods_oracle.py` or `scripts/eval_2_headed.py --score`. Rubric: `docs/eval/eval-2/afc-sample-83d10b06/rubric.eval2.md`. Unit tests use tiny generated ODS fixtures (no headed soffice).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6862a4e1-7036-4e31-b6b4-836b57471df0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6862a4e1-7036-4e31-b6b4-836b57471df0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

