### PR TITLE
Clarify add_comment parent_name can reuse a prior success name

### DIFF
--- a/plugin/writer/specialized/comments.py
+++ b/plugin/writer/specialized/comments.py
@@ -76,7 +76,7 @@ class AddComment(ToolBase):
     description = (
         "Add a comment/annotation. For a new root comment, pass search (and optional occurrence) "
         "so the comment SPANS the matched passage. To reply without resolving, pass parent_name "
-        "(the 'name' from comment_list); search is not required. Replies nest under that immediate "
+        "(the 'name' from a prior add_comment success, or from comment_list); search is not required. Replies nest under that immediate "
         "parent (including other replies) and do not mark it resolved — use comment_resolve for "
         "reply-and-resolve. Use author to sign the comment."
     )
@@ -85,7 +85,7 @@ class AddComment(ToolBase):
         "search": {"type": "string", "description": "Anchor a new root comment to text matching this string. Not required when parent_name is set."},
         "occurrence": {"type": "integer", "description": "0-based match to comment on when search repeats (default 0). Ignored when parent_name is set."},
         "author": {"type": "string", "description": "Comment author (default 'WriterAgent')."},
-        "parent_name": {"type": "string", "description": "Reply to this comment (the 'name' from comment_list). Immediate parent — not coerced to the thread root. When set, search/occurrence are skipped."},
+        "parent_name": {"type": "string", "description": "Reply to this comment. Pass the 'name' from a prior add_comment success, or the 'name' field from comment_list. Immediate parent — not coerced to the thread root. When set, search/occurrence are skipped."},
     }, "required": ["content"]}
     uno_services = ["com.sun.star.text.TextDocument"]
     is_mutation = True

--- a/plugin/writer/specialized/mail_merge.py
+++ b/plugin/writer/specialized/mail_merge.py
@@ -40,7 +40,8 @@ def _to_file_url(path_or_url: str) -> str:
     if path_or_url.startswith("file://"):
         return path_or_url
     try:
-        if uno and hasattr(uno, "systemPathToFileUrl"):
+        # import uno is unconditional; ty treats `if uno` as always-true once UNO is linked.
+        if hasattr(uno, "systemPathToFileUrl"):
             res = uno.systemPathToFileUrl(os.path.abspath(path_or_url))
             if isinstance(res, str):
                 return res


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #636 / merged PR #651.

The `add_comment` `parent_name` schema only said the id comes from `comment_list`. Models can already reply using the `name` returned by a prior `add_comment` success (that path shipped in #651); this updates the tool and parameter descriptions so that is explicit.

## Change
- `parent_name` description now says: pass the `name` from a prior `add_comment` success, or the `name` field from `comment_list`. Immediate parent — not coerced to the thread root. When set, search/occurrence are skipped.
- Tool `description` aligned in one sentence so it no longer says “from comment_list” alone.

## Typecheck
CI `ty` failed on a pre-existing guard in `mail_merge._to_file_url`: `if uno and hasattr(...)`. `import uno` is unconditional, so after system UNO is linked `ty` treats `uno` as always truthy. Dropped the redundant `uno and`; kept `hasattr` plus the existing fallback. No `add_comment` behavior change.

## Out of scope
- No behavior, payload, or `prompts.py` changes.
- This does not close #636.

## Tests
- `tests/writer/specialized/test_comments.py` + `test_mail_merge.py`: 18 passed
- Local `make typecheck`: green (`ty` included)

Related: #636, #651
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7fee192-a9f5-41f5-8037-68807be57949?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7fee192-a9f5-41f5-8037-68807be57949&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

