### PR TITLE
Align eval-2 Writer prompt Q2/Q3 axes with Population

### DIFF
--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -6,17 +6,22 @@ Intentional delta vs [`prompt.gdpval.txt`](prompt.gdpval.txt) (byte-identical to
 2. Step 4 only: instead of creating a **separate** spreadsheet file titled ‘Sample’ with two tabs, produce sheets **in this open workbook**:
    - sheet titled ‘Sample’
    - sheet titled ‘Sample Size Calculation’
+3. Step 2 parenthetical: gold says “columns H and I” (I is not on Population). Writer prompt uses fixture axes plus the in-workbook oracle: Q2 is in H, Q3 is in G; variance = (G−H)/H into J; flags in K.
 
-Unified diff of the two prompt files should show only those lines.
+## In-workbook axes (fixture + oracle, not gold letters)
+
+Population headers are A–H only: **G = Q3 2024 KRI**, **H = Q2 2024 KRI**. QoQ variance is (Q3−Q2)/Q2 = (G−H)/H. Eval-2 writes that into **J** and sample flags into **K** (already the writer prompt / harness convention).
+
+Gold `Sample v2` is a **different** deliverable (variance in **I**, flags in **J**). `rubric_pretty.txt` is not a letter-shift of that layout (S-total wording even points at **K** while other lines treat **J** as variance or as the flag). Do not rewrite gold rubric letters for eval-2.
 
 ## Not changed
 
-- Column letters **J** (variance) and **K** (sample flag “1”)
 - Entity list (CB Cash Italy, CB Correspondent Banking Greece, IB Debt Markets Luxembourg, CB Trade Finance Brazil, PB EMEA UAE)
 - Metrics A1 / C1, zero-both-quarters, Trade Finance / Correspondent Banking, Cayman Islands / Pakistan / UAE
 - Coverage across all Divisions and sub-Divisions
 - Sample-size parameters (90% confidence, 10% tolerable error)
-- Formula / workings wording in steps 1–3 (including “second tab titled ‘Sample Size Calculation’” in step 1)
-- Gold rubric, `task.json`, `meta.txt`, Population fixture, Sample gold workbook
+- Step 1 wording (“second tab titled ‘Sample Size Calculation’”)
+- Gold rubric, `task.json`, `meta.txt`, `prompt.gdpval.txt`, Population fixture, Sample gold workbook
+- `docs/eval/gdpval/`
 
 The gold rubric still describes a separate Excel file named `Sample`. This variant is for iterating WriterAgent/Calc in-workbook behavior; do not treat gold rubric items about a separate deliverable filename as automatically rewritten.

--- a/docs/eval/eval-2/afc-sample-83d10b06/prompt.writeragent.txt
+++ b/docs/eval/eval-2/afc-sample-83d10b06/prompt.writeragent.txt
@@ -5,7 +5,7 @@ This spreadsheet titled ‘Population’ contains Anti-Financial Crime Risk Metr
 Using the data in the ‘Population’ spreadsheet, complete the following:
 1. Calculate the required sample size for audit testing based on a 90% confidence level and a 10% tolerable error rate. Include your workings in a second tab titled ‘Sample Size Calculation’.
 
-2. Perform a variance analysis on Q2 and Q3 data (columns H and I).
+2. Perform a variance analysis on Q2 and Q3 data (Q2 is in H, Q3 is in G; variance = (G−H)/H into J; flags in K).
 - Calculate quarter-on-quarter variance and capture the result in column J.
 
 3. Select a sample for audit testing based on the following criteria and indicate sampled rows in column K by entering “1”. Ensure that i) each sample selected satisfies at least one criteria listed below, and ii) across all samples selected, each criteria below is satisfied by at least one selected sample among all samples selected.

--- a/docs/eval/eval-2/first-principles-analysis-v4.md
+++ b/docs/eval/eval-2/first-principles-analysis-v4.md
@@ -152,10 +152,10 @@ Deepseek ~450 `getCellAddress` errors then Ready. ~50 rounds **without** a brake
 **Verified**
 
 - Fixture headers: A=No … **G=Q3 2024 KRI, H=Q2 2024 KRI** (8 columns A–H).  
-- Writer prompt: “columns **H and I**” for variance → **J** / flags **K** — **I does not exist**; Q2/Q3 axes wrong.  
+- Writer prompt now uses the one-liner below (was “columns **H and I**”; I does not exist on Population).  
 - Gold `rubric_pretty.txt` is **structurally** a different deliverable (separate Sample workbook; variance in **I**; flags in **J**; S-total wording references **K** while other lines treat **J** as variance). Not a letter-shift of the in-workbook variant.
 
-**One-line prompt fix (eval-2):**  
+**Eval-2 writer prompt one-liner:**  
 *“Q2 is in H, Q3 is in G; variance = (G−H)/H into J; flags in K.”*
 
 Derive `rubric.eval2` from **fixture + in-workbook oracle**, not by substituting letters in gold. Leave `docs/eval/gdpval/` untouched.

--- a/tests/scripts/test_eval_2_afc_prompt.py
+++ b/tests/scripts/test_eval_2_afc_prompt.py
@@ -1,0 +1,70 @@
+# WriterAgent tests for eval-2 AFC writer prompt column axes
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Writer prompt axes come from the Population fixture, not gold H/I."""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+_AFC = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "eval"
+    / "eval-2"
+    / "afc-sample-83d10b06"
+)
+_WRITER_PROMPT = _AFC / "prompt.writeragent.txt"
+_GDPVAL_PROMPT = _AFC / "prompt.gdpval.txt"
+_POPULATION = _AFC / "fixtures" / "Population v2.xlsx"
+_SSML = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+
+# Locked eval-2 one-liner (fixture G=Q3, H=Q2; in-workbook J/K).
+_AXES = "Q2 is in H, Q3 is in G; variance = (G−H)/H into J; flags in K"
+
+
+def _xlsx_header_row(path: Path) -> list[str]:
+    """First-row labels from an xlsx shared-string sheet. No LibreOffice."""
+    with zipfile.ZipFile(path) as zf:
+        shared_root = ET.fromstring(zf.read("xl/sharedStrings.xml"))
+        shared: list[str] = []
+        for si in shared_root.findall(f"{{{_SSML}}}si"):
+            shared.append("".join(t.text or "" for t in si.findall(f".//{{{_SSML}}}t")))
+        sheet = ET.fromstring(zf.read("xl/worksheets/sheet1.xml"))
+        row = sheet.find(f"{{{_SSML}}}sheetData/{{{_SSML}}}row")
+        assert row is not None, f"no rows in {path}"
+        headers: list[str] = []
+        for cell in row.findall(f"{{{_SSML}}}c"):
+            value = cell.findtext(f"{{{_SSML}}}v") or ""
+            if cell.get("t") == "s" and value.isdigit():
+                headers.append(shared[int(value)])
+            else:
+                headers.append(value)
+        return headers
+
+
+def test_writer_prompt_uses_fixture_qh_axes() -> None:
+    text = _WRITER_PROMPT.read_text(encoding="utf-8")
+    assert _AXES in text
+    assert "columns H and I" not in text
+    # Gold copy stays the GDPval wording; do not “fix” it by letter-shift.
+    gold = _GDPVAL_PROMPT.read_text(encoding="utf-8")
+    assert "columns H and I" in gold
+
+
+def test_population_fixture_headers_are_g_q3_h_q2() -> None:
+    headers = _xlsx_header_row(_POPULATION)
+    assert headers[:8] == [
+        "No",
+        "Division",
+        "Sub-Division",
+        "Country",
+        "Legal Entity",
+        "KRIs",
+        "Q3 2024 KRI",
+        "Q2 2024 KRI",
+    ]
+    # A–H only: I is not a Population field (gold H/I wording is wrong here).
+    assert len([h for h in headers if h]) == 8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Population fixture is A–H: **G = Q3 2024 KRI**, **H = Q2 2024 KRI**. The eval-2 Writer prompt taught variance from **H and I**; I is not on the fixture.

One-line Writer prompt correction:

`Q2 is in H, Q3 is in G; variance = (G−H)/H into J; flags in K.`

Notes come from the fixture plus the in-workbook J/K convention, not a letter-shift of gold `rubric_pretty.txt`. `docs/eval/gdpval/` is untouched.

A pytest pin checks the Writer prompt text and Population header row.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af6fda0e-eb80-47a4-849a-30587fa46ec8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af6fda0e-eb80-47a4-849a-30587fa46ec8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

