### PR TITLE
eval-2: clean trial dir + document_research prompt tweak

### DIFF
--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -6,7 +6,7 @@ Each subdirectory is one experiment. First: `afc-sample-83d10b06/` (GDPval audit
 
 See each task’s `run.md` for how to execute a trial.
 
-Headed GDPval/AFC: run `scripts/eval_2_headed.py` (writes `chatbot.max_tool_rounds` to 50, restores when done). Do not hand-edit `writeragent.json`. Everyday default stays 15.
+Headed GDPval/AFC: run `scripts/eval_2_headed.py --launch` (writes `chatbot.max_tool_rounds` to 50, restores when done). `--launch` copies **only** `Population v2.ods` into a clean trial dir (`$TMP/writeragent-eval2-afc` by default) and opens that copy — prompt/rubric/gold and fixture siblings stay out of the folder `document_research` can list. Do not open `fixtures/` or the task directory. Do not hand-edit `writeragent.json`. Everyday default stays 15.
 
 After a trial, score the saved workbook (not chat Ready):
 

--- a/docs/eval/eval-2/afc-sample-83d10b06/run.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/run.md
@@ -4,16 +4,15 @@ Manual Calc chat trial. Not wired into `dataset.py` / `run_eval`.
 
 ## Setup
 
-1. From the repo root, start the headed helper. It **writes** `"chatbot.max_tool_rounds": 50` into `writeragent.json` and restores the previous value (or removes the key) on Enter / Ctrl-C. Do not edit the JSON by hand.
+1. From the repo root, start the headed helper **with `--launch`**. It **writes** `"chatbot.max_tool_rounds": 50` into `writeragent.json` and restores the previous value (or removes the key) on Enter / Ctrl-C. Do not edit the JSON by hand.
 
    ```bash
-   .venv/bin/python scripts/eval_2_headed.py
+   .venv/bin/python scripts/eval_2_headed.py --launch
    ```
 
-   Optional: `--launch` opens Calc / the Population fixture; trailing args run a command as the session (`-- soffice --calc workbook.ods`). Confirm in the debug log: `Tool-calling loop START (max 50 rounds)`. Everyday chat stays at 15 after the helper exits.
-2. If the workbook is not open, open `fixtures/Population v2.xlsx` (or `fixtures/Population v2.ods` if present) in LibreOffice Calc.
-3. Set the chat model to `openai/gpt-oss-120b:nitro`.
-4. Paste the full contents of `prompt.writeragent.txt` as the user message. Do not paste `prompt.gdpval.txt`.
+   `--launch` copies **only** `fixtures/Population v2.ods` into `$TMP/writeragent-eval2-afc` (override with `--trial-dir`) and opens that copy. Prompt, rubric, gold, notes, and the xlsx / min-range siblings stay outside that folder so `document_research` cannot list them. Do **not** open `fixtures/` or this task directory. Trailing args run a command as the session (`-- soffice --calc workbook.ods`) and skip staging — use that only if the workbook is already in a clean dir. Confirm in the debug log: `Tool-calling loop START (max 50 rounds)`. Everyday chat stays at 15 after the helper exits.
+2. Set the chat model to `openai/gpt-oss-120b:nitro`.
+3. Paste the full contents of `prompt.writeragent.txt` as the user message. Do not paste `prompt.gdpval.txt`.
 
 ## After the run
 
@@ -23,7 +22,7 @@ Create `runs/<stamp>-gpt-oss-120b/` (example: `runs/20260906-1530-gpt-oss-120b/`
 |------|----------|
 | `prompt_used.txt` | Exact text sent (should match `prompt.writeragent.txt`) |
 | `thinking_and_tools.md` | Model thinking plus tool calls |
-| `final_workbook.ods` | Workbook after the agent finished |
+| `final_workbook.ods` | Workbook after the agent finished (the staged trial-dir copy, not `fixtures/`) |
 | `notes.txt` | Observer notes: failures, extra files created, rubric mismatches, timing |
 
 Then score the saved workbook. Ready / STREAM_DONE is ignored — an empty Sample fails:

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -38,8 +38,19 @@ Other important prompts (not assembled here):
 # ---------------------------------------------------------------------------
 
 # Research routing (short); domain bullets use these strings as-is.
-DELEGATION_USER_FILE_DATA_HINT = "to use information that is not in the current document, and may be in (my / our) personal or business documents"
+# Other documents the user names — not a re-read of the open workbook (eval-2
+# models were fishing prompt/rubric siblings via document_research).
+DELEGATION_USER_FILE_DATA_HINT = (
+    "to use information from other documents the user points at "
+    "((my / our) personal or business files), not the open workbook"
+)
 DELEGATION_PUBLIC_WEB_HINT = "to research public topics"
+# Extra specialized-template line (Writer/Calc). Keep single-line; "same folder"
+# taught models to scan leftover notes next to the open file.
+DOCUMENT_RESEARCH_OTHER_DOCS_LINE = (
+    "document_research: other documents the user points at, not the open "
+    "workbook or leftover notes/prompts in its folder (one delegation per file set). "
+)
 
 APPLY_DOCUMENT_CONTENT_TOOL_RESEARCH_HINT = "Required after web_research or document_research delegates return."
 
@@ -316,7 +327,7 @@ WRITER_SPECIALIZED_DELEGATION_TEMPLATE = (
     "SPECIALIZED WRITER (nested tools): The default tool list hides deep Writer features. "
     "When the user needs those, call delegate_to_specialized_writer_toolset with: domain one of: {domains} "
     "and a `task` string that fully specifies what the specialized task must do. The executor has the real tools for that domain. "
-    "document_research: other personal/business files in the same folder (one delegation per file set). "
+    f"{DOCUMENT_RESEARCH_OTHER_DOCS_LINE}"
     "web_research: public web topics; main agent writes returned report to document (apply_document_content). "
     f"{SPECIALIZED_TASK_RULES}"
 )
@@ -398,7 +409,7 @@ DEFAULT_WRITER_GREETING = "AI: I can edit or translate your document instantly w
 # has_header is a plain constraint under SORT. Do not restack Don't+Do
 # (duplicates, ~2× prompt). Because-clause is PR 616's: rewriting by hand
 # loses the header row — do not name write_formula_range / =PY in the why.
-CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_HINT} (another file/sheet by name or path, e.g. "my spreadsheet", "cell A9 from PythonInCalc"):
+CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_HINT} (another file the user names — not this open workbook, e.g. "my spreadsheet", "cell A9 from PythonInCalc"):
 - You MUST NOT ask the user where the file is stored, or to upload, paste, or share its contents.
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
@@ -427,6 +438,7 @@ CALC_SPECIALIZED_DELEGATION_TEMPLATE = (
     "SPECIALIZED CALC (nested tools): The default tool list hides advanced Calc features. "
     "When the user needs those, call delegate_to_specialized_calc_toolset with: domain one of: {domains} "
     "and a `task` string that fully specifies what the specialized task must do. The task executor has full tool access for that domain. "
+    f"{DOCUMENT_RESEARCH_OTHER_DOCS_LINE}"
     f"{SPECIALIZED_TASK_RULES}"
 )
 

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -38,19 +38,8 @@ Other important prompts (not assembled here):
 # ---------------------------------------------------------------------------
 
 # Research routing (short); domain bullets use these strings as-is.
-# Other documents the user names — not a re-read of the open workbook (eval-2
-# models were fishing prompt/rubric siblings via document_research).
-DELEGATION_USER_FILE_DATA_HINT = (
-    "to use information from other documents the user points at "
-    "((my / our) personal or business files), not the open workbook"
-)
+DELEGATION_USER_FILE_DATA_HINT = "to use information that is not in the current document, and may be in (my / our) personal or business documents"
 DELEGATION_PUBLIC_WEB_HINT = "to research public topics"
-# Extra specialized-template line (Writer/Calc). Keep single-line; "same folder"
-# taught models to scan leftover notes next to the open file.
-DOCUMENT_RESEARCH_OTHER_DOCS_LINE = (
-    "document_research: other documents the user points at, not the open "
-    "workbook or leftover notes/prompts in its folder (one delegation per file set). "
-)
 
 APPLY_DOCUMENT_CONTENT_TOOL_RESEARCH_HINT = "Required after web_research or document_research delegates return."
 
@@ -327,7 +316,7 @@ WRITER_SPECIALIZED_DELEGATION_TEMPLATE = (
     "SPECIALIZED WRITER (nested tools): The default tool list hides deep Writer features. "
     "When the user needs those, call delegate_to_specialized_writer_toolset with: domain one of: {domains} "
     "and a `task` string that fully specifies what the specialized task must do. The executor has the real tools for that domain. "
-    f"{DOCUMENT_RESEARCH_OTHER_DOCS_LINE}"
+    "document_research: other personal/business files, not the open workbook (one delegation per file set). "
     "web_research: public web topics; main agent writes returned report to document (apply_document_content). "
     f"{SPECIALIZED_TASK_RULES}"
 )
@@ -409,7 +398,7 @@ DEFAULT_WRITER_GREETING = "AI: I can edit or translate your document instantly w
 # has_header is a plain constraint under SORT. Do not restack Don't+Do
 # (duplicates, ~2× prompt). Because-clause is PR 616's: rewriting by hand
 # loses the header row — do not name write_formula_range / =PY in the why.
-CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_HINT} (another file the user names — not this open workbook, e.g. "my spreadsheet", "cell A9 from PythonInCalc"):
+CALC_CORE_DIRECTIVES: str = f"""When the user wants {DELEGATION_USER_FILE_DATA_HINT} (another file/sheet by name or path, e.g. "my spreadsheet", "cell A9 from PythonInCalc"):
 - You MUST NOT ask the user where the file is stored, or to upload, paste, or share its contents.
 - You MUST call delegate_to_specialized_calc_toolset(domain="document_research") once with their described file(s) and task in task; nearby files are matched (paths not required).
 When the user wants {DELEGATION_PUBLIC_WEB_HINT}, delegate_to_specialized_calc_toolset(domain="web_research").
@@ -438,7 +427,6 @@ CALC_SPECIALIZED_DELEGATION_TEMPLATE = (
     "SPECIALIZED CALC (nested tools): The default tool list hides advanced Calc features. "
     "When the user needs those, call delegate_to_specialized_calc_toolset with: domain one of: {domains} "
     "and a `task` string that fully specifies what the specialized task must do. The task executor has full tool access for that domain. "
-    f"{DOCUMENT_RESEARCH_OTHER_DOCS_LINE}"
     f"{SPECIALIZED_TASK_RULES}"
 )
 

--- a/scripts/eval_2_headed.py
+++ b/scripts/eval_2_headed.py
@@ -4,9 +4,15 @@
 
 No new yaml knobs. Everyday chat stays at the schema default (15).
 
+``--launch`` copies only the Population ODS into a clean trial directory
+(default ``$TMP/writeragent-eval2-afc``) so ``document_research`` cannot see
+prompt/rubric/gold or fixture siblings. Do not open ``fixtures/`` or the
+task folder.
+
 Usage:
   .venv/bin/python scripts/eval_2_headed.py
   .venv/bin/python scripts/eval_2_headed.py --launch
+  .venv/bin/python scripts/eval_2_headed.py --launch --trial-dir /tmp/my-afc
   .venv/bin/python scripts/eval_2_headed.py -- soffice --calc workbook.ods
   .venv/bin/python scripts/eval_2_headed.py --score path/to/final_workbook.ods
 """
@@ -18,6 +24,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -27,10 +34,13 @@ MAX_TOOL_ROUNDS_KEY = "chatbot.max_tool_rounds"
 DEFAULT_MAX_TOOL_ROUNDS = 15
 EVAL_2_MAX_TOOL_ROUNDS = 50
 _AFC_DIR = REPO_ROOT / "docs" / "eval" / "eval-2" / "afc-sample-83d10b06"
+POPULATION_ODS_NAME = "Population v2.ods"
+_FIXTURE_ODS = _AFC_DIR / "fixtures" / POPULATION_ODS_NAME
 _FIXTURE_CANDIDATES = (
-    _AFC_DIR / "fixtures" / "Population v2.ods",
+    _FIXTURE_ODS,
     _AFC_DIR / "fixtures" / "Population v2.xlsx",
 )
+DEFAULT_TRIAL_DIR_NAME = "writeragent-eval2-afc"
 
 
 def writeragent_json_candidates() -> list[Path]:
@@ -146,6 +156,67 @@ def find_afc_fixture() -> Path | None:
     return None
 
 
+def find_afc_population_ods() -> Path:
+    """Population ODS only. XLSX stay in fixtures/ (sibling, researchable)."""
+    if _FIXTURE_ODS.is_file():
+        return _FIXTURE_ODS
+    raise FileNotFoundError(
+        f"Missing {_FIXTURE_ODS}. Convert the xlsx fixture with "
+        "soffice --convert-to ods; do not open fixtures/ (siblings leak)."
+    )
+
+
+def default_eval2_trial_dir() -> Path:
+    return Path(tempfile.gettempdir()) / DEFAULT_TRIAL_DIR_NAME
+
+
+def _is_protected_trial_dest(dest_dir: Path, source: Path) -> bool:
+    """Refuse dest that would wipe the task tree, fixtures, or a filesystem root."""
+    dest_dir = dest_dir.resolve()
+    source = source.resolve()
+    afc = _AFC_DIR.resolve()
+    if dest_dir == source.parent or dest_dir in source.parents:
+        return True
+    if dest_dir == afc or dest_dir == afc.parent:
+        return True
+    try:
+        dest_dir.relative_to(afc)
+        return True
+    except ValueError:
+        pass
+    if dest_dir == Path(dest_dir.anchor) or dest_dir == Path(tempfile.gettempdir()):
+        return True
+    return False
+
+
+def stage_clean_trial_ods(source: Path, dest_dir: Path) -> Path:
+    """Copy only *source* into *dest_dir* (wiped). Prompt/rubric/gold stay outside.
+
+    document_research lists the open workbook's folder. Opening from fixtures/
+    or the AFC task dir exposes xlsx, min-range ODS, prompt.txt, rubric, notes.
+    """
+    source = source.resolve()
+    dest_dir = dest_dir.resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"Population fixture not found: {source}")
+    if _is_protected_trial_dest(dest_dir, source):
+        raise ValueError(
+            f"refusing to stage into protected path {dest_dir} "
+            "(task tree, fixture folder, or filesystem/temp root)"
+        )
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    # Previous trials may have leftover Sample notes or extra ODS — wipe so
+    # list_nearby_files sees only the Population copy.
+    for child in dest_dir.iterdir():
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+    dest = dest_dir / source.name
+    shutil.copy2(source, dest)
+    return dest
+
+
 def launch_calc(fixture: Path | None) -> None:
     soffice = shutil.which("soffice")
     if soffice is None:
@@ -174,7 +245,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--launch",
         action="store_true",
-        help="Start soffice --calc with the AFC Population fixture when present",
+        help="Stage Population ODS only into a clean trial dir, then soffice --calc",
+    )
+    parser.add_argument(
+        "--trial-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory that will contain only the Population ODS "
+            f"(default: $TMP/{DEFAULT_TRIAL_DIR_NAME})"
+        ),
     )
     parser.add_argument(
         "--score",
@@ -203,7 +283,16 @@ def main(argv: list[str] | None = None) -> int:
         if command:
             exit_code = subprocess.call(command)
         elif args.launch:
-            launch_calc(find_afc_fixture())
+            try:
+                trial_ods = stage_clean_trial_ods(
+                    find_afc_population_ods(),
+                    args.trial_dir or default_eval2_trial_dir(),
+                )
+            except (FileNotFoundError, ValueError) as exc:
+                print(str(exc), file=sys.stderr)
+                return 1
+            print(f"Staged clean trial dir {trial_ods.parent} ({trial_ods.name} only)")
+            launch_calc(trial_ods)
             _wait_for_finish()
         else:
             _wait_for_finish()

--- a/tests/framework/test_constants.py
+++ b/tests/framework/test_constants.py
@@ -6,19 +6,22 @@ from plugin.tests.testing_utils import setup_uno_mocks
 setup_uno_mocks()
 
 from plugin.framework.prompts import (
-    DELEGATION_USER_FILE_DATA_HINT,
-    SIDEBAR_VS_DOCUMENT,
-    get_greeting_for_document,
-    get_chat_system_prompt_for_document,
-    get_core_directives,
-    get_specialized_delegation_for_model,
-    python_specialized_sub_agent_hint,
-    WRITER_CORE_DIRECTIVES,
     CALC_CORE_DIRECTIVES,
-    DRAW_CORE_DIRECTIVES,
-    DEFAULT_WRITER_GREETING,
+    CALC_SPECIALIZED_DELEGATION_TEMPLATE,
     DEFAULT_CALC_GREETING,
     DEFAULT_DRAW_GREETING,
+    DEFAULT_WRITER_GREETING,
+    DELEGATION_USER_FILE_DATA_HINT,
+    DOCUMENT_RESEARCH_OTHER_DOCS_LINE,
+    DRAW_CORE_DIRECTIVES,
+    SIDEBAR_VS_DOCUMENT,
+    WRITER_CORE_DIRECTIVES,
+    WRITER_SPECIALIZED_DELEGATION_TEMPLATE,
+    get_chat_system_prompt_for_document,
+    get_core_directives,
+    get_greeting_for_document,
+    get_specialized_delegation_for_model,
+    python_specialized_sub_agent_hint,
 )
 
 # NOTE: the EXTERNAL_AGENT_GUIDANCE pin test moved to tests/chatbot/test_agent_manual.py —
@@ -473,4 +476,30 @@ def test_document_research_multi_file_delegation_in_prompts():
     for directives in (WRITER_CORE_DIRECTIVES, CALC_CORE_DIRECTIVES, DRAW_CORE_DIRECTIVES):
         assert "described file(s)" in directives
         assert "once with" in directives or "once with their" in directives
+
+
+def test_document_research_prompt_is_other_docs_not_open_workbook():
+    # Eval-2 escape: models used document_research on sibling prompt/rubric.
+    # Product wording only — no gateway firewall.
+    assert "other documents the user points at" in DELEGATION_USER_FILE_DATA_HINT
+    assert "not the open workbook" in DELEGATION_USER_FILE_DATA_HINT
+    assert "(my / our) personal or business files" in DELEGATION_USER_FILE_DATA_HINT
+    assert "same folder" not in DELEGATION_USER_FILE_DATA_HINT
+    assert "same folder" not in DOCUMENT_RESEARCH_OTHER_DOCS_LINE
+    assert "not the open workbook" in DOCUMENT_RESEARCH_OTHER_DOCS_LINE
+    assert "leftover notes/prompts" in DOCUMENT_RESEARCH_OTHER_DOCS_LINE
+    assert DOCUMENT_RESEARCH_OTHER_DOCS_LINE in WRITER_SPECIALIZED_DELEGATION_TEMPLATE
+    assert DOCUMENT_RESEARCH_OTHER_DOCS_LINE in CALC_SPECIALIZED_DELEGATION_TEMPLATE
+    assert "not this open workbook" in CALC_CORE_DIRECTIVES
+    assert "same folder" not in CALC_CORE_DIRECTIVES
+    calc_model = MagicMock()
+
+    def supportsService(service):
+        return service == "com.sun.star.sheet.SpreadsheetDocument"
+
+    calc_model.supportsService.side_effect = supportsService
+    calc_prompt = get_chat_system_prompt_for_document(calc_model)
+    assert "other documents the user points at" in calc_prompt
+    assert "not the open workbook" in calc_prompt
+    assert "other personal/business files in the same folder" not in calc_prompt
 

--- a/tests/framework/test_constants.py
+++ b/tests/framework/test_constants.py
@@ -7,12 +7,10 @@ setup_uno_mocks()
 
 from plugin.framework.prompts import (
     CALC_CORE_DIRECTIVES,
-    CALC_SPECIALIZED_DELEGATION_TEMPLATE,
     DEFAULT_CALC_GREETING,
     DEFAULT_DRAW_GREETING,
     DEFAULT_WRITER_GREETING,
     DELEGATION_USER_FILE_DATA_HINT,
-    DOCUMENT_RESEARCH_OTHER_DOCS_LINE,
     DRAW_CORE_DIRECTIVES,
     SIDEBAR_VS_DOCUMENT,
     WRITER_CORE_DIRECTIVES,
@@ -479,27 +477,7 @@ def test_document_research_multi_file_delegation_in_prompts():
 
 
 def test_document_research_prompt_is_other_docs_not_open_workbook():
-    # Eval-2 escape: models used document_research on sibling prompt/rubric.
-    # Product wording only — no gateway firewall.
-    assert "other documents the user points at" in DELEGATION_USER_FILE_DATA_HINT
-    assert "not the open workbook" in DELEGATION_USER_FILE_DATA_HINT
-    assert "(my / our) personal or business files" in DELEGATION_USER_FILE_DATA_HINT
-    assert "same folder" not in DELEGATION_USER_FILE_DATA_HINT
-    assert "same folder" not in DOCUMENT_RESEARCH_OTHER_DOCS_LINE
-    assert "not the open workbook" in DOCUMENT_RESEARCH_OTHER_DOCS_LINE
-    assert "leftover notes/prompts" in DOCUMENT_RESEARCH_OTHER_DOCS_LINE
-    assert DOCUMENT_RESEARCH_OTHER_DOCS_LINE in WRITER_SPECIALIZED_DELEGATION_TEMPLATE
-    assert DOCUMENT_RESEARCH_OTHER_DOCS_LINE in CALC_SPECIALIZED_DELEGATION_TEMPLATE
-    assert "not this open workbook" in CALC_CORE_DIRECTIVES
-    assert "same folder" not in CALC_CORE_DIRECTIVES
-    calc_model = MagicMock()
-
-    def supportsService(service):
-        return service == "com.sun.star.sheet.SpreadsheetDocument"
-
-    calc_model.supportsService.side_effect = supportsService
-    calc_prompt = get_chat_system_prompt_for_document(calc_model)
-    assert "other documents the user points at" in calc_prompt
-    assert "not the open workbook" in calc_prompt
-    assert "other personal/business files in the same folder" not in calc_prompt
+    # Tiny wording only: "same folder" taught models to scan leftover siblings.
+    assert "not the open workbook" in WRITER_SPECIALIZED_DELEGATION_TEMPLATE
+    assert "same folder" not in WRITER_SPECIALIZED_DELEGATION_TEMPLATE
 

--- a/tests/scripts/test_eval_2_headed.py
+++ b/tests/scripts/test_eval_2_headed.py
@@ -111,7 +111,7 @@ def test_find_writeragent_json_missing() -> None:
 def _afc_style_tree(root: Path) -> Path:
     """Task dir + fixtures siblings that document_research would otherwise see."""
     fixtures = root / "fixtures"
-    fixtures.mkdir()
+    fixtures.mkdir(parents=True)
     (fixtures / POPULATION_ODS_NAME).write_bytes(b"ODS-BYTES")
     (fixtures / "Population v2.xlsx").write_bytes(b"XLSX")
     (fixtures / "min-range-too-large.ods").write_bytes(b"MIN")

--- a/tests/scripts/test_eval_2_headed.py
+++ b/tests/scripts/test_eval_2_headed.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -15,10 +16,14 @@ from eval_2_headed import (  # noqa: E402
     DEFAULT_MAX_TOOL_ROUNDS,
     EVAL_2_MAX_TOOL_ROUNDS,
     MAX_TOOL_ROUNDS_KEY,
+    POPULATION_ODS_NAME,
+    _AFC_DIR,
     apply_max_tool_rounds,
+    default_eval2_trial_dir,
     find_writeragent_json,
     read_max_tool_rounds,
     restore_max_tool_rounds,
+    stage_clean_trial_ods,
     temporary_max_tool_rounds,
 )
 
@@ -101,3 +106,65 @@ def test_find_writeragent_json_explicit(tmp_path: Path) -> None:
 def test_find_writeragent_json_missing() -> None:
     with pytest.raises(FileNotFoundError, match="writeragent.json"):
         find_writeragent_json(candidates=[])
+
+
+def _afc_style_tree(root: Path) -> Path:
+    """Task dir + fixtures siblings that document_research would otherwise see."""
+    fixtures = root / "fixtures"
+    fixtures.mkdir()
+    (fixtures / POPULATION_ODS_NAME).write_bytes(b"ODS-BYTES")
+    (fixtures / "Population v2.xlsx").write_bytes(b"XLSX")
+    (fixtures / "min-range-too-large.ods").write_bytes(b"MIN")
+    (root / "prompt.writeragent.txt").write_text("PROMPT-LEAK", encoding="utf-8")
+    (root / "rubric_pretty.txt").write_text("RUBRIC-LEAK", encoding="utf-8")
+    (root / "notes.md").write_text("NOTES-LEAK", encoding="utf-8")
+    gold = root / "gold"
+    gold.mkdir()
+    (gold / "Sample v2.xlsx").write_bytes(b"GOLD")
+    return fixtures / POPULATION_ODS_NAME
+
+
+def test_stage_clean_trial_dir_contains_only_population_ods(tmp_path: Path) -> None:
+    source = _afc_style_tree(tmp_path / "afc-sample")
+    dest = tmp_path / "trial"
+    result = stage_clean_trial_ods(source, dest)
+    names = sorted(p.name for p in dest.iterdir())
+    assert names == [POPULATION_ODS_NAME]
+    assert result == dest / POPULATION_ODS_NAME
+    assert result.read_bytes() == b"ODS-BYTES"
+
+
+def test_stage_clean_trial_dir_wipes_leftovers(tmp_path: Path) -> None:
+    source = _afc_style_tree(tmp_path / "afc-sample")
+    dest = tmp_path / "trial"
+    dest.mkdir()
+    (dest / "prompt.writeragent.txt").write_text("old", encoding="utf-8")
+    (dest / "extra.ods").write_bytes(b"extra")
+    leftover_dir = dest / "notes"
+    leftover_dir.mkdir()
+    (leftover_dir / "rubric.txt").write_text("old", encoding="utf-8")
+    stage_clean_trial_ods(source, dest)
+    assert sorted(p.name for p in dest.iterdir()) == [POPULATION_ODS_NAME]
+
+
+def test_stage_clean_trial_dir_refuses_fixture_folder(tmp_path: Path) -> None:
+    source = _afc_style_tree(tmp_path / "afc-sample")
+    with pytest.raises(ValueError, match="protected"):
+        stage_clean_trial_ods(source, source.parent)
+
+
+def test_stage_clean_trial_dir_refuses_real_afc_task_dir(tmp_path: Path) -> None:
+    source = _afc_style_tree(tmp_path / "afc-sample")
+    with pytest.raises(ValueError, match="protected"):
+        stage_clean_trial_ods(source, _AFC_DIR)
+
+
+def test_stage_clean_trial_dir_missing_source(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Population fixture"):
+        stage_clean_trial_ods(tmp_path / "missing.ods", tmp_path / "trial")
+
+
+def test_default_eval2_trial_dir_is_tmp_subdir() -> None:
+    path = default_eval2_trial_dir()
+    assert path.name == "writeragent-eval2-afc"
+    assert path.parent == Path(tempfile.gettempdir())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
eval-2 / AFC models were escaping through `document_research` into sibling prompt, rubric, gold, and fixture files.

**Clean trial dir (main fix).** `scripts/eval_2_headed.py --launch` copies **only** `Population v2.ods` into `$TMP/writeragent-eval2-afc` (or `--trial-dir`) and opens that copy. Prompt, rubric, gold, notes, and fixture siblings stay outside the folder research can list.

**Prompt tweak (tiny).** One phrase swap on the Writer specialized line: `in the same folder` → `not the open workbook`. No longer research-policy rewrite. No product gateway firewall.

Runbook: `docs/eval/eval-2/README.md` and `afc-sample-83d10b06/run.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13284add-fc9b-497e-880a-9c3dc7396ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13284add-fc9b-497e-880a-9c3dc7396ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

