### PR TITLE
Draw/Impress paper-form fill and name-stable ControlShape edits

### DIFF
--- a/docs/chat/peer-messaging.md
+++ b/docs/chat/peer-messaging.md
@@ -340,7 +340,7 @@ GDPval GMP change-control ([`docs/eval/gdpval/58ac1cc5-…`](../eval/gdpval/58ac
 
 **Staging fact, not a product claim:** LibreOffice File → Open on a PDF often imports as **editable Draw text and shapes**, not live AcroForm widgets. A headed poke may land the gold PDF in Draw. That is eval/harness staging. It is **not** “WriterAgent edits PDFs” and **not** an AcroForm API.
 
-The Draw sidebar fills the stand-in with Draw tools (`get_draw_tree`, `delegate_to_specialized_draw_toolset` → `shape_upsert` / tree, shared `form_*` if present). Then it `send_peer_message`s back with the `peer_ask_id`.
+The Draw sidebar fills the stand-in with Draw tools (`get_draw_tree` marks empty boxes as fill targets; `delegate_to_specialized_draw_toolset` → `fill_draw_fields` / `shape_upsert` by name from the tree; shared `form_*` only for live ControlShapes). Do not spawn new ControlShapes for paper-form blanks. Then it `send_peer_message`s back with the `peer_ask_id`.
 
 ### 4.8 Worked scenarios
 
@@ -357,7 +357,7 @@ The Draw sidebar fills the stand-in with Draw tools (`get_draw_tree`, `delegate_
 
 1. Writer drafts the memo with Writer tools.
 2. `send_peer_message(document_url=<stand-in uid>, message="Fill the change-control fields from this discrepancy summary: … Reply with a short confirmation.")` → `{ok, accepted, peer_ask_id}`. Writer Readys.
-3. Draw sidebar sees the Writer envelope, runs `get_draw_tree` / specialized shapes or `form_*` **on the Draw model only**.
+3. Draw sidebar sees the Writer envelope, runs `get_draw_tree` then `fill_draw_fields` (or `shape_upsert` by name) **on the Draw model only**. Empty text boxes are the fill targets; use the name from the tree. `form_*` is only for live ControlShapes.
 4. Draw `send_peer_message(document_url=<Writer uid or url from the envelope>, message=<confirmation>, peer_ask_id=…)`. Writer follow-up cites the form in the memo.
 
 Reverse (Draw asks Writer for a paragraph) is the same tool with a Writer uid.

--- a/docs/draw/impress-specialized-toolsets.md
+++ b/docs/draw/impress-specialized-toolsets.md
@@ -42,7 +42,7 @@ These tools are **always available** to the main agent for Draw/Impress document
 | `set_active_page` | `pages.py` | Drawing+Presentation | Switch current view to slide |
 | `read_slide_text` | `pages.py` | Drawing+Presentation | Extract text from all shapes on a page |
 | `get_presentation_info` | `pages.py` | Drawing+Presentation | Metadata: slide count, dimensions, masters |
-| `get_draw_tree` | `tree.py` | Drawing+Presentation | JSON DOM of shapes and layout hierarchy |
+| `get_draw_tree` | `tree.py` | Drawing+Presentation | JSON DOM of shapes and layout; `fillable` blanks + ControlShape value/state |
 | `list_placeholders` | `placeholders.py` | Presentation | List placeholder shapes (title, subtitle, body) |
 | `get_placeholder_text` | `placeholders.py` | Presentation | Get text from a placeholder |
 | `set_placeholder_text` | `placeholders.py` | Presentation | Set text in a placeholder |
@@ -55,7 +55,8 @@ These are available only via `delegate_to_specialized_draw_toolset`:
 | Tool | Domain | Module | Purpose | Services |
 |------|--------|--------|---------|---------|
 | `shape_summary` | `shapes` | `draw/shapes.py` | Summary of shapes on page | Drawing+Presentation |
-| `shape_upsert` | `shapes` | `draw/shapes.py` | Create or edit shapes (1/100mm coordinates) | Drawing+Presentation |
+| `shape_upsert` | `shapes` | `draw/shapes.py` | Create or edit shapes (1/100mm); edit by **name** or index | Drawing+Presentation |
+| `fill_draw_fields` | `shapes` | `draw/field_fill.py` | Batch-fill paper-form blanks / ControlShape values by name, index, or `label_hint` | Drawing+Presentation |
 | `shape_delete` | `shapes` | `draw/shapes.py` | Delete a shape by index | Drawing+Presentation |
 | `shape_connect` | `shapes` | `draw/shapes.py` | Connect two shapes with a connector line | Drawing+Presentation |
 | `shape_group` | `shapes` | `draw/shapes.py` | Group multiple shapes | Drawing+Presentation |
@@ -76,7 +77,7 @@ These are available only via `delegate_to_specialized_draw_toolset`:
 | `get_headers_footers` | `headers_footers` | `draw/headers_footers.py` | Read slide/master header and footer settings (Impress) | Presentation |
 | `set_headers_footers` | `headers_footers` | `draw/headers_footers.py` | Update slide/master header and footer settings (Impress) | Presentation |
 | `manage_charts` | `charts` | `draw/charts.py` | Unified charts CRUD | Drawing+Presentation |
-| `form_*` (6 tools) | `forms` | `writer/forms.py` | Form controls | Drawing+Presentation+Spreadsheet+Text |
+| `form_*` (6 tools) | `forms` | `writer/specialized/forms.py` | Live ControlShape widgets (name-addressable; checkbox/radio State) | Drawing+Presentation+Spreadsheet+Text |
 | `insert_math` | `math` | `math_insert.py` | Insert LibreOffice Math (OLE) from LaTeX or MathML | Drawing+Presentation |
 | `WebResearchTool` | `web_research` | `web_research.py` | Web search for context | All |
 
@@ -151,7 +152,7 @@ The existing sidebar doesn't need new UI elements; the "Insert Image" action dyn
 | **Charts (specialized)** | ✅ Complete | 5 tools | Full CRUD + info |
 | **Tree Structure (core)** | ✅ Complete | 1 tool | JSON DOM for LLM understanding |
 | **Web Research (specialized)** | ✅ Complete | 1 tool | Delegated search |
-| **Forms (specialized)** | ✅ Complete | 6 tools | Form controls (shared with Writer) |
+| **Forms (specialized)** | ✅ ControlShapes + paper-form fill | 6 `form_*` + `fill_draw_fields` | Two problems — see [§3.1](#31-controlshapes-vs-paper-form-fill) |
 | **Math (specialized)** | partial | 1 tool (`insert_math`) | LaTeX/MathML → OLE Math on slide; **bounding-box sizing still unreliable** — see [§2.3](#23-insert_math-math-domain) |
 | **Animations** | ❌ Missing | — | Slide + shape-level animations |
 | **Layers** | ❌ Missing | — | Draw layer management |
@@ -169,6 +170,36 @@ The existing sidebar doesn't need new UI elements; the "Insert Image" action dyn
 | **Export** | ❌ Missing | — | PDF, image, video export |
 | **Macros** | ❌ Missing | — | Automation scripts |
 | **Versioning** | ❌ Missing | — | Document history |
+
+----
+
+## 3. Form fill — ControlShapes vs paper forms
+
+These are **two different problems**. The old “Forms ✅ Complete” row only covered interactive widgets.
+
+| Kind | What it is | How to fill | Do not |
+|------|------------|-------------|--------|
+| **A. Paper form** | Empty / near-empty TextShapes (and other text-capable boxes) next to labels. Typical when LibreOffice opens a PDF as editable Draw text/shapes. | `get_draw_tree` → `fill_draw_fields` (batch) or `shape_upsert` `action=edit` by **name** | Do not create new ControlShapes unless the user asked. Do not claim PDF/AcroForm fill. |
+| **B. Live ControlShapes** | `com.sun.star.drawing.ControlShape` + `com.sun.star.form.component.*` | Shared `form_*` (list/edit/delete by **name** or draw-page index; checkbox/radio `State`) | Index-only addressing — non-controls between widgets shift the draw-page index. |
+| **C. PDF AcroForm** | Live PDF form widgets | **Out of scope.** Not a product API. | Do not add AcroForm bindings. |
+
+**Staging fact, not a product claim:** File → Open on a PDF often imports as an editable Draw stand-in. That is harness/eval staging (see [peer messaging §4.7](../chat/peer-messaging.md#47-gmp-staging--not-a-pdf-product)). WriterAgent does **not** edit PDFs and does **not** expose an AcroForm API.
+
+### 3.1 ControlShapes vs paper-form fill
+
+**Slice 1 — paper-form (`plugin/draw/tree.py`, `field_fill.py`, `shapes.py`)**
+
+- `get_draw_tree` marks empty / near-empty text-capable shapes with `fillable=true`, always includes `name` + `geometry` (bbox) on those nodes, and adds `label_hint`: nearest sibling text **to the left** (vertically aligned) or **above** (horizontally aligned). Left wins a distance tie. Slack is 200 units (2 mm) so PDF→Draw imports that barely overlap still match. Heuristic, not a reading-order parser.
+- ControlShape nodes include `control.type`, `control.name`, and current `text` / `state` / `selected` so the main agent can see widgets without a forms delegation.
+- `shape_upsert` edit accepts **name or index**. Create can set `Name` so later fills stay stable.
+- `fill_draw_fields` (`domain=shapes`) takes `fields: [{name\|index\|label_hint, value}, …]` and optional `page`. Resolves via the tree, then `setString` (or ControlShape `Text` / `State`). Returns per-field ok/fail.
+
+**Slice 2 — live widgets (`plugin/writer/specialized/forms.py`)**
+
+- Descriptions name Writer, Calc, **and Draw/Impress**.
+- `form_list_controls` / `form_edit_control` / `form_delete_control` address by **name** (index remains). Optional `page` on Draw/Impress.
+- List/edit expose checkbox/radio **State** (0/1/2). When `index` is omitted, `name` is the lookup; `new_name` renames. `index` + `name` still means rename (older callers).
+- Shared registration stays `ToolWriterFormBase` ∪ `ToolDrawFormBase`. No Draw-only fork.
 
 ----
 
@@ -198,7 +229,7 @@ Core **placeholders** remain on the default list (`list_placeholders`, `get_plac
 Some tools are implemented in shared modules but work with Draw/Impress:
 
 - **Charts** (`plugin/draw/charts.py`): Chart tools work across all document types that support charts
-- **Forms** (`writer/forms.py`): Form tools inherit from `ToolDrawFormBase` (`plugin/draw/base.py`) and work across document types that support form controls
+- **Forms** (`plugin/writer/specialized/forms.py`): Live ControlShape tools inherit from `ToolWriterFormBase` ∪ `ToolDrawFormBase` and work across Writer/Calc/Draw/Impress. Paper-form blanks (empty TextShapes) are a different path — `get_draw_tree` + `fill_draw_fields` / `shape_upsert` — see [§3.1](#31-controlshapes-vs-paper-form-fill).
 
 > This document focuses on Draw/Impress-specific usage of these shared tools.
 
@@ -363,7 +394,7 @@ Use the existing Writer/Calc `image_*` tools (`domain="images"`). On Draw/Impres
 
 | Domain | Tools | Use Case |
 |--------|-------|---------|
-| `shapes` | `shape_upsert`, `create_diagram`, `align_shapes`, `distribute_shapes`, `shape_connect`, `shape_group` | Vector graphics & flowcharts |
+| `shapes` | `shape_upsert`, `fill_draw_fields`, `create_diagram`, `align_shapes`, `distribute_shapes`, `shape_connect`, `shape_group` | Vector graphics, flowcharts, paper-form fill |
 | `images` | `image_insert`, `image_list`, `image_delete`, `image_generate` | Images on slides (millimetres) |
 | `tables` | `table_insert`, `table_list`, `table_get_cells`, `table_set_cell`, `manage_table_structure` | Slide tables |
 | `animations` | `get_animations`, `set_animations`, `add_animation` | Element entrance/motion builds |
@@ -456,9 +487,10 @@ Use the existing Writer/Calc `image_*` tools (`domain="images"`). On Draw/Impres
 - Test **edge cases**: deleting last slide, grouping all shapes, etc.
 
 **Recommended test additions:**
-- `tests/draw/test_draw_uno.py` - Draw/Impress UNO shape and page coverage
+- `tests/draw/test_draw_uno.py` - Draw/Impress UNO shape and page coverage (tree blanks, name-based `shape_upsert`)
+- `tests/draw/test_tree.py` / `tests/draw/test_field_fill.py` - blank detection, label hints, `fill_draw_fields` resolve
 - `tests/draw/test_draw_specialized_tiers.py` - Specialized tier registration
-- `tests/draw/test_draw_forms_uno.py` - Forms
+- `tests/draw/test_draw_forms_uno.py` - ControlShapes (list/edit by name, checkbox State) + `fill_draw_fields`
 - `tests/draw/test_draw_headers_footers.py` - Headers/footers
 
 ----

--- a/docs/features.md
+++ b/docs/features.md
@@ -84,7 +84,7 @@ Contracts and RPC: [calc/analysis-tools.md](calc/analysis-tools.md).
 
 | Topic | Docs |
 |-------|------|
-| Specialized toolsets | [draw/impress-specialized-toolsets.md](draw/impress-specialized-toolsets.md) · peer send (design): [chat/peer-messaging.md](chat/peer-messaging.md) |
+| Specialized toolsets | [draw/impress-specialized-toolsets.md](draw/impress-specialized-toolsets.md) — ControlShapes (`form_*`) vs paper-form blanks (`get_draw_tree` / `fill_draw_fields`); no PDF/AcroForm fill · peer send (design): [chat/peer-messaging.md](chat/peer-messaging.md) |
 | Shapes | [draw/shape-support.md](draw/shape-support.md) |
 | PPT-Master | [ppt-master-integration-plan.md](ppt-master-integration-plan.md) |
 

--- a/docs/writer/lo-dom-semantic-tree.md
+++ b/docs/writer/lo-dom-semantic-tree.md
@@ -20,8 +20,10 @@ The `get_draw_tree` tool extracts the hierarchical structure of a Draw page or I
 
 **Features of the Draw Tree:**
 * **Hierarchy:** Grouped shapes become parent nodes with nested children.
-* **Spatial Geometry:** Extracts precise `x`, `y`, `width`, and `height` properties.
+* **Spatial Geometry:** Extracts precise `x`, `y`, `width`, and `height` properties (the bbox used for paper-form neighbor labels).
 * **Semantic Attributes:** Reads the underlying `text`, `name`, `alt_title`, and `alt_description`.
+* **Paper-form blanks:** Empty or near-empty text-capable shapes are marked `fillable=true` with an optional `label_hint` (nearest text to the left or above). Address them by `name` via `fill_draw_fields` / `shape_upsert`. This is **not** PDF/AcroForm fill — a PDF opened in Draw is an editable stand-in.
+* **ControlShapes:** Live form widgets include `control.type`, `control.name`, and current `text` / `state` so the main agent can see them without a forms delegation.
 * **Relational Logic:** For `ConnectorShape`s, it directly extracts the `StartShape` and `EndShape`, proving unambiguous flow logic for flowcharts.
 * **Visual Style:** Captures `FillColor`, `LineColor`, and `ZOrder`.
 

--- a/plugin/draw/base.py
+++ b/plugin/draw/base.py
@@ -58,7 +58,9 @@ class ToolDrawChartBase(ToolDrawSpecialBase):
 
 class ToolDrawShapeBase(ToolDrawSpecialBase):
     specialized_domain: ClassVar[str | None] = "shapes"
-    specialized_domain_description: ClassVar[str | None] = "Create and edit drawing shapes, connectors, and groups."
+    specialized_domain_description: ClassVar[str | None] = (
+        "Create and edit drawing shapes, connectors, and groups; fill paper-form blanks by name."
+    )
     uno_services = ["com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
 
 

--- a/plugin/draw/field_fill.py
+++ b/plugin/draw/field_fill.py
@@ -1,0 +1,258 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Batch fill for Draw/Impress paper-form blanks and ControlShapes.
+
+Empty text boxes imported from a PDF stand-in are fill targets. This
+tool writes existing shapes; it does not create ControlShapes. Live
+PDF/AcroForm widgets are out of scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from plugin.draw.base import ToolDrawShapeBase
+from plugin.draw.tree import (
+    build_shape_tree,
+    coerce_control_state,
+    find_shape_on_page,
+    is_control_shape_type,
+)
+def _flatten_tree(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for node in nodes:
+        out.append(node)
+        children = node.get("children")
+        if children:
+            out.extend(_flatten_tree(children))
+    return out
+
+
+def resolve_field_node(
+    tree: list[dict[str, Any]],
+    *,
+    name: str | None = None,
+    index: int | None = None,
+    label_hint: str | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Pick a tree node for a fill request. Name, then index, then label_hint."""
+    flat = _flatten_tree(tree)
+    wanted_name = (name or "").strip()
+    if wanted_name:
+        name_hits = [n for n in flat if (n.get("name") or "") == wanted_name]
+        if not name_hits:
+            name_hits = [
+                n
+                for n in flat
+                if isinstance(n.get("control"), dict) and (n["control"].get("name") or "") == wanted_name
+            ]
+        if len(name_hits) == 1:
+            return name_hits[0], None
+        if not name_hits:
+            return None, "No shape named %r on this page." % wanted_name
+        return None, "Several shapes named %r; pass index as well." % wanted_name
+
+    if index is not None:
+        try:
+            idx = int(index)
+        except (TypeError, ValueError):
+            return None, "Invalid shape index: %s" % index
+        for node in flat:
+            if node.get("index") == idx:
+                return node, None
+        return None, "No shape at index %s on this page." % idx
+
+    hint = (label_hint or "").strip().lower()
+    if hint:
+        hint_hits = [
+            n
+            for n in flat
+            if n.get("fillable") and (n.get("label_hint") or "").strip().lower() == hint
+        ]
+        if len(hint_hits) == 1:
+            return hint_hits[0], None
+        if not hint_hits:
+            return None, "No fillable shape with label_hint %r." % label_hint
+        return None, "Several fillable shapes match label_hint %r; pass name or index." % label_hint
+
+    return None, "Each field needs name, index, or label_hint."
+
+
+def apply_fill_value(shape: Any, value: Any) -> tuple[bool, str]:
+    """Write *value* onto a paper-form shape or ControlShape model."""
+    try:
+        shape_type = shape.getShapeType()
+    except Exception:
+        shape_type = ""
+
+    if is_control_shape_type(shape_type):
+        return _apply_control_value(shape, value)
+
+    if hasattr(shape, "setString"):
+        try:
+            shape.setString("" if value is None else str(value))
+            return True, "set text"
+        except Exception as exc:
+            return False, "setString failed: %s" % exc
+    return False, "Shape cannot hold text."
+
+
+def _apply_control_value(shape: Any, value: Any) -> tuple[bool, str]:
+    try:
+        model = shape.Control
+    except Exception as exc:
+        return False, "ControlShape has no model: %s" % exc
+    if model is None:
+        return False, "ControlShape has no model."
+
+    if hasattr(model, "State") and not hasattr(model, "Text"):
+        state = coerce_control_state(value)
+        if state is None:
+            return False, "Could not interpret %r as a checkbox/radio State." % value
+        try:
+            model.State = state
+            return True, "set state"
+        except Exception as exc:
+            return False, "Setting State failed: %s" % exc
+
+    if hasattr(model, "Text"):
+        try:
+            model.Text = "" if value is None else str(value)
+            return True, "set text"
+        except Exception as exc:
+            return False, "Setting Text failed: %s" % exc
+
+    if hasattr(model, "State"):
+        state = coerce_control_state(value)
+        if state is None:
+            return False, "Could not interpret %r as a control State." % value
+        try:
+            model.State = state
+            return True, "set state"
+        except Exception as exc:
+            return False, "Setting State failed: %s" % exc
+
+    if hasattr(shape, "setString"):
+        try:
+            shape.setString("" if value is None else str(value))
+            return True, "set text"
+        except Exception as exc:
+            return False, "setString failed: %s" % exc
+    return False, "Control cannot accept a text or State value."
+
+
+class FillDrawFields(ToolDrawShapeBase):
+    """Batch-write existing blanks / widgets. Does not spawn new controls."""
+
+    name = "fill_draw_fields"
+    description = (
+        "Fill existing empty text boxes (paper-form fields) or ControlShape values on a Draw/Impress page "
+        "so a GMP-style stand-in can be completed in one call. Empty boxes are fill targets — do not create "
+        "new ControlShapes unless the user asked for live form widgets. Resolve each field by name (preferred), "
+        "draw-page index, or label_hint from get_draw_tree. Returns per-field ok/fail so you can recover. "
+        "Not a PDF/AcroForm API."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "page": {"type": "integer", "description": "0-based page index (active page if omitted)."},
+            "fields": {
+                "type": "array",
+                "description": "Fields to write. Each item needs a value plus name, index, or label_hint.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Shape Name or Control.Name from get_draw_tree."},
+                        "index": {"type": "integer", "description": "0-based draw-page shape index (fragile when non-fields sit between boxes)."},
+                        "label_hint": {"type": "string", "description": "Neighbor label from get_draw_tree (left/above heuristic)."},
+                        "value": {"type": "string", "description": "Text to write, or checkbox/radio State (0/1, yes/no, checked)."},
+                    },
+                    "required": ["value"],
+                },
+            },
+        },
+        "required": ["fields"],
+    }
+    doc_types = ["draw", "impress"]
+    is_mutation = True
+    required_core_tools = frozenset(["get_draw_tree"])
+
+    def execute(self, ctx, **kwargs):
+        from plugin.draw.bridge import DrawBridge
+
+        fields = kwargs.get("fields") or []
+        if not isinstance(fields, list) or not fields:
+            return self._tool_error("fields must be a non-empty list of {name|index|label_hint, value}.")
+
+        bridge = DrawBridge(ctx.doc)
+        idx = kwargs.get("page")
+        actual_idx = idx if idx is not None else ctx.active_page_index
+        if actual_idx is None:
+            actual_idx = bridge.get_active_page_index()
+
+        try:
+            page = bridge.get_pages().getByIndex(actual_idx)
+        except Exception:
+            return self._tool_error("Invalid page index: %s" % actual_idx)
+        if page is None:
+            return self._tool_error("No draw page available.")
+
+        tree = build_shape_tree(page)
+        results: list[dict[str, Any]] = []
+        ok_count = 0
+        for i, raw in enumerate(fields):
+            if not isinstance(raw, dict):
+                results.append({"ok": False, "error": "Field %s is not an object." % i})
+                continue
+            node, err = resolve_field_node(
+                tree,
+                name=raw.get("name"),
+                index=raw.get("index"),
+                label_hint=raw.get("label_hint"),
+            )
+            if err or node is None:
+                results.append({"ok": False, "error": err or "Could not resolve field.", "name": raw.get("name"), "index": raw.get("index"), "label_hint": raw.get("label_hint")})
+                continue
+            shape_idx, shape, find_err = find_shape_on_page(page, index=node.get("index"), name=node.get("name") or None)
+            if find_err or shape is None:
+                # Group children expose path_index only; fall back to name.
+                shape_idx, shape, find_err = find_shape_on_page(page, name=node.get("name") or None)
+            if find_err or shape is None:
+                results.append({"ok": False, "error": find_err or "Resolved tree node but the shape is gone.", "name": node.get("name"), "index": node.get("index")})
+                continue
+            applied, detail = apply_fill_value(shape, raw.get("value"))
+            entry: dict[str, Any] = {
+                "ok": applied,
+                "index": shape_idx,
+                "name": node.get("name") or "",
+                "detail": detail,
+            }
+            if node.get("label_hint"):
+                entry["label_hint"] = node["label_hint"]
+            if not applied:
+                entry["error"] = detail
+            else:
+                ok_count += 1
+            results.append(entry)
+
+        status = "ok" if ok_count == len(fields) else ("partial" if ok_count else "error")
+        return {
+            "status": status,
+            "page": actual_idx,
+            "ok_count": ok_count,
+            "fail_count": len(fields) - ok_count,
+            "results": results,
+        }

--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -452,8 +452,15 @@ class DrawShapes:
 
 def _apply_shape_properties(shape, kwargs):
     """Helper to apply rich formatting properties to a shape."""
-    if kwargs.get("text") and hasattr(shape, "setString"):
-        shape.setString(kwargs["text"])
+    # "text" in kwargs (not truthy) so paper-form fills can write "" or keep a Name-only edit.
+    if "text" in kwargs and hasattr(shape, "setString"):
+        shape.setString("" if kwargs["text"] is None else str(kwargs["text"]))
+
+    if kwargs.get("name") and hasattr(shape, "Name"):
+        try:
+            shape.Name = str(kwargs["name"])
+        except Exception:
+            pass
 
     # Background/Fill Color
     if kwargs.get("fill_color"):
@@ -564,12 +571,16 @@ _CREATE_SHAPE_SHAPE_TYPE_DESC = (
 
 class UpsertShape(ToolDrawShapeBase):
     name = "shape_upsert"
-    description = "Creates a new shape or modifies an existing shape on a page."
+    description = (
+        "Create or edit a shape on a page. When filling a paper-form blank, edit by shape Name "
+        "from get_draw_tree — draw-page index shifts when other shapes sit between fields."
+    )
     parameters = {
         "type": "object",
         "properties": {
             "action": {"type": "string", "enum": ["create", "edit"], "description": "Action to perform: 'create' a new shape, or 'edit' an existing one."},
-            "index": {"type": "integer", "description": "0-based index of the shape on the page (required only for action='edit')"},
+            "index": {"type": "integer", "description": "0-based index of the shape on the page (edit: pass index or name)"},
+            "name": {"type": "string", "description": "Shape Name. Edit: look up by Name when index is omitted. Create: set the new shape's Name so later fills stay stable."},
             "page": {"type": "integer", "description": "0-based page index (active page if omitted)"},
             "shape_type": {"type": "string", "description": _CREATE_SHAPE_SHAPE_TYPE_DESC + " (required only for action='create')"},
             "x": {"type": "integer", "description": "X position (100ths of mm) (required only for action='create')"},
@@ -603,8 +614,8 @@ class UpsertShape(ToolDrawShapeBase):
                 if r not in kwargs:
                     return False, f"Parameter '{r}' is required when action is 'create'"
         elif action == "edit":
-            if "index" not in kwargs:
-                return False, "Parameter 'index' is required when action is 'edit'"
+            if "index" not in kwargs and not str(kwargs.get("name") or "").strip():
+                return False, "Parameter 'index' or 'name' is required when action is 'edit'"
         else:
             return False, f"Unknown action: '{action}'. Must be 'create' or 'edit'"
             
@@ -704,10 +715,14 @@ class UpsertShape(ToolDrawShapeBase):
             return result
 
         elif action == "edit":
-            try:
-                shape = page.getByIndex(kwargs["index"])
-            except Exception as e:
-                return self._tool_error(f"Failed to find shape at index {kwargs['index']}: {str(e)}")
+            from plugin.draw.tree import find_shape_on_page
+
+            # Index is fragile for peer "fill field X"; Name from get_draw_tree stays stable
+            # when non-fields sit between boxes. Index wins when both are passed.
+            lookup_name = kwargs.get("name") if "index" not in kwargs else None
+            shape_idx, shape, find_err = find_shape_on_page(page, index=kwargs.get("index"), name=lookup_name)
+            if find_err or shape is None:
+                return self._tool_error(find_err or "Shape not found.")
 
             if "x" in kwargs or "y" in kwargs:
                 pos = shape.getPosition()
@@ -718,7 +733,7 @@ class UpsertShape(ToolDrawShapeBase):
 
             _apply_shape_properties(shape, kwargs)
 
-            return {"status": "ok", "message": "Shape updated", "page": actual_idx}
+            return {"status": "ok", "message": "Shape updated", "page": actual_idx, "index": shape_idx, "name": getattr(shape, "Name", "") or ""}
 
 
 class ConnectShapes(ToolDrawShapeBase):

--- a/plugin/draw/tree.py
+++ b/plugin/draw/tree.py
@@ -14,19 +14,433 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Tree (LO-DOM) tools for Draw/Impress documents."""
+"""Tree (LO-DOM) tools for Draw/Impress documents.
+
+``get_draw_tree`` is the main-agent read of a page. Paper-form blanks
+(empty/near-empty text boxes) are marked ``fillable`` with an optional
+``label_hint`` (nearest text to the left or above). ControlShapes are
+surfaced with type/name/value/state so the main agent can see widgets
+without a forms delegation.
+
+Neighbor heuristic (documented for callers): among sibling nodes with
+non-empty text, prefer the nearest whose bbox is strictly left with
+roughly aligned vertical centers, else the nearest strictly above with
+roughly aligned horizontal centers. Left wins a distance tie. Gap slack
+is 200 units (2 mm) so PDF→Draw imports that barely overlap still match.
+This is a hint, not a reading-order parser.
+"""
+
+from __future__ import annotations
 
 import logging
+import re
+from typing import Any
 
 from plugin.framework.tool import ToolBase
 
 log = logging.getLogger(__name__)
 
+# Placeholder-only text: underscores, leaders, box drawings, whitespace.
+_NEAR_EMPTY_RE = re.compile(r"^[\s._\-–—•·□■☐☑☒╳]+$")
+
+# Shapes that can hold paper-form text. Lines/connectors/graphics/tables/OLE
+# are not fill targets even when getString exists.
+_NON_FILLABLE_TYPE_MARKERS = (
+    "LineShape",
+    "ConnectorShape",
+    "GroupShape",
+    "GraphicObjectShape",
+    "OLE2Shape",
+    "TableShape",
+    "PluginShape",
+    "MediaShape",
+    "ControlShape",
+    "PageShape",
+    "MeasureShape",
+)
+
+# 2 mm of import slop when deciding left/above alignment.
+_LABEL_ALIGN_SLACK = 200
+
+
+def short_shape_type(shape_type: str) -> str:
+    return (shape_type or "").replace("com.sun.star.drawing.", "")
+
+
+def is_near_empty_text(text: str | None) -> bool:
+    """True when *text* is empty or only placeholder marks (____, …, boxes)."""
+    raw = "" if text is None else str(text)
+    stripped = raw.strip()
+    if not stripped:
+        return True
+    return bool(_NEAR_EMPTY_RE.fullmatch(stripped))
+
+
+def is_control_shape_type(shape_type: str) -> bool:
+    return "ControlShape" in short_shape_type(shape_type)
+
+
+def is_text_capable_shape_type(shape_type: str) -> bool:
+    short = short_shape_type(shape_type)
+    if not short or short == "UnknownShape":
+        return False
+    return not any(marker in short for marker in _NON_FILLABLE_TYPE_MARKERS)
+
+
+def coerce_control_state(value: Any) -> int | None:
+    """Map a model/tool value to LibreOffice form State (0/1/2).
+
+    Accepts bools, ints, and common strings (yes/checked → 1). Returns
+    None when the value cannot be interpreted as a state.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    s = str(value).strip().lower()
+    if s in ("1", "true", "yes", "on", "checked", "selected"):
+        return 1
+    if s in ("0", "false", "no", "off", "unchecked"):
+        return 0
+    if s in ("2", "unknown", "indeterminate"):
+        return 2
+    try:
+        return int(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def control_snapshot(model: Any) -> dict[str, Any]:
+    """Type, name, and current value/state from a form component model."""
+    info: dict[str, Any] = {"type": _readable_control_type(model), "name": _safe_attr(model, "Name")}
+    label = _safe_attr(model, "Label")
+    if label:
+        info["label"] = label
+    if hasattr(model, "Text"):
+        try:
+            info["text"] = model.Text
+        except Exception:
+            pass
+    if hasattr(model, "State"):
+        try:
+            info["state"] = int(model.State)
+        except Exception:
+            pass
+    if hasattr(model, "StringItemList"):
+        try:
+            info["items"] = list(model.StringItemList)
+        except Exception:
+            pass
+    if hasattr(model, "SelectedItems"):
+        try:
+            info["selected"] = list(model.SelectedItems)
+        except Exception:
+            pass
+    return info
+
+
+def _readable_control_type(model: Any) -> str:
+    # Local map avoids importing writer.forms (UNO-heavy) from the tree path.
+    mapping = (
+        ("checkbox", "com.sun.star.form.component.CheckBox"),
+        ("text", "com.sun.star.form.component.TextField"),
+        ("radio", "com.sun.star.form.component.RadioButton"),
+        ("date", "com.sun.star.form.component.DateField"),
+        ("combobox", "com.sun.star.form.component.ComboBox"),
+        ("button", "com.sun.star.form.component.CommandButton"),
+        ("listbox", "com.sun.star.form.component.ListBox"),
+    )
+    for type_str, service in mapping:
+        try:
+            if model is not None and model.supportsService(service):
+                return type_str
+        except Exception:
+            continue
+    return "unknown"
+
+
+def _safe_attr(obj: Any, name: str, default: str = "") -> str:
+    try:
+        val = getattr(obj, name, default)
+        return default if val is None else str(val)
+    except Exception:
+        return default
+
+
+def _shape_name(shape: Any) -> str:
+    return _safe_attr(shape, "Name")
+
+
+def _shape_text(shape: Any) -> str:
+    try:
+        if hasattr(shape, "getString"):
+            return shape.getString() or ""
+    except Exception:
+        pass
+    return ""
+
+
+def _shape_geometry(shape: Any) -> dict[str, int] | None:
+    try:
+        pos = shape.getPosition()
+        size = shape.getSize()
+        return {"x": int(pos.X), "y": int(pos.Y), "width": int(size.Width), "height": int(size.Height)}
+    except Exception:
+        return None
+
+
+def _cx(g: dict[str, int]) -> float:
+    return g["x"] + g["width"] / 2.0
+
+
+def _cy(g: dict[str, int]) -> float:
+    return g["y"] + g["height"] / 2.0
+
+
+def _is_left_of(label_g: dict[str, int], blank_g: dict[str, int]) -> bool:
+    return label_g["x"] + label_g["width"] <= blank_g["x"] + _LABEL_ALIGN_SLACK and abs(_cy(label_g) - _cy(blank_g)) <= max(label_g["height"], blank_g["height"], 1)
+
+
+def _is_above(label_g: dict[str, int], blank_g: dict[str, int]) -> bool:
+    return label_g["y"] + label_g["height"] <= blank_g["y"] + _LABEL_ALIGN_SLACK and abs(_cx(label_g) - _cx(blank_g)) <= max(label_g["width"], blank_g["width"], 1)
+
+
+def _left_gap(label_g: dict[str, int], blank_g: dict[str, int]) -> int:
+    return blank_g["x"] - (label_g["x"] + label_g["width"])
+
+
+def _above_gap(label_g: dict[str, int], blank_g: dict[str, int]) -> int:
+    return blank_g["y"] - (label_g["y"] + label_g["height"])
+
+
+def nearest_label_hint(blank: dict[str, Any], candidates: list[dict[str, Any]]) -> str | None:
+    """Return text of the nearest left-or-above labeled sibling, or None.
+
+    *candidates* should already be filtered to nodes with non-empty text.
+    Left-of wins a distance tie so a side label beats a heading above.
+    """
+    blank_g = blank.get("geometry")
+    if not blank_g:
+        return None
+    best_text: str | None = None
+    best_key: tuple[int, int] | None = None
+    for cand in candidates:
+        if cand is blank:
+            continue
+        text = (cand.get("text") or "").strip()
+        geom = cand.get("geometry")
+        if not text or not geom:
+            continue
+        if _is_left_of(geom, blank_g):
+            key = (0, max(0, _left_gap(geom, blank_g)))
+        elif _is_above(geom, blank_g):
+            key = (1, max(0, _above_gap(geom, blank_g)))
+        else:
+            continue
+        if best_key is None or key < best_key:
+            best_key = key
+            best_text = text
+    return best_text
+
+
+def attach_label_hints(nodes: list[dict[str, Any]]) -> None:
+    """Set ``label_hint`` on fillable siblings; recurse into groups."""
+    labeled = [n for n in nodes if (n.get("text") or "").strip() and not n.get("fillable")]
+    for blank in nodes:
+        if not blank.get("fillable"):
+            continue
+        hint = nearest_label_hint(blank, labeled)
+        if hint:
+            blank["label_hint"] = hint
+    for node in nodes:
+        children = node.get("children")
+        if children:
+            attach_label_hints(children)
+
+
+def find_shape_on_page(page: Any, *, index: int | None = None, name: str | None = None) -> tuple[int | None, Any | None, str | None]:
+    """Resolve a page shape by index or Name (shape.Name or Control.Name).
+
+    Returns ``(index, shape, error)``. Name match is exact; several hits
+    prefer a unique ``shape.Name`` match, else error so the caller can recover.
+    """
+    if index is not None:
+        try:
+            idx = int(index)
+            if idx < 0 or idx >= page.getCount():
+                return None, None, "Invalid shape index: %s" % idx
+            return idx, page.getByIndex(idx), None
+        except Exception as exc:
+            return None, None, "Failed to find shape at index %s: %s" % (index, exc)
+
+    wanted = (name or "").strip()
+    if not wanted:
+        return None, None, "Pass name or index to address the shape."
+
+    name_hits: list[tuple[int, Any]] = []
+    control_hits: list[tuple[int, Any]] = []
+    try:
+        count = page.getCount()
+    except Exception as exc:
+        return None, None, "Could not read page shapes: %s" % exc
+
+    for i in range(count):
+        try:
+            shape = page.getByIndex(i)
+        except Exception:
+            continue
+        if _shape_name(shape) == wanted:
+            name_hits.append((i, shape))
+            continue
+        try:
+            if is_control_shape_type(shape.getShapeType()):
+                control = getattr(shape, "Control", None)
+                if control is not None and _safe_attr(control, "Name") == wanted:
+                    control_hits.append((i, shape))
+        except Exception:
+            continue
+
+    hits = name_hits if name_hits else control_hits
+    if len(hits) == 1:
+        return hits[0][0], hits[0][1], None
+    if not hits:
+        return None, None, "No shape named %r on this page." % wanted
+    return None, None, "Several shapes named %r; pass index as well." % wanted
+
+
+def build_shape_tree(xshapes: Any, base_index: str | None = None) -> list[dict[str, Any]]:
+    """Recursively build a semantic tree from an XShapes collection."""
+    tree = _collect_shape_nodes(xshapes, base_index)
+    attach_label_hints(tree)
+    return tree
+
+
+def _collect_shape_nodes(xshapes: Any, base_index: str | None = None) -> list[dict[str, Any]]:
+    tree: list[dict[str, Any]] = []
+    try:
+        count = xshapes.getCount()
+    except Exception:
+        return tree
+
+    for i in range(count):
+        try:
+            shape = xshapes.getByIndex(i)
+        except Exception:
+            continue
+
+        current_index = str(i) if base_index is None else f"{base_index}.{i}"
+
+        try:
+            shape_type = shape.getShapeType()
+        except Exception:
+            shape_type = "UnknownShape"
+
+        node: dict[str, Any] = {"type": short_shape_type(shape_type)}
+
+        if base_index is None:
+            node["index"] = i
+        else:
+            node["path_index"] = current_index
+
+        name = _shape_name(shape)
+        text = _shape_text(shape)
+        text_capable = is_text_capable_shape_type(shape_type)
+        control = is_control_shape_type(shape_type)
+
+        if name or text_capable or control:
+            node["name"] = name
+
+        if text.strip():
+            node["text"] = text.strip()
+
+        if text_capable and is_near_empty_text(text):
+            node["fillable"] = True
+
+        if control:
+            try:
+                model = getattr(shape, "Control", None)
+                if model is not None:
+                    node["control"] = control_snapshot(model)
+            except Exception:
+                node["control"] = {"type": "unknown", "name": name}
+
+        try:
+            desc = getattr(shape, "Description", "")
+            if desc:
+                node["alt_description"] = desc
+            title = getattr(shape, "Title", "")
+            if title:
+                node["alt_title"] = title
+        except Exception:
+            pass
+
+        geom = _shape_geometry(shape)
+        if geom:
+            node["geometry"] = geom
+
+        if "ConnectorShape" in shape_type:
+            try:
+                start_shape = shape.getPropertyValue("StartShape")
+                if start_shape:
+                    s_name = _shape_name(start_shape)
+                    s_text = _shape_text(start_shape).strip()
+                    node["connected_start"] = {"name": s_name, "text": s_text}
+            except Exception:
+                pass
+            try:
+                end_shape = shape.getPropertyValue("EndShape")
+                if end_shape:
+                    e_name = _shape_name(end_shape)
+                    e_text = _shape_text(end_shape).strip()
+                    node["connected_end"] = {"name": e_name, "text": e_text}
+            except Exception:
+                pass
+
+        style: dict[str, Any] = {}
+        for prop in ["FillColor", "LineColor", "ZOrder", "RotateAngle", "LineWidth"]:
+            try:
+                val = shape.getPropertyValue(prop)
+                if val is not None:
+                    if prop in ["FillColor", "LineColor"] and isinstance(val, int) and val != -1:
+                        style[prop] = f"#{val:06X}"
+                    else:
+                        style[prop] = val
+            except Exception:
+                pass
+
+        try:
+            geom_props = shape.getPropertyValue("CustomShapeGeometry")
+            if geom_props:
+                for p in geom_props:
+                    if p.Name == "Type":
+                        node["custom_shape_type"] = p.Value
+        except Exception:
+            pass
+
+        if style:
+            node["style"] = style
+
+        if "GroupShape" in shape_type:
+            node["children"] = _collect_shape_nodes(shape, current_index)
+
+        tree.append(node)
+
+    return tree
+
 
 class GetDrawTree(ToolBase):
     name = "get_draw_tree"
     intent = "read"
-    description = "Returns a semantic tree (DOM) of the shapes on the active or specified draw page. Use this instead of requesting a screenshot to understand the layout, text, connections, and hierarchy of objects (like flowcharts or diagrams)."
+    description = (
+        "Read the page as a shape tree so you can fill blanks and see widgets without a screenshot. "
+        "Empty or near-empty text boxes are fill targets (fillable=true) with name, geometry, and a "
+        "label_hint (nearest text to the left or above). ControlShapes include type, name, and current "
+        "value/state. Address shapes by name from this tree — draw-page index shifts when other shapes sit between fields."
+    )
     parameters = {"type": "object", "properties": {"page": {"type": "integer", "description": "0-based page index (active page if omitted)"}}, "required": []}
     uno_services = ["com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
     doc_types = ["draw", "impress"]
@@ -37,11 +451,11 @@ class GetDrawTree(ToolBase):
 
         bridge = DrawBridge(ctx.doc)
         idx = kwargs.get("page")
-        
+
         # Use provided index or resolved active index from context
         actual_idx = idx if idx is not None else ctx.active_page_index
         if actual_idx is None:
-             actual_idx = bridge.get_active_page_index()
+            actual_idx = bridge.get_active_page_index()
 
         try:
             page = bridge.get_pages().getByIndex(actual_idx)
@@ -51,113 +465,7 @@ class GetDrawTree(ToolBase):
         if page is None:
             return self._tool_error("No draw page available.")
 
-        return {"status": "ok", "page": actual_idx, "tree": self._build_shape_tree(page)}
+        return {"status": "ok", "page": actual_idx, "tree": build_shape_tree(page)}
 
     def _build_shape_tree(self, xshapes, base_index=None):
-        """Recursively build a semantic tree from an XShapes collection (DrawPage or GroupShape)."""
-        tree = []
-        try:
-            count = xshapes.getCount()
-        except Exception:
-            return tree
-
-        for i in range(count):
-            try:
-                shape = xshapes.getByIndex(i)
-            except Exception:
-                continue
-
-            current_index = str(i) if base_index is None else f"{base_index}.{i}"
-
-            try:
-                shape_type = shape.getShapeType()
-            except Exception:
-                shape_type = "UnknownShape"
-
-            node = {"type": shape_type.replace("com.sun.star.drawing.", "")}
-
-            if base_index is None:
-                node["index"] = i
-            else:
-                node["path_index"] = current_index
-
-            try:
-                name = getattr(shape, "Name", "")
-                if name:
-                    node["name"] = name
-            except Exception:
-                pass
-
-            try:
-                if hasattr(shape, "getString"):
-                    text = shape.getString().strip()
-                    if text:
-                        node["text"] = text
-            except Exception:
-                pass
-
-            try:
-                desc = getattr(shape, "Description", "")
-                if desc:
-                    node["alt_description"] = desc
-                title = getattr(shape, "Title", "")
-                if title:
-                    node["alt_title"] = title
-            except Exception:
-                pass
-
-            try:
-                pos = shape.getPosition()
-                size = shape.getSize()
-                node["geometry"] = {"x": pos.X, "y": pos.Y, "width": size.Width, "height": size.Height}
-            except Exception:
-                pass
-
-            if "ConnectorShape" in shape_type:
-                try:
-                    start_shape = shape.getPropertyValue("StartShape")
-                    if start_shape:
-                        s_name = getattr(start_shape, "Name", "")
-                        s_text = start_shape.getString().strip() if hasattr(start_shape, "getString") else ""
-                        node["connected_start"] = {"name": s_name, "text": s_text}
-                except Exception:
-                    pass
-                try:
-                    end_shape = shape.getPropertyValue("EndShape")
-                    if end_shape:
-                        e_name = getattr(end_shape, "Name", "")
-                        e_text = end_shape.getString().strip() if hasattr(end_shape, "getString") else ""
-                        node["connected_end"] = {"name": e_name, "text": e_text}
-                except Exception:
-                    pass
-
-            style = {}
-            for prop in ["FillColor", "LineColor", "ZOrder", "RotateAngle", "LineWidth"]:
-                try:
-                    val = shape.getPropertyValue(prop)
-                    if val is not None:
-                        if prop in ["FillColor", "LineColor"] and isinstance(val, int) and val != -1:
-                            style[prop] = f"#{val:06X}"
-                        else:
-                            style[prop] = val
-                except Exception:
-                    pass
-
-            try:
-                geom = shape.getPropertyValue("CustomShapeGeometry")
-                if geom:
-                    for p in geom:
-                        if p.Name == "Type":
-                            node["custom_shape_type"] = p.Value
-            except Exception:
-                pass
-
-            if style:
-                node["style"] = style
-
-            if "GroupShape" in shape_type:
-                node["children"] = self._build_shape_tree(shape, current_index)
-
-            tree.append(node)
-
-        return tree
+        return build_shape_tree(xshapes, base_index)

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -515,7 +515,7 @@ Do not explain - do the operation directly using tools. Perform as many steps as
 WORKFLOW:
 1. Understand the user's request.
 2. If needed, use list_pages, read_slide_text, or get_presentation_info to understand current slides and layout.
-3. Use the specialized delegation tool to perform shape operations (create, edit, group, etc.), transitions, masters, notes, or charts.
+3. Use the specialized delegation tool to perform shape operations (create, edit, group, paper-form fill via fill_draw_fields), transitions, masters, notes, or charts.
 4. Give a short confirmation; when you changed pages/shapes, mention them.
 
 TOOLS (grouped by use):
@@ -524,7 +524,7 @@ READ:
 - list_pages: List pages/slides in the document.
 - read_slide_text: Extract text content and speaker notes from a slide.
 - get_presentation_info: Slide count, dimensions, master slide names, and Impress status.
-- get_draw_tree: Semantic tree (DOM) of shapes, layout, and hierarchy on a page.
+- get_draw_tree: Semantic tree (DOM) of shapes, layout, and hierarchy on a page. Empty/near-empty text boxes are fill targets (fillable, label_hint, name); ControlShapes include type/name/value/state. Address by name. Do not spawn ControlShapes to fill paper-form blanks.
 - list_placeholders: List text placeholders (title, subtitle, body) on a slide (Impress).
 - get_placeholder_text: Get text from a slide placeholder by role or index.
 

--- a/plugin/scripting/writeragent_api.py
+++ b/plugin/scripting/writeragent_api.py
@@ -174,6 +174,7 @@ DOMAIN_TOOLS = {   'bookmark': [   'bookmark_cleanup',
     'shape': [   'align_shapes',
                  'create_diagram',
                  'distribute_shapes',
+                 'fill_draw_fields',
                  'shape_connect',
                  'shape_delete',
                  'shape_group',
@@ -614,21 +615,21 @@ class _FormsProxy:
         """Creates a single interactive form control (checkbox, text field, radio button, date field, combobox, or button)."""
         return _rpc_call("form_create_control", control=control, label=label, name=name, group_name=group_name, items=items, placeholder=placeholder, default_value=default_value, width=width, height=height)
 
-    def delete_control(self, index: int) -> dict:
-        """Deletes a form control by index (Calc: active sheet draw page)."""
-        return _rpc_call("form_delete_control", index=index)
+    def delete_control(self, index: int | None = None, *, name: str | None = None, page: int | None = None) -> dict:
+        """Delete a live form widget by name (preferred) or draw-page index."""
+        return _rpc_call("form_delete_control", index=index, name=name, page=page)
 
-    def edit_control(self, index: int, *, name: str | None = None, label: str | None = None, text: str | None = None, items: list | None = None, x: int | None = None, y: int | None = None, width: int | None = None, height: int | None = None) -> dict:
-        """Modifies an existing form control by index (from form_list_controls)."""
-        return _rpc_call("form_edit_control", index=index, name=name, label=label, text=text, items=items, x=x, y=y, width=width, height=height)
+    def edit_control(self, index: int | None = None, *, name: str | None = None, new_name: str | None = None, label: str | None = None, text: str | None = None, state: int | None = None, items: list | None = None, x: int | None = None, y: int | None = None, width: int | None = None, height: int | None = None, page: int | None = None) -> dict:
+        """Edit a live form widget by name (preferred) or draw-page index from form_list_controls."""
+        return _rpc_call("form_edit_control", index=index, name=name, new_name=new_name, label=label, text=text, state=state, items=items, x=x, y=y, width=width, height=height, page=page)
 
     def generate(self, description: str) -> dict:
         """Generates a document or sheet layout with interactive form fields from a description."""
         return _rpc_call("form_generate", description=description)
 
-    def list_controls(self) -> dict:
-        """Lists interactive form controls (checkboxes, text fields, etc.) with indices and values."""
-        return _rpc_call("form_list_controls")
+    def list_controls(self, *, page: int | None = None) -> dict:
+        """List live form widgets (ControlShapes) with name, type, current text/State, and draw-page index."""
+        return _rpc_call("form_list_controls", page=page)
 
 forms = _FormsProxy()
 
@@ -906,6 +907,10 @@ class _ShapeProxy:
         """Evenly distribute three or more shapes between the first and last along an axis."""
         return _rpc_call("distribute_shapes", page=page, indices=indices, axis=axis)
 
+    def fill_draw_fields(self, fields: list, *, page: int | None = None) -> dict:
+        """Fill existing empty text boxes (paper-form fields) or ControlShape values on a Draw/Impress page."""
+        return _rpc_call("fill_draw_fields", page=page, fields=fields)
+
     def group(self, indices: list, *, page: int | None = None) -> dict:
         """Groups multiple shapes together on the same page."""
         return _rpc_call("shape_group", indices=indices, page=page)
@@ -914,9 +919,9 @@ class _ShapeProxy:
         """Returns a summary of shapes on the active or specified page."""
         return _rpc_call("shape_summary", page=page)
 
-    def upsert(self, action: str, *, index: int | None = None, page: int | None = None, shape_type: str | None = None, x: int | None = None, y: int | None = None, width: int | None = None, height: int | None = None, text: str | None = None, fill_color: str | None = None, fill_style: str | None = None, line_color: str | None = None, line_width: int | None = None, text_color: str | None = None, font_size: float | None = None, font_name: str | None = None, rotation_angle: float | None = None) -> dict:
-        """Creates a new shape or modifies an existing shape on a page."""
-        return _rpc_call("shape_upsert", action=action, index=index, page=page, shape_type=shape_type, x=x, y=y, width=width, height=height, text=text, fill_color=fill_color, fill_style=fill_style, line_color=line_color, line_width=line_width, text_color=text_color, font_size=font_size, font_name=font_name, rotation_angle=rotation_angle)
+    def upsert(self, action: str, *, index: int | None = None, name: str | None = None, page: int | None = None, shape_type: str | None = None, x: int | None = None, y: int | None = None, width: int | None = None, height: int | None = None, text: str | None = None, fill_color: str | None = None, fill_style: str | None = None, line_color: str | None = None, line_width: int | None = None, text_color: str | None = None, font_size: float | None = None, font_name: str | None = None, rotation_angle: float | None = None) -> dict:
+        """Create or edit a shape on a page."""
+        return _rpc_call("shape_upsert", action=action, index=index, name=name, page=page, shape_type=shape_type, x=x, y=y, width=width, height=height, text=text, fill_color=fill_color, fill_style=fill_style, line_color=line_color, line_width=line_width, text_color=text_color, font_size=font_size, font_name=font_name, rotation_angle=rotation_angle)
 
 shape = _ShapeProxy()
 

--- a/plugin/writer/specialized/forms.py
+++ b/plugin/writer/specialized/forms.py
@@ -14,8 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-Form tools for Writer and Calc (shared registration: dual specialized bases + union uno_services).
+Form tools for Writer, Calc, and Draw/Impress (shared registration: ToolWriterFormBase ∪ ToolDrawFormBase).
 Adapted from OnlyOfficeAI patterns. Original source: onlyofficeai/scripts/helpers/helpers.js (generateForm)
+
+These tools address live LibreOffice ControlShapes (com.sun.star.form.component.*).
+They do not fill PDF/AcroForm widgets. Draw "paper forms" (empty TextShapes next
+to labels) use get_draw_tree + fill_draw_fields / shape_upsert instead.
 """
 
 import logging
@@ -26,6 +30,7 @@ from com.sun.star.text.TextContentAnchorType import AS_CHARACTER
 from ..specialized_base import ToolWriterFormBase
 from plugin.doc.doc_type import is_calc, is_draw
 from plugin.doc.visual_helpers import get_active_draw_page
+from plugin.draw.tree import coerce_control_state
 from plugin.framework.errors import format_error_payload, ToolExecutionError
 from plugin.framework.queue_executor import execute_on_main_thread
 from plugin.framework.thread_guard import on_main_thread
@@ -37,7 +42,7 @@ def _run_on_main(fn, *args, **kwargs):
 
 log = logging.getLogger("writeragent.writer.forms")
 
-# One registration per tool name; union services for Writer + Calc (see AGENTS.md shared tools).
+# One registration per tool name; union services for Writer + Calc + Draw/Impress (see AGENTS.md shared tools).
 _FORM_DOC_SERVICES = ["com.sun.star.text.TextDocument", "com.sun.star.sheet.SpreadsheetDocument", "com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"]
 
 _CONTROL_TYPE_MAP = {
@@ -66,6 +71,93 @@ _get_form_draw_page = get_active_draw_page
 
 def _no_form_draw_page_payload():
     return format_error_payload(ToolExecutionError("No draw page available for form operations."))
+
+
+def _resolve_form_page(doc, page=None):
+    """Active draw page, or a Draw/Impress page index when *page* is set.
+
+    Writer/Calc ignore *page* (Writer has one canvas; Calc uses the active sheet).
+    """
+    if page is not None and _is_draw_doc(doc):
+        try:
+            from plugin.draw.bridge import DrawBridge
+
+            return DrawBridge(doc).get_pages().getByIndex(int(page))
+        except Exception:
+            return None
+    return _get_form_draw_page(doc)
+
+
+def _control_value_fields(model):
+    """Current value/state for list/edit so Draw widgets are visible without guessing."""
+    info = {}
+    if hasattr(model, "Label"):
+        info["label"] = model.Label
+    if hasattr(model, "Text"):
+        info["text"] = model.Text
+    if hasattr(model, "State"):
+        try:
+            info["state"] = int(model.State)
+        except Exception:
+            pass
+    if hasattr(model, "StringItemList"):
+        info["items"] = list(model.StringItemList)
+    if hasattr(model, "SelectedItems"):
+        try:
+            info["selected"] = list(model.SelectedItems)
+        except Exception:
+            pass
+    return info
+
+
+def _find_control_shape(dp, index=None, name=None):
+    """Resolve a ControlShape by draw-page index or control/shape Name.
+
+    Index is the draw-page shape index from form_list_controls (not a
+    control-only ordinal). Non-controls between widgets shift that index;
+    Name is the stable address.
+    """
+    if index is not None:
+        try:
+            idx = int(index)
+        except (TypeError, ValueError):
+            return None, None, format_error_payload(ToolExecutionError(f"Invalid shape index: {index}"))
+        if idx < 0 or idx >= dp.getCount():
+            return None, None, format_error_payload(ToolExecutionError(f"Invalid shape index: {idx}"))
+        shape = dp.getByIndex(idx)
+        if shape.getShapeType() != "com.sun.star.drawing.ControlShape":
+            return None, None, format_error_payload(ToolExecutionError(f"Shape at index {idx} is not a form control"))
+        return idx, shape, None
+
+    wanted = (name or "").strip()
+    if not wanted:
+        return None, None, format_error_payload(ToolExecutionError("Pass name or index to address the form control."))
+
+    hits = []
+    for i in range(dp.getCount()):
+        shape = dp.getByIndex(i)
+        if shape.getShapeType() != "com.sun.star.drawing.ControlShape":
+            continue
+        model = shape.Control
+        model_name = getattr(model, "Name", "") or ""
+        shape_name = getattr(shape, "Name", "") or ""
+        if model_name == wanted or shape_name == wanted:
+            hits.append((i, shape))
+    if len(hits) == 1:
+        return hits[0][0], hits[0][1], None
+    if not hits:
+        return None, None, format_error_payload(ToolExecutionError(f"No form control named '{wanted}'."))
+    return None, None, format_error_payload(ToolExecutionError(f"Several form controls named '{wanted}'; pass index as well."))
+
+
+def _apply_control_state(model, state_value):
+    if not hasattr(model, "State"):
+        return format_error_payload(ToolExecutionError("This control has no State (not a checkbox/radio)."))
+    coerced = coerce_control_state(state_value)
+    if coerced is None:
+        return format_error_payload(ToolExecutionError(f"Could not interpret {state_value!r} as a checkbox/radio State."))
+    model.State = coerced
+    return None
 
 
 def _next_stacked_position_on_draw_page(dp, default_width: int, default_height: int) -> Point:
@@ -110,7 +202,12 @@ class FormCreateControl(ToolWriterFormBase):
 
     name = "form_create_control"
     uno_services = _FORM_DOC_SERVICES
-    description = "Creates a single interactive form control (checkbox, text field, radio button, date field, combobox, or button). In Writer: anchored 'As Character' at the cursor. In Calc: placed on the active sheet draw page (stacked below existing shapes)."
+    description = (
+        "Create one live LibreOffice form widget (checkbox, text field, radio, date, combobox, or button) "
+        "because the user asked for an interactive ControlShape. Writer: anchored As Character at the cursor. "
+        "Calc: stacked on the active sheet draw page. Draw/Impress: stacked on the active page (or page=). "
+        "Do not use this to fill paper-form blanks (empty TextShapes) — those are fill_draw_fields / shape_upsert targets."
+    )
     parameters = {
         "type": "object",
         "properties": {
@@ -123,6 +220,7 @@ class FormCreateControl(ToolWriterFormBase):
             "default_value": {"type": "string", "description": "Initial value for text or date fields."},
             "width": {"type": "integer", "description": "Width in 100ths of mm (default varies by type)."},
             "height": {"type": "integer", "description": "Height in 100ths of mm (default varies by type)."},
+            "page": {"type": "integer", "description": "Draw/Impress 0-based page index (active page if omitted). Ignored in Writer/Calc."},
         },
         "required": ["control", "name"],
     }
@@ -180,7 +278,7 @@ class FormCreateControl(ToolWriterFormBase):
             shape.Control = model
 
             if _is_spreadsheet_doc(doc) or _is_draw_doc(doc):
-                dp = _get_form_draw_page(doc)
+                dp = _resolve_form_page(doc, kwargs.get("page"))
                 if dp is None:
                     return _no_form_draw_page_payload()
                 pos = _next_stacked_position_on_draw_page(dp, w, h)
@@ -209,7 +307,10 @@ class FormCreate(ToolWriterFormBase):
 
     name = "form_create"
     uno_services = _FORM_DOC_SERVICES
-    description = "Creates multiple form controls at once from a list of field definitions. Useful for generating a complete form section in one call."
+    description = (
+        "Create several live form widgets in one call (Writer/Calc/Draw/Impress). "
+        "Use this for interactive ControlShapes, not to fill empty paper-form text boxes."
+    )
     parameters = {
         "type": "object",
         "properties": {
@@ -263,7 +364,12 @@ class FormGenerate(ToolWriterFormBase):
 
     name = "form_generate"
     uno_services = _FORM_DOC_SERVICES
-    description = "Generates a document or sheet layout with interactive form fields from a description. Writer: HTML inserted at the cursor. Calc: plain text is inserted into the active cell area; fields go on the active sheet draw page."
+    description = (
+        "Generate a layout with interactive form widgets from a description. "
+        "Writer: HTML at the cursor. Calc: plain text in the active cell area; widgets on the sheet draw page. "
+        "Draw/Impress: labels as TextShapes and widgets stacked on the active page. "
+        "Not a PDF/AcroForm fill — paper-form blanks stay empty TextShapes."
+    )
     parameters = {"type": "object", "properties": {"description": {"type": "string", "description": "Description of the form to generate (e.g. 'Medical intake form')."}}, "required": ["description"]}
 
     def execute(self, ctx, **kwargs):
@@ -364,15 +470,26 @@ class FormListControls(ToolWriterFormBase):
 
     name = "form_list_controls"
     uno_services = _FORM_DOC_SERVICES
-    description = "Lists interactive form controls (checkboxes, text fields, etc.) with indices and values. Writer: document draw page. Calc: active sheet draw page only."
-    parameters = {"type": "object", "properties": {}, "required": []}
+    description = (
+        "List live form widgets (ControlShapes) with name, type, current text/State, and draw-page index "
+        "so you can edit or delete by name. Writer: document draw page. Calc: active sheet only. "
+        "Draw/Impress: active page, or page= for a specific slide. Index is the draw-page shape index — "
+        "it shifts when non-controls sit between widgets; prefer name."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "page": {"type": "integer", "description": "Draw/Impress 0-based page index (active page if omitted). Ignored in Writer/Calc."},
+        },
+        "required": [],
+    }
 
     def execute(self, ctx, **kwargs):
         return _run_on_main(self._execute_main, ctx, **kwargs)
 
     def _execute_main(self, ctx, **kwargs):
         doc = ctx.doc
-        dp = _get_form_draw_page(doc)
+        dp = _resolve_form_page(doc, kwargs.get("page"))
         if dp is None:
             return _no_form_draw_page_payload()
         controls = []
@@ -382,12 +499,7 @@ class FormListControls(ToolWriterFormBase):
             if shape.getShapeType() == "com.sun.star.drawing.ControlShape":
                 model = shape.Control
                 info = {"index": i, "name": getattr(model, "Name", ""), "type": _get_readable_type(model)}
-                if hasattr(model, "Label"):
-                    info["label"] = model.Label
-                if hasattr(model, "Text"):
-                    info["text"] = model.Text
-                if hasattr(model, "StringItemList"):
-                    info["items"] = list(model.StringItemList)
+                info.update(_control_value_fields(model))
 
                 # Geometry
                 pos = shape.getPosition()
@@ -402,6 +514,8 @@ class FormListControls(ToolWriterFormBase):
         out: dict = {"status": "ok", "controls": controls, "count": len(controls)}
         if _is_spreadsheet_doc(doc):
             out["note"] = "Indices are ControlShapes on the active sheet draw page only."
+        elif _is_draw_doc(doc):
+            out["note"] = "Address controls by name; index is the draw-page shape index and shifts when other shapes sit between widgets."
         return out
 
 
@@ -410,21 +524,29 @@ class FormEditControl(ToolWriterFormBase):
 
     name = "form_edit_control"
     uno_services = _FORM_DOC_SERVICES
-    description = "Modifies an existing form control by index (from form_list_controls). Calc: index is on the active sheet draw page."
+    description = (
+        "Edit a live form widget by name (preferred) or draw-page index from form_list_controls. "
+        "Set checkbox/radio State (0/1/2 or yes/no) and text-field Text. Writer/Calc/Draw/Impress. "
+        "When index is omitted, name looks up the control; use new_name to rename. "
+        "When index is passed, name still renames (older callers)."
+    )
     parameters = {
         "type": "object",
         "properties": {
-            "index": {"type": "integer", "description": "The index of the control (from form_list_controls)."},
-            "name": {"type": "string", "description": "New internal name."},
+            "index": {"type": "integer", "description": "Draw-page shape index from form_list_controls (optional if name is set)."},
+            "name": {"type": "string", "description": "Lookup Name when index is omitted; rename when index is passed."},
+            "new_name": {"type": "string", "description": "Rename the control (use this when looking up by name)."},
             "label": {"type": "string", "description": "New label text."},
             "text": {"type": "string", "description": "New text value (for text fields)."},
+            "state": {"type": "integer", "description": "Checkbox/radio State: 0 unchecked, 1 checked, 2 indeterminate (yes/no/checked strings also accepted)."},
             "items": {"type": "array", "items": {"type": "string"}, "description": "New item list (for comboboxes)."},
             "x": {"type": "integer"},
             "y": {"type": "integer"},
             "width": {"type": "integer"},
             "height": {"type": "integer"},
+            "page": {"type": "integer", "description": "Draw/Impress 0-based page index (active page if omitted). Ignored in Writer/Calc."},
         },
-        "required": ["index"],
+        "required": [],
     }
 
     def execute(self, ctx, **kwargs):
@@ -432,27 +554,30 @@ class FormEditControl(ToolWriterFormBase):
 
     def _execute_main(self, ctx, **kwargs):
         doc = ctx.doc
-        dp = _get_form_draw_page(doc)
+        dp = _resolve_form_page(doc, kwargs.get("page"))
         if dp is None:
             return _no_form_draw_page_payload()
-        idx = kwargs["index"]
 
-        if idx < 0 or idx >= dp.getCount():
-            return format_error_payload(ToolExecutionError(f"Invalid shape index: {idx}"))
-
-        shape = dp.getByIndex(idx)
-        if shape.getShapeType() != "com.sun.star.drawing.ControlShape":
-            return format_error_payload(ToolExecutionError(f"Shape at index {idx} is not a form control"))
+        lookup_name = None if "index" in kwargs else kwargs.get("name")
+        idx, shape, err = _find_control_shape(dp, index=kwargs.get("index"), name=lookup_name)
+        if err or shape is None:
+            return err or format_error_payload(ToolExecutionError("Form control not found."))
 
         model = shape.Control
 
-        # Update Model
-        if "name" in kwargs:
+        # Update Model. index+name keeps the old "name means rename" meaning.
+        if "new_name" in kwargs:
+            model.Name = kwargs["new_name"]
+        elif "index" in kwargs and "name" in kwargs:
             model.Name = kwargs["name"]
         if "label" in kwargs and hasattr(model, "Label"):
             model.Label = kwargs["label"]
         if "text" in kwargs and hasattr(model, "Text"):
             model.Text = kwargs["text"]
+        if "state" in kwargs:
+            state_err = _apply_control_state(model, kwargs["state"])
+            if state_err:
+                return state_err
         if "items" in kwargs and hasattr(model, "StringItemList"):
             model.StringItemList = tuple(kwargs["items"])
 
@@ -465,7 +590,8 @@ class FormEditControl(ToolWriterFormBase):
             sz = shape.getSize()
             shape.setSize(Size(kwargs.get("width", sz.Width), kwargs.get("height", sz.Height)))
 
-        return {"status": "ok", "message": f"Updated form control at index {idx}", "control_name": model.Name}
+        values = _control_value_fields(model)
+        return {"status": "ok", "message": f"Updated form control at index {idx}", "control_name": model.Name, "index": idx, **{k: values[k] for k in ("text", "state", "selected") if k in values}}
 
 
 class FormDeleteControl(ToolWriterFormBase):
@@ -473,26 +599,32 @@ class FormDeleteControl(ToolWriterFormBase):
 
     name = "form_delete_control"
     uno_services = _FORM_DOC_SERVICES
-    description = "Deletes a form control by index (Calc: active sheet draw page)."
-    parameters = {"type": "object", "properties": {"index": {"type": "integer", "description": "The index of the control to delete."}}, "required": ["index"]}
+    description = (
+        "Delete a live form widget by name (preferred) or draw-page index. "
+        "Writer/Calc/Draw/Impress. Index shifts when non-controls sit between widgets."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "index": {"type": "integer", "description": "Draw-page shape index (optional if name is set)."},
+            "name": {"type": "string", "description": "Control Name from form_list_controls."},
+            "page": {"type": "integer", "description": "Draw/Impress 0-based page index (active page if omitted). Ignored in Writer/Calc."},
+        },
+        "required": [],
+    }
 
     def execute(self, ctx, **kwargs):
         return _run_on_main(self._execute_main, ctx, **kwargs)
 
     def _execute_main(self, ctx, **kwargs):
         doc = ctx.doc
-        dp = _get_form_draw_page(doc)
+        dp = _resolve_form_page(doc, kwargs.get("page"))
         if dp is None:
             return _no_form_draw_page_payload()
-        idx = kwargs["index"]
-
-        if idx < 0 or idx >= dp.getCount():
-            return format_error_payload(ToolExecutionError(f"Invalid shape index: {idx}"))
-
-        shape = dp.getByIndex(idx)
-        if shape.getShapeType() != "com.sun.star.drawing.ControlShape":
-            return format_error_payload(ToolExecutionError(f"Shape at index {idx} is not a form control"))
+        idx, shape, err = _find_control_shape(dp, index=kwargs.get("index"), name=kwargs.get("name"))
+        if err or shape is None:
+            return err or format_error_payload(ToolExecutionError("Form control not found."))
 
         dp.remove(shape)
 
-        return {"status": "ok", "message": f"Deleted form control at index {idx}"}
+        return {"status": "ok", "message": f"Deleted form control at index {idx}", "index": idx}

--- a/tests/draw/test_draw_forms_uno.py
+++ b/tests/draw/test_draw_forms_uno.py
@@ -43,6 +43,99 @@ def test_draw_form_lifecycle(ctx, doc):
 
 @native_test
 @with_native_doc("draw")
+def test_form_edit_by_name_and_checkbox_state(ctx, doc):
+    # Non-control between widgets would break index-only addressing.
+    from plugin.draw.bridge import DrawBridge
+
+    bridge = DrawBridge(doc)
+    page = bridge.get_active_page()
+    deco = bridge.create_shape("com.sun.star.drawing.RectangleShape", 200, 200, 800, 800, page=page)
+    deco.Name = "decoration"
+
+    res = _exec_tool(doc, ctx, "form_create_control", {"control": "checkbox", "name": "MyCheck", "label": "Agree"})
+    assert res["status"] == "ok", f"create failed: {res}"
+
+    listed = _exec_tool(doc, ctx, "form_list_controls", {})
+    assert listed["status"] == "ok"
+    assert listed["count"] == 1
+    assert listed["controls"][0]["name"] == "MyCheck"
+    assert listed["controls"][0]["index"] != 0, "checkbox should not be the first shape on the page"
+    assert listed["controls"][0].get("state") == 0
+
+    edited = _exec_tool(doc, ctx, "form_edit_control", {"name": "MyCheck", "state": 1, "label": "Confirmed"})
+    assert edited["status"] == "ok", f"edit by name failed: {edited}"
+    assert edited.get("state") == 1
+
+    listed2 = _exec_tool(doc, ctx, "form_list_controls", {})
+    assert listed2["controls"][0]["name"] == "MyCheck"
+    assert listed2["controls"][0]["label"] == "Confirmed"
+    assert listed2["controls"][0]["state"] == 1
+
+    deleted = _exec_tool(doc, ctx, "form_delete_control", {"name": "MyCheck"})
+    assert deleted["status"] == "ok", f"delete by name failed: {deleted}"
+    listed3 = _exec_tool(doc, ctx, "form_list_controls", {})
+    assert listed3["count"] == 0
+
+
+@native_test
+@with_native_doc("draw")
+def test_fill_draw_fields_happy_and_miss(ctx, doc):
+    page_idx = 0
+    try:
+        ctrl = doc.getCurrentController()
+        if ctrl is not None and hasattr(ctrl, "getCurrentPage"):
+            cur = ctrl.getCurrentPage()
+            pages = doc.getDrawPages()
+            for i in range(pages.getCount()):
+                if pages.getByIndex(i) == cur:
+                    page_idx = i
+                    break
+    except Exception:
+        page_idx = 0
+
+    _exec_tool(doc, ctx, "shape_upsert", {
+        "action": "create",
+        "shape_type": "text",
+        "x": 500, "y": 3000, "width": 3500, "height": 800,
+        "text": "Lot:",
+        "name": "lbl_lot",
+        "page": page_idx,
+    })
+    _exec_tool(doc, ctx, "shape_upsert", {
+        "action": "create",
+        "shape_type": "text",
+        "x": 4500, "y": 3000, "width": 5000, "height": 800,
+        "text": "",
+        "name": "fld_lot",
+        "page": page_idx,
+    })
+
+    res = _exec_tool(doc, ctx, "fill_draw_fields", {
+        "page": page_idx,
+        "fields": [
+            {"name": "fld_lot", "value": "LOT-42"},
+            {"name": "no_such_field", "value": "x"},
+        ],
+    })
+    assert res["status"] == "partial", f"expected partial: {res}"
+    assert res["ok_count"] == 1
+    assert res["fail_count"] == 1
+    assert res["results"][0]["ok"] is True
+    assert res["results"][1]["ok"] is False
+
+    page = doc.getDrawPages().getByIndex(page_idx)
+    found = None
+    for i in range(page.getCount()):
+        shape = page.getByIndex(i)
+        if getattr(shape, "Name", "") == "fld_lot":
+            found = shape
+            break
+    assert found is not None
+    assert found.getString() == "LOT-42"
+
+
+@native_test
+@with_native_doc("draw")
 def test_generate_form_draw(ctx, doc):
     # Test that generate_form is registered for Draw
     from plugin.main import get_tools

--- a/tests/draw/test_draw_specialized_tiers.py
+++ b/tests/draw/test_draw_specialized_tiers.py
@@ -67,7 +67,7 @@ def test_impress_default_tool_schemas_exclude_slide_specialized_apis() -> None:
         ("images", {"image_insert", "image_list", "image_delete", "image_generate"}),
         (
             "shapes",
-            {"align_shapes", "distribute_shapes", "create_diagram"},
+            {"align_shapes", "distribute_shapes", "create_diagram", "fill_draw_fields"},
         ),
     ],
 )

--- a/tests/draw/test_draw_uno.py
+++ b/tests/draw/test_draw_uno.py
@@ -340,6 +340,79 @@ def test_insert_math_draw(ctx, doc):
 
 
 @native_test
+@with_native_doc("draw")
+def test_get_draw_tree_marks_blank_and_label_hint(ctx, doc):
+    page_idx = _active_draw_page_index(doc)
+    _exec_tool(doc, ctx, "shape_upsert", {
+        "action": "create",
+        "shape_type": "text",
+        "x": 500, "y": 2000, "width": 3500, "height": 800,
+        "text": "Product:",
+        "name": "lbl_product",
+        "page": page_idx,
+    })
+    _exec_tool(doc, ctx, "shape_upsert", {
+        "action": "create",
+        "shape_type": "text",
+        "x": 4500, "y": 2000, "width": 5000, "height": 800,
+        "text": "",
+        "name": "fld_product",
+        "page": page_idx,
+    })
+
+    result = _exec_tool(doc, ctx, "get_draw_tree", {"page": page_idx})
+    data = json.loads(result)
+    assert data.get("status") == "ok", f"get_draw_tree failed: {result}"
+    blanks = [n for n in data.get("tree", []) if n.get("fillable")]
+    assert blanks, f"expected a fillable blank in tree: {data.get('tree')}"
+    named = [n for n in blanks if n.get("name") == "fld_product"]
+    assert named, f"blank named fld_product missing: {blanks}"
+    assert named[0].get("label_hint") == "Product:"
+    assert "geometry" in named[0]
+
+
+@native_test
+@with_native_doc("draw")
+def test_shape_upsert_edit_by_name(ctx, doc):
+    page_idx = _active_draw_page_index(doc)
+    create = json.loads(_exec_tool(doc, ctx, "shape_upsert", {
+        "action": "create",
+        "shape_type": "text",
+        "x": 1000, "y": 1000, "width": 4000, "height": 800,
+        "text": "",
+        "name": "fld_stable",
+        "page": page_idx,
+    }))
+    assert create.get("status") == "ok", f"create failed: {create}"
+
+    # A later shape would shift a naive "last index" fill; Name stays stable.
+    _exec_tool(doc, ctx, "shape_upsert", {
+        "action": "create",
+        "shape_type": "rectangle",
+        "x": 100, "y": 100, "width": 500, "height": 500,
+        "page": page_idx,
+    })
+
+    edit = json.loads(_exec_tool(doc, ctx, "shape_upsert", {
+        "action": "edit",
+        "name": "fld_stable",
+        "text": "filled-by-name",
+        "page": page_idx,
+    }))
+    assert edit.get("status") == "ok", f"edit by name failed: {edit}"
+
+    page = doc.getCurrentController().getCurrentPage()
+    found = None
+    for i in range(page.getCount()):
+        shape = page.getByIndex(i)
+        if getattr(shape, "Name", "") == "fld_stable":
+            found = shape
+            break
+    assert found is not None, "named shape missing after edit"
+    assert found.getString() == "filled-by-name"
+
+
+@native_test
 def test_shape_upsert_validation():
     from plugin.main import get_tools
     shape_upsert_tool = get_tools().get("shape_upsert")
@@ -355,10 +428,15 @@ def test_shape_upsert_validation():
     assert not ok
     assert "required when action is 'create'" in err
 
-    # Test validation when action='edit' but missing index
+    # Test validation when action='edit' but missing index and name
     ok, err = shape_upsert_tool.validate(action="edit")
     assert not ok
-    assert "Parameter 'index' is required" in err
+    assert "index" in err and "name" in err
+
+    # Name-only edit is valid (paper-form fill by stable Name)
+    ok, err = shape_upsert_tool.validate(action="edit", name="fld_product")
+    assert ok
+    assert err is None
 
     # Test validation when action='create' and all required parameters are present
     ok, err = shape_upsert_tool.validate(action="create", shape_type="rectangle", x=1000, y=1000, width=5000, height=3000)

--- a/tests/draw/test_field_fill.py
+++ b/tests/draw/test_field_fill.py
@@ -1,0 +1,118 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for fill_draw_fields resolution and value apply (no soffice)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from plugin.draw.field_fill import FillDrawFields, apply_fill_value, resolve_field_node
+
+
+def _tree():
+    return [
+        {"type": "TextShape", "index": 0, "name": "lbl_product", "text": "Product:"},
+        {
+            "type": "TextShape",
+            "index": 1,
+            "name": "fld_product",
+            "fillable": True,
+            "label_hint": "Product:",
+        },
+        {
+            "type": "ControlShape",
+            "index": 3,
+            "name": "AgreeBox",
+            "control": {"type": "checkbox", "name": "AgreeBox", "state": 0},
+        },
+    ]
+
+
+def test_resolve_field_by_name_index_and_label_hint():
+    tree = _tree()
+    node, err = resolve_field_node(tree, name="fld_product")
+    assert err is None
+    assert node is not None
+    assert node["index"] == 1
+
+    node, err = resolve_field_node(tree, index=3)
+    assert err is None
+    assert node is not None
+    assert node["name"] == "AgreeBox"
+
+    node, err = resolve_field_node(tree, label_hint="Product:")
+    assert err is None
+    assert node is not None
+    assert node["name"] == "fld_product"
+
+
+def test_resolve_field_miss_and_ambiguous_hint():
+    tree = _tree()
+    node, err = resolve_field_node(tree, name="missing")
+    assert node is None
+    assert err is not None
+    assert "No shape named" in err
+
+    tree[0]["fillable"] = True
+    tree[0]["label_hint"] = "Product:"
+    node, err = resolve_field_node(tree, label_hint="Product:")
+    assert node is None
+    assert err is not None
+    assert "Several" in err
+
+
+def test_apply_fill_value_setstring_and_checkbox_state():
+    shape = MagicMock()
+    shape.getShapeType.return_value = "com.sun.star.drawing.TextShape"
+    ok, detail = apply_fill_value(shape, "Widget-7")
+    assert ok
+    shape.setString.assert_called_once_with("Widget-7")
+    assert "text" in detail
+
+    class _CheckModel:
+        State = 0
+
+    class _CheckShape:
+        Control = _CheckModel()
+
+        def getShapeType(self):
+            return "com.sun.star.drawing.ControlShape"
+
+    box = _CheckShape()
+    ok, detail = apply_fill_value(box, "yes")
+    assert ok
+    assert box.Control.State == 1
+    assert "state" in detail
+
+
+def test_fill_draw_fields_happy_and_miss_on_mock_page():
+    page = MagicMock()
+    blank = MagicMock()
+    blank.getShapeType.return_value = "com.sun.star.drawing.TextShape"
+    blank.Name = "fld_product"
+    blank.getString.return_value = ""
+    page.getCount.return_value = 2
+    page.getByIndex.side_effect = lambda i: blank if i == 1 else MagicMock(Name="other", getShapeType=lambda: "com.sun.star.drawing.TextShape")
+
+    tree = _tree()
+    ctx = MagicMock()
+    ctx.active_page_index = 0
+    ctx.doc = MagicMock()
+
+    with patch("plugin.draw.bridge.DrawBridge") as bridge_cls, patch("plugin.draw.field_fill.build_shape_tree", return_value=tree):
+        bridge_cls.return_value.get_pages.return_value.getByIndex.return_value = page
+        out = FillDrawFields().execute(
+            ctx,
+            fields=[
+                {"name": "fld_product", "value": "Widget-7"},
+                {"name": "no_such_field", "value": "x"},
+            ],
+        )
+    assert out["status"] == "partial"
+    assert out["ok_count"] == 1
+    assert out["fail_count"] == 1
+    assert out["results"][0]["ok"] is True
+    assert out["results"][1]["ok"] is False
+    blank.setString.assert_called_once_with("Widget-7")

--- a/tests/draw/test_shapes.py
+++ b/tests/draw/test_shapes.py
@@ -153,3 +153,17 @@ def test_page_index_for_uses_uno_same_ladder():
     assert _page_index_for(bridge, second) == 1
     assert _page_index_for(bridge, first) == 0
     assert _page_index_for(bridge, object()) == 0
+
+
+def test_shape_upsert_edit_accepts_name_without_index():
+    tool = UpsertShape()
+    ok, err = tool.validate(action="edit")
+    assert not ok
+    assert err is not None
+    assert "index" in err and "name" in err
+    ok, err = tool.validate(action="edit", name="fld_product")
+    assert ok
+    assert err is None
+    ok, err = tool.validate(action="edit", index=0)
+    assert ok
+    assert err is None

--- a/tests/draw/test_tree.py
+++ b/tests/draw/test_tree.py
@@ -1,0 +1,81 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Unit tests for Draw tree blank detection, label hints, and control snapshots."""
+
+from __future__ import annotations
+
+from plugin.draw.tree import (
+    attach_label_hints,
+    coerce_control_state,
+    control_snapshot,
+    is_near_empty_text,
+    is_text_capable_shape_type,
+    nearest_label_hint,
+)
+
+
+def test_is_near_empty_text_treats_placeholders_as_blank():
+    assert is_near_empty_text("")
+    assert is_near_empty_text("   ")
+    assert is_near_empty_text("____")
+    assert is_near_empty_text("...")
+    assert is_near_empty_text("☐")
+    assert not is_near_empty_text("Name")
+    assert not is_near_empty_text("A")
+
+
+def test_is_text_capable_excludes_lines_graphics_controls():
+    assert is_text_capable_shape_type("com.sun.star.drawing.TextShape")
+    assert is_text_capable_shape_type("RectangleShape")
+    assert is_text_capable_shape_type("CustomShape")
+    assert not is_text_capable_shape_type("com.sun.star.drawing.LineShape")
+    assert not is_text_capable_shape_type("ConnectorShape")
+    assert not is_text_capable_shape_type("GraphicObjectShape")
+    assert not is_text_capable_shape_type("ControlShape")
+    assert not is_text_capable_shape_type("TableShape")
+
+
+def test_nearest_label_hint_prefers_left_over_above():
+    blank = {"geometry": {"x": 5000, "y": 2000, "width": 4000, "height": 800}}
+    left = {"text": "Name:", "geometry": {"x": 500, "y": 1900, "width": 4000, "height": 800}}
+    above = {"text": "Heading", "geometry": {"x": 5000, "y": 200, "width": 4000, "height": 800}}
+    assert nearest_label_hint(blank, [left, above]) == "Name:"
+
+
+def test_attach_label_hints_marks_fillable_only():
+    nodes = [
+        {"text": "Product:", "geometry": {"x": 100, "y": 1000, "width": 2000, "height": 400}},
+        {"fillable": True, "name": "", "geometry": {"x": 2500, "y": 1000, "width": 3000, "height": 400}},
+        {"text": "Already filled", "geometry": {"x": 2500, "y": 2000, "width": 3000, "height": 400}},
+    ]
+    attach_label_hints(nodes)
+    assert nodes[1]["label_hint"] == "Product:"
+    assert "label_hint" not in nodes[2]
+
+
+def test_coerce_control_state_accepts_yes_no_and_ints():
+    assert coerce_control_state(True) == 1
+    assert coerce_control_state(False) == 0
+    assert coerce_control_state(1) == 1
+    assert coerce_control_state("checked") == 1
+    assert coerce_control_state("no") == 0
+    assert coerce_control_state("indeterminate") == 2
+    assert coerce_control_state("not-a-state") is None
+
+
+def test_control_snapshot_reads_state_and_text():
+    class _Model:
+        Name = "Agree"
+        Label = "I agree"
+        State = 1
+
+        def supportsService(self, svc):
+            return svc.endswith("CheckBox")
+
+    snap = control_snapshot(_Model())
+    assert snap["type"] == "checkbox"
+    assert snap["name"] == "Agree"
+    assert snap["state"] == 1
+    assert snap["label"] == "I agree"

--- a/tests/scripts/test_eval_catalog.py
+++ b/tests/scripts/test_eval_catalog.py
@@ -74,8 +74,9 @@ def test_calc_catalog_has_write_formula() -> None:
 
 def test_draw_shapes_domain_advertises_upsert() -> None:
     names = {_schema_name(s) for s in build_eval_tool_schemas(kind="draw", active_domain="shapes")}
-    assert {"shape_upsert", "shape_connect", "specialized_workflow_finished"} <= names
+    assert {"shape_upsert", "shape_connect", "fill_draw_fields", "specialized_workflow_finished"} <= names
     assert "shape_upsert" not in _names("draw")
+    assert "fill_draw_fields" not in _names("draw")
 
 
 def test_calc_ranges_domain_advertises_sort() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two different Draw/Impress form problems, one PR. Shared `form_*` already covered live ControlShapes; that was marked Forms complete even though GMP-style “paper forms” (blank TextShapes next to labels) had no fill path. This adds paper-form fill and polishes widget addressing. It does **not** add PDF/AcroForm fill.

## ControlShapes vs paper-form blanks

| Kind | What | Approach |
|------|------|----------|
| A. Paper form | Empty / near-empty text boxes | Slice 1: `get_draw_tree` marks `fillable` + `label_hint`; `shape_upsert` edit by **Name**; new specialized `fill_draw_fields` |
| B. Live ControlShapes | LO form widgets | Slice 2: `form_*` descriptions name Draw/Impress; list/edit/delete by **name**; checkbox/radio **State**; optional `page` |
| C. PDF AcroForm | Live PDF widgets | **Out of scope** — not a product API. PDF→Draw editable stand-in is harness/eval staging only (see #669). |

Empty boxes are fill targets. Use the name from the tree. Do not spawn new ControlShapes for paper forms unless the user asked.

## Slice 1

- `get_draw_tree` (`plugin/draw/tree.py`): `fillable` on empty/near-empty text-capable shapes; name + geometry; neighbor label hint (nearest text left, else above; 2 mm slack). ControlShape nodes include type, name, text/state.
- `shape_upsert`: optional `name` for edit lookup and create; index still works. Empty `text` can be written.
- `fill_draw_fields` (`plugin/draw/field_fill.py`, `domain=shapes`): `fields: [{name\|index\|label_hint, value}, …]` + optional `page`. Per-field ok/fail. Writes `setString` or ControlShape Text/State.

## Slice 2

- Shared `plugin/writer/specialized/forms.py` (`ToolWriterFormBase` ∪ `ToolDrawFormBase`). No Draw-only fork.
- `form_list_controls` / `form_edit_control` / `form_delete_control` accept `name` (index remains). When index is omitted, `name` looks up; `new_name` renames. `index` + `name` still means rename.
- List/edit return/set checkbox/radio State.
- Optional `page` on Draw/Impress.

## Docs

- `docs/draw/impress-specialized-toolsets.md` §3 distinguishes the three kinds and stops saying Forms complete without that split.
- Peer-messaging GMP staging and LO-DOM notes: empty boxes = fill targets; name from tree; no AcroForm product claim.

## Tests

- Unit: blank detection, label hints, `fill_draw_fields` resolve happy/miss, `shape_upsert` name-or-index validate.
- UNO: tree blank + label_hint; name-based `shape_upsert`; `fill_draw_fields` happy+miss; form list/edit/delete by name; checkbox State round-trip.

## Intentional deferrals

- No mid-session spawn/create of blank forms.
- No PDF/AcroForm APIs.
- Neighbor `label_hint` is a spatial heuristic, not a reading-order parser.
- `fill_draw_fields` stays specialized (`domain=shapes`), not a main-chat core tool.

## Test plan

- `make typecheck`
- pytest: `tests/draw/test_tree.py`, `tests/draw/test_field_fill.py`, `tests/draw/test_shapes.py`, `tests/draw/test_draw_specialized_tiers.py`, `tests/scripts/test_eval_catalog.py`
- UNO: `tests/draw/test_draw_uno.py`, `tests/draw/test_draw_forms_uno.py` (plus existing Writer form UNO if needed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c10f788-41e2-4f93-a168-b35799440ad5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c10f788-41e2-4f93-a168-b35799440ad5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

