### PR TITLE
Raise chatbot.max_tool_rounds schema max from 50 to 150

### DIFF
--- a/docs/writeragent-config-schema.md
+++ b/docs/writeragent-config-schema.md
@@ -87,7 +87,7 @@ Top-level keys from the config dataclass (Settings dialog, chat, images).
 
 | Key | Type | Default | Range | Description |
 | --- | --- | --- | --- | --- |
-| `max_tool_rounds` | `int` | `15` | `1`–`50` | Max Tool Rounds |
+| `max_tool_rounds` | `int` | `15` | `1`–`150` | Max Tool Rounds |
 | `context_strategy` | `string` | `"auto"` |  | How much document content to include in LLM context Options: auto (Auto (by document size)), full (Full document text), page (Pages around cursor), tree (Outline + excerpt), stats (Stats + outline only) |
 | `extend_selection_max_tokens` | `int` | `1000` | `10`–`4096` | Internal. Extend max tokens |
 | `edit_selection_max_new_tokens` | `int` | `1000` | `0`–`4096` | Internal. Extra tokens beyond original text length. 0 = same length as original. |

--- a/plugin/chatbot/module.yaml
+++ b/plugin/chatbot/module.yaml
@@ -14,7 +14,7 @@ config:
     type: int
     default: 15
     min: 1
-    max: 50
+    max: 150
     widget: number
     label: Max Tool Rounds
 

--- a/tests/framework/test_config_schema.py
+++ b/tests/framework/test_config_schema.py
@@ -99,6 +99,26 @@ def test_module_yaml_defaults_bind_from_manifest_modules() -> None:
     assert schema.MODULES is schema._DEFAULT_MODULES
 
 
+def test_max_tool_rounds_schema_allows_150() -> None:
+    """Eval-2 headed trials may set 150; schema max used to clamp that to 50."""
+    from plugin.framework import config_schema as schema
+
+    assert schema.MODULES, "empty MODULES; run make manifest"
+    for key in ("chatbot.max_tool_rounds", "max_tool_rounds"):
+        field = get_config_schema(key)
+        assert field is not None, key
+        assert field["min"] == 1
+        assert field["max"] == 150
+        assert field["default"] == 15
+        assert clamp_schema_value(key, 150) == 150
+        assert clamp_schema_value(key, 151) == 150
+        assert clamp_schema_value(key, 15) == 15
+
+    cfg = WriterAgentConfig.from_dict({"endpoint": "http://x", "chatbot.max_tool_rounds": 150})
+    cfg.validate(coerce_out_of_range=True)
+    assert cfg._extra_config["chatbot.max_tool_rounds"] == 150
+
+
 def test_config_schema_has_no_forbidden_imports() -> None:
     source = _SCHEMA_PATH.read_text(encoding="utf-8")
     imported = _imported_modules(ast.parse(source))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Keith wants eval-2 / GDPval headed trials at ~150 tool rounds when needed. The schema max was 50, so writing `150` was clamped and the tool loop logged `max 50 rounds`. Everyday chat stays at the default of 15.

## Change

- `plugin/chatbot/module.yaml`: raise `max_tool_rounds` `"max"` from 50 to 150 (default 15, min 1). This is the source for generated `plugin/_manifest.py` (`chatbot.max_tool_rounds` and legacy `max_tool_rounds`).
- `docs/writeragent-config-schema.md`: Max Tool Rounds range is now `1`–`150`.
- Unit test: `test_max_tool_rounds_schema_allows_150` asserts both keys accept 150, still default to 15, and clamp 151 to 150.

Settings number widget and `clamp_schema_value` read this schema, so 150 is accepted end-to-end. No other hard caps of 50 on this setting needed changing. The headed helper still writes 50 by default; operators can set 150 in `writeragent.json` without clamping.

## Testing

- `pytest tests/framework/test_config_schema.py`: 13 passed
- `make typecheck`: passed
- Runtime check: default 15; `clamp(150) = 150`; `clamp(151) = 150`; `from_dict`+`validate` keeps 150

## Notes

Default remains 15. This PR does not change everyday chat behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-066f5bf3-a566-4ac6-a173-53b1bbdc51c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066f5bf3-a566-4ac6-a173-53b1bbdc51c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

