### PR TITLE
Soften eval-2 Cadaver Proposal oracle after headed false-red

### DIFF
--- a/docs/eval/eval-2/cadaver-proposal-61b0946a/notes.md
+++ b/docs/eval/eval-2/cadaver-proposal-61b0946a/notes.md
@@ -30,6 +30,42 @@ Exact dollars, lab-fee share, per-dept ranges, and chart aesthetics are
 ODT scoring reads `text:h` and `text:p` in document order so a headed
 title still counts.
 
+## Oracle format soften (headed-proposal false-FAIL)
+
+A real Gemini headed proposal (~9 pages; four departments; costs; ethics;
+freeze/thaw; embedded visual) false-failed the v1 structural oracle on
+**regex brittleness**, not substance. Soften (do **not** weaken the four
+departments, title theme, anatomy map, 10–12 cycles, 3h thawed,
+no-mixing, husk/`Error:` ban, or the requirement that **both** Supplies
+and Education are named; do **not** change `prompt.writeragent.txt`):
+
+1. Word max is **3200** (min stays 250).
+2. Intro accepts `introduction` / `executive summary` / `program overview`
+   / `overview`.
+3. Cost-first is heading-order (first major cost/financial H2 before
+   ethics/anatomy H2) **or** first cost saving(s) before the dedicated
+   stewardship/ethics section. Early “honor donor” in an overview does
+   not fail.
+4. Lab fee aliases: `lab fee` / `anatomy lab … fee` / `lab facility fee`
+   / facility fee that is still anatomy- or lab-tied (fixture:
+   “Annual Anatomy Lab Facility Fee”).
+5. Exclude: either order supplies↔education with an exclude verb; both
+   names still required.
+6. Formula: algebraic `(4 × per-cadaver/specimen) + lab/facility fee`
+   **or** explicit baseline arithmetic (`$3k+$1k=$13k` / `$3,000 × 4 +
+   $1,000 = $13,000`). No literal string required.
+7. Graph/table: `graph` / `chart` / `figure` / `graphical representation`,
+   **or** an ODT `draw:frame` (chart/image/object) / `table:table` whose
+   nearby caption/text mentions savings or 1–4 departments. Bare frames
+   do not count. “chart” inside “charter” is not a figure.
+8. Standard duration: `1–1.5` hours **or** `60–90` minutes.
+9. Simple window: `≤4` / `up to 4` / `3–4` / `3 to 4` per thaw/window.
+
+If `runs/20260908-2246-gemini-3.8-flash-r200/final_proposal.odt` is on
+disk, re-score it after this soften — substance checks should **PASS**
+(or only fail on a genuine content gap). That artifact is not committed
+here.
+
 ## Gold vs fixture (do not “fix” gold)
 
 - Gold rubric mentions a **Costs** tab and “per-cadaver cost … category

--- a/docs/eval/eval-2/cadaver-proposal-61b0946a/rubric.eval2.md
+++ b/docs/eval/eval-2/cadaver-proposal-61b0946a/rubric.eval2.md
@@ -19,16 +19,16 @@ ODT `text:h` and `text:p` (document order), plus DOCX paragraphs
 
 | # | Check | Source | Fail closed |
 |---|--------|--------|-------------|
-| 1 | Writer doc present; body non-empty; word band **250–2500** (tune after first headed) | Mini proposal; Ready-empty husks are far shorter | Missing / unreadable / no text; `< 250` or `> 2500` |
+| 1 | Writer doc present; body non-empty; word band **250–3200** (first headed was ~9 pages / above 2500) | Mini proposal; Ready-empty husks are far shorter | Missing / unreadable / no text; `< 250` or `> 3200` |
 | 2 | Title theme **Collaborative Cadaver Program** (Proposal) | Gold name + writer prompt | Missing that program name |
 | 3 | Four departments named | Prompt + gold rubric | Missing General Surgery, Thoracic Surgery, Otolaryngology, or Orthopedic Surgery |
-| 4 | Intro / cost-savings purpose **first** | Writer prompt: start with intro + highlight cost savings | Missing introduction or cost-savings, or ethics/anatomy appears before cost-savings |
-| 5 | Cost inputs: per-cadaver **Cadaver** + **Annual Cadaver Lab Fee**; **excludes Supplies and Education** (must say exclude) | Fixture line items; gold rubric | Missing per-cadaver / lab-fee names, or no exclude + supplies + education |
-| 6 | Baseline **4 cadavers/year** General Surgery; formula **(4 × per-cadaver) + lab fee** | Prompt C2=4; gold rubric | Missing 4-cadaver/year baseline or the formula shape |
-| 7 | Savings vs **1–4** departments; **graph or** a clearly labeled savings table | Writer prompt graph | Missing graph/chart **and** missing labeled 1–4 savings table |
+| 4 | Intro / cost-savings purpose **first** | Writer prompt: start with intro + highlight cost savings | Missing introduction (**or** Overview / Executive Summary / Program Overview); missing cost-savings; or first cost/financial H2 is after ethics/anatomy H2 **and** first cost-saving(s) is after the dedicated stewardship/ethics section. Early “honor donor” in an overview does **not** fail |
+| 5 | Cost inputs: per-cadaver **Cadaver** + lab/facility fee; **excludes Supplies and Education** (both names + exclude, either order) | Fixture line items; gold rubric | Missing per-cadaver; missing lab fee / anatomy lab … fee / lab facility fee (anatomy- or lab-tied); or exclude without **both** Supplies and Education |
+| 6 | Baseline **4 cadavers/year** General Surgery; formula algebraic **or** explicit $3k×4+$1k=$13k arithmetic | Prompt C2=4; gold rubric | Missing 4-cadaver/year baseline, and missing both the (4 × per-cadaver/specimen + lab/facility fee) shape **and** the $3k+$1k=$13k arithmetic |
+| 7 | Savings vs **1–4** departments; **graph or** a clearly labeled savings table | Writer prompt graph | Missing graph/chart/figure/graphical representation **and** missing labeled 1–4 savings table **and** no ODT `draw:frame` / `table:table` (or DOCX drawing/table) with nearby savings or 1–4-department caption. Bare frames do not count. “chart” inside “charter” is not a figure |
 | 8 | Ethical maximize-use / honor donors | Writer prompt first required section | Missing donor / honor / maximize-use theme |
 | 9 | Anatomy: abdomen→Gen Surg, thorax→Thoracic, head/neck→Oto, limb(s)→Ortho | Gold rubric | Any of the four assignments missing |
-| 10 | Constraints: **10–12** freeze/thaw; **3h** thawed; simple **30–45m** / standard **1–1.5h** / complex **2–3h**; per window simple **≤4**, standard **2–3**, complex **1**; totals simple **40–48**, standard **20–36**, complex **10–12** | Prompt + gold rubric | Any band missing |
+| 10 | Constraints: **10–12** freeze/thaw; **3h** thawed; simple **30–45m** / standard **1–1.5h or 60–90m** / complex **2–3h**; per window simple **≤4 / up to 4 / 3–4 / 3 to 4**, standard **2–3**, complex **1**; totals simple **40–48**, standard **20–36**, complex **10–12** | Prompt + gold rubric | Any band missing |
 | 11 | Explicit **no mixing** complexities | Writer prompt second section | Missing mixing disclaimer |
 | 12 | Ban empty / Ready-only / `Error:` husks | Observed residue | Body matches `Error:` / `#DIV/0!` husks or is blank |
 

--- a/scripts/eval_2_cadaver_oracle.py
+++ b/scripts/eval_2_cadaver_oracle.py
@@ -4,12 +4,15 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Fail-closed structural scorer for an eval-2 Cadaver Proposal.
 
-Eliyezer-locked v1. Pass/fail is document-local. Chat Ready / STREAM_DONE
-is never consulted. Exact dollars, lab-fee share, and chart pixels are
-out of v1. Gold's Silverview hospital name is not a scored string.
+Eliyezer-locked v1, softened after a headed Gemini false-red (Tenant #665
+style). Pass/fail is document-local. Chat Ready / STREAM_DONE is never
+consulted. Exact lab-fee share and chart pixels stay out of v1. Gold's
+Silverview hospital name is not a scored string.
 
 ODT extraction reads ``text:h`` and ``text:p`` in document order (headed
 Writer often puts the title in a heading). DOCX headings are ``w:p``.
+Embedded ``draw:frame`` / ``table:table`` count as graph/table evidence
+only when nearby caption/text mentions savings or 1–4 departments.
 
 Usage:
   .venv/bin/python scripts/eval_2_cadaver_oracle.py path/to/final_proposal.odt
@@ -27,8 +30,17 @@ from xml.etree import ElementTree as ET
 
 _W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 _TEXT_NS = "urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+_DRAW_NS = "urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"
+_TABLE_NS = "urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+_TEXT_H = f"{{{_TEXT_NS}}}h"
+_TEXT_P = f"{{{_TEXT_NS}}}p"
+_DRAW_FRAME = f"{{{_DRAW_NS}}}frame"
+_TABLE_TABLE = f"{{{_TABLE_NS}}}table"
 _WORD_MIN = 250
-_WORD_MAX = 2500
+# First headed Gemini proposal was ~9 pages and above 2500; 3200 is the
+# Eliyezer lock (min stays 250 so Ready-empty husks still fail).
+_WORD_MAX = 3200
+_VISUAL_NEAR_RADIUS = 3
 
 _I = re.IGNORECASE | re.DOTALL
 _HUSK_RE = re.compile(
@@ -40,23 +52,71 @@ _GEN_SURG_RE = re.compile(r"general\s+surgery", re.I)
 _THORACIC_RE = re.compile(r"thoracic\s+surgery", re.I)
 _ENT_RE = re.compile(r"otolaryngology", re.I)
 _ORTHO_RE = re.compile(r"orthopedic\s+surgery", re.I)
-_INTRO_RE = re.compile(r"\bintroduction\b", re.I)
+# Headed drafts use Overview / Executive Summary instead of "Introduction".
+_INTRO_RE = re.compile(
+    r"\bintroduction\b|\bexecutive\s+summary\b|\bprogram\s+overview\b|\boverview\b",
+    re.I,
+)
 _COST_RE = re.compile(r"cost\s+saving|cost-saving|\bsavings\b", re.I)
 _ETHICS_RE = re.compile(
     r"donat|donor|honor.{0,20}donor|final\s+wishes|maximi[sz]e.{0,40}(?:cadaver|use)",
     _I,
 )
-_GRAPH_RE = re.compile(r"\bgraphs?\b|\bcharts?\b", re.I)
+# Dedicated ethics/stewardship *section* — not mid-overview "honor donors".
+_ETHICS_SECTION_HEADING_RE = re.compile(
+    r"^(?:#{1,3}\s*|\d+[\.\):]\s*)?(?:ethical(?:\s+use|\s+consider|\s+import|\s+steward)?"
+    r"|ethics|stewardship"
+    r"|honou?ring\s+donors?"
+    r"|respect(?:ing)?\s+(?:the\s+)?(?:bodies|donors)"
+    r"|maximi[sz]ing\s+(?:cadaver\s+)?use"
+    r"|anatomical\s+assignment|anatomy\s+(?:assignment|map|section))\b",
+    re.I | re.M,
+)
+_COST_HEADING_RE = re.compile(
+    r"cost\s*[- ]*saving|financial|budget|savings?\s+analys|cost\s+analys"
+    r"|program\s+costs?|annual\s+costs?",
+    re.I,
+)
+# Anatomy *assignment* headings, not "Anatomy Lab Fee" cost titles.
+_ETHICS_ANATOMY_HEADING_RE = re.compile(
+    r"\bethic|\bstewardship\b|anatomical\s+assign|anatomy\s+(?:assign|map|section|areas)"
+    r"|honou?ring\s+donors?|donor\s+respect|maximi[sz]ing\s+(?:cadaver\s+)?use",
+    re.I,
+)
+# "chart" inside "charter" is not a figure; accept Graphical / Figure N too.
+_GRAPH_RE = re.compile(
+    r"\bgraphs?\b|\bcharts?\b|\bfigures?\b|graphical\s+representation",
+    re.I,
+)
 _SAVINGS_TABLE_RE = re.compile(
     r"(?:savings?\s+table|table.{0,40}savings?|1\s*[-–to]+\s*4.{0,40}depart)",
     _I,
 )
+# Nearby caption/text for an embedded frame or table — not the frame alone.
+_SAVINGS_NEAR_RE = re.compile(
+    r"saving|1\s*[-–to]+\s*4.{0,48}depart|departments?.{0,32}participat",
+    re.I,
+)
 _PER_CADAVER_RE = re.compile(r"per[\s\-]*cadaver", re.I)
-_LAB_FEE_RE = re.compile(r"annual\s+cadaver\s+lab\s+fee|(?:anatomy\s+)?lab\s+fee", re.I)
-_EXCLUDE_RE = re.compile(
-    r"exclud(?:e|es|ed|ing).{0,80}supplies.{0,60}education"
-    r"|exclud(?:e|es|ed|ing).{0,80}education.{0,60}supplies"
-    r"|supplies.{0,40}and.{0,20}education.{0,40}exclud",
+# Fixture used "Annual Anatomy Lab Facility Fee"; require an anatomy/lab tie.
+_LAB_FEE_RE = re.compile(
+    r"(?:annual\s+)?(?:cadaver\s+)?lab\s+fee"
+    r"|anatomy\s+lab.{0,48}fee"
+    r"|lab\s+facility\s+fee"
+    r"|(?:anatomy|cadaver).{0,32}facility\s+fee"
+    r"|facility\s+fee.{0,32}(?:anatomy|cadaver|lab)",
+    re.I,
+)
+_SUPPLIES_RE = re.compile(r"\bsupplies\b", re.I)
+_EDUCATION_RE = re.compile(r"\beducation\b", re.I)
+# Either order supplies↔education with an exclude verb; both names required.
+_EXCLUDE_BOTH_RE = re.compile(
+    r"exclud(?:e|es|ed|ing).{0,160}supplies.{0,80}education"
+    r"|exclud(?:e|es|ed|ing).{0,160}education.{0,80}supplies"
+    r"|supplies.{0,80}education.{0,80}exclud(?:e|es|ed|ing)"
+    r"|education.{0,80}supplies.{0,80}exclud(?:e|es|ed|ing)"
+    r"|supplies.{0,80}exclud(?:e|es|ed|ing).{0,80}education"
+    r"|education.{0,80}exclud(?:e|es|ed|ing).{0,80}supplies",
     _I,
 )
 _FOUR_YEAR_RE = re.compile(
@@ -64,8 +124,23 @@ _FOUR_YEAR_RE = re.compile(
     re.I,
 )
 _FORMULA_RE = re.compile(
-    r"\(?\s*4\s*[×x*]\s*(?:the\s+)?per[\s\-]*cadaver.?\)?\s*(?:\+|plus)\s*.{0,24}lab\s+fee"
-    r"|4\s*[×x*]\s*(?:the\s+)?per[\s\-]*cadaver.{0,40}(?:\+|plus).{0,20}lab\s+fee",
+    r"\(?\s*4\s*[×x*]\s*(?:the\s+)?per[\s\-]*(?:cadaver|specimen).?\)?\s*(?:\+|plus)\s*.{0,24}(?:lab|facility)\s+fee"
+    r"|4\s*[×x*]\s*(?:the\s+)?per[\s\-]*(?:cadaver|specimen).{0,40}(?:\+|plus).{0,24}(?:lab|facility)\s+fee"
+    r"|(?:4|four)\s+(?:times|x)\s+(?:the\s+)?per[\s\-]*(?:cadaver|specimen).{0,40}(?:\+|plus).{0,40}(?:lab|facility)\s+fee",
+    _I,
+)
+_THOUSANDS_RE = r"(?:\$?\s*3(?:\s*,\s*)?000|\b3k\b|\$?\s*3\s*thousand)"
+_ONE_K_RE = r"(?:\$?\s*1(?:\s*,\s*)?000|\b1k\b|\$?\s*1\s*thousand)"
+_THIRTEEN_K_RE = r"(?:\$?\s*13(?:\s*,\s*)?000|\b13k\b|\$?\s*13\s*thousand)"
+# Gold baseline is 4 × $3,000 + $1,000 = $13,000. Accept that arithmetic
+# in prose so a literal "(4 × per-cadaver) + lab fee" string is not required.
+_ARITH_FORMULA_RE = re.compile(
+    rf"(?:{_THOUSANDS_RE}.{{0,28}}(?:[×x*]|times).{{0,16}}(?:4|four).{{0,28}}"
+    rf"(?:\+|plus).{{0,28}}{_ONE_K_RE}.{{0,28}}(?:(?:=|equals).{{0,16}}{_THIRTEEN_K_RE})?)"
+    rf"|(?:(?:4|four).{{0,16}}(?:[×x*]|times).{{0,28}}{_THOUSANDS_RE}.{{0,28}}"
+    rf"(?:\+|plus).{{0,28}}{_ONE_K_RE}.{{0,28}}(?:(?:=|equals).{{0,16}}{_THIRTEEN_K_RE})?)"
+    rf"|(?:{_THOUSANDS_RE}.{{0,16}}(?:\+|plus).{{0,16}}{_ONE_K_RE}.{{0,16}}"
+    rf"(?:=|equals).{{0,16}}{_THIRTEEN_K_RE})",
     _I,
 )
 _ABDOMEN_RE = re.compile(r"\babdomen\b|\babdominal\b", re.I)
@@ -75,10 +150,16 @@ _LIMB_RE = re.compile(r"\blimbs?\b", re.I)
 _CYCLES_RE = re.compile(r"10\s*[-–to]+\s*12", re.I)
 _THREE_HOUR_RE = re.compile(r"\b3[\s\-]*h(?:ours?)?\b", re.I)
 _SIMPLE_MIN_RE = re.compile(r"30\s*[-–to]+\s*45")
-_STANDARD_HR_RE = re.compile(r"1\s*[-–.]+\s*1\.?5|1\s*[-–]\s*1\.5|hour to an hour and a half", re.I)
-_COMPLEX_HR_RE = re.compile(r"2\s*[-–to]+\s*3")
+_STANDARD_HR_RE = re.compile(
+    r"1\s*[-–.]+\s*1\.?5|1\s*[-–]\s*1\.5|hour to an hour and a half"
+    r"|60\s*[-–to]+\s*90|60\s+to\s+90",
+    re.I,
+)
 _WINDOW_SIMPLE_RE = re.compile(
-    r"simple.{0,50}(?:up\s+to|<=|≤)\s*4|(?:up\s+to|<=|≤)\s*4.{0,30}simple",
+    r"simple.{0,60}(?:up\s+to|<=|≤|at\s+most)\s*4"
+    r"|(?:up\s+to|<=|≤)\s*4.{0,40}simple"
+    r"|3\s*(?:[-–]|to)\s*4.{0,50}(?:simple|per\s+(?:thaw|window)|procedures?\s+per)"
+    r"|(?:simple|per\s+(?:thaw|window)).{0,50}3\s*(?:[-–]|to)\s*4",
     _I,
 )
 _WINDOW_STANDARD_RE = re.compile(
@@ -114,36 +195,135 @@ class OracleResult:
         return asdict(self)
 
 
-def _docx_blocks(path: Path) -> list[str]:
-    """DOCX headings are ordinary ``w:p`` nodes; walk document order."""
+@dataclass
+class ProposalExtract:
+    """Text blocks plus heading-order / embedded-visual evidence."""
+
+    blocks: list[str]
+    headings: list[str]
+    has_savings_visual: bool
+
+
+def _elem_text(elem: ET.Element) -> str:
+    return "".join(elem.itertext())
+
+
+def _docx_is_heading(para: ET.Element) -> bool:
+    ppr = para.find(f"{{{_W_NS}}}pPr")
+    if ppr is None:
+        return False
+    style = ppr.find(f"{{{_W_NS}}}pStyle")
+    if style is not None:
+        val = style.get(f"{{{_W_NS}}}val") or ""
+        if re.search(r"heading|title", val, re.I):
+            return True
+    return ppr.find(f"{{{_W_NS}}}outlineLvl") is not None
+
+
+def _docx_has_drawing(para: ET.Element) -> bool:
+    return (
+        para.find(f"{{{_W_NS}}}drawing") is not None
+        or para.find(f"{{{_W_NS}}}pict") is not None
+    )
+
+
+def _window_has_savings(items: list[tuple[str, str]], index: int) -> bool:
+    start = max(0, index - _VISUAL_NEAR_RADIUS)
+    end = min(len(items), index + _VISUAL_NEAR_RADIUS + 1)
+    blob = " ".join(text for unused_kind, text in items[start:end])
+    return bool(_SAVINGS_NEAR_RE.search(blob))
+
+
+def _has_savings_visual(items: list[tuple[str, str]]) -> bool:
+    """Embedded frame/table counts only with nearby savings / 1–4 depts."""
+    for index, (kind, unused_text) in enumerate(items):
+        if kind in {"frame", "table"} and _window_has_savings(items, index):
+            return True
+    return False
+
+
+def _docx_extract(path: Path) -> ProposalExtract:
+    """DOCX headings are ordinary ``w:p``; drawings/tables are visual items."""
     with zipfile.ZipFile(path) as zf:
         root = ET.fromstring(zf.read("word/document.xml"))
     blocks: list[str] = []
-    for para in root.iter(f"{{{_W_NS}}}p"):
-        text = "".join(node.text or "" for node in para.iter(f"{{{_W_NS}}}t"))
+    headings: list[str] = []
+    items: list[tuple[str, str]] = []
+    body = root.find(f"{{{_W_NS}}}body")
+    for child in body if body is not None else root:
+        if child.tag == f"{{{_W_NS}}}tbl":
+            text = _elem_text(child)
+            items.append(("table", text))
+            blocks.append(text)
+            continue
+        if child.tag != f"{{{_W_NS}}}p":
+            continue
+        text = "".join(node.text or "" for node in child.iter(f"{{{_W_NS}}}t"))
         blocks.append(text)
-    return blocks
+        if _docx_is_heading(child):
+            headings.append(text)
+            items.append(("h", text))
+        else:
+            items.append(("p", text))
+        if _docx_has_drawing(child):
+            items.append(("frame", text))
+    return ProposalExtract(
+        blocks=blocks,
+        headings=headings,
+        has_savings_visual=_has_savings_visual(items),
+    )
 
 
-def _odt_blocks(path: Path) -> list[str]:
+def _walk_odt(elem: ET.Element) -> list[tuple[str, str]]:
+    """Document-order items: headings, paras, frames, tables."""
+    items: list[tuple[str, str]] = []
+    tag = elem.tag
+    if tag == _DRAW_FRAME:
+        name = elem.get(f"{{{_DRAW_NS}}}name") or ""
+        items.append(("frame", f"{_elem_text(elem)} {name}".strip()))
+        for child in elem:
+            items.extend(_walk_odt(child))
+        return items
+    if tag == _TABLE_TABLE:
+        items.append(("table", _elem_text(elem)))
+        for child in elem:
+            items.extend(_walk_odt(child))
+        return items
+    if tag == _TEXT_H:
+        items.append(("h", _elem_text(elem)))
+        return items
+    if tag == _TEXT_P:
+        items.append(("p", _elem_text(elem)))
+        return items
+    for child in elem:
+        items.extend(_walk_odt(child))
+    return items
+
+
+def _odt_extract(path: Path) -> ProposalExtract:
     """Headed Writer titles often live in ``text:h``, body in ``text:p``."""
-    heading = f"{{{_TEXT_NS}}}h"
-    para = f"{{{_TEXT_NS}}}p"
     with zipfile.ZipFile(path) as zf:
         root = ET.fromstring(zf.read("content.xml"))
-    return [
-        "".join(node.itertext())
-        for node in root.iter()
-        if node.tag in {heading, para}
-    ]
+    items = _walk_odt(root)
+    blocks = [text for kind, text in items if kind in {"h", "p"}]
+    headings = [text for kind, text in items if kind == "h"]
+    return ProposalExtract(
+        blocks=blocks,
+        headings=headings,
+        has_savings_visual=_has_savings_visual(items),
+    )
 
 
 def read_proposal_blocks(path: Path) -> list[str]:
+    return read_proposal(path).blocks
+
+
+def read_proposal(path: Path) -> ProposalExtract:
     suffix = path.suffix.lower()
     if suffix == ".docx":
-        return _docx_blocks(path)
+        return _docx_extract(path)
     if suffix == ".odt":
-        return _odt_blocks(path)
+        return _odt_extract(path)
     raise ValueError(f"unsupported proposal type: {path.suffix}")
 
 
@@ -151,18 +331,71 @@ def _word_count(text: str) -> int:
     return len(re.findall(r"\S+", text))
 
 
-def _cost_savings_comes_first(text: str) -> bool:
-    """Intro must lead with cost savings, not the ethics/anatomy section."""
+def _heading_kind(heading: str) -> str | None:
+    """Cost/financial vs ethics/anatomy H2. Cost wins if a title matches both."""
+    if _COST_HEADING_RE.search(heading):
+        return "cost"
+    if _ETHICS_ANATOMY_HEADING_RE.search(heading):
+        return "ethics"
+    return None
+
+
+def _dedicated_ethics_pos(text: str, headings: list[str] | None) -> int | None:
+    """Start index of the dedicated stewardship/ethics section, if any."""
+    if headings:
+        for heading in headings:
+            if _ETHICS_SECTION_HEADING_RE.search(heading.strip()):
+                pos = text.find(heading)
+                if pos >= 0:
+                    return pos
+    match = _ETHICS_SECTION_HEADING_RE.search(text)
+    return match.start() if match else None
+
+
+def _cost_purpose_leads(text: str, headings: list[str] | None) -> bool:
+    """Cost/financial H2 before ethics/anatomy H2, or cost-savings before ethics section.
+
+    Early overview "honor donors" is not a dedicated ethics section. The old
+    first-regex-hit of honor/donor was a false-red on headed Gemini drafts.
+    """
+    if headings:
+        cost_i: int | None = None
+        ethics_i: int | None = None
+        for index, heading in enumerate(headings):
+            kind = _heading_kind(heading)
+            if kind == "cost" and cost_i is None:
+                cost_i = index
+            elif kind == "ethics" and ethics_i is None:
+                ethics_i = index
+        if cost_i is not None and (ethics_i is None or cost_i < ethics_i):
+            return True
     cost = _COST_RE.search(text)
-    ethics = _ETHICS_RE.search(text)
     if cost is None:
         return False
-    if ethics is None:
+    ethics_pos = _dedicated_ethics_pos(text, headings)
+    if ethics_pos is None:
         return True
-    return cost.start() < ethics.start()
+    return cost.start() < ethics_pos
 
 
-def score_text(text: str, *, para_count: int) -> OracleResult:
+def _has_baseline_formula(text: str) -> bool:
+    """Algebraic (4 × per-cadaver/specimen + lab/facility fee) or $3k+$1k=$13k."""
+    return bool(_FORMULA_RE.search(text) or _ARITH_FORMULA_RE.search(text))
+
+
+def _has_graph_or_savings_table(text: str, *, has_savings_visual: bool) -> bool:
+    if _GRAPH_RE.search(text) or _SAVINGS_TABLE_RE.search(text):
+        return True
+    return has_savings_visual
+
+
+def score_text(
+    text: str,
+    *,
+    para_count: int,
+    headings: list[str] | None = None,
+    has_savings_visual: bool = False,
+) -> OracleResult:
     """Apply Eliyezer-locked v1 checks to extracted proposal text."""
     failures: list[str] = []
     words = _word_count(text)
@@ -188,19 +421,19 @@ def score_text(text: str, *, para_count: int) -> OracleResult:
         failures.append("missing introduction")
     if not _COST_RE.search(text):
         failures.append("missing cost-savings purpose")
-    elif not _cost_savings_comes_first(text):
+    elif not _cost_purpose_leads(text, headings):
         failures.append("cost-savings purpose is not first")
     if not _PER_CADAVER_RE.search(text):
         failures.append("missing per-cadaver cost input")
     if not _LAB_FEE_RE.search(text):
         failures.append("missing Annual Cadaver Lab Fee / lab fee")
-    if not _EXCLUDE_RE.search(text):
+    if not (_SUPPLIES_RE.search(text) and _EDUCATION_RE.search(text) and _EXCLUDE_BOTH_RE.search(text)):
         failures.append("missing exclude Supplies and Education")
     if not _FOUR_YEAR_RE.search(text):
         failures.append("missing 4 cadavers/year General Surgery baseline")
-    if not _FORMULA_RE.search(text):
+    if not _has_baseline_formula(text):
         failures.append("missing (4 × per-cadaver) + lab fee formula")
-    if not _GRAPH_RE.search(text) and not _SAVINGS_TABLE_RE.search(text):
+    if not _has_graph_or_savings_table(text, has_savings_visual=has_savings_visual):
         failures.append("missing graph/chart or labeled 1-4 savings table")
     if not _ETHICS_RE.search(text):
         failures.append("missing donor-respect / maximize-use section")
@@ -249,12 +482,17 @@ def score_proposal(path: Path | str) -> OracleResult:
     if not proposal.is_file():
         return OracleResult(passed=False, failures=[f"proposal not found: {proposal}"])
     try:
-        blocks = read_proposal_blocks(proposal)
+        extract = read_proposal(proposal)
     except Exception as exc:
         return OracleResult(passed=False, failures=[f"cannot read proposal: {exc}"])
-    text = "\n".join(blocks)
-    nonempty = sum(1 for block in blocks if block.strip())
-    return score_text(text, para_count=nonempty)
+    text = "\n".join(extract.blocks)
+    nonempty = sum(1 for block in extract.blocks if block.strip())
+    return score_text(
+        text,
+        para_count=nonempty,
+        headings=extract.headings,
+        has_savings_visual=extract.has_savings_visual,
+    )
 
 
 def format_result(result: OracleResult) -> str:

--- a/scripts/eval_2_cadaver_oracle.py
+++ b/scripts/eval_2_cadaver_oracle.py
@@ -155,6 +155,7 @@ _STANDARD_HR_RE = re.compile(
     r"|60\s*[-–to]+\s*90|60\s+to\s+90",
     re.I,
 )
+_COMPLEX_HR_RE = re.compile(r"2\s*[-–to]+\s*3")
 _WINDOW_SIMPLE_RE = re.compile(
     r"simple.{0,60}(?:up\s+to|<=|≤|at\s+most)\s*4"
     r"|(?:up\s+to|<=|≤)\s*4.{0,40}simple"

--- a/tests/scripts/test_eval_2_cadaver_oracle.py
+++ b/tests/scripts/test_eval_2_cadaver_oracle.py
@@ -103,7 +103,7 @@ Collaborative Cadaver Program Proposal for General Surgery, Thoracic
 Surgery, Otolaryngology, and Orthopedic Surgery.
 
 This overview honors donors and their final wishes. The hospital charter
-does not use the standalone chart token.
+is the governing document for shared specimens.
 
 Cost Savings
 Baseline is 4 cadavers/year for General Surgery. Annual cost is
@@ -397,6 +397,7 @@ def test_gemini_shaped_softened_proposal_passes() -> None:
     assert "Introduction" not in text
     assert "1-1.5" not in text
     assert "up to 4" not in text
+    assert not _has_chart_or_graph_word(text)
     result = score_text(
         text,
         para_count=18,

--- a/tests/scripts/test_eval_2_cadaver_oracle.py
+++ b/tests/scripts/test_eval_2_cadaver_oracle.py
@@ -1,23 +1,39 @@
 # WriterAgent tests for scripts/eval_2_cadaver_oracle.py
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
 from docx import Document
+from odf.draw import Frame, TextBox
 from odf.opendocument import OpenDocumentText
+from odf.table import Table, TableCell, TableRow
 from odf.text import H, P
 
 _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+_REPO = Path(__file__).resolve().parents[2]
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from eval_2_cadaver_oracle import (  # noqa: E402
     main as oracle_main,
+    read_proposal,
     score_proposal,
     score_text,
 )
 from eval_2_headed import main as headed_main  # noqa: E402
+
+_GEMINI_FIXTURE = (
+    _REPO
+    / "docs"
+    / "eval"
+    / "eval-2"
+    / "cadaver-proposal-61b0946a"
+    / "runs"
+    / "20260908-2246-gemini-3.8-flash-r200"
+    / "final_proposal.odt"
+)
 
 _PASSING = """
 Introduction
@@ -61,8 +77,51 @@ def _write_odt(path: Path, text: str, *, title_as_heading: bool = False) -> Path
     return path
 
 
+def _add_savings_frame(doc: OpenDocumentText, caption: str) -> None:
+    # Name must not contain "saving" — that would leak into the visual window.
+    frame = Frame(width="10cm", height="6cm", name="EmbeddedObject")
+    box = TextBox()
+    box.addElement(P(text="embedded object"))
+    frame.addElement(box)
+    doc.text.addElement(frame)
+    doc.text.addElement(P(text=caption))
+
+
+def _has_chart_or_graph_word(text: str) -> bool:
+    return bool(re.search(r"\bcharts?\b|\bgraphs?\b", text, re.I))
+
+
 def _padded() -> str:
     return _PASSING + (" Shared cadaver training capacity. " * 80)
+
+
+def _gemini_shaped() -> str:
+    """Headed Gemini wording: Overview, lab facility fee, 60–90 min, 3 to 4."""
+    return """
+Program Overview
+Collaborative Cadaver Program Proposal for General Surgery, Thoracic
+Surgery, Otolaryngology, and Orthopedic Surgery.
+
+This overview honors donors and their final wishes. The hospital charter
+does not use the standalone chart token.
+
+Cost Savings
+Baseline is 4 cadavers/year for General Surgery. Annual cost is
+$3,000 × 4 + $1,000 = $13,000 using the per-cadaver bundle plus the
+Annual Anatomy Lab Facility Fee. The analysis excludes specialty-unique
+Supplies and Education. Graphical representation of annual savings for
+1-4 departments is embedded.
+
+Ethical Stewardship
+We maximize cadaver use to honor donors and respect final wishes.
+Anatomy: abdomen for General Surgery; thorax for Thoracic Surgery; head and
+neck for Otolaryngology; limbs for Orthopedic Surgery.
+
+Freeze/thaw cycles are 10-12. Once thawed there is a 3-hour window.
+Simple 30-45 minutes (3 to 4 per window; totals 40-48). Standard 60-90
+minutes (2-3 per window; totals 20-36). Complex 2-3 hours (1 per window;
+totals 10-12). This proposal does not account for mixing complexity.
+"""
 
 
 def test_passing_proposal_docx_and_odt(tmp_path: Path) -> None:
@@ -72,7 +131,7 @@ def test_passing_proposal_docx_and_odt(tmp_path: Path) -> None:
     for path in (docx, odt):
         result = score_proposal(path)
         assert result.passed, (path.name, result.failures)
-        assert 250 <= result.word_count <= 2500
+        assert 250 <= result.word_count <= 3200
 
 
 def test_odt_heading_title_is_scored(tmp_path: Path) -> None:
@@ -156,3 +215,199 @@ def test_oracle_cli_json(tmp_path: Path, capsys) -> None:
     assert oracle_main(["--json", str(path)]) == 0
     out = capsys.readouterr().out
     assert '"passed": true' in out
+
+
+def test_overview_and_executive_summary_count_as_introduction() -> None:
+    for title in ("Overview", "Executive Summary", "Program Overview"):
+        text = _padded().replace("Introduction", title, 1)
+        assert "Introduction" not in text
+        result = score_text(text, para_count=12)
+        assert result.passed, (title, result.failures)
+
+
+def test_lab_facility_fee_alias_passes() -> None:
+    text = _padded().replace("Annual Cadaver Lab Fee", "Annual Anatomy Lab Facility Fee")
+    assert "lab fee" not in text.lower()
+    result = score_text(text, para_count=12)
+    assert result.passed, result.failures
+
+
+def test_exclude_either_order_still_requires_both_names() -> None:
+    text = _padded().replace(
+        "The analysis excludes\nSupplies and Education.",
+        "Education and Supplies are excluded as specialty-unique costs.",
+    )
+    result = score_text(text, para_count=12)
+    assert result.passed, result.failures
+    missing_education = _padded().replace("Supplies and Education", "Supplies")
+    result = score_text(missing_education, para_count=12)
+    assert not result.passed
+    assert any("exclude" in item for item in result.failures)
+
+
+def test_arithmetic_baseline_formula_passes() -> None:
+    text = _padded().replace(
+        "(4 × per-cadaver) + Annual Cadaver Lab Fee",
+        "$3k + $1k = $13k plus the Annual Cadaver Lab Fee per-cadaver baseline",
+    )
+    assert "(4 × per-cadaver)" not in text
+    result = score_text(text, para_count=12)
+    assert result.passed, result.failures
+
+
+def test_graphical_and_figure_pass_without_chart_word() -> None:
+    for token in ("Graphical representation", "Figure 1"):
+        text = _padded().replace(
+            "Graph and savings table for 1-4 departments below.",
+            f"{token} of annual savings.",
+        )
+        assert not _has_chart_or_graph_word(text)
+        result = score_text(text, para_count=12)
+        assert result.passed, (token, result.failures)
+
+
+def test_standard_60_90_minutes_and_simple_3_to_4() -> None:
+    text = (
+        _padded()
+        .replace("Standard 1-1.5\nhours", "Standard 60-90 minutes")
+        .replace("(up to 4 per window", "(3 to 4 per window")
+    )
+    assert "1-1.5" not in text
+    assert "up to 4" not in text
+    result = score_text(text, para_count=12)
+    assert result.passed, result.failures
+
+
+def test_word_band_allows_2501_to_3200() -> None:
+    text = _PASSING
+    filler = " Shared cadaver training capacity."
+    result = score_text(text, para_count=12)
+    while result.word_count < 2600:
+        text += filler
+        result = score_text(text, para_count=12)
+    assert 2501 <= result.word_count <= 3200
+    assert result.passed, result.failures
+    while result.word_count <= 3200:
+        text += filler
+        result = score_text(text, para_count=12)
+    assert result.word_count > 3200
+    assert not result.passed
+    assert any("word_count" in item for item in result.failures)
+
+
+def test_early_honor_donor_in_overview_does_not_fail_cost_first() -> None:
+    """Overview may mention donors before the Cost Savings heading."""
+    text = _gemini_shaped() + (" Shared cadaver training capacity. " * 80)
+    # First honor/donor hit is in the overview, before "Cost Savings".
+    honor_at = text.lower().index("honors donors")
+    cost_heading_at = text.index("Cost Savings")
+    assert honor_at < cost_heading_at
+    result = score_text(
+        text,
+        para_count=16,
+        headings=["Program Overview", "Cost Savings", "Ethical Stewardship"],
+    )
+    assert result.passed, result.failures
+
+
+def test_ethics_heading_before_cost_heading_still_fails() -> None:
+    text = _padded()
+    ethics = "Ethical use: we maximize cadaver use to honor donors and respect final wishes."
+    cost = "Cost savings come first."
+    swapped = text.replace(ethics, "PLACEHOLDER_ETHICS").replace(cost, ethics).replace(
+        "PLACEHOLDER_ETHICS", cost
+    )
+    result = score_text(
+        swapped,
+        para_count=12,
+        headings=["Ethical Stewardship", "Cost Savings"],
+    )
+    assert not result.passed
+    assert any("not first" in item for item in result.failures)
+
+
+def test_odt_frame_with_savings_caption_counts_as_graph(tmp_path: Path) -> None:
+    """Bare 'charter' is not a chart; a draw:frame + savings caption is."""
+    body = (
+        _padded()
+        .replace("Graph and savings table for 1-4 departments below.", "See the embedded object.")
+        .replace("Introduction", "Program Overview", 1)
+    )
+    assert not _has_chart_or_graph_word(body)
+    doc = OpenDocumentText()
+    for line in body.strip().splitlines():
+        if line in {"Program Overview"}:
+            doc.text.addElement(H(outlinelevel=1, text=line))
+        else:
+            doc.text.addElement(P(text=line))
+    _add_savings_frame(doc, "Annual savings by participating departments.")
+    path = tmp_path / "framed.odt"
+    doc.save(str(path))
+    extract = read_proposal(path)
+    assert extract.has_savings_visual
+    result = score_proposal(path)
+    assert result.passed, result.failures
+
+
+def test_bare_frame_without_savings_caption_is_not_graph(tmp_path: Path) -> None:
+    body = _padded().replace(
+        "Graph and savings table for 1-4 departments below.",
+        "See the embedded object in the hospital charter.",
+    )
+    doc = OpenDocumentText()
+    for line in body.strip().splitlines():
+        doc.text.addElement(P(text=line))
+    _add_savings_frame(doc, "Decorative logo only.")
+    path = tmp_path / "bare-frame.odt"
+    doc.save(str(path))
+    extract = read_proposal(path)
+    assert not extract.has_savings_visual
+    result = score_proposal(path)
+    assert not result.passed
+    assert any("graph" in item or "chart" in item for item in result.failures)
+
+
+def test_savings_table_element_counts_as_graph(tmp_path: Path) -> None:
+    body = _padded().replace(
+        "Graph and savings table for 1-4 departments below.",
+        "See the embedded object in the hospital charter.",
+    )
+    doc = OpenDocumentText()
+    for line in body.strip().splitlines():
+        doc.text.addElement(P(text=line))
+    table = Table()
+    for rec in (("Departments", "Annual Savings"), ("1", "0"), ("4", "39000")):
+        row = TableRow()
+        for val in rec:
+            cell = TableCell(valuetype="string")
+            cell.addElement(P(text=val))
+            row.addElement(cell)
+        table.addElement(row)
+    doc.text.addElement(table)
+    path = tmp_path / "savings-table.odt"
+    doc.save(str(path))
+    extract = read_proposal(path)
+    assert extract.has_savings_visual
+    result = score_proposal(path)
+    assert result.passed, result.failures
+
+
+def test_gemini_shaped_softened_proposal_passes() -> None:
+    text = _gemini_shaped() + (" Shared cadaver training capacity. " * 80)
+    assert "Introduction" not in text
+    assert "1-1.5" not in text
+    assert "up to 4" not in text
+    result = score_text(
+        text,
+        para_count=18,
+        headings=["Program Overview", "Cost Savings", "Ethical Stewardship"],
+    )
+    assert result.passed, result.failures
+
+
+def test_gemini_headed_fixture_passes_when_present() -> None:
+    """Re-score the headed Gemini artifact when Keith's run is on disk."""
+    if not _GEMINI_FIXTURE.is_file():
+        return
+    result = score_proposal(_GEMINI_FIXTURE)
+    assert result.passed, result.failures


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A Gemini headed run of Collaborative Cadaver Program Proposal (~9 pages; charts; four departments; costs; ethics; freeze/thaw) is a substance **solve** that false-failed the v1 structural oracle on brittle regexes (Tenant #665 style). Keith confirmed treat as a scoring issue, not a missing-content FAIL.

Reproduce (when the headed artifact is on disk):

```bash
.venv/bin/python scripts/eval_2_headed.py --task cadaver-proposal --score docs/eval/eval-2/cadaver-proposal-61b0946a/runs/20260908-2246-gemini-3.8-flash-r200/final_proposal.odt
```

That `final_proposal.odt` is **not in this clone** (runs/ only has `.gitkeep`, same as the Tenant headed memo). Re-score locally after pull.

## Soften (Eliyezer locks)

Harness/oracle only — no product/OXT or Writer prompt change. Keep-strict: four departments, title theme, anatomy map, 10–12 cycles, 3h thawed, no-mixing, husks, both Supplies and Education named.

1. `_WORD_MAX` **3200** (min 250 stays)
2. Intro synonyms: introduction | executive summary | program overview | overview
3. Cost-first: first major cost/financial H2 before ethics/anatomy H2, **or** first cost saving(s) before the dedicated stewardship/ethics section. Early “honor donor” in an overview does not fail.
4. Lab fee aliases: lab fee | anatomy lab … fee | lab facility fee | facility fee (anatomy/lab-tied)
5. Exclude: either order supplies↔education with exclude; both names still required
6. Formula: algebraic **or** explicit baseline arithmetic (`$3k+$1k=$13k`); no literal string required
7. Graph/table: graph|chart|figure|graphical representation, **or** ODT `draw:frame` / `table:table` (or DOCX drawing/table) when nearby caption/text mentions savings or 1–4 departments — not bare frames. “chart” inside “charter” is not a figure.
8. Standard duration: 1–1.5 hours **or** 60–90 minutes
9. Simple window: ≤4 | up to 4 | 3–4 | 3 to 4 per thaw/window

## Tests / docs

- `tests/scripts/test_eval_2_cadaver_oracle.py` — 26 passed (Overview, Lab Facility Fee, Graphical/frames, 60–90 min, 3-to-4 simple, word band 2501–3200, heading-order cost-first, `$3k+$1k=$13k`)
- `make typecheck` passed
- `docs/eval/eval-2/cadaver-proposal-61b0946a/rubric.eval2.md` and `notes.md` updated
- Hypothesis check on Gemini-shaped wording: old intro / lab-fee / formula / graph-word / 1–1.5h / ≤4 / first-donor-hit checks all FAIL; keep-strict strings still present; new oracle **PASS**

[pytest 26 passed](https://cursor.com/agents/bc-0c3f7410-bb49-4d38-b42a-7b11a40aa05e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcadaver_oracle_pytest.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c3f7410-bb49-4d38-b42a-7b11a40aa05e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c3f7410-bb49-4d38-b42a-7b11a40aa05e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

