### PR TITLE
A1 async send_peer_message (Writer ↔ Calc ↔ Draw sidebar peers)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,7 +52,7 @@ Open work already has a topic doc. Do not copy those Open lists here.
 | Doc | Remaining (one line) |
 |-----|----------------------|
 | [chat/multi-document-dev-plan.md](chat/multi-document-dev-plan.md) | Prompt integration, hidden-open hardening, `@` mentions |
-| [chat/peer-messaging.md](chat/peer-messaging.md) | Design only: async A1 `send_peer_agent` (envelope from caller frame) |
+| [chat/peer-messaging.md](chat/peer-messaging.md) | A1 shipped (`send_peer_message`); later: A2 / multiplex / waiting chrome / Impress |
 | [chat/responses-api-plan.md](chat/responses-api-plan.md) | Opt-in Responses API + `previous_response_id` (unstarted) |
 | [scripting/monaco-editor-dev-plan.md](scripting/monaco-editor-dev-plan.md) | Syntax squiggles, range picker, Flatpak extra windows |
 | [eval/eval-dev-plan.md](eval/eval-dev-plan.md) | Live 17-task ranking run; multimodal eval; LO ranking still out of scope |

--- a/docs/chat/multi-document-dev-plan.md
+++ b/docs/chat/multi-document-dev-plan.md
@@ -587,7 +587,7 @@ Per [AGENTS.md](../../AGENTS.md): matching `test_*.py` names; run `make test` be
 - [../writer/specialized-toolsets.md](../writer/specialized-toolsets.md) — nested delegation, gateway pattern
 - [../framework/streaming-and-threading.md](../framework/streaming-and-threading.md) — main-thread UNO, queue drain
 - [../calc/specialized-toolsets.md](../calc/specialized-toolsets.md) — Calc tool surface
-- [peer-messaging.md](peer-messaging.md) — Writer ↔ Calc ↔ Draw async `send_peer_agent` (A1 user-send + caller-frame envelope; research stays read-only)
+- [peer-messaging.md](peer-messaging.md) — Writer ↔ Calc ↔ Draw async `send_peer_message` (A1 user-send + `ctx.doc` envelope; research stays read-only)
 - [../mcp-protocol.md](../mcp-protocol.md) — `X-Document-URL`, MCP tool policy
 - [../chat/search.md](../chat/search.md) — external fetch (contrast with nearby files)
 
@@ -597,7 +597,7 @@ Per [AGENTS.md](../../AGENTS.md): matching `test_*.py` names; run `make test` be
 
 | Date | Phase / change | PR / notes |
 | ---- | -------------- | ---------- |
-| 2026-09-08 | Peer-send design (separate feature): Writer ↔ Calc ↔ Draw via async A1 `send_peer_*`; research stays read-only — [peer-messaging.md](peer-messaging.md) | — |
+| 2026-09-08 | Peer-send A1 shipped: Writer ↔ Calc ↔ Draw via async `send_peer_message`; research stays read-only — [peer-messaging.md](peer-messaging.md) | — |
 | 2026-05-20 | **Phase 7.1 shipped:** `grep_nearby_files` + `document_research_grep.py`; shared Writer/Calc search helpers; CPU caps + `processEventsToIdle` between files | — |
 | 2026-05-19 | **Chat status (open-only):** tool + preview blocks for `delegate_read_document` via `chat_append_callback` — [`web_research_chat.py`](../../plugin/chatbot/web_research_chat.py), [`specialized_base.py`](../../plugin/doc/specialized_base.py), [`tool_loop.py`](../../plugin/chatbot/tool_loop.py) | — |
 | 2026-05-17 | **Phase 0 shipped:** `nearby.py`, `nearby_tools.py`, `nearby_specialized.py`; `document_research` on Writer/Calc/Draw delegates; two-tier smol (outer list/delegate_read, inner `READ_TOOLS_BY_DOC_TYPE`); `ToolContext.read_only_target` + `READ_ONLY_TARGET`; untitled → Work path then open-docs fallback; tests in `tests/doc/test_nearby*.py` | — |

--- a/docs/chat/peer-messaging.md
+++ b/docs/chat/peer-messaging.md
@@ -1,6 +1,6 @@
 # Cross-app sidebar peer messaging (Writer ↔ Calc ↔ Draw)
 
-**Status:** Design only (no product code). Decisions below are current v1; alternate designs stay in [§3](#3-candidate-designs) if we change our mind.  
+**Status:** Implemented (A1 v1). Decisions below match the shipped code; alternate designs stay in [§3](#3-candidate-designs) if we change our mind.  
 **One-liner:** three peers, A1 async `send_peer_message` (user-send equivalence), chat-only, pre-open only, GMP via a staged Draw/Writer form (not a PDF product claim), no spawn.
 
 **Assumption:** Writer, Calc, and Draw documents are already open in **one LibreOffice process** / one WriterAgent extension. Talk-to-already-open is enough for SAR/floorstand (Writer ↔ Calc) and GMP (Writer ↔ Draw). Creating or spawning a peer mid-session is later product polish.
@@ -17,7 +17,7 @@ Recorded 2026-09-08. Implement these; do not implement the older “don’t Read
 | -------- | ---------- |
 | **Name** | `send_peer_message` (not `send_peer_agent`, not `ask_peer_*`). |
 | **Surface** | Sidebar chat only. New tool tier `"chat"` (see [§4.5](#45-call-sites--prompts--registration)). Hidden from MCP `tools/list` / `find_tools`. `execute()` refuses `ctx.caller != "chat"`. |
-| **Shape** | `send_peer_message(document_url=target, message=body)` plus `peer_ask_id` on replies. Required `document_url` every call. No `reply=true`, no `last_peer_from`. |
+| **Shape** | `send_peer_message(document_url=target, message=body)` plus `peer_ask_id` on replies. Required `document_url` every call. `document_url` is the **one** target arg: file URL, RuntimeUID, or a display `name` that matches **exactly one** open peer. No separate `name` parameter. No `reply=true`, no `last_peer_from`. |
 | **Return** | `{"status": "ok", "accepted": true, "peer_ask_id": "…"}`. FSM success is `status == "ok"`; do **not** return `status: "accepted"` alone. `is_mutation = False`. |
 | **Sender** | Derived from `ToolContext.doc` (`get_runtime_uid`, display name, file URL). Not authored in `message`. `ToolContext` has no frame. |
 | **Ready** | After `ok`/`accepted`, the caller **Readys** (local work first is OK). Do **not** teach “don’t Ready until the reply.” Reply is a **follow-up user turn** when the caller is idle. SAR/GMP are **two caller turns**. |
@@ -29,7 +29,9 @@ Recorded 2026-09-08. Implement these; do not implement the older “don’t Read
 | **Lock** | No extra per-doc lock in v1. Sidebar chat does not take MCP’s uid gate. |
 | **Focus** | No `toFront`, no `query.setFocus` on the extracted send. |
 
-**Still later (kept, not v1):** A2 blocking `ask_*` / silent fallback; multiplexed drain + mid-loop `PEER_REPLY`; last-sender default; MCP exposure; Impress; spawn; PDF/AcroForm. See [§3](#3-candidate-designs) and [§3.1](#31-alternatives-considered--kept).
+**Shipped in this v1:** `send_peer_message` (`plugin/doc/peer_message.py`, tier `"chat"`); live-panel `WeakValueDictionary` (`plugin/doc/live_panels.py`); schema-time visibility + peer catalog; MCP hide + `execute()` chat-only guard; `ctx.doc` envelope; inject-now / start-later + per-listener queue (cap 8); extracted send (no Ask / setFocus / librarian); Ready-after-accepted prompts.
+
+**Still later (kept, not v1):** A2 blocking `ask_*` / silent fallback; multiplexed drain + mid-loop `PEER_REPLY`; waiting chrome; last-sender default; MCP exposure; Impress; spawn; PDF/AcroForm. See [§3](#3-candidate-designs) and [§3.1](#31-alternatives-considered--kept). Do **not** sneak Ready-hold back in — that deadlocks the queue.
 
 ```mermaid
 sequenceDiagram
@@ -152,7 +154,7 @@ Do **not** nest `_do_send_chat_with_tools` / `_start_tool_calling_async` on the 
 One **chat-tier** tool, advertised only when a **resolvable other peer** exists ([§4.2](#42-tool-visibility)).
 
 - **Name:** `send_peer_message`. Not an existing API. Not `ask_peer_agent`.
-- **Args:** `document_url` = **target** only (URL or RuntimeUID) — **required on every call**. `message` = NL body only. Replies also pass `peer_ask_id` (copied from the inbound envelope). There is no `reply=true` and no `last_peer_from` default ([§4.1](#41-envelope-and-correlation)).
+- **Args:** `document_url` = **target** only (file URL, RuntimeUID, or a display name that matches exactly one open peer) — **required on every call**. No separate `name` parameter. `message` = NL body only. Replies also pass `peer_ask_id` (copied from the inbound envelope). There is no `reply=true` and no `last_peer_from` default ([§4.1](#41-envelope-and-correlation)).
 - **Caller must not put a from-url in `message`.** Source identity is automatic ([§4.1](#41-envelope-and-correlation)).
 - **Behavior:** Do **not** change the caller’s schemas or `ToolContext.doc`. Resolve an **open** supported peer. Find that uid’s live panel / `SendButtonListener`. Gateway builds the envelope from **`ctx.doc`**, prepends it to `message`, injects on the peer session, **schedules** that host’s extracted send, returns immediately `{status: "ok", "accepted": true, "peer_ask_id"}`.
 - **Reply:** the peer later calls the same tool with `document_url` = the envelope’s from uid/url and that `peer_ask_id`. Same inject + schedule onto the **caller** session (symmetric envelope). Prompt + protocol **require** the reply; do not hope the peer mentions it in passing. Delivery is a follow-up user turn when idle ([Current decisions](#current-decisions-v1)).
@@ -199,7 +201,7 @@ Reviewed against the current send/drain code. Not v1; do not delete — we may r
 
 **Tool shape (v1):** `send_peer_message(document_url=target, message=body)` plus `peer_ask_id` on replies.
 
-- `document_url` addresses the **peer** (file URL or RuntimeUID). It is never “who I am.”
+- `document_url` addresses the **peer**. It is the **one** target argument: a file URL, a RuntimeUID, or a display `name` that matches **exactly one** open peer. Do **not** add a separate `name` parameter. It is never “who I am.”
 - `message` is the NL body only. Prompts must tell the model **not** to paste its own path, uid, or URL into `message`. LLMs will get that wrong; the gateway always has `ctx.doc`.
 
 **Sender is derived, not authored.** On `execute`, read the **caller** bound model (`ctx.doc`): display **name**, `RuntimeUID`, and file URL if the doc is saved (untitled → empty url, uid still required). Build a one-line envelope in **code**, then the body. Inject so the peer transcript and the send path see the same wrapped user turn:
@@ -279,7 +281,7 @@ Harness pre-open is in scope; mid-session create/spawn is not.
 1. `get_open_documents(ctx.ctx, ctx.doc)` — reject self (same uid).
 2. v1 peer services only: `TextDocument`, `SpreadsheetDocument`, `DrawingDocument` **minus** `PresentationDocument` on the resolved model. Do not trust catalog `doc_type == "draw"`.
 3. `resolve_document_by_url` — open model only. Do not `loadComponentFromURL` / `open_document_for_read`.
-4. Ambiguous set (two `.ods`, two Draw forms): require `document_url` / uid, or a `name` that matches **exactly one**. Never silently pick the first Calc or first Draw.
+4. Ambiguous set (two `.ods`, two Draw forms): require a file URL / uid, or a display `name` passed as `document_url` that matches **exactly one**. Never silently pick the first Calc or first Draw. Two peers with the same name → `PEER_AMBIGUOUS`.
 5. No matching open peer → clear error. Do not create, load, or spawn.
 
 Suggested error codes: `PEER_NOT_FOUND`, `PEER_SIDEBAR_NOT_OPEN`, `PEER_UNSUPPORTED` (Impress), `PEER_QUEUE_FULL`, `VALIDATION_ERROR` (missing `document_url`), `PEER_CHAT_ONLY` (non-chat caller).
@@ -340,7 +342,7 @@ GDPval GMP change-control ([`docs/eval/gdpval/58ac1cc5-…`](../eval/gdpval/58ac
 
 **Staging fact, not a product claim:** LibreOffice File → Open on a PDF often imports as **editable Draw text and shapes**, not live AcroForm widgets. A headed poke may land the gold PDF in Draw. That is eval/harness staging. It is **not** “WriterAgent edits PDFs” and **not** an AcroForm API.
 
-The Draw sidebar fills the stand-in with Draw tools (`get_draw_tree`, `delegate_to_specialized_draw_toolset` → `shape_upsert` / tree, shared `form_*` if present). Then it `send_peer_message`s back with the `peer_ask_id`.
+The Draw sidebar fills **blank / fillable shapes** on that stand-in — not a product PDF/AcroForm API. Point at fields with `get_draw_tree`. Write text via name-based `shape_upsert` (and `fill_draw_fields` when that tool is on the branch). **ControlShapes** stay on shared `form_*` (`form_list_controls` / `form_edit_control` / `form_create_control`). Then it `send_peer_message`s back with the `peer_ask_id`.
 
 ### 4.8 Worked scenarios
 
@@ -357,7 +359,7 @@ The Draw sidebar fills the stand-in with Draw tools (`get_draw_tree`, `delegate_
 
 1. Writer drafts the memo with Writer tools.
 2. `send_peer_message(document_url=<stand-in uid>, message="Fill the change-control fields from this discrepancy summary: … Reply with a short confirmation.")` → `{ok, accepted, peer_ask_id}`. Writer Readys.
-3. Draw sidebar sees the Writer envelope, runs `get_draw_tree` / specialized shapes or `form_*` **on the Draw model only**.
+3. Draw sidebar sees the Writer envelope, runs `get_draw_tree` (then `shape_upsert` / `fill_draw_fields` if present for shape text; `form_*` for ControlShapes) **on the Draw model only**.
 4. Draw `send_peer_message(document_url=<Writer uid or url from the envelope>, message=<confirmation>, peer_ask_id=…)`. Writer follow-up cites the form in the memo.
 
 Reverse (Draw asks Writer for a paragraph) is the same tool with a Writer uid.

--- a/docs/chat/peer-messaging.md
+++ b/docs/chat/peer-messaging.md
@@ -303,7 +303,8 @@ Suggested error codes: `PEER_NOT_FOUND`, `PEER_SIDEBAR_NOT_OPEN`, `PEER_UNSUPPOR
 
 **Prompts** (short block next to Writer / Calc / Draw specialized-delegation templates in [`plugin/framework/prompts.py`](../../plugin/framework/prompts.py)):
 
-- Need the other **open** app’s writes? `send_peer_message(document_url=<peer uid or url from the tool description>, message=<task>)`. Do **not** put your own path, uid, or URL in `message` — the gateway inserts `[Peer from: …]`. Need a **file** fact only? `document_research`.
+- Do `send_peer_message(document_url=<peer uid, file URL, or unique display name from the Open peers list>, message=<task>)` when that peer is listed and the task is aimed at that app (compute / fill / write / “ask the budget workbook agent”). Why: only the peer sidebar has those tools. Do **not** put your own path, uid, or URL in `message` — the gateway inserts `[Peer from: …]`. No `reply=true`; every send needs `document_url`.
+- `document_research` is only a silent file fact when you do **not** need the peer sidebar to run. Do not use it as the default for an Open peers Writer/Calc/Draw document.
 - After `ok`/`accepted`, finish local work if any, then **Ready**. The reply arrives as a later user turn with a peer envelope.
 - When you **receive** a peer envelope: do the work with **your** tools; then `send_peer_message(document_url=<uid or url from the envelope>, message=<result>, peer_ask_id=<id from the envelope>)`. Say what you completed. Never omit `document_url`.
 - Never invent the other app’s write tools on this loop.

--- a/docs/draw/impress-specialized-toolsets.md
+++ b/docs/draw/impress-specialized-toolsets.md
@@ -507,5 +507,5 @@ This pattern could be extended to other domains.
 - [LibreOffice API Reference — Presentation](https://api.libreoffice.org/docs/idl/ref/interfacecom_1_1star_1_1presentation_1_1XPresentation.html)
 - [LibreOffice Draw/Impress UNO Examples](https://wiki.documentfoundation.org/Documentation/DevGuide/Drawings/Tutorial)
 - [Writer specialized toolsets](../writer/specialized-toolsets.md) — Architecture reference
-- [Peer messaging (design)](../chat/peer-messaging.md) — Writer ↔ Calc ↔ Draw async `send_peer_agent`; Draw is a v1 peer, not a mega-agent tool list
+- [Peer messaging](../chat/peer-messaging.md) — Writer ↔ Calc ↔ Draw async `send_peer_message`; Draw is a v1 peer, not a mega-agent tool list
 - [AGENTS.md](../../AGENTS.md) — Project overview

--- a/docs/features.md
+++ b/docs/features.md
@@ -21,7 +21,7 @@ Product overview lives in the root [README](../README.md). This page maps each a
 | Reviewable edits | [writer/reviewable-agent-edits.md](writer/reviewable-agent-edits.md) |
 | Rich-text sidebar | [chat/rich-text-control-sidebar.md](chat/rich-text-control-sidebar.md) |
 | Chat sidebar | [chat/sidebar-implementation.md](chat/sidebar-implementation.md) · slash `/` popup (commands mostly stubs): [chat/slash-commands.md](chat/slash-commands.md) |
-| Peer messaging (design) | [chat/peer-messaging.md](chat/peer-messaging.md) — Writer ↔ Calc ↔ Draw async `send_peer_agent` |
+| Peer messaging | [chat/peer-messaging.md](chat/peer-messaging.md) — Writer ↔ Calc ↔ Draw async `send_peer_message` (sidebar chat only) |
 
 ## Calc
 
@@ -84,7 +84,7 @@ Contracts and RPC: [calc/analysis-tools.md](calc/analysis-tools.md).
 
 | Topic | Docs |
 |-------|------|
-| Specialized toolsets | [draw/impress-specialized-toolsets.md](draw/impress-specialized-toolsets.md) · peer send (design): [chat/peer-messaging.md](chat/peer-messaging.md) |
+| Specialized toolsets | [draw/impress-specialized-toolsets.md](draw/impress-specialized-toolsets.md) · peer send: [chat/peer-messaging.md](chat/peer-messaging.md) |
 | Shapes | [draw/shape-support.md](draw/shape-support.md) |
 | PPT-Master | [ppt-master-integration-plan.md](ppt-master-integration-plan.md) |
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -62,7 +62,7 @@ Start here by task.
 | Threading architecture (pool, marshal, MCP) | [framework/threading.md](framework/threading.md) |
 | UNO thread-safety enforcement | [framework/uno-thread-safety.md](framework/uno-thread-safety.md) |
 | Smol vs main chat HTTP | [chat/smol-tool-architecture.md](chat/smol-tool-architecture.md) |
-| Writer ↔ Calc ↔ Draw `send_peer_agent` (design) | [chat/peer-messaging.md](chat/peer-messaging.md) |
+| Writer ↔ Calc ↔ Draw `send_peer_message` | [chat/peer-messaging.md](chat/peer-messaging.md) |
 | Writer specialized tool tiers | [writer/specialized-toolsets.md](writer/specialized-toolsets.md) |
 | Styles / LLM styling | [writer/llm-styles.md](writer/llm-styles.md) |
 | Writer API references | [writer/bookmarks-api-reference.md](writer/bookmarks-api-reference.md), [writer/footnotes-api-reference.md](writer/footnotes-api-reference.md), [writer/page-api-reference.md](writer/page-api-reference.md), [writer/tracking-api-reference.md](writer/tracking-api-reference.md) |

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -935,6 +935,9 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
                 if scope is not None:
                     scope.cancel()
                 self._stop_requested_fallback = True
+                from plugin.doc.peer_message import drop_listener_queue
+
+                drop_listener_queue(self)
 
             case _:
                 log.debug("SendButtonListener: unhandled effect type %s", type(effect).__name__)
@@ -988,6 +991,9 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
                 self.dispatch(SendEvent(SendEventKind.SEND_COMPLETED))
                 if self._terminal_status:
                     self._set_status(_(self._terminal_status))
+            from plugin.doc.peer_message import kick_pending_peer_starts
+
+            kick_pending_peer_starts()
 
     def _get_doc_type_str(self, model):
         from plugin.doc.doc_type import doc_type_title_for_label
@@ -1171,6 +1177,102 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
         # Cast to Any to satisfy ty since SendButtonListener mixes in multiple protocol hosts
         getattr(self, "_do_send_chat_with_tools")(query_text, model, doc_type_label)
 
+    def start_extracted_peer_send(self, query_text: str, *, already_appended: bool) -> bool:
+        """Start a peer-injected turn. Caller must not hold a drain owner.
+
+        Does not read/clear Ask, setFocus, or route librarian/image.
+        """
+        from plugin.framework.async_drain_guard import get_drain_owner
+
+        if get_drain_owner() is not None:
+            return False
+        if self.sidebar_state.send.is_busy:
+            return False
+        self._extracted_peer_query = query_text
+        self._extracted_peer_already_appended = already_appended
+        self.dispatch(SendEvent(SendEventKind.EXTRACTED_SEND))
+        if not self.sidebar_state.send.is_busy:
+            return False
+        self._run_extracted_peer_drain()
+        return True
+
+    def _run_extracted_peer_drain(self) -> None:
+        """Same completion FSM as ``_run_send_drain``, without Ask-box ``_do_send``."""
+        from plugin.framework.i18n import _
+        from plugin.framework.queue_executor import SendCancellation, agent_session
+        from plugin.doc.peer_message import kick_pending_peer_starts
+
+        query_text = getattr(self, "_extracted_peer_query", "") or ""
+        already_appended = bool(getattr(self, "_extracted_peer_already_appended", True))
+        self._stop_requested_fallback = False
+        self._terminal_status = "Ready"
+        try:
+            scope = SendCancellation()
+            self._send_cancellation = scope
+            with agent_session(scope) as cancel_scope:
+                cancel_scope.bind_executor(self.queue_executor)
+                self._send_cancellation = cancel_scope
+                try:
+                    if cancel_scope.is_cancelled() or self._stop_requested_fallback:
+                        return
+                    self._do_send_extracted_peer(query_text, already_appended=already_appended)
+                finally:
+                    self._send_cancellation = None
+        except Exception as e:
+            doc_type_for_log = getattr(self, "initial_doc_type", "unknown")
+            log.exception("Extracted peer send unhandled exception [doc: %s]", doc_type_for_log)
+            self._append_response("\n\n[Error: %s]\n" % str(e))
+            self._terminal_status = "Error"
+        finally:
+            update_activity_state("")
+            if self._terminal_status == "Error":
+                self.dispatch(SendEvent(SendEventKind.ERROR_OCCURRED))
+            else:
+                self.dispatch(SendEvent(SendEventKind.SEND_COMPLETED))
+                if self._terminal_status:
+                    self._set_status(_(self._terminal_status))
+            kick_pending_peer_starts()
+
+    def _do_send_extracted_peer(self, query_text: str, *, already_appended: bool) -> None:
+        """Force chat-with-tools. No Ask read/clear, no setFocus, no librarian/image."""
+        from plugin.framework.i18n import _
+        from plugin.framework.html_stripper import StreamingHTMLStripper
+        from plugin.chatbot.chat_sidebar_mode import (
+            CHAT_MODE_CHAT,
+            mode_from_selector_with_flags,
+            sidebar_mode_flags_for_doc_type,
+        )
+
+        self._plain_text_stripper = StreamingHTMLStripper()
+        self._set_status(_("Starting..."))
+        update_activity_state("do_send")
+        if self.ensure_path_fn:
+            self.ensure_path_fn(self.ctx)
+        model = self._get_document_model()
+        if not model:
+            self._append_response("\n" + _("[No compatible LibreOffice document (Writer, Calc, or Draw) found in the active window.]") + "\n")
+            self._terminal_status = "Error"
+            return
+        doc_type_label = getattr(self, "cached_doc_type", None)
+        if not doc_type_label or doc_type_label == "unknown":
+            self._append_response("\n[Internal Error: Could not identify document type.]\n")
+            self._terminal_status = "Error"
+            return
+        flags = getattr(self, "sidebar_mode_flags", None) or sidebar_mode_flags_for_doc_type(doc_type_label or "writer")
+        sidebar_mode = mode_from_selector_with_flags(self.chat_mode_selector, flags)
+        if sidebar_mode != CHAT_MODE_CHAT:
+            self._append_response(
+                "\n" + _("[Peer send requires Chat mode on this sidebar.]") + "\n"
+            )
+            self._terminal_status = "Error"
+            return
+        if not already_appended:
+            self.session.add_user_message(query_text)
+            self._append_response(query_text, role="user")
+        getattr(self, "_do_send_chat_with_tools")(
+            query_text, model, doc_type_label, skip_append_user=True
+        )
+
     # _do_send_direct_image is provided by SendHandlersMixin.
 
     # _do_send_chat_with_tools is provided by ToolCallingMixin.
@@ -1203,6 +1305,12 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
         if scope is not None:
             scope.cancel()
         self._stop_requested_fallback = True
+        try:
+            from plugin.doc.peer_message import drop_listener_queue
+
+            drop_listener_queue(self)
+        except Exception as e:
+            log.debug("SendButtonListener.disposing: drop peer queue: %s", e)
         try:
             from plugin.framework.event_bus import global_event_bus
 

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -367,6 +367,8 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
         self._approval_ui_backup = None
         self._approval_query_for_engine = None
         self._dispatch_reenter: list[Any] | None = None
+        self._extracted_peer_query = ""
+        self._extracted_peer_already_appended = False
         self.slash_popup = None
         self.clear_listener = None
         self.rich_text_widget = None

--- a/plugin/chatbot/panel.py
+++ b/plugin/chatbot/panel.py
@@ -1230,9 +1230,11 @@ class SendButtonListener(SendHandlersMixin, ToolCallingMixin, BaseActionListener
             if self._terminal_status == "Error":
                 self.dispatch(SendEvent(SendEventKind.ERROR_OCCURRED))
             else:
+                # Extracted send only uses Ready or Error (unlike _do_send, which
+                # may leave ""). Always set Ready here so ty does not treat a
+                # nonempty-string check as a redundant condition.
                 self.dispatch(SendEvent(SendEventKind.SEND_COMPLETED))
-                if self._terminal_status:
-                    self._set_status(_(self._terminal_status))
+                self._set_status(_("Ready"))
             kick_pending_peer_starts()
 
     def _do_send_extracted_peer(self, query_text: str, *, already_appended: bool) -> None:

--- a/plugin/chatbot/panel_factory.py
+++ b/plugin/chatbot/panel_factory.py
@@ -405,6 +405,15 @@ class ChatPanelElement(unohelper.Base, XUIElement):
                  hasattr(self, "send_listener") and bool(self.send_listener))
         unregister_debug_live_panel(self)
         try:
+            from plugin.doc.live_panels import unregister_live_panel
+            from plugin.framework.uno_context import get_document_from_frame, get_runtime_uid
+
+            model = get_document_from_frame(self.xFrame) if getattr(self, "xFrame", None) else None
+            if model is not None:
+                unregister_live_panel(get_runtime_uid(model))
+        except Exception as e:
+            log.debug("live panel unregister on dispose: %s", e)
+        try:
             if hasattr(self, "send_listener") and self.send_listener:
                 self.send_listener.disposing(None)
         except Exception as e:
@@ -964,6 +973,10 @@ class ChatPanelElement(unohelper.Base, XUIElement):
             # Save it to the instance so panel_wiring can use it for QueryTextListener
             self.send_listener = send_listener
             register_debug_live_panel(self)
+            from plugin.doc.live_panels import register_live_panel
+            from plugin.framework.uno_context import get_runtime_uid
+
+            register_live_panel(get_runtime_uid(model), self)
 
 
 

--- a/plugin/chatbot/send_state.py
+++ b/plugin/chatbot/send_state.py
@@ -30,6 +30,7 @@ class SendEventKind(Enum):
     RECORD_CLICKED = auto()
     STOP_REC_CLICKED = auto()
     SEND_CLICKED = auto()
+    EXTRACTED_SEND = auto()
     STOP_CLICKED = auto()
     SEND_COMPLETED = auto()
     ERROR_OCCURRED = auto()
@@ -182,6 +183,21 @@ def next_state(state: SendButtonState, event: SendEvent) -> FsmTransition[SendBu
             )
         )
         effects.append(StartSendEffect())
+        return FsmTransition(new_state, effects)
+
+    elif event.kind == SendEventKind.EXTRACTED_SEND:
+        # Peer inject: set busy without StartSendEffect (that posts _do_send / Ask-box).
+        if state.is_busy or state.is_recording:
+            return FsmTransition(state, effects)
+        new_state = SendButtonState(is_busy=True, is_recording=False, has_text=state.has_text, has_audio=state.has_audio, audio_supported=state.audio_supported)
+        effects.append(
+            UpdateUIEffect(
+                send_enabled=False,
+                stop_enabled=True,
+                send_label="Send",
+                status_text="Starting...",
+            )
+        )
         return FsmTransition(new_state, effects)
 
     elif event.kind == SendEventKind.STOP_CLICKED:

--- a/plugin/chatbot/tool_loop.py
+++ b/plugin/chatbot/tool_loop.py
@@ -217,6 +217,9 @@ class ToolCallingMixin:
                 ctx=self.ctx,
                 doc=model,
             )
+            from plugin.doc.peer_message import log_peer_tool_on_wire
+
+            log_peer_tool_on_wire(active_tools)
             execute_fn = build_tool_execute_fn(self, doc_type_str, active_domain, python_tool_domain, set_active_domain)
 
         except Exception as e:
@@ -411,6 +414,9 @@ class ToolCallingMixin:
                 ctx=getattr(self, "ctx", None),
                 doc=refresh_doc,
             )
+            from plugin.doc.peer_message import log_peer_tool_on_wire
+
+            log_peer_tool_on_wire(self._active_tools)
         except Exception as e:
             log.warning("Failed to refresh active tools: %s", e)
 

--- a/plugin/chatbot/tool_loop.py
+++ b/plugin/chatbot/tool_loop.py
@@ -180,7 +180,7 @@ class ToolCallingMixin:
     def rerender_rich_text_session(self: ToolLoopHost) -> None:
         """Re-render session with HTML formatting. Overridden in SendButtonListener."""
 
-    def _do_send_chat_with_tools(self: ToolLoopHost, query_text: str, model: Any, doc_type_str: str) -> None:
+    def _do_send_chat_with_tools(self: ToolLoopHost, query_text: str, model: Any, doc_type_str: str, skip_append_user: bool = False) -> None:
         try:
             log.debug("_do_send: importing core modules...")
             from plugin.main import get_tools
@@ -215,6 +215,7 @@ class ToolCallingMixin:
                 uno_services_supported=getattr(self, "cached_uno_services", None),
                 active_domain=active_domain,
                 ctx=self.ctx,
+                doc=model,
             )
             execute_fn = build_tool_execute_fn(self, doc_type_str, active_domain, python_tool_domain, set_active_domain)
 
@@ -313,22 +314,29 @@ class ToolCallingMixin:
             self._set_status("Error")
             return
 
-        # Check for vision capability and selected image base64
-        # Note: `model` here is the UNO document object, not the model ID string.
-        # The text model ID is in api_config["text_model"].
-        b64_image = None
-        from plugin.framework.client.model_fetcher import has_native_vision
-        text_model_id = api_config.get("text_model", "")
-        if has_native_vision(text_model_id, client._endpoint()):
-            doc = self._get_document_model() if hasattr(self, "_get_document_model") else None
-            if doc:
-                try:
-                    from plugin.writer.images.image_tools import get_selected_image_base64
-                    b64_image = get_selected_image_base64(doc, self.ctx)
-                except Exception as e:
-                    log.debug("Failed to get selected image base64: %s", e)
+        # Peer extracted send already appended the envelope + body once.
+        # Calling add_user_message again would double-post that turn.
+        if skip_append_user:
+            b64_image = None
+        else:
+            # Check for vision capability and selected image base64
+            # Note: `model` here is the UNO document object, not the model ID string.
+            # The text model ID is in api_config["text_model"].
+            b64_image = None
+            from plugin.framework.client.model_fetcher import has_native_vision
+            text_model_id = api_config.get("text_model", "")
+            if has_native_vision(text_model_id, client._endpoint()):
+                doc = self._get_document_model() if hasattr(self, "_get_document_model") else None
+                if doc:
+                    try:
+                        from plugin.writer.images.image_tools import get_selected_image_base64
+                        b64_image = get_selected_image_base64(doc, self.ctx)
+                    except Exception as e:
+                        log.debug("Failed to get selected image base64: %s", e)
 
-        if b64_image or self.audio_wav_path:
+        if skip_append_user:
+            pass
+        elif b64_image or self.audio_wav_path:
             content_list: list[dict[str, Any]] = []
             if query_text:
                 content_list.append({"type": "text", "text": query_text})
@@ -394,12 +402,14 @@ class ToolCallingMixin:
             from plugin.main import get_tools
 
             active_domain = getattr(self.session, "active_specialized_domain", None) if hasattr(self, "session") and self.session else None
+            refresh_doc = self._get_document_model() if hasattr(self, "_get_document_model") else None
             self._active_tools = get_tools().get_schemas(
                 "openai",
                 doc_type=getattr(self, "cached_doc_type", None),
                 uno_services_supported=getattr(self, "cached_uno_services", None),
                 active_domain=active_domain,
                 ctx=getattr(self, "ctx", None),
+                doc=refresh_doc,
             )
         except Exception as e:
             log.warning("Failed to refresh active tools: %s", e)

--- a/plugin/doc/common_module.py
+++ b/plugin/doc/common_module.py
@@ -24,6 +24,7 @@ class CommonModule(ModuleBase):
             document_research_specialized,
             document_research_tools,
             find_tools_tool,
+            peer_message,
             print_doc,
             undo,
         )
@@ -38,6 +39,7 @@ class CommonModule(ModuleBase):
             document_research_fts_tool,
             document_research_specialized,
             find_tools_tool,
+            peer_message,
             print_doc,
             undo,
         )

--- a/plugin/doc/document_research.py
+++ b/plugin/doc/document_research.py
@@ -638,7 +638,17 @@ def get_open_documents(uno_ctx: Any, active_model: Any = None) -> list[dict[str,
         return []
     enum = comps.createEnumeration()
     docs = []
-    while enum and enum.hasMoreElements():
+    # Real UNO hasMoreElements() is bool. unittest MagicMock is always truthy
+    # and never becomes False, so `while enum.hasMoreElements()` spun forever.
+    # That wedged unit pytest at ~99% after send_peer_message started calling
+    # this from list_v1_peers / chat prompts with ctx=MagicMock().
+    while enum is not None:
+        try:
+            more = enum.hasMoreElements()
+        except Exception:
+            break
+        if more is not True and more != 1:
+            break
         elem = enum.nextElement()
         model = _office_model_from_desktop_element(elem)
         if model is None or not hasattr(model, "getURL"):

--- a/plugin/doc/live_panels.py
+++ b/plugin/doc/live_panels.py
@@ -1,0 +1,54 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Process-wide weak map of open sidebar panels keyed by RuntimeUID.
+
+A1 peer messaging looks up the target ``SendButtonListener`` by the peer
+document's uid. This is a production registry (not the debug ``WeakSet`` in
+``panel_factory``, which is gated / stripped in release).
+
+``panel_factory`` registers after ``_wire_buttons``. The peer tool reads this
+module only — it must not import ``panel_factory`` or ``panel`` (cycle:
+``CommonModule`` → tool → ``panel`` → ``get_tools()``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from weakref import WeakValueDictionary
+
+# Last-write-wins when two windows share one model (one RuntimeUID).
+_PANELS: WeakValueDictionary[str, Any] = WeakValueDictionary()
+
+
+def register_live_panel(uid: str, panel: Any) -> None:
+    """Remember *panel* for *uid*. Empty uid is skipped (cannot address)."""
+    if not uid or panel is None:
+        return
+    _PANELS[uid] = panel
+
+
+def unregister_live_panel(uid: str) -> None:
+    """Drop the map slot for *uid* if present."""
+    if not uid:
+        return
+    _PANELS.pop(uid, None)
+
+
+def get_live_panel(uid: str) -> Any | None:
+    """Return the live panel handle for *uid*, or None."""
+    if not uid:
+        return None
+    return _PANELS.get(uid)
+
+
+def iter_live_panel_uids() -> list[str]:
+    """Snapshot of registered uids (tests / catalog)."""
+    return list(_PANELS.keys())
+
+
+def reset_live_panels() -> None:
+    """Test hook: clear the weak map."""
+    _PANELS.clear()

--- a/plugin/doc/peer_message.py
+++ b/plugin/doc/peer_message.py
@@ -1,0 +1,573 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Sidebar-only A1 peer send: ``send_peer_message``.
+
+Queues a user-equivalent turn on another already-open Writer/Calc/Draw
+sidebar and returns immediately. See ``docs/chat/peer-messaging.md``.
+
+This module must not import ``plugin.chatbot.panel`` or
+``plugin.chatbot.panel_factory`` (cycle: CommonModule → tool → panel →
+``get_tools()``).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+import uuid
+import weakref
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+from weakref import WeakKeyDictionary
+
+from plugin.framework.async_drain_guard import add_drain_idle_callback, get_drain_owner
+from plugin.framework.tool import ToolBase, ToolContext
+
+log = logging.getLogger("writeragent.doc.peer_message")
+
+PEER_TOOL_NAME = "send_peer_message"
+PEER_QUEUE_CAP = 8
+
+_TEXT_SERVICE = "com.sun.star.text.TextDocument"
+_CALC_SERVICE = "com.sun.star.sheet.SpreadsheetDocument"
+_DRAW_SERVICE = "com.sun.star.drawing.DrawingDocument"
+_IMPRESS_SERVICE = "com.sun.star.presentation.PresentationDocument"
+
+_BASE_DESCRIPTION = (
+    "Send a natural-language turn to another already-open Writer, Calc, or Draw "
+    "sidebar (not Impress). Returns immediately {status: ok, accepted: true, "
+    "peer_ask_id}. The peer runs after this sidebar Readys; the reply arrives "
+    "later as a follow-up user turn — do not wait in this loop. "
+    "document_url is the one target argument: a file URL, RuntimeUID, or a "
+    "display name that matches exactly one open peer. Required on every call. "
+    "Never put your own path, uid, or URL in message — the gateway inserts "
+    "[Peer from: name | uid | url | peer_ask_id]. On replies, pass peer_ask_id "
+    "copied from the inbound envelope. Never invent the other app's write tools."
+)
+
+
+@dataclass
+class PeerPendingTurn:
+    """One queued extracted send on a listener."""
+
+    wrapped_text: str
+    already_appended: bool
+    peer_ask_id: str
+
+
+_listener_queues: WeakKeyDictionary[Any, deque[PeerPendingTurn]] = WeakKeyDictionary()
+_global_fifo: deque[tuple[weakref.ref[Any], PeerPendingTurn]] = deque()
+_idle_kick_scheduled = False
+
+
+def _supports_service(model: Any, service: str) -> bool:
+    try:
+        supports = getattr(model, "supportsService", None)
+        if not callable(supports):
+            return False
+        return bool(supports(service))
+    except Exception:
+        return False
+
+
+def is_v1_peer_model(model: Any) -> bool:
+    """True for Writer / Calc / Draw. Impress is out of v1 — check the model.
+
+    Catalog ``doc_type: "draw"`` includes Impress. Reject PresentationDocument
+    first; Impress also supports DrawingDocument so a Draw-only check is not enough.
+    """
+    if model is None:
+        return False
+    if _supports_service(model, _IMPRESS_SERVICE):
+        return False
+    return (
+        _supports_service(model, _TEXT_SERVICE)
+        or _supports_service(model, _CALC_SERVICE)
+        or _supports_service(model, _DRAW_SERVICE)
+    )
+
+
+def v1_peer_type_label(model: Any) -> str | None:
+    """``writer`` / ``calc`` / ``draw``, or None if unsupported (including Impress)."""
+    if model is None or _supports_service(model, _IMPRESS_SERVICE):
+        return None
+    if _supports_service(model, _TEXT_SERVICE):
+        return "writer"
+    if _supports_service(model, _CALC_SERVICE):
+        return "calc"
+    if _supports_service(model, _DRAW_SERVICE):
+        return "draw"
+    return None
+
+
+def identity_from_doc(doc: Any) -> dict[str, str]:
+    """Sender fields from ``ToolContext.doc`` (not authored in ``message``)."""
+    from plugin.framework.uno_context import get_runtime_uid
+
+    uid = ""
+    url = ""
+    name = "Untitled"
+    if doc is None:
+        return {"name": name, "uid": uid, "url": url}
+    try:
+        uid = get_runtime_uid(doc) or ""
+    except Exception:
+        uid = ""
+    try:
+        raw_url = doc.getURL() if hasattr(doc, "getURL") else ""
+        url = str(raw_url or "")
+    except Exception:
+        url = ""
+    if url:
+        try:
+            from plugin.doc.document_research import _system_path_from_url
+
+            path = _system_path_from_url(url) or ""
+            base = os.path.basename(path) if path else ""
+            if base:
+                name = base
+        except Exception:
+            pass
+    if name == "Untitled":
+        try:
+            title = doc.getTitle() if hasattr(doc, "getTitle") else None
+            if title:
+                name = str(title)
+        except Exception:
+            pass
+    return {"name": name, "uid": uid, "url": url}
+
+
+def format_peer_envelope(*, name: str, uid: str, url: str, peer_ask_id: str, message: str) -> str:
+    """Code-inserted wrapper. ``message`` is the body only."""
+    header = f"[Peer from: {name} | uid={uid} | url={url} | peer_ask_id={peer_ask_id}]"
+    body = message if message.endswith("\n") else message
+    return f"{header}\n\n{body}"
+
+
+def format_peer_catalog(peers: list[dict[str, str]]) -> str:
+    """Short open-peer list for the tool description / prompt block."""
+    if not peers:
+        return ""
+    parts = []
+    for p in peers:
+        parts.append(
+            f"{p.get('name') or 'Untitled'} (uid={p.get('uid') or ''}, "
+            f"url={p.get('url') or ''}, type={p.get('type') or ''})"
+        )
+    return "Open peers: " + "; ".join(parts) + "."
+
+
+def list_v1_peers(uno_ctx: Any, self_doc: Any) -> list[dict[str, str]]:
+    """Resolvable other v1 peers (distinct uid, supported model, addressable)."""
+    from plugin.doc.document_research import get_open_documents
+    from plugin.framework.uno_context import get_runtime_uid, resolve_document_by_url
+
+    self_uid = ""
+    if self_doc is not None:
+        try:
+            self_uid = get_runtime_uid(self_doc) or ""
+        except Exception:
+            self_uid = ""
+    peers: list[dict[str, str]] = []
+    try:
+        catalog = get_open_documents(uno_ctx, self_doc)
+    except Exception:
+        log.debug("list_v1_peers: get_open_documents failed", exc_info=True)
+        return []
+    seen: set[str] = set()
+    for rec in catalog:
+        uid = str(rec.get("uid") or "")
+        url = str(rec.get("url") or "")
+        if not uid or uid == self_uid or uid in seen:
+            continue
+        model = None
+        try:
+            model, _unused_type = resolve_document_by_url(uno_ctx, uid)
+        except Exception:
+            model = None
+        if model is None and url:
+            try:
+                model, _unused_type = resolve_document_by_url(uno_ctx, url)
+            except Exception:
+                model = None
+        label = v1_peer_type_label(model)
+        if label is None:
+            continue
+        seen.add(uid)
+        peers.append(
+            {
+                "name": str(rec.get("name") or "Untitled"),
+                "uid": uid,
+                "url": url,
+                "type": label,
+            }
+        )
+    return peers
+
+
+def resolve_peer_target(
+    uno_ctx: Any,
+    self_doc: Any,
+    document_url: str,
+) -> tuple[Any | None, str | None, str]:
+    """Resolve *document_url* as file URL, RuntimeUID, or unique display name.
+
+    Returns ``(model, error_code, error_message)``. Success: ``(model, None, "")``.
+    """
+    from plugin.framework.uno_context import get_runtime_uid, resolve_document_by_url
+
+    target = (document_url or "").strip()
+    if not target:
+        return None, "VALIDATION_ERROR", "document_url is required."
+
+    self_uid = ""
+    if self_doc is not None:
+        try:
+            self_uid = get_runtime_uid(self_doc) or ""
+        except Exception:
+            self_uid = ""
+
+    model = None
+    try:
+        model, _unused_type = resolve_document_by_url(uno_ctx, target)
+    except Exception:
+        model = None
+
+    if model is None:
+        peers = list_v1_peers(uno_ctx, self_doc)
+        name_hits = [p for p in peers if p.get("name") == target]
+        if len(name_hits) > 1:
+            return (
+                None,
+                "PEER_AMBIGUOUS",
+                f"document_url {target!r} matches more than one open peer; use a uid or file URL.",
+            )
+        if len(name_hits) == 1:
+            try:
+                model, _unused_type = resolve_document_by_url(uno_ctx, name_hits[0]["uid"])
+            except Exception:
+                model = None
+
+    if model is None:
+        return None, "PEER_NOT_FOUND", f"No open Writer, Calc, or Draw peer matches {target!r}."
+
+    peer_uid = ""
+    try:
+        peer_uid = get_runtime_uid(model) or ""
+    except Exception:
+        peer_uid = ""
+    if self_uid and peer_uid and self_uid == peer_uid:
+        return None, "PEER_SELF", "Cannot send a peer message to the same document."
+
+    if _supports_service(model, _IMPRESS_SERVICE):
+        return None, "PEER_UNSUPPORTED", "Impress is not a v1 peer. Open a Writer, Calc, or Draw document."
+    if not is_v1_peer_model(model):
+        return None, "PEER_UNSUPPORTED", "Target is not a Writer, Calc, or Draw document."
+    return model, None, ""
+
+
+def listener_is_busy(listener: Any) -> bool:
+    """Busy if the send FSM, active stream queue, or cancellation scope is live."""
+    if listener is None:
+        return True
+    state = getattr(listener, "sidebar_state", None)
+    send = getattr(state, "send", None) if state is not None else None
+    if send is not None and bool(getattr(send, "is_busy", False)):
+        return True
+    if getattr(listener, "_active_q", None) is not None:
+        return True
+    if getattr(listener, "_send_cancellation", None) is not None:
+        return True
+    return False
+
+
+def listener_queue_len(listener: Any) -> int:
+    q = _listener_queues.get(listener)
+    return len(q) if q is not None else 0
+
+
+def enqueue_peer_turn(listener: Any, turn: PeerPendingTurn) -> str | None:
+    """Queue *turn*. Returns ``PEER_QUEUE_FULL`` or None."""
+    q = _listener_queues.get(listener)
+    if q is None:
+        q = deque()
+        _listener_queues[listener] = q
+    if len(q) >= PEER_QUEUE_CAP:
+        return "PEER_QUEUE_FULL"
+    q.append(turn)
+    _global_fifo.append((weakref.ref(listener), turn))
+    return None
+
+
+def drop_listener_queue(listener: Any) -> None:
+    """Stop / dispose: drop that listener's pending injects only."""
+    global _global_fifo
+    if listener is None:
+        return
+    q = _listener_queues.pop(listener, None)
+    if q is not None:
+        q.clear()
+    _global_fifo = deque(item for item in _global_fifo if item[0]() is not listener)
+
+
+def reset_peer_queues() -> None:
+    """Test hook: clear all pending turns."""
+    global _global_fifo, _idle_kick_scheduled
+    _listener_queues.clear()
+    _global_fifo.clear()
+    _idle_kick_scheduled = False
+
+
+def kick_pending_peer_starts() -> None:
+    """Start at most one queued extracted send when the process drain is idle."""
+    global _idle_kick_scheduled
+    _idle_kick_scheduled = False
+    if get_drain_owner() is not None:
+        return
+    skipped: list[tuple[weakref.ref[Any], PeerPendingTurn]] = []
+    started = False
+    while _global_fifo and not started:
+        ref, turn = _global_fifo.popleft()
+        listener = ref()
+        if listener is None:
+            continue
+        q = _listener_queues.get(listener)
+        if q is None:
+            continue
+        try:
+            q.remove(turn)
+        except ValueError:
+            continue
+        if listener_is_busy(listener) or get_drain_owner() is not None:
+            q.appendleft(turn)
+            skipped.append((ref, turn))
+            continue
+        start_fn = getattr(listener, "start_extracted_peer_send", None)
+        if not callable(start_fn):
+            continue
+        started = True
+        start_fn(turn.wrapped_text, already_appended=turn.already_appended)
+    for item in reversed(skipped):
+        _global_fifo.appendleft(item)
+
+
+def _on_drain_idle() -> None:
+    """Schedule a kick after the current stack unwinds.
+
+    Starting the peer drain inside ``drain_owner_scope``'s ``finally`` would
+    run it before the caller’s ``SEND_COMPLETED`` (Ready). ``QueueExecutor.post``
+    is inline under ``WRITERAGENT_TESTING=1``, so we never start here — only
+    mark that a kick is due. Production posts to the next VCL tick.
+    """
+    global _idle_kick_scheduled
+    if get_drain_owner() is not None:
+        return
+    if not _global_fifo:
+        return
+    _idle_kick_scheduled = True
+    try:
+        from plugin.framework.queue_executor import default_executor
+
+        if not default_executor._should_run_inline():
+            default_executor.post(kick_pending_peer_starts)
+    except Exception:
+        log.debug("peer drain-idle schedule failed", exc_info=True)
+
+
+add_drain_idle_callback(_on_drain_idle)
+
+
+def schedule_peer_turn(listener: Any, turn: PeerPendingTurn) -> str | None:
+    """Enqueue and start now only when the process drain owner is unset."""
+    err = enqueue_peer_turn(listener, turn)
+    if err:
+        return err
+    # Never start from caller execute() while a drain owns the pump (accidental A2).
+    if get_drain_owner() is None and not listener_is_busy(listener):
+        kick_pending_peer_starts()
+    return None
+
+
+def _schema_function_name(schema: dict[str, Any]) -> str:
+    fn = schema.get("function")
+    if isinstance(fn, dict):
+        return str(fn.get("name") or "")
+    return str(schema.get("name") or "")
+
+
+def filter_peer_message_schemas(
+    schemas: list[dict[str, Any]],
+    ctx: Any,
+    doc: Any = None,
+) -> list[dict[str, Any]]:
+    """Hide ``send_peer_message`` unless a resolvable other v1 peer exists.
+
+    When shown, bake the open-peer catalog into the tool description.
+    """
+    if not any(_schema_function_name(s) == PEER_TOOL_NAME for s in schemas):
+        return schemas
+    peers: list[dict[str, str]] = []
+    if ctx is not None and doc is not None:
+        try:
+            peers = list_v1_peers(ctx, doc)
+        except Exception:
+            log.debug("filter_peer_message_schemas: catalog failed", exc_info=True)
+            peers = []
+    if not peers:
+        return [s for s in schemas if _schema_function_name(s) != PEER_TOOL_NAME]
+    catalog = format_peer_catalog(peers)
+    out: list[dict[str, Any]] = []
+    for schema in schemas:
+        if _schema_function_name(schema) != PEER_TOOL_NAME:
+            out.append(schema)
+            continue
+        enriched = copy.deepcopy(schema)
+        fn = enriched.get("function")
+        if isinstance(fn, dict):
+            desc = str(fn.get("description") or "")
+            fn["description"] = (desc + " " + catalog).strip()
+        elif "description" in enriched:
+            enriched["description"] = (str(enriched.get("description") or "") + " " + catalog).strip()
+        out.append(enriched)
+    return out
+
+
+def _peer_not_chat_mode(listener: Any) -> bool:
+    """True when the target sidebar is not in Chat mode (do not flip librarian/image)."""
+    try:
+        from plugin.chatbot.chat_sidebar_mode import CHAT_MODE_CHAT, mode_from_selector_with_flags
+
+        flags = getattr(listener, "sidebar_mode_flags", None)
+        selector = getattr(listener, "chat_mode_selector", None)
+        if selector is None:
+            return False
+        mode = mode_from_selector_with_flags(selector, flags)
+        return mode != CHAT_MODE_CHAT
+    except Exception:
+        return False
+
+
+def _inject_on_listener(listener: Any, wrapped: str) -> None:
+    session = getattr(listener, "session", None)
+    if session is not None and hasattr(session, "add_user_message"):
+        session.add_user_message(wrapped)
+    append = getattr(listener, "_append_response", None)
+    if callable(append):
+        append(wrapped, role="user")
+
+
+class SendPeerMessage(ToolBase):
+    """Chat-only async inject onto another live sidebar."""
+
+    name = PEER_TOOL_NAME
+    description = _BASE_DESCRIPTION
+    tier = "chat"
+    is_mutation = False
+    uno_services = [_TEXT_SERVICE, _CALC_SERVICE, _DRAW_SERVICE]
+    parameters = {
+        "type": "object",
+        "properties": {
+            "document_url": {
+                "type": "string",
+                "description": (
+                    "The one target argument: file URL, RuntimeUID, or a display name "
+                    "that matches exactly one open peer. Required on every call "
+                    "(including replies). Never omit it; never put your own identity here."
+                ),
+            },
+            "message": {
+                "type": "string",
+                "description": (
+                    "Natural-language task body only. Do not paste your own path, uid, or URL — "
+                    "the gateway inserts the [Peer from: …] envelope."
+                ),
+            },
+            "peer_ask_id": {
+                "type": "string",
+                "description": (
+                    "Correlation id from the inbound envelope. Required by protocol on replies; "
+                    "the host does not default the target from it."
+                ),
+            },
+        },
+        "required": ["document_url", "message"],
+    }
+
+    def is_async(self) -> bool:
+        return False
+
+    def execute(self, ctx: ToolContext, **kwargs: Any) -> dict[str, Any]:
+        if getattr(ctx, "caller", "") != "chat":
+            return self._tool_error(
+                "send_peer_message is sidebar chat only.",
+                code="PEER_CHAT_ONLY",
+            )
+        document_url = str(kwargs.get("document_url") or "").strip()
+        message = str(kwargs.get("message") or "")
+        if not document_url:
+            return self._tool_error("document_url is required.", code="VALIDATION_ERROR")
+        if not message.strip():
+            return self._tool_error("message is required.", code="VALIDATION_ERROR")
+
+        inbound_id = str(kwargs.get("peer_ask_id") or "").strip()
+        peer_ask_id = inbound_id or uuid.uuid4().hex
+
+        model, err_code, err_msg = resolve_peer_target(ctx.ctx, ctx.doc, document_url)
+        if err_code or model is None:
+            return self._tool_error(err_msg, code=err_code or "PEER_NOT_FOUND")
+
+        from plugin.doc.live_panels import get_live_panel
+        from plugin.framework.uno_context import get_runtime_uid
+
+        uid = get_runtime_uid(model) or ""
+        if not uid:
+            return self._tool_error(
+                "Peer document has no RuntimeUID.",
+                code="PEER_NOT_FOUND",
+            )
+        panel = get_live_panel(uid)
+        listener = getattr(panel, "send_listener", None) if panel is not None else None
+        if listener is None:
+            return self._tool_error(
+                "Open the peer sidebar once so a live chat panel exists. "
+                "Peer messaging cannot start a second agent loop.",
+                code="PEER_SIDEBAR_NOT_OPEN",
+            )
+        if _peer_not_chat_mode(listener):
+            return self._tool_error(
+                "The peer sidebar must be in Chat mode (not Librarian, Image, or a sub-agent).",
+                code="PEER_NOT_CHAT_MODE",
+            )
+
+        sender = identity_from_doc(ctx.doc)
+        wrapped = format_peer_envelope(
+            name=sender["name"],
+            uid=sender["uid"],
+            url=sender["url"],
+            peer_ask_id=peer_ask_id,
+            message=message,
+        )
+
+        busy = listener_is_busy(listener)
+        already_appended = not busy
+        if already_appended:
+            _inject_on_listener(listener, wrapped)
+
+        turn = PeerPendingTurn(
+            wrapped_text=wrapped,
+            already_appended=already_appended,
+            peer_ask_id=peer_ask_id,
+        )
+        overflow = schedule_peer_turn(listener, turn)
+        if overflow:
+            return self._tool_error(
+                f"Peer sidebar queue is full (max {PEER_QUEUE_CAP} pending turns).",
+                code="PEER_QUEUE_FULL",
+            )
+        return {"status": "ok", "accepted": True, "peer_ask_id": peer_ask_id}

--- a/plugin/doc/peer_message.py
+++ b/plugin/doc/peer_message.py
@@ -401,6 +401,23 @@ def _schema_function_name(schema: dict[str, Any]) -> str:
     return str(schema.get("name") or "")
 
 
+def summarize_peer_tool_on_wire(schemas: list[dict[str, Any]]) -> tuple[bool, int]:
+    """Whether ``send_peer_message`` is advertised, plus Open-peers count from the catalog."""
+    for schema in schemas:
+        if _schema_function_name(schema) != PEER_TOOL_NAME:
+            continue
+        fn = schema.get("function")
+        desc = str(fn.get("description") or "") if isinstance(fn, dict) else str(schema.get("description") or "")
+        return True, desc.count("uid=")
+    return False, 0
+
+
+def log_peer_tool_on_wire(schemas: list[dict[str, Any]]) -> None:
+    """Headed dig: prove the tool was on the chat wire (vs the model not calling it)."""
+    on_wire, peer_count = summarize_peer_tool_on_wire(schemas)
+    log.info("peer tools: send_peer_message on_wire=%s peer_count=%d", on_wire, peer_count)
+
+
 def filter_peer_message_schemas(
     schemas: list[dict[str, Any]],
     ctx: Any,

--- a/plugin/doc/peer_message.py
+++ b/plugin/doc/peer_message.py
@@ -441,9 +441,15 @@ def filter_peer_message_schemas(
 def _peer_not_chat_mode(listener: Any) -> bool:
     """True when the target sidebar is not in Chat mode (do not flip librarian/image)."""
     try:
-        from plugin.chatbot.chat_sidebar_mode import CHAT_MODE_CHAT, mode_from_selector_with_flags
+        from plugin.chatbot.chat_sidebar_mode import (
+            CHAT_MODE_CHAT,
+            SidebarModeFlags,
+            mode_from_selector_with_flags,
+        )
 
         flags = getattr(listener, "sidebar_mode_flags", None)
+        if not isinstance(flags, SidebarModeFlags):
+            flags = SidebarModeFlags()
         selector = getattr(listener, "chat_mode_selector", None)
         if selector is None:
             return False

--- a/plugin/framework/async_drain_guard.py
+++ b/plugin/framework/async_drain_guard.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import threading
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -33,6 +33,9 @@ _drain_lock = threading.Lock()
 _active_owner_name: str | None = None
 _drain_depth: int = 0
 _suppressed_vcl_count: int = 0
+# Peer messaging (and similar): start queued work only after the pump is free.
+# Callbacks must not start a drain on this stack when ``post`` would run inline.
+_drain_idle_callbacks: list[Callable[[], None]] = []
 
 
 class NestedDrainOwnerError(RuntimeError):
@@ -57,6 +60,7 @@ def drain_owner_scope(owner_name: str) -> Generator[None, None, None]:
         _active_owner_name = owner_name
         _drain_depth += 1
 
+    became_idle = False
     try:
         yield
     finally:
@@ -64,8 +68,11 @@ def drain_owner_scope(owner_name: str) -> Generator[None, None, None]:
             _drain_depth -= 1
             if _drain_depth == 0:
                 _active_owner_name = None
+                became_idle = True
             else:
                 _active_owner_name = previous_owner
+        if became_idle:
+            _notify_drain_idle()
 
 
 # Sentry alias for backward compatibility
@@ -118,6 +125,21 @@ def reset_suppressed_vcl_pump_count() -> None:
     global _suppressed_vcl_count
     with _drain_lock:
         _suppressed_vcl_count = 0
+
+
+def add_drain_idle_callback(fn: Callable[[], None]) -> None:
+    """Register *fn* to run when drain depth hits 0 (outside the sentry lock)."""
+    if fn not in _drain_idle_callbacks:
+        _drain_idle_callbacks.append(fn)
+
+
+def _notify_drain_idle() -> None:
+    """Invoke idle callbacks. Never raise into the drain ``finally``."""
+    for cb in list(_drain_idle_callbacks):
+        try:
+            cb()
+        except Exception:
+            log.exception("drain idle callback failed")
 
 
 def reset_sentry_state() -> None:

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -505,6 +505,13 @@ DRAW_SPECIALIZED_DELEGATION_TEMPLATE = (
 )
 
 
+# Shown only when send_peer_message is on the wire (another v1 peer is open).
+PEER_MESSAGING_RULES = """PEER SIDEBARS: Need writes in another already-open Writer, Calc, or Draw window? Call send_peer_message(document_url=<peer uid, file URL, or unique display name from the tool description>, message=<task>). Do not put your own path, uid, or URL in message — the gateway inserts [Peer from: name | uid | url | peer_ask_id]. Need a file fact only? document_research.
+After status ok/accepted, finish any local work then Ready. The reply arrives later as a follow-up user turn with a peer envelope — do not wait in this loop.
+When you receive a peer envelope: do the work with your tools; then send_peer_message(document_url=<uid or url from the envelope>, message=<result>, peer_ask_id=<id from the envelope>). Say what you completed. Never omit document_url.
+Never invent the other app's write tools on this loop."""
+
+
 DEFAULT_DRAW_CHAT_SYSTEM_PROMPT_TEMPLATE = """You are a LibreOffice Draw/Impress assistant who creates polished, professional, and colorful visual content.
 Do not explain - do the operation directly using tools. Perform as many steps as needed in one turn when possible.
 
@@ -548,6 +555,21 @@ DEFAULT_DRAW_GREETING = "AI: I can help you create and edit polished, colorful s
 DEFAULT_CHAT_SYSTEM_PROMPT = ""
 DEFAULT_CALC_CHAT_SYSTEM_PROMPT = ""
 DEFAULT_DRAW_CHAT_SYSTEM_PROMPT = ""
+
+
+def get_peer_messaging_prompt_block(model, ctx) -> str:
+    """Short peer-send rules plus open-peer catalog when a v1 peer is visible."""
+    if ctx is None or model is None:
+        return ""
+    try:
+        from plugin.doc.peer_message import format_peer_catalog, list_v1_peers
+
+        peers = list_v1_peers(ctx, model)
+        if not peers:
+            return ""
+        return PEER_MESSAGING_RULES + "\n" + format_peer_catalog(peers)
+    except Exception:
+        return ""
 
 
 def get_core_directives(model) -> str:
@@ -758,6 +780,10 @@ def get_chat_system_prompt_for_document(model, additional_instructions="", ctx=N
     vision_directive = get_vision_core_directive(model, ctx)
     if vision_directive:
         base += "\n\n" + vision_directive
+
+    peer_block = get_peer_messaging_prompt_block(model, ctx)
+    if peer_block:
+        base += "\n\n" + peer_block
 
     if ctx:
         try:

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -506,7 +506,9 @@ DRAW_SPECIALIZED_DELEGATION_TEMPLATE = (
 
 
 # Shown only when send_peer_message is on the wire (another v1 peer is open).
-PEER_MESSAGING_RULES = """PEER SIDEBARS: Need writes in another already-open Writer, Calc, or Draw window? Call send_peer_message(document_url=<peer uid, file URL, or unique display name from the tool description>, message=<task>). Do not put your own path, uid, or URL in message — the gateway inserts [Peer from: name | uid | url | peer_ask_id]. Need a file fact only? document_research.
+PEER_MESSAGING_RULES = """PEER SIDEBARS: Do call send_peer_message(document_url=<that peer’s uid, file URL, or unique display name from the Open peers list>, message=<the task for that sidebar>) when an Open peers entry is listed and the task is aimed at that peer’s app — compute, fill, write, or “ask the budget workbook / Draw form agent”. Why: only that sidebar has the peer’s tools; this loop must not invent them, and “take numbers from the open budget” is a peer send, not a silent read.
+Do not put your own path, uid, or URL in message — the gateway inserts [Peer from: name | uid | url | peer_ask_id]. There is no reply=true; every send needs an explicit document_url.
+document_research is only for a silent file fact when you do not need the peer sidebar to run (no peer agent work, no peer write). Do not use document_research as the default for an Open peers Writer/Calc/Draw document.
 After status ok/accepted, finish any local work then Ready. The reply arrives later as a follow-up user turn with a peer envelope — do not wait in this loop.
 When you receive a peer envelope: do the work with your tools; then send_peer_message(document_url=<uid or url from the envelope>, message=<result>, peer_ask_id=<id from the envelope>). Say what you completed. Never omit document_url.
 Never invent the other app's write tools on this loop."""

--- a/plugin/framework/tool.py
+++ b/plugin/framework/tool.py
@@ -377,7 +377,8 @@ class ToolBase(ABC):
         tier:        Main chat and MCP default lists use ``"core"``. Nested
                      specialized toolsets use ``"specialized"`` or
                      ``"specialized_control"`` (hidden from default lists via
-                     ``exclude_tiers``). Default ``"core"``.
+                     ``exclude_tiers``). Sidebar-only tools use ``"chat"``
+                     (on the chat wire; hidden from MCP). Default ``"core"``.
         intent:      Optional group label (e.g. "navigate", "edit", "review",
                      "media") for ``get_tools(intent=...)`` filtering.
         is_mutation:  Whether the tool mutates the document.  ``None``
@@ -834,6 +835,9 @@ class ToolRegistry:
                 from plugin.vision.vision_availability import filter_vision_delegate_schemas
 
                 schemas = filter_vision_delegate_schemas(schemas, ctx)
+            from plugin.doc.peer_message import filter_peer_message_schemas
+
+            schemas = filter_peer_message_schemas(schemas, ctx, doc=kwargs.get("doc"))
             return schemas
         elif protocol == "mcp":
             return [to_mcp_schema(t, doc_type=doc_type) for t in tools]

--- a/plugin/mcp/mcp_protocol.py
+++ b/plugin/mcp/mcp_protocol.py
@@ -64,8 +64,9 @@ def _document_echo_payload(doc):
 
 # Chat keeps specialized + mcp off the default list (_DEFAULT_EXCLUDE_TIERS in tool.py).
 # MCP advertise policy is forked: keep mcp-tier tools; hide specialized except in direct_flat.
-MCP_DELEGATE_EXCLUDE_TIERS = frozenset({"specialized", "specialized_control"})
-MCP_DIRECT_FLAT_EXCLUDE_TIERS = frozenset({"specialized_control"})
+# tier="chat" (send_peer_message) stays off both MCP lists.
+MCP_DELEGATE_EXCLUDE_TIERS = frozenset({"specialized", "specialized_control", "chat"})
+MCP_DIRECT_FLAT_EXCLUDE_TIERS = frozenset({"specialized_control", "chat"})
 
 
 def drop_unavailable_domains(schemas, registry, ctx):

--- a/tests/chatbot/test_fsm_verification.py
+++ b/tests/chatbot/test_fsm_verification.py
@@ -106,6 +106,7 @@ def test_send_state_mutual_exclusion_oracle() -> None:
         SendEvent(SendEventKind.RECORD_CLICKED),
         SendEvent(SendEventKind.STOP_REC_CLICKED),
         SendEvent(SendEventKind.SEND_CLICKED),
+        SendEvent(SendEventKind.EXTRACTED_SEND),
         SendEvent(SendEventKind.STOP_CLICKED),
         SendEvent(SendEventKind.SEND_COMPLETED),
         SendEvent(SendEventKind.ERROR_OCCURRED),

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -212,6 +212,10 @@ def test_peer_busy_queues_then_starts(ctx):
 
 @native_test
 def test_peer_unique_name_and_self_reject(ctx):
+    import tempfile
+
+    import uno
+
     reset_peer_queues()
     reset_live_panels()
     writer = None
@@ -219,14 +223,24 @@ def test_peer_unique_name_and_self_reject(ctx):
     try:
         writer = _load(ctx, "private:factory/swriter")
         calc = _load(ctx, "private:factory/scalc")
+        from plugin.doc.peer_message import list_v1_peers
+
         writer_uid = get_runtime_uid(writer)
         model, code, _msg = resolve_peer_target(ctx, writer, writer_uid)
         assert model is None
         assert code == "PEER_SELF"
-        calc_name = calc.getTitle()
-        model, code, _msg = resolve_peer_target(ctx, writer, calc_name)
-        assert code is None
-        assert get_runtime_uid(model) == get_runtime_uid(calc)
+        # Untitled Writer + Calc both catalog as "Untitled"; save Calc so the
+        # display name is unique and document_url-as-name can resolve.
+        calc_path = tempfile.mkdtemp() + "/BudgetPeer.ods"
+        calc.storeAsURL(uno.systemPathToFileUrl(calc_path), ())
+        peers = list_v1_peers(ctx, writer)
+        calc_uid = get_runtime_uid(calc)
+        rec = next((p for p in peers if p.get("uid") == calc_uid), None)
+        assert rec is not None, peers
+        assert rec["name"] == "BudgetPeer.ods"
+        model, code, _msg = resolve_peer_target(ctx, writer, rec["name"])
+        assert code is None, _msg
+        assert get_runtime_uid(model) == calc_uid
     finally:
         _close(calc)
         _close(writer)

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -1,0 +1,234 @@
+"""UNO tests for A1 peer messaging: addressing, missing deck, inject/queue."""
+
+from __future__ import annotations
+
+from plugin.doc.live_panels import register_live_panel, reset_live_panels, unregister_live_panel
+from plugin.doc.peer_message import (
+    SendPeerMessage,
+    drop_listener_queue,
+    kick_pending_peer_starts,
+    listener_queue_len,
+    reset_peer_queues,
+    resolve_peer_target,
+)
+from plugin.framework.async_drain_guard import drain_owner_scope, reset_sentry_state
+from plugin.framework.tool import ToolContext
+from plugin.framework.uno_context import get_desktop, get_runtime_uid
+from plugin.testing_runner import native_test
+
+
+class _Listener:
+    def __init__(self):
+        self.session = _Session()
+        self.appended = []
+        self.started = []
+        self.sidebar_state = _SendState()
+        self._active_q = None
+        self._send_cancellation = None
+        self.chat_mode_selector = None
+
+    def _append_response(self, text, role="assistant"):
+        self.appended.append((text, role))
+
+    def start_extracted_peer_send(self, query_text, *, already_appended):
+        self.started.append((query_text, already_appended))
+        return True
+
+
+class _Session:
+    def __init__(self):
+        self.messages = []
+
+    def add_user_message(self, content):
+        self.messages.append({"role": "user", "content": content})
+
+
+class _SendState:
+    def __init__(self):
+        self.send = type("S", (), {"is_busy": False})()
+
+
+def _hidden_prop():
+    import uno
+
+    return uno.createUnoStruct("com.sun.star.beans.PropertyValue", Name="Hidden", Value=True)
+
+
+def _load(ctx, factory_url):
+    desktop = get_desktop(ctx)
+    return desktop.loadComponentFromURL(factory_url, "_blank", 0, (_hidden_prop(),))
+
+
+def _close(doc):
+    if doc is None:
+        return
+    try:
+        doc.close(True)
+    except Exception:
+        pass
+
+
+def _tool_ctx(ctx, doc):
+    return ToolContext(doc=doc, ctx=ctx, doc_type="writer", services=None, caller="chat")
+
+
+@native_test
+def test_peer_impress_rejected_on_resolved_model(ctx):
+    reset_peer_queues()
+    reset_live_panels()
+    reset_sentry_state()
+    writer = None
+    impress = None
+    try:
+        writer = _load(ctx, "private:factory/swriter")
+        impress = _load(ctx, "private:factory/simpress")
+        assert writer is not None and impress is not None
+        impress_uid = get_runtime_uid(impress)
+        assert impress_uid
+        model, code, msg = resolve_peer_target(ctx, writer, impress_uid)
+        assert model is None
+        assert code == "PEER_UNSUPPORTED"
+        assert "Impress" in msg
+    finally:
+        _close(impress)
+        _close(writer)
+        reset_peer_queues()
+        reset_live_panels()
+
+
+@native_test
+def test_peer_catalog_draw_label_is_not_enough_for_impress(ctx):
+    """get_open_documents labels Impress as draw; v1 still rejects the model."""
+    from plugin.doc.document_research import get_open_documents
+    from plugin.doc.peer_message import list_v1_peers
+
+    reset_live_panels()
+    writer = None
+    impress = None
+    try:
+        writer = _load(ctx, "private:factory/swriter")
+        impress = _load(ctx, "private:factory/simpress")
+        catalog = get_open_documents(ctx, writer)
+        impress_uid = get_runtime_uid(impress)
+        rec = next((r for r in catalog if r.get("uid") == impress_uid), None)
+        assert rec is not None
+        assert rec.get("doc_type") == "draw"
+        peers = list_v1_peers(ctx, writer)
+        assert all(p.get("uid") != impress_uid for p in peers)
+    finally:
+        _close(impress)
+        _close(writer)
+
+
+@native_test
+def test_peer_missing_deck_is_clear_error(ctx):
+    reset_peer_queues()
+    reset_live_panels()
+    reset_sentry_state()
+    writer = None
+    other = None
+    try:
+        writer = _load(ctx, "private:factory/swriter")
+        other = _load(ctx, "private:factory/swriter")
+        other_uid = get_runtime_uid(other)
+        tool = SendPeerMessage()
+        result = tool.execute(_tool_ctx(ctx, writer), document_url=other_uid, message="Hello peer")
+        assert result["status"] == "error"
+        assert result["code"] == "PEER_SIDEBAR_NOT_OPEN"
+        assert "sidebar" in result["message"].lower()
+    finally:
+        _close(other)
+        _close(writer)
+        reset_peer_queues()
+        reset_live_panels()
+
+
+@native_test
+def test_peer_inject_defers_until_drain_idle(ctx):
+    reset_peer_queues()
+    reset_live_panels()
+    reset_sentry_state()
+    writer = None
+    other = None
+    listener = _Listener()
+    try:
+        writer = _load(ctx, "private:factory/swriter")
+        other = _load(ctx, "private:factory/swriter")
+        other_uid = get_runtime_uid(other)
+        panel = type("P", (), {"send_listener": listener})()
+        register_live_panel(other_uid, panel)
+        tool = SendPeerMessage()
+        with drain_owner_scope("stream"):
+            result = tool.execute(_tool_ctx(ctx, writer), document_url=other_uid, message="Compute Q4")
+            assert result["status"] == "ok"
+            assert result["accepted"] is True
+            assert listener.started == []
+            assert listener.session.messages
+            assert "[Peer from:" in listener.session.messages[0]["content"]
+        kick_pending_peer_starts()
+        assert listener.started
+        assert listener.started[0][1] is True
+    finally:
+        drop_listener_queue(listener)
+        unregister_live_panel(get_runtime_uid(other) if other is not None else "")
+        _close(other)
+        _close(writer)
+        reset_peer_queues()
+        reset_live_panels()
+        reset_sentry_state()
+
+
+@native_test
+def test_peer_busy_queues_then_starts(ctx):
+    reset_peer_queues()
+    reset_live_panels()
+    reset_sentry_state()
+    writer = None
+    other = None
+    listener = _Listener()
+    try:
+        writer = _load(ctx, "private:factory/swriter")
+        other = _load(ctx, "private:factory/swriter")
+        other_uid = get_runtime_uid(other)
+        panel = type("P", (), {"send_listener": listener})()
+        register_live_panel(other_uid, panel)
+        listener.sidebar_state.send.is_busy = True
+        tool = SendPeerMessage()
+        result = tool.execute(_tool_ctx(ctx, writer), document_url=other_uid, message="Queued")
+        assert result["status"] == "ok"
+        assert listener.started == []
+        assert listener_queue_len(listener) == 1
+        listener.sidebar_state.send.is_busy = False
+        kick_pending_peer_starts()
+        assert listener.started
+    finally:
+        drop_listener_queue(listener)
+        _close(other)
+        _close(writer)
+        reset_peer_queues()
+        reset_live_panels()
+        reset_sentry_state()
+
+
+@native_test
+def test_peer_unique_name_and_self_reject(ctx):
+    reset_peer_queues()
+    reset_live_panels()
+    writer = None
+    calc = None
+    try:
+        writer = _load(ctx, "private:factory/swriter")
+        calc = _load(ctx, "private:factory/scalc")
+        writer_uid = get_runtime_uid(writer)
+        model, code, _msg = resolve_peer_target(ctx, writer, writer_uid)
+        assert model is None
+        assert code == "PEER_SELF"
+        calc_name = calc.getTitle()
+        model, code, _msg = resolve_peer_target(ctx, writer, calc_name)
+        assert code is None
+        assert get_runtime_uid(model) == get_runtime_uid(calc)
+    finally:
+        _close(calc)
+        _close(writer)
+        reset_peer_queues()
+        reset_live_panels()

--- a/tests/chatbot/test_send_state.py
+++ b/tests/chatbot/test_send_state.py
@@ -104,6 +104,23 @@ def test_send_clicked_with_no_input_emits_no_start_send():
     assert not any(isinstance(e, StartSendEffect) for e in tr.effects)
 
 
+def test_extracted_send_sets_busy_without_start_send():
+    state = SendButtonState(False, False, False, False, True)
+    tr = next_state(state, SendEvent(SendEventKind.EXTRACTED_SEND))
+    assert tr.state.is_busy is True
+    assert not any(isinstance(e, StartSendEffect) for e in tr.effects)
+    ui_effect = next(e for e in tr.effects if isinstance(e, UpdateUIEffect))
+    assert ui_effect.send_enabled is False
+    assert ui_effect.stop_enabled is True
+
+
+def test_extracted_send_while_busy_is_noop():
+    state = SendButtonState(True, False, True, False, True)
+    tr = next_state(state, SendEvent(SendEventKind.EXTRACTED_SEND))
+    assert tr.state == state
+    assert tr.effects == []
+
+
 def test_send_clicked_with_audio_only_starts_send():
     """Cold send with recorded audio and no text (not via Stop Rec auto-send)."""
     state = SendButtonState(False, False, False, True, True)

--- a/tests/chatbot/test_tool_loop.py
+++ b/tests/chatbot/test_tool_loop.py
@@ -543,6 +543,7 @@ def test_refresh_active_tools_for_session():
             uno_services_supported=frozenset({"com.sun.star.text.TextDocument"}),
             active_domain="tables",
             ctx=panel.ctx,
+            doc=None,
         )
         assert panel._active_tools == [{"function": {"name": "fresh"}}]
     finally:

--- a/tests/doc/test_live_panels.py
+++ b/tests/doc/test_live_panels.py
@@ -1,0 +1,55 @@
+"""Unit tests for the production live-panel uid map."""
+
+from plugin.doc.live_panels import (
+    get_live_panel,
+    iter_live_panel_uids,
+    register_live_panel,
+    reset_live_panels,
+    unregister_live_panel,
+)
+
+
+class _Panel:
+    def __init__(self, name):
+        self.name = name
+
+
+def setup_function():
+    reset_live_panels()
+
+
+def teardown_function():
+    reset_live_panels()
+
+
+def test_register_and_get():
+    panel = _Panel("a")
+    register_live_panel("uid-1", panel)
+    assert get_live_panel("uid-1") is panel
+    assert "uid-1" in iter_live_panel_uids()
+
+
+def test_skip_empty_uid():
+    register_live_panel("", _Panel("x"))
+    assert iter_live_panel_uids() == []
+    assert get_live_panel("") is None
+
+
+def test_last_write_wins():
+    first = _Panel("first")
+    second = _Panel("second")
+    register_live_panel("uid-1", first)
+    register_live_panel("uid-1", second)
+    assert get_live_panel("uid-1") is second
+
+
+def test_unregister():
+    panel = _Panel("a")
+    register_live_panel("uid-1", panel)
+    unregister_live_panel("uid-1")
+    assert get_live_panel("uid-1") is None
+
+
+def test_weak_value_drops_when_unreferenced():
+    register_live_panel("uid-1", _Panel("gone"))
+    assert get_live_panel("uid-1") is None

--- a/tests/doc/test_peer_message.py
+++ b/tests/doc/test_peer_message.py
@@ -135,6 +135,22 @@ def test_impress_rejected_on_model_not_catalog_draw():
     assert v1_peer_type_label(draw) == "draw"
 
 
+def test_list_v1_peers_magicmock_ctx_does_not_hang():
+    """Regression: prompt/schema catalog with ctx=MagicMock() must not spin."""
+    from plugin.doc.peer_message import list_v1_peers
+    from plugin.framework.prompts import get_chat_system_prompt_for_document
+
+    ctx = MagicMock()
+    doc = MagicMock()
+    doc.getRuntimeUID.return_value = "self"
+    assert list_v1_peers(ctx, doc) == []
+    model = MagicMock()
+    model.supportsService.return_value = False
+    prompt = get_chat_system_prompt_for_document(model, ctx=ctx)
+    assert isinstance(prompt, str)
+    assert "send_peer_message" not in prompt
+
+
 def test_visibility_filter_alone_hides_tool():
     schemas = [
         {"type": "function", "function": {"name": PEER_TOOL_NAME, "description": "base"}},

--- a/tests/doc/test_peer_message.py
+++ b/tests/doc/test_peer_message.py
@@ -82,8 +82,7 @@ def test_peer_message_module_does_not_import_panel_factory():
             imported.append(node.module or "")
     assert "plugin.chatbot.panel_factory" not in imported
     assert "plugin.chatbot.panel" not in imported
-    assert "panel_factory" not in src
-    assert "from plugin.chatbot.panel" not in src
+    assert not any(name.endswith("panel_factory") for name in imported)
 
 
 def test_envelope_from_ctx_doc():
@@ -318,7 +317,7 @@ def test_execute_queue_full():
 def test_registry_chat_tier_on_default_list():
     registry = ToolRegistry(services=None)
     registry.register(SendPeerMessage())
-    names = {t.name for t in registry.get_tools()}
+    names = {t.name for t in registry.get_tools(doc_type="writer")}
     assert PEER_TOOL_NAME in names
     mcp_names = {t.name for t in registry.get_tools(exclude_tiers=frozenset({"specialized", "specialized_control", "chat"}))}
     assert PEER_TOOL_NAME not in mcp_names

--- a/tests/doc/test_peer_message.py
+++ b/tests/doc/test_peer_message.py
@@ -354,6 +354,26 @@ def test_prompts_ready_after_accepted_not_wait():
     assert "do not wait" in PEER_MESSAGING_RULES.lower()
     assert "don't Ready" not in PEER_MESSAGING_RULES
     assert "do not Ready" not in PEER_MESSAGING_RULES
+    assert "Need a file fact only?" not in PEER_MESSAGING_RULES
+    assert "Do call send_peer_message" in PEER_MESSAGING_RULES
+    assert "Do not use document_research as the default" in PEER_MESSAGING_RULES
+    assert "reply=true" in PEER_MESSAGING_RULES
+
+
+def test_summarize_peer_tool_on_wire():
+    from plugin.doc.peer_message import log_peer_tool_on_wire, summarize_peer_tool_on_wire
+
+    assert summarize_peer_tool_on_wire([{"function": {"name": "undo"}}]) == (False, 0)
+    schemas = [
+        {
+            "function": {
+                "name": PEER_TOOL_NAME,
+                "description": "base Open peers: Budget.ods (uid=u2, url=, type=calc).",
+            }
+        }
+    ]
+    assert summarize_peer_tool_on_wire(schemas) == (True, 1)
+    log_peer_tool_on_wire(schemas)
 
 
 def test_chat_tier_excluded_from_mcp_frozensets():

--- a/tests/doc/test_peer_message.py
+++ b/tests/doc/test_peer_message.py
@@ -1,0 +1,348 @@
+"""Unit tests for A1 send_peer_message (no live soffice)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from plugin.doc.peer_message import (
+    PEER_QUEUE_CAP,
+    PEER_TOOL_NAME,
+    PeerPendingTurn,
+    SendPeerMessage,
+    drop_listener_queue,
+    enqueue_peer_turn,
+    filter_peer_message_schemas,
+    format_peer_envelope,
+    identity_from_doc,
+    is_v1_peer_model,
+    kick_pending_peer_starts,
+    listener_queue_len,
+    reset_peer_queues,
+    resolve_peer_target,
+    schedule_peer_turn,
+    v1_peer_type_label,
+)
+from plugin.framework.async_drain_guard import drain_owner_scope, reset_sentry_state
+from plugin.framework.tool import ToolContext, ToolRegistry
+
+
+class _Listener:
+    """Weakref-capable stand-in for SendButtonListener."""
+
+    def __init__(self):
+        self.session = MagicMock()
+        self.session.messages = []
+        self.appended = []
+        self.started = []
+        self.sidebar_state = MagicMock()
+        self.sidebar_state.send.is_busy = False
+        self._active_q = None
+        self._send_cancellation = None
+        self.chat_mode_selector = None
+
+    def _append_response(self, text, role="assistant"):
+        self.appended.append((text, role))
+
+    def start_extracted_peer_send(self, query_text, *, already_appended):
+        self.started.append((query_text, already_appended))
+        return True
+
+
+def setup_function():
+    reset_peer_queues()
+    reset_sentry_state()
+
+
+def teardown_function():
+    reset_peer_queues()
+    reset_sentry_state()
+
+
+def _ctx(caller="chat", doc=None):
+    if doc is None:
+        doc = MagicMock()
+        doc.getURL.return_value = "file:///tmp/self.odt"
+        doc.getTitle.return_value = "self.odt"
+        doc.getRuntimeUID.return_value = "self-uid"
+        doc.RuntimeUID = "self-uid"
+        doc.supportsService.side_effect = lambda s: s == "com.sun.star.text.TextDocument"
+    return ToolContext(doc=doc, ctx=object(), doc_type="writer", services=None, caller=caller)
+
+
+def test_peer_message_module_does_not_import_panel_factory():
+    src = Path("plugin/doc/peer_message.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    imported = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+    assert "plugin.chatbot.panel_factory" not in imported
+    assert "plugin.chatbot.panel" not in imported
+    assert "panel_factory" not in src
+    assert "from plugin.chatbot.panel" not in src
+
+
+def test_envelope_from_ctx_doc():
+    doc = MagicMock()
+    doc.getURL.return_value = "file:///tmp/Budget%202026.ods"
+    doc.getTitle.return_value = "Budget 2026.ods"
+    doc.getRuntimeUID.return_value = "uid-budget"
+    doc.RuntimeUID = "uid-budget"
+    with patch("plugin.doc.document_research._system_path_from_url", return_value="/tmp/Budget 2026.ods"):
+        ident = identity_from_doc(doc)
+    assert ident["name"] == "Budget 2026.ods"
+    assert ident["uid"] == "uid-budget"
+    assert ident["url"] == "file:///tmp/Budget%202026.ods"
+    wrapped = format_peer_envelope(
+        name=ident["name"],
+        uid=ident["uid"],
+        url=ident["url"],
+        peer_ask_id="ask-1",
+        message="Compute Q4.",
+    )
+    assert wrapped.startswith("[Peer from: Budget 2026.ods | uid=uid-budget |")
+    assert "peer_ask_id=ask-1" in wrapped
+    assert wrapped.endswith("Compute Q4.")
+
+
+def test_envelope_untitled_url_empty():
+    doc = MagicMock()
+    doc.getURL.return_value = ""
+    doc.getTitle.return_value = "Untitled 1"
+    doc.getRuntimeUID.return_value = "uid-untitled"
+    doc.RuntimeUID = "uid-untitled"
+    ident = identity_from_doc(doc)
+    assert ident["url"] == ""
+    assert ident["uid"] == "uid-untitled"
+    assert ident["name"] == "Untitled 1"
+
+
+def test_impress_rejected_on_model_not_catalog_draw():
+    impress = MagicMock()
+    impress.supportsService.side_effect = lambda s: s in (
+        "com.sun.star.drawing.DrawingDocument",
+        "com.sun.star.presentation.PresentationDocument",
+    )
+    assert is_v1_peer_model(impress) is False
+    assert v1_peer_type_label(impress) is None
+
+    draw = MagicMock()
+    draw.supportsService.side_effect = lambda s: s == "com.sun.star.drawing.DrawingDocument"
+    assert is_v1_peer_model(draw) is True
+    assert v1_peer_type_label(draw) == "draw"
+
+
+def test_visibility_filter_alone_hides_tool():
+    schemas = [
+        {"type": "function", "function": {"name": PEER_TOOL_NAME, "description": "base"}},
+        {"type": "function", "function": {"name": "undo", "description": "u"}},
+    ]
+    out = filter_peer_message_schemas(schemas, ctx=object(), doc=object())
+    names = [s["function"]["name"] for s in out]
+    assert PEER_TOOL_NAME not in names
+    assert "undo" in names
+
+
+def test_visibility_filter_two_writer_shows_catalog():
+    schemas = [
+        {"type": "function", "function": {"name": PEER_TOOL_NAME, "description": "base"}},
+    ]
+    peers = [{"name": "Other.odt", "uid": "u2", "url": "file:///tmp/Other.odt", "type": "writer"}]
+    with patch("plugin.doc.peer_message.list_v1_peers", return_value=peers):
+        out = filter_peer_message_schemas(schemas, ctx=object(), doc=object())
+    assert len(out) == 1
+    desc = out[0]["function"]["description"]
+    assert "Other.odt" in desc
+    assert "uid=u2" in desc
+    assert "type=writer" in desc
+
+
+def test_addressing_self_rejected():
+    self_doc = MagicMock()
+    self_doc.getRuntimeUID.return_value = "uid-self"
+    self_doc.RuntimeUID = "uid-self"
+    peer = MagicMock()
+    peer.getRuntimeUID.return_value = "uid-self"
+    peer.RuntimeUID = "uid-self"
+    peer.supportsService.side_effect = lambda s: s == "com.sun.star.text.TextDocument"
+    with patch("plugin.framework.uno_context.resolve_document_by_url", return_value=(peer, "writer")):
+        with patch("plugin.framework.uno_context.get_runtime_uid", return_value="uid-self"):
+            model, code, _msg = resolve_peer_target(object(), self_doc, "uid-self")
+    assert model is None
+    assert code == "PEER_SELF"
+
+
+def test_addressing_missing():
+    self_doc = MagicMock()
+    with patch("plugin.framework.uno_context.resolve_document_by_url", return_value=(None, None)):
+        with patch("plugin.doc.peer_message.list_v1_peers", return_value=[]):
+            model, code, _msg = resolve_peer_target(object(), self_doc, "file:///missing.odt")
+    assert model is None
+    assert code == "PEER_NOT_FOUND"
+
+
+def test_addressing_ambiguous_name():
+    self_doc = MagicMock()
+    peers = [
+        {"name": "Budget.ods", "uid": "a", "url": "", "type": "calc"},
+        {"name": "Budget.ods", "uid": "b", "url": "", "type": "calc"},
+    ]
+    with patch("plugin.framework.uno_context.resolve_document_by_url", return_value=(None, None)):
+        with patch("plugin.doc.peer_message.list_v1_peers", return_value=peers):
+            model, code, _msg = resolve_peer_target(object(), self_doc, "Budget.ods")
+    assert model is None
+    assert code == "PEER_AMBIGUOUS"
+
+
+def test_addressing_unique_name():
+    self_doc = MagicMock()
+    self_doc.getRuntimeUID.return_value = "self"
+    peer = MagicMock()
+    peer.getRuntimeUID.return_value = "peer-uid"
+    peer.supportsService.side_effect = lambda s: s == "com.sun.star.sheet.SpreadsheetDocument"
+    peers = [{"name": "Budget.ods", "uid": "peer-uid", "url": "", "type": "calc"}]
+
+    def _resolve(_ctx, target):
+        if target == "peer-uid":
+            return peer, "calc"
+        return None, None
+
+    with patch("plugin.framework.uno_context.resolve_document_by_url", side_effect=_resolve):
+        with patch("plugin.doc.peer_message.list_v1_peers", return_value=peers):
+            with patch("plugin.framework.uno_context.get_runtime_uid", side_effect=lambda m: "self" if m is self_doc else "peer-uid"):
+                model, code, _msg = resolve_peer_target(object(), self_doc, "Budget.ods")
+    assert code is None
+    assert model is peer
+
+
+def test_queue_fifo_cap_overflow_and_stop_drops():
+    listener = _Listener()
+    turns = [PeerPendingTurn(f"t{i}", False, f"id{i}") for i in range(PEER_QUEUE_CAP)]
+    for turn in turns:
+        assert enqueue_peer_turn(listener, turn) is None
+    assert listener_queue_len(listener) == PEER_QUEUE_CAP
+    overflow = enqueue_peer_turn(listener, PeerPendingTurn("extra", False, "x"))
+    assert overflow == "PEER_QUEUE_FULL"
+    drop_listener_queue(listener)
+    assert listener_queue_len(listener) == 0
+
+
+def test_schedule_does_not_start_while_drain_owned():
+    listener = _Listener()
+    turn = PeerPendingTurn("wrapped", True, "ask")
+    with drain_owner_scope("stream"):
+        err = schedule_peer_turn(listener, turn)
+        assert err is None
+        assert listener_queue_len(listener) == 1
+        assert listener.started == []
+    # idle callback may schedule but testing post is deferred; kick explicitly
+    kick_pending_peer_starts()
+    assert listener.started == [("wrapped", True)]
+    assert listener_queue_len(listener) == 0
+
+
+def test_user_busy_wins_over_queued_inject():
+    listener = _Listener()
+    listener.sidebar_state.send.is_busy = True
+    turn = PeerPendingTurn("wrapped", False, "ask")
+    assert schedule_peer_turn(listener, turn) is None
+    assert listener.started == []
+    assert listener_queue_len(listener) == 1
+    listener.sidebar_state.send.is_busy = False
+    kick_pending_peer_starts()
+    assert listener.started == [("wrapped", False)]
+
+
+def test_execute_status_ok_accepted():
+    tool = SendPeerMessage()
+    ctx = _ctx()
+    peer = MagicMock()
+    listener = _Listener()
+    panel = MagicMock()
+    panel.send_listener = listener
+    with patch("plugin.doc.peer_message.resolve_peer_target", return_value=(peer, None, "")):
+        with patch("plugin.framework.uno_context.get_runtime_uid", return_value="peer-uid"):
+            with patch("plugin.doc.live_panels.get_live_panel", return_value=panel):
+                with drain_owner_scope("stream"):
+                    result = tool.execute(ctx, document_url="peer-uid", message="Do the thing")
+    assert result["status"] == "ok"
+    assert result["accepted"] is True
+    assert result["peer_ask_id"]
+    assert listener.session.add_user_message.called
+    assert listener.appended
+
+
+def test_execute_refuses_non_chat_caller():
+    tool = SendPeerMessage()
+    ctx = _ctx(caller="mcp")
+    result = tool.execute(ctx, document_url="x", message="hi")
+    assert result["status"] == "error"
+    assert result["code"] == "PEER_CHAT_ONLY"
+
+
+def test_execute_missing_sidebar():
+    tool = SendPeerMessage()
+    ctx = _ctx()
+    peer = MagicMock()
+    with patch("plugin.doc.peer_message.resolve_peer_target", return_value=(peer, None, "")):
+        with patch("plugin.framework.uno_context.get_runtime_uid", return_value="peer-uid"):
+            with patch("plugin.doc.live_panels.get_live_panel", return_value=None):
+                result = tool.execute(ctx, document_url="peer-uid", message="hi")
+    assert result["status"] == "error"
+    assert result["code"] == "PEER_SIDEBAR_NOT_OPEN"
+    assert "sidebar" in result["message"].lower()
+
+
+def test_execute_queue_full():
+    tool = SendPeerMessage()
+    ctx = _ctx()
+    peer = MagicMock()
+    listener = _Listener()
+    panel = MagicMock()
+    panel.send_listener = listener
+    for i in range(PEER_QUEUE_CAP):
+        enqueue_peer_turn(listener, PeerPendingTurn(f"t{i}", False, str(i)))
+    with patch("plugin.doc.peer_message.resolve_peer_target", return_value=(peer, None, "")):
+        with patch("plugin.framework.uno_context.get_runtime_uid", return_value="peer-uid"):
+            with patch("plugin.doc.live_panels.get_live_panel", return_value=panel):
+                with drain_owner_scope("stream"):
+                    result = tool.execute(ctx, document_url="peer-uid", message="one more")
+    assert result["status"] == "error"
+    assert result["code"] == "PEER_QUEUE_FULL"
+
+
+def test_registry_chat_tier_on_default_list():
+    registry = ToolRegistry(services=None)
+    registry.register(SendPeerMessage())
+    names = {t.name for t in registry.get_tools()}
+    assert PEER_TOOL_NAME in names
+    mcp_names = {t.name for t in registry.get_tools(exclude_tiers=frozenset({"specialized", "specialized_control", "chat"}))}
+    assert PEER_TOOL_NAME not in mcp_names
+
+
+def test_is_mutation_false_and_sync():
+    tool = SendPeerMessage()
+    assert tool.detects_mutation() is False
+    assert tool.is_async() is False
+    assert tool.tier == "chat"
+    assert tool.name == "send_peer_message"
+
+
+def test_prompts_ready_after_accepted_not_wait():
+    from plugin.framework.prompts import PEER_MESSAGING_RULES
+
+    assert "Ready" in PEER_MESSAGING_RULES
+    assert "do not wait" in PEER_MESSAGING_RULES.lower()
+    assert "don't Ready" not in PEER_MESSAGING_RULES
+    assert "do not Ready" not in PEER_MESSAGING_RULES
+
+
+def test_chat_tier_excluded_from_mcp_frozensets():
+    from plugin.mcp.mcp_protocol import MCP_DELEGATE_EXCLUDE_TIERS, MCP_DIRECT_FLAT_EXCLUDE_TIERS
+
+    assert "chat" in MCP_DELEGATE_EXCLUDE_TIERS
+    assert "chat" in MCP_DIRECT_FLAT_EXCLUDE_TIERS

--- a/tests/mcp/test_list_open_documents.py
+++ b/tests/mcp/test_list_open_documents.py
@@ -95,6 +95,16 @@ def test_list_open_documents_execute():
         assert docs[1]["modified"] is False
 
 
+def test_get_open_documents_magicmock_enum_does_not_hang():
+    """Default MagicMock.hasMoreElements() is always truthy; must not spin."""
+    from plugin.doc.document_research import get_open_documents
+
+    desktop = MagicMock()
+    with patch("plugin.framework.uno_context.get_desktop", return_value=desktop):
+        docs = get_open_documents(MagicMock(), active_model=None)
+    assert docs == []
+
+
 def test_get_open_documents_lists_untitled_even_when_type_lookup_fails():
     """D5: an untitled doc (no URL) must never be dropped from the listing on a type-lookup error --
     its uid is the only handle a caller can target it by. It's listed with doc_type 'unknown'."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ships **A1 async peer messaging** per the current `docs/chat/peer-messaging.md` (Ready-after-accepted + queue-on-busy; not the older #669 fail-fast / “don’t Ready” text).

`send_peer_message(document_url, message)` is a **sidebar chat-only** tool (`tier="chat"`). It injects a code-built `[Peer from: name | uid | url | peer_ask_id]` envelope onto another already-open Writer/Calc/Draw sidebar and returns immediately:

```json
{"status": "ok", "accepted": true, "peer_ask_id": "…"}
```

The caller **Readys**. The peer extracted send starts after the process drain owner is `None`. Replies use the same tool with an explicit `document_url` plus `peer_ask_id` and land as a **follow-up user turn**.

`document_url` is the one target argument: file URL, RuntimeUID, or a display name that matches exactly one open peer. No separate `name` parameter.

This branch includes latest `master` (#670 `fill_draw_fields`). Docs keep A1 implemented status and master’s paper-form fill wording.

## Prompt steer (headed Scrolly)

`PEER_MESSAGING_RULES` no longer says “Need a file fact only? document_research” as the default for an open budget. When an Open peers entry is listed and the task is aimed at that app, **Do** `send_peer_message`. `document_research` is only a silent file fact when the peer sidebar does not need to run. Chat send logs `send_peer_message on_wire=` plus `peer_count=` for headed proof.

## Behavior

- Visible on chat `get_schemas` only when another resolvable v1 peer is open; catalog (name/uid/url/type) is baked into the tool description and a short prompt block.
- Hidden from MCP `tools/list` / `find_tools`; `execute()` refuses `ctx.caller != "chat"`.
- Queue-on-busy (FIFO, cap 8, overflow error). User Ask wins. Stop/dispose drops that listener’s queue.
- Inject now, start later — never start the peer drain from caller `execute()` while `get_drain_owner()` is set.
- Missing peer sidebar → clear error (“open the peer sidebar once”). No silent A2.
- Impress rejected on the **resolved model** (`PresentationDocument`), not catalog `doc_type: "draw"`.
- No `toFront` / `query.setFocus` on extracted send. No extra per-doc lock.

## GMP / Draw fill

Paper-form fill is a staged Draw/Writer stand-in, not a product PDF/AcroForm API. `get_draw_tree` marks empty boxes as fill targets; `fill_draw_fields` / name-based `shape_upsert` write them. `form_*` is only for live ControlShapes. Do not spawn ControlShapes for paper-form blanks.

## Non-goals (not in this PR)

- Blocking `ask_*` / A2 fallback
- Multiplexed drain / mid-loop `PEER_REPLY` / waiting chrome
- Ready-hold until reply (deadlocks the queue)
- MCP exposure, Impress, spawn, last-sender default

## Tests

- Unit: envelope, visibility, addressing, queue, chat-only, MagicMock catalog must not hang, prompt steer
- UNO: Impress reject, missing deck, inject/defer-until-idle, busy queue, unique name / self

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8912c12a-9f7b-4403-b65c-ee1f737e74e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8912c12a-9f7b-4403-b65c-ee1f737e74e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

