### PR TITLE
Soften eval-2 Tenant Retention oracle for headed-memo format

### DIFF
--- a/docs/eval/eval-2/tenant-retention-ed2bc14c/notes.md
+++ b/docs/eval/eval-2/tenant-retention-ed2bc14c/notes.md
@@ -34,13 +34,36 @@ The expert gold memo states 45% / 25% but omits Stamford and the 9/20
 and 5/20 counts. Eval-2 scores the **saved trial memo**, not that gold
 file, and fail-closes on the counts (wrong analysis = FAIL).
 
+## Oracle format soften (headed-memo false-FAIL)
+
+A real Gemini headed memo (~1476 words; Harborview/Stamford; +10%/6mo;
+early-bird 90d / 60d / M2M; 90/60/30; two events; table cells `9` /
+`45.0%` and `5` / `25.0%`; section titles in ODT `text:h`) false-failed
+the v1 structural oracle on **format**, not substance. Soften (do **not**
+weaken Harborview Flats, Stamford, 10% retention, 6 months, or the
+husk/`Error:` ban; do **not** change `prompt.writeragent.txt`):
+
+1. Extract walks `text:h` as well as `text:p` (heading titles were invisible).
+2. Percents accept `45%` / `45.0%` / `45 percent` (same for 25).
+3. Counts pass on literal `9/20` / `9 out of 20` / `9 of 20`, **or**
+   digit `9` near the rent-increase theme plus survey N=`20` somewhere
+   (same for community `5`).
+4. Section titles allow a short synonym OR list (secondary; `text:h`
+   extract is the main fix).
+5. Word max is **1800** (min stays 180) so table-heavy 1–2 page memos pass.
+
+If `runs/20260908-0121-gemini-3.8-flash-r200/final_memo.odt` is on disk,
+re-score it after this soften — substance checks should **PASS** (or only
+fail on a genuine content gap). That artifact is not committed here.
+
 ## Not changed
 
-- Four required sections and the 1–2 page memo length
+- Four required section themes (titles may be synonyms / `text:h`)
 - Early-bird 90d / standard 60d / month-to-month premium
 - 90/60/30 communication touchpoints and two next-quarter events
 - Permission to use web examples for events (oracle does not require cites)
 - Gold rubric, `task.json`, `meta.txt`, `prompt.gdpval.txt`, gold memo bytes
+- Writer prompt (`prompt.writeragent.txt`)
 - `docs/eval/gdpval/` contents (this PR only **adds** this task id)
 
 Harness pass/fail for this variant is [`rubric.eval2.md`](rubric.eval2.md),

--- a/docs/eval/eval-2/tenant-retention-ed2bc14c/rubric.eval2.md
+++ b/docs/eval/eval-2/tenant-retention-ed2bc14c/rubric.eval2.md
@@ -17,12 +17,12 @@ basename typo `Rentention`.
 | Check | Source | Fail closed |
 |-------|--------|-------------|
 | Writer doc present (`.odt` / `.docx`) and body is non-empty | Writer prompt: memo in this open document | Missing file / unreadable / no extractable text |
-| ~1–2 pages (word band 180–1400) | Gold + writer prompt “concise, 1-2 page” | `< 180` (Ready-empty) or `> 1400` |
+| ~1–2 pages (word band 180–1800) | Gold + writer prompt “concise, 1-2 page”; 1800 leaves headroom for table-heavy headed memos (~1500 words) | `< 180` (Ready-empty) or `> 1800` |
 | `Harborview Flats` and `Stamford` present | Prompt + gold rubric | Either string missing |
 | Objective: **+10% retention / 6 months** | Prompt + gold rubric | Missing `10%` or `6 month` |
-| Four section themes present | Writer prompt components 1–4 | Missing departure analysis, tiered renewal, communication plan, or community engagement |
-| Top reason: **rent increase** **9/20 (45%)** | Fixture: 9 of 20 comments; gold rubric | Missing rent-increase theme, `9/20` (or `9 out of 20`), or `45%` |
-| Top reason: **lack of community / disconnected** **5/20 (25%)** | Fixture: 5 of 20 comments; gold rubric | Missing community/disconnected theme, `5/20` (or `5 out of 20`), or `25%` |
+| Four section themes present | Writer prompt components 1–4. ODT extract includes `text:h` (LibreOffice headings). Titles may be synonyms (`departure reason/categor`, `exit survey/analysis`, `communication plan/template/cadence`, `email draft/timeline`, `community engagement` / `engagement initiative`) | Missing departure analysis, tiered renewal, communication plan, or community engagement |
+| Top reason: **rent increase** **9/20 (45%)** | Fixture: 9 of 20 comments; gold rubric | Missing rent-increase theme; missing count (`9/20`, `9 out of 20`, `9 of 20`, **or** digit `9` near the rent theme **and** survey N=`20` somewhere); or missing `45%` / `45.0%` / `45 percent` |
+| Top reason: **lack of community / disconnected** **5/20 (25%)** | Fixture: 5 of 20 comments; gold rubric | Missing community/disconnected theme; missing count (`5/20` / `5 out of 20` / `5 of 20`, **or** digit `5` near the community theme **and** survey N=`20`); or missing `25%` / `25.0%` / `25 percent` |
 | Early-bird **90d**, standard **60d**, month-to-month **premium** | Writer prompt §2; letter is the current 60-day one-size offer | Missing any of the three tiers |
 | Touchpoints **90 / 60 / 30** | Writer prompt §3 | Any of 90, 60, 30 absent |
 | **Two** events | Writer prompt §4 | No “two … event(s)” wording |

--- a/scripts/eval_2_tenant_oracle.py
+++ b/scripts/eval_2_tenant_oracle.py
@@ -24,8 +24,11 @@ from xml.etree import ElementTree as ET
 
 _W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 _TEXT_NS = "urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+_TEXT_P = f"{{{_TEXT_NS}}}p"
+_TEXT_H = f"{{{_TEXT_NS}}}h"
 _WORD_MIN = 180
-_WORD_MAX = 1400
+# Table-heavy headed memos land ~1500 words; 1400 was a false-FAIL on format.
+_WORD_MAX = 1800
 
 _HUSK_RE = re.compile(
     r"(?:#DIV/0!|Err:507|\bError:|_deal_|DEAL_|PYTHONFUNCTION)",
@@ -36,25 +39,54 @@ _STAMFORD_RE = re.compile(r"stamford", re.I)
 _TEN_PCT_RE = re.compile(r"10\s*%")
 _SIX_MONTHS_RE = re.compile(r"6\s*-\s*months?|6\s+months?", re.I)
 _RENT_COUNT_RE = re.compile(r"9\s*/\s*20|9\s+out\s+of\s+20|9\s+of\s+20", re.I)
-_RENT_PCT_RE = re.compile(r"45\s*%")
+# Writer tables often store 45.0% (office:value) rather than "45%".
+_RENT_PCT_RE = re.compile(r"45(?:\.0+)?\s*%|45\s+percent", re.I)
 _RENT_THEME_RE = re.compile(r"rent\s+increase|price\s+sensitivity", re.I)
 _COMMUNITY_COUNT_RE = re.compile(r"5\s*/\s*20|5\s+out\s+of\s+20|5\s+of\s+20", re.I)
-_COMMUNITY_PCT_RE = re.compile(r"25\s*%")
+_COMMUNITY_PCT_RE = re.compile(r"25(?:\.0+)?\s*%|25\s+percent", re.I)
 _COMMUNITY_THEME_RE = re.compile(
     r"lack\s+of\s+community|feeling\s+disconnected|disconnected",
     re.I,
+)
+# Survey N lives in prose or a caption, not always glued to 9/20.
+_SURVEY_N20_RE = re.compile(
+    r"(?i)"
+    r"(?:n\s*=\s*20)"
+    r"|(?:\b20\s+(?:comments?|residents?|respondents?|exits?|surveys?|tenants?|responses?|people))"
+    r"|(?:(?:survey|sample|feedback|comments?|respondents?|residents?).{0,48}\b20\b)"
+    r"|(?:\b20\b.{0,48}(?:survey|comments?|residents?|respondents?|exits?|responses?))"
 )
 _EARLY_BIRD_RE = re.compile(r"early[\s\-]*bird", re.I)
 _MONTH_TO_MONTH_RE = re.compile(r"month[\s\-]*to[\s\-]*month|\bm2m\b", re.I)
 _PREMIUM_RE = re.compile(r"premium", re.I)
 _TWO_EVENTS_RE = re.compile(r"\btwo\b.{0,40}\bevents?\b|\b2\b.{0,20}\bevents?\b", re.I)
-_DEPARTURE_RE = re.compile(r"departure\s+reasons|analysis\s+of\s+departure", re.I)
+# Heading extract is the main section fix; these ORs are belt-and-suspenders.
+_DEPARTURE_RE = re.compile(
+    r"departure\s+(?:reason|categor)\w*"
+    r"|exit\s+(?:survey|analysis)"
+    r"|why\s+(?:residents|tenants)\s+(?:left|leave)"
+    r"|analysis\s+of\s+(?:resident\s+)?departure",
+    re.I,
+)
 _TIERED_RE = re.compile(r"tiered\s+renewal", re.I)
-_COMM_PLAN_RE = re.compile(r"communication\s+plan", re.I)
-_ENGAGEMENT_RE = re.compile(r"community\s+engagement", re.I)
+_COMM_PLAN_RE = re.compile(
+    r"communication\s+(?:plan|template|cadence)"
+    r"|email\s+(?:draft|timeline|plan)"
+    r"|renewal\s+notification",
+    re.I,
+)
+_ENGAGEMENT_RE = re.compile(
+    r"community\s+engagement"
+    r"|resident\s+events?"
+    r"|engagement\s+initiative",
+    re.I,
+)
 _DAY_90_RE = re.compile(r"\b90[\s\-]*day|\b90\s+days?\b", re.I)
 _DAY_60_RE = re.compile(r"\b60[\s\-]*day|\b60\s+days?\b", re.I)
 _DAY_30_RE = re.compile(r"\b30[\s\-]*day|\b30\s+days?\b", re.I)
+# Window for table-split "9" / "5" sitting in a cell next to the theme label.
+_COUNT_WINDOW_BEFORE = 80
+_COUNT_WINDOW_AFTER = 300
 
 
 @dataclass
@@ -81,9 +113,20 @@ def _docx_paragraphs(path: Path) -> list[str]:
 
 
 def _odt_paragraphs(path: Path) -> list[str]:
+    """Body blocks in document order: ``text:p`` and ``text:h``.
+
+    Heading-only section titles live in ``text:h``. Walking ``text:p``
+    alone hid those titles (Gemini headed memo) and false-failed the
+    section checks. Table cells already wrap ``text:p``, so cell text
+    is included; document order keeps count-near-theme windows honest.
+    """
     with zipfile.ZipFile(path) as zf:
         root = ET.fromstring(zf.read("content.xml"))
-    return ["".join(node.itertext()) for node in root.iter(f"{{{_TEXT_NS}}}p")]
+    blocks: list[str] = []
+    for node in root.iter():
+        if node.tag in (_TEXT_P, _TEXT_H):
+            blocks.append("".join(node.itertext()))
+    return blocks
 
 
 def read_memo_paragraphs(path: Path) -> list[str]:
@@ -97,6 +140,36 @@ def read_memo_paragraphs(path: Path) -> list[str]:
 
 def _word_count(text: str) -> int:
     return len(re.findall(r"\S+", text))
+
+
+def _digit_near_theme(text: str, theme_re: re.Pattern[str], digit: int) -> bool:
+    """Standalone digit in a short window around a theme mention."""
+    digit_re = re.compile(rf"\b{digit}\b")
+    for match in theme_re.finditer(text):
+        start = max(0, match.start() - _COUNT_WINDOW_BEFORE)
+        end = min(len(text), match.end() + _COUNT_WINDOW_AFTER)
+        if digit_re.search(text[start:end]):
+            return True
+    return False
+
+
+def _has_survey_count(
+    text: str,
+    *,
+    digit: int,
+    literal_re: re.Pattern[str],
+    theme_re: re.Pattern[str],
+) -> bool:
+    """Literal ``9/20`` / ``9 of 20``, or split table: digit near theme + N=20.
+
+    Writer tables put the count in one cell and the percent in the next, so
+    the body never contains the token ``9/20``. Requiring that glue was a
+    false-FAIL on format; the fixture still has to state survey N=20 and
+    place ``9`` (or ``5``) next to the rent / community theme.
+    """
+    if literal_re.search(text):
+        return True
+    return bool(_SURVEY_N20_RE.search(text) and _digit_near_theme(text, theme_re, digit))
 
 
 def score_text(text: str, *, para_count: int) -> OracleResult:
@@ -129,13 +202,17 @@ def score_text(text: str, *, para_count: int) -> OracleResult:
         failures.append("missing community engagement section")
     if not _RENT_THEME_RE.search(text):
         failures.append("missing rent-increase theme")
-    if not _RENT_COUNT_RE.search(text):
+    if not _has_survey_count(
+        text, digit=9, literal_re=_RENT_COUNT_RE, theme_re=_RENT_THEME_RE
+    ):
         failures.append("missing rent-increase 9/20 count")
     if not _RENT_PCT_RE.search(text):
         failures.append("missing rent-increase 45%")
     if not _COMMUNITY_THEME_RE.search(text):
         failures.append("missing lack of community / disconnected theme")
-    if not _COMMUNITY_COUNT_RE.search(text):
+    if not _has_survey_count(
+        text, digit=5, literal_re=_COMMUNITY_COUNT_RE, theme_re=_COMMUNITY_THEME_RE
+    ):
         failures.append("missing community 5/20 count")
     if not _COMMUNITY_PCT_RE.search(text):
         failures.append("missing community 25%")

--- a/tests/scripts/test_eval_2_tenant_oracle.py
+++ b/tests/scripts/test_eval_2_tenant_oracle.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 from docx import Document
 from odf.opendocument import OpenDocumentText
-from odf.text import P
+from odf.table import Table, TableCell, TableRow
+from odf.text import H, P
 
 _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
 if str(_SCRIPTS) not in sys.path:
@@ -15,6 +16,7 @@ if str(_SCRIPTS) not in sys.path:
 from eval_2_headed import main as headed_main  # noqa: E402
 from eval_2_tenant_oracle import (  # noqa: E402
     main as oracle_main,
+    read_memo_paragraphs,
     score_memo,
     score_text,
 )
@@ -59,6 +61,55 @@ def _write_odt(path: Path, text: str) -> Path:
     return path
 
 
+def _write_heading_table_odt(path: Path) -> Path:
+    """Tiny headed-memo fixture: section titles in ``text:h``, counts in cells.
+
+    Matches the Gemini false-FAIL shape (headings + ``9`` / ``45.0%`` split
+    across table cells, no literal ``9/20``). Would fail the old extract and
+    the old count/percent regexes.
+    """
+    doc = OpenDocumentText()
+    doc.text.addElement(P(text="Business Memo"))
+    doc.text.addElement(
+        P(text="Subject: Tenant Retention Strategy for Harborview Flats, Stamford, Connecticut")
+    )
+    doc.text.addElement(
+        P(text="Objective: increase resident retention by 10% in the next 6 months.")
+    )
+    doc.text.addElement(P(text="Exit Survey Feedback (N=20)."))
+    doc.text.addElement(H(outlinelevel=1, text="1. Analysis of Resident Departure Reasons"))
+    table = Table()
+    for rec in (
+        ("Reason", "Count", "Share"),
+        ("rent increase", "9", "45.0%"),
+        ("lack of community / feeling disconnected", "5", "25.0%"),
+    ):
+        row = TableRow()
+        for val in rec:
+            cell = TableCell(valuetype="string")
+            cell.addElement(P(text=val))
+            row.addElement(cell)
+        table.addElement(row)
+    doc.text.addElement(table)
+    doc.text.addElement(H(outlinelevel=1, text="2. Tiered Renewal Offer Structure"))
+    doc.text.addElement(
+        P(text="early-bird offer at 90 days, standard offer at 60 days, month-to-month premium.")
+    )
+    doc.text.addElement(
+        H(outlinelevel=1, text="3. Resident Communication Plan & Outreach Sequence")
+    )
+    doc.text.addElement(P(text="Touchpoints at 90-day, 60-day, and 30-day marks before lease end."))
+    doc.text.addElement(
+        H(outlinelevel=1, text="4. Low-Cost, High-Impact Community Engagement Initiatives")
+    )
+    doc.text.addElement(
+        P(text="We will host two resident events next quarter on the front lawn and in the lounge.")
+    )
+    doc.text.addElement(P(text=("Retention follow-through. " * 80).strip()))
+    doc.save(str(path))
+    return path
+
+
 def _padded() -> str:
     return _PASSING + (" Retention follow-through. " * 80)
 
@@ -70,7 +121,7 @@ def test_passing_memo_docx_and_odt(tmp_path: Path) -> None:
     for path in (docx, odt):
         result = score_memo(path)
         assert result.passed, (path.name, result.failures)
-        assert 180 <= result.word_count <= 1400
+        assert 180 <= result.word_count <= 1800
 
 
 def test_empty_memo_fails(tmp_path: Path) -> None:
@@ -106,6 +157,86 @@ def test_oracle_does_not_require_gold_typo() -> None:
     text = _padded()
     assert "Rentention" not in text
     result = score_text(text, para_count=12)
+    assert result.passed, result.failures
+
+
+def test_decimal_and_word_percents_pass() -> None:
+    for pct45, pct25 in (("45.0%", "25.0%"), ("45 percent", "25 percent"), ("45%", "25%")):
+        text = _padded().replace("45%", pct45).replace("25%", pct25)
+        result = score_text(text, para_count=12)
+        assert result.passed, (pct45, pct25, result.failures)
+
+
+def test_split_table_counts_pass() -> None:
+    text = (
+        _padded()
+        .replace("rent increase 9/20 (45%)", "rent increase\n9\n45.0%")
+        .replace(
+            "lack of community / feeling disconnected 5/20 (25%)",
+            "lack of community / feeling disconnected\n5\n25.0%",
+        )
+    )
+    assert "9/20" not in text
+    assert "5/20" not in text
+    result = score_text(text, para_count=16)
+    assert result.passed, result.failures
+
+
+def test_wrong_split_counts_still_fail() -> None:
+    text = (
+        _padded()
+        .replace("rent increase 9/20 (45%)", "rent increase\n4\n45.0%")
+        .replace(
+            "lack of community / feeling disconnected 5/20 (25%)",
+            "lack of community / feeling disconnected\n2\n25.0%",
+        )
+    )
+    result = score_text(text, para_count=16)
+    assert not result.passed
+    assert any("9/20" in item for item in result.failures)
+    assert any("5/20" in item for item in result.failures)
+
+
+def test_word_count_between_1400_and_1800_passes() -> None:
+    text = _PASSING
+    filler = " Retention follow-through."
+    result = score_text(text, para_count=12)
+    while result.word_count < 1450:
+        text += filler
+        result = score_text(text, para_count=12)
+    assert 1400 < result.word_count <= 1800
+    assert result.passed, result.failures
+
+
+def test_synonym_section_titles_pass() -> None:
+    text = (
+        _padded()
+        .replace("1. Analysis of Departure Reasons", "1. Exit Survey Analysis")
+        .replace("3. Communication Plan", "3. Email Timeline")
+        .replace("4. Community Engagement Initiatives", "4. Engagement Initiative")
+    )
+    result = score_text(text, para_count=12)
+    assert result.passed, result.failures
+
+
+def test_odt_extracts_text_h_headings(tmp_path: Path) -> None:
+    doc = OpenDocumentText()
+    doc.text.addElement(H(outlinelevel=1, text="1. Analysis of Resident Departure Reasons"))
+    doc.text.addElement(P(text="body paragraph only"))
+    path = tmp_path / "heading-only.odt"
+    doc.save(str(path))
+    paras = read_memo_paragraphs(path)
+    assert any("Analysis of Resident Departure Reasons" in para for para in paras)
+
+
+def test_odt_heading_and_split_table_fixture(tmp_path: Path) -> None:
+    path = _write_heading_table_odt(tmp_path / "headed-table.odt")
+    paras = read_memo_paragraphs(path)
+    joined = "\n".join(paras)
+    assert "Analysis of Resident Departure Reasons" in joined
+    assert "9/20" not in joined
+    assert "45.0%" in joined
+    result = score_memo(path)
     assert result.passed, result.failures
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A real Gemini headed memo (~1476 words; Harborview/Stamford; +10%/6mo; `text:h` section titles; table cells `9`/`45.0%` and `5`/`25.0%`) false-failed the v1 structural oracle on **format**, not substance.

## Soften (A–D + heading extract)

- **Extract:** ODT body used for scoring now walks `text:h` as well as `text:p` (LibreOffice headings were invisible). Table cells already wrap `text:p`.
- **A. Percents:** accept `45%` / `45.0%` / `45 percent` (same for 25).
- **B. Counts:** pass on literal `9/20` | `9 out of 20` | `9 of 20`, **or** digit `9` near the rent-increase theme **and** survey N=`20` somewhere (same for community `5`).
- **C. Sections:** short synonym ORs (belt-and-suspenders). The Gemini titles already match today’s regexes once `text:h` is extracted.
- **D. Length:** word max **1800** (min stays 180) so table-heavy 1–2 page memos pass.

## Not weakened

Harborview Flats, Stamford, 10% retention, 6 months, husk/`Error:` ban. Writer prompt unchanged. Wrong survey digits still fail.

## Tests / docs

- `tests/scripts/test_eval_2_tenant_oracle.py`: `text:h` extract, `45.0%`, split count+pct table style, synonym titles, 1400–1800 words, plus a tiny in-memory ODT fixture (`text:h` + cells `9`/`45.0%`) that would have failed before.
- `docs/eval/eval-2/tenant-retention-ed2bc14c/rubric.eval2.md` and `notes.md` updated.

The headed artifact `runs/20260908-0121-gemini-3.8-flash-r200/final_memo.odt` is not on this branch. After merge, re-score it if present — substance checks should PASS (or only fail on a genuine content gap).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ce68203-a451-4efd-9993-7f2d878aca60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ce68203-a451-4efd-9993-7f2d878aca60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

