### PR TITLE
Un-skip mock-sidebar E12/G17: open Calc after Writer deck without URP hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ help:
 	@echo "  make test-uno               UNO tests only via testing_runner (serial live soffice)"
 	@echo "  make test-uno FILTER=…      Same; FILTER=path or test_* name (native runner)"
 	@echo "  make test-mock-sidebar      Packet F+B+C+D+E+G mock-LLM sidebar (visible soffice, your user profile)"
-	@echo "  make test-mock-sidebar FILTER=E   Packet letter (B/C/D/E/F/G), case id (f3a), or test_* name"
+	@echo "  make test-mock-sidebar FILTER=E   Packet letter (B/C/D/E/F/G), case id (e12 / g17), or test_* name"
 	@echo "  make excel-py-roundtrip     Excel↔DAG sample fidelity over PythonExcelSamples/"
 	@echo ""
 	@echo "Benchmarks (prompt optimization / eval):"

--- a/docs/chat/peer-messaging.md
+++ b/docs/chat/peer-messaging.md
@@ -387,7 +387,7 @@ Concrete touch points so this is implementable without rediscovering the review.
 **Tests (required):**
 
 - Unit: envelope from `ctx.doc` (untitled url empty); visibility (main hides even with peers; specialized shows catalog; Impress rejected); addressing (self, missing, ambiguous); queue policy (FIFO, cap, overflow error, Stop drops); `status: ok` + `accepted`; `execute` allows specialized `document_research` and refuses MCP; no `panel_factory` import from the tool module.
-- UNO: two live sidebars — inject, defer-until-idle, busy queue, missing deck error, Impress reject. Follow `tests/chatbot/test_hamburger_menu_uno.py` style (`@native_test`, `ctx`).
+- UNO: two live sidebars — inject, defer-until-idle, busy queue, missing deck error, Impress reject. Follow `tests/chatbot/test_hamburger_menu_uno.py` style (`@native_test`, `ctx`). Mock-sidebar / user-profile URP must open Calc with `open_calc_document` in [`sidebar_test_hooks.py`](../../plugin/chatbot/sidebar_test_hooks.py) (`_blank`, VCL-posted factory load) — never `loadComponentFromURL("private:factory/scalc")` from the URP client after a Writer deck (E12 hang). Then `adopt_chat_sidebar(ctx, calc)` for the live Calc deck. Headless `make test-uno` hidden `_blank` factory loads stay fine.
 
 ---
 

--- a/docs/tests/mock-llm-sidebar.md
+++ b/docs/tests/mock-llm-sidebar.md
@@ -10,16 +10,16 @@ Visual rendering, scroll pin, theme, resize, and “watch the sidebar” cases a
 
 Packets **B through G** run via `testing_runner`. There is no Packet A or H.
 
-This plan is **finished** except one optional follow-up: **Calc deck URP hang** (E12 / G17). Mouse Stop, HITL Change dialog, live DuckDuckGo, and F11/F18 wait mismatches are dropped — not a backlog.
+This plan is **finished**. Mouse Stop, HITL Change dialog, live DuckDuckGo, and F11/F18 wait mismatches are dropped — not a backlog.
 
 | Packet | Focus Area | Mode | Status |
 |:------:|------------|:----:|--------|
 | **[Packet B](#packet-b--stop-drain-loop-sendrecord-fsm)** | Stop button, drain loop, Send/Record FSM | Automated (CI) | **Done.** 16 Landed (incl. B13). |
 | **[Packet C](#packet-c--empty--truncated-model)** | Empty / truncated model responses & banners | Automated (CI) | **Done.** 4 Landed. |
 | **[Packet D](#packet-d--reasoning-vs-content)** | Reasoning deltas (`[Thinking]`) vs HTML content | Automated (CI) | **Done.** 4 Landed. |
-| **[Packet E](#packet-e--tools-delegate-hitl-context-refresh)** | Tool loop, nested delegate, HITL, context refresh | Automated (CI) | **Done.** 17 Landed. Optional: E12 Calc hang. |
+| **[Packet E](#packet-e--tools-delegate-hitl-context-refresh)** | Tool loop, nested delegate, HITL, context refresh | Automated (CI) | **Done.** 18 Landed (incl. E12 Calc). |
 | **[Packet F](#packet-f--http--sse-errors-and-hangs)** | HTTP 4xx/5xx errors, socket hangs, SSE quirks | Automated (CI) | **Done.** 15 Landed. |
-| **[Packet G](#packet-g--mocked-audio-and-stt)** | Mocked Record / Stop Rec, `input_audio`, STT | Automated (CI) | **Done.** 20 Landed. Optional: G17 same Calc hang as E12. |
+| **[Packet G](#packet-g--mocked-audio-and-stt)** | Mocked Record / Stop Rec, `input_audio`, STT | Automated (CI) | **Done.** 21 Landed (incl. G17 Calc deck). |
 
 
 
@@ -95,6 +95,8 @@ make test-mock-sidebar FILTER=E        # Run Packet E (Tools & HITL)
 make test-mock-sidebar FILTER=F        # Run Packet F (HTTP/SSE errors)
 make test-mock-sidebar FILTER=G        # Run Packet G (Mocked audio & STT)
 make test-mock-sidebar FILTER=b13      # Run a single case by ID
+make test-mock-sidebar FILTER=e12      # Calc list_sheets (opens Calc after Writer deck)
+make test-mock-sidebar FILTER=g17      # Calc deck native audio (same open helper as E12)
 make test-mock-sidebar FILTER="B E"    # Run multiple packets
 ```
 
@@ -120,6 +122,7 @@ Linux starts a virtual framebuffer (`xvfb-run` + `dbus-run-session`) because `te
 - **Sidebar Deck Activation:** Tests dispatch `.uno:SidebarDeck.WriterAgentDeck` to show the deck. When already visible, `showDecks` / `XDeck.activate` is used to prevent accidental toggling.
 - **Thread Guard:** Dev builds set `WRITERAGENT_UNO_THREAD_GUARD=0` in the child process so URP deck dispatch can initialize `ChatPanel`.
 - **Out-of-Process URP:** Live `SendButtonListener` runs inside `soffice`. Tests drive actions via `uno_click`, query text manipulation, and polling `Enabled` properties. Do not call `processEventsToIdle()` directly on the URP bridge.
+- **Opening Calc after a Writer deck:** Do **not** call `desktop.loadComponentFromURL("private:factory/scalc", …)` from the URP test process. After setup shows the Writer deck, that call never returns (120s watchdog; last mock log is often `GET /v1/models`). File→New Spreadsheet by hand is a different path — it starts on VCL. Use `open_calc_document(ctx)` in [`sidebar_test_hooks.py`](../../plugin/chatbot/sidebar_test_hooks.py): it dispatches `chatbot.debug_sidebar.OPEN_CALC`, which posts `factory/scalc` + `_blank` onto soffice `QueueExecutor` (force-marshal; same Dummy-thread rule as Packet G). The URP client polls `XDesktop.getComponents()` until a Calc model appears. Then `adopt_chat_sidebar(ctx, calc)` shows WriterAgentDeck on that frame. Dual-peer tests must keep Writer open (`_blank`, never `_default`) and close Calc in `finally` if later cases expect the Writer session. Isolated: `make test-mock-sidebar FILTER=e12` (or `FILTER=g17`).
 
 ### 2.4. Test Harness & Hooks Reference
 
@@ -144,6 +147,8 @@ Debug test hooks live in [`plugin/chatbot/sidebar_test_hooks.py`](../../plugin/c
 | `stub_recorder_child()` | Fakes IPC: `{"status":"ready"}` without opening hardware device. `hang_ready=True` never emits ready (G21 timeout) | Audio init vs recording state |
 | `set_audio_supported(bool)` | Overrides `SendButtonState.audio_supported` | Audio support gating (G8, STT) |
 | `audio_status()` | Returns `AudioRecorderState.status` and `has_audio` | Audio state assertions |
+| `open_calc_document(ctx)` | Posts `factory/scalc` onto soffice VCL (`OPEN_CALC`); polls until a Calc model exists | E12 / G17 / dual-peer Writer+Calc |
+| `adopt_chat_sidebar(ctx, doc)` | Show WriterAgentDeck on *doc*; return `(controls, send_listener)` | Bind Calc (or Writer) deck after open |
 | `press_accept()` | Fires Send action when label is `Accept` | HITL approval |
 | `press_change()` / `press_reject()` | Fires Stop listener `Change` / `Reject` branch | HITL change / rejection |
 | `approval_active()` | Checks if `_approval_event is not None` | HITL state verification |
@@ -245,8 +250,7 @@ Every test must satisfy:
 - **Focus:** Executing UNO mutations on the UI thread during drain, nested agent delegation, Human-in-the-Loop (HITL) approval, document context refresh.
 - **Mode:** Automated (`make test-mock-sidebar FILTER=E`).
 - **Status Summary:**
-  - **Landed:** E1, E3, E4, E5, E6, E7, E8a, E9, E9a, E9b, E9e, E10, E11, E13, E14, E15, E17, E21, E22.
-  - **Optional later:** E12 (Calc URP hang — same as G17).
+  - **Landed:** E1, E3, E4, E5, E6, E7, E8a, E9, E9a, E9b, E9e, E10, E11, E12, E13, E14, E15, E17, E21, E22.
   - **Dropped:** E2 (live net), E8b/E9d (mouse), E9c (Change dialog), E16, E18, E19, E20, E23, E24.
 
 | ID | Mode | Mock / Trigger | Steps / Actions | Expected Pass Behavior | Status / Notes |
@@ -268,7 +272,7 @@ Every test must satisfy:
 | **E9e** | CI | E9 state | Call `press_stop()` ActionEvent | Dispatches Change/Reject branch, NOT `StopSendEffect` | **OK / Landed** |
 | **E10** | CI | Tool follow-up returning 500 | Send tool query | Tool error displayed in transcript; returns to idle; `next_hello_ok()` | **OK / Landed** |
 | **E11** | CI | `insert filler` then `add a comment` | Send as two sequential turns | Both mutations applied; context refreshed between turns; `next_hello_ok()` | **OK / Landed** |
-| **E12** | CI | Calc doc, `list sheets` | Send in Calc sidebar | `list_sheets` executes; HTML wrap-up | **Optional** (URP hang on `factory/scalc` even isolated `FILTER=e12`; GUI two-window Calc chat does not repro) |
+| **E12** | CI | Calc doc, `list sheets` | `open_calc_document` + Calc deck send | `list_sheets` executes; HTML wrap-up; Writer session restored | **OK / Landed** |
 | **E13** | CI | `add_comment` with mock tool delay | Call `press_stop()` during tool execution | Partial/no mutation; not stuck busy; no UI freeze; `next_hello_ok()` | **OK / Landed** |
 | **E14** | CI | `outline this` | Run delegate twice in succession | Nested agent functions repeatedly without stale session leaks; `next_hello_ok()` | **OK / Landed** |
 | **E15** | CI | `insert filler` | Stop after tool result queued, before HTML | Mutation applied; UI returns to idle; no double drain; `next_hello_ok()` | **OK / Landed** |
@@ -331,8 +335,7 @@ Every test must satisfy:
 - **Focus:** Dual state machines (`SendButtonState` vs `AudioRecorderState`), mock audio child process via IPC stub (`/tmp/writeragent_stub_recorder.json`), native `input_audio` chat completions, fallback to `/v1/audio/transcriptions` STT.
 - **Mode:** Automated (`make test-mock-sidebar FILTER=G`).
 - **Status Summary:**
-  - **Landed:** G1–G16, G21, G27, G28, G29.
-  - **Optional later:** G17 (same Calc URP hang as E12).
+  - **Landed:** G1–G17, G21, G27, G28, G29.
   - **Dropped:** G18 (HITL Record), G19–G26, G30.
 
 | ID | Mode | Mock / Trigger | Steps / Actions | Expected Pass Behavior | Status / Notes |
@@ -353,7 +356,7 @@ Every test must satisfy:
 | **G14** | CI | Missing / 0-byte WAV | Record → Stop Rec with missing WAV | Send aborted or error surfaced; returns to idle; `next_hello_ok()` | **OK / Landed** |
 | **G15** | CI | Active recording | Call `press_send()` while recording | FSM ignores Send; recording continues; Stop Rec then send succeeds | **OK / Landed** |
 | **G16** | CI | Rapid retake | Record → Stop Rec → immediately Record again | Second recording replaces previous audio; single in-flight capture | **OK / Landed** |
-| **G17** | CI | Calc deck | G1 flow in Calc sidebar | Native audio path functions on Calc deck | **Optional** (same Calc URP hang as E12) |
+| **G17** | CI | Calc deck | G1 flow after `open_calc_document` | Native audio path functions on Calc deck; Writer session restored | **OK / Landed** |
 | **G18** | CI | HITL active | Call `press_record()` during HITL approval | Record ignored (approval owns button states); E9 flow remains valid | **Dropped** (HITL; E9 covers approval buttons) |
 | **G21** | CI | Stub hang (`hang_ready`) | Record with child that never reports `ready` | Init timeout fires; `audio_status` error; returns to idle Send; `next_hello_ok()` | **OK / Landed** |
 | **G27** | CI | STT empty text | STT returns empty string from valid WAV | Query stays empty; no chat send; returns to idle; `next_hello_ok()` | **OK / Landed** |

--- a/docs/tests/mock-llm-sidebar.md
+++ b/docs/tests/mock-llm-sidebar.md
@@ -272,7 +272,7 @@ Every test must satisfy:
 | **E9e** | CI | E9 state | Call `press_stop()` ActionEvent | Dispatches Change/Reject branch, NOT `StopSendEffect` | **OK / Landed** |
 | **E10** | CI | Tool follow-up returning 500 | Send tool query | Tool error displayed in transcript; returns to idle; `next_hello_ok()` | **OK / Landed** |
 | **E11** | CI | `insert filler` then `add a comment` | Send as two sequential turns | Both mutations applied; context refreshed between turns; `next_hello_ok()` | **OK / Landed** |
-| **E12** | CI | Calc doc, `list sheets` | `open_calc_document` + Calc deck send | `list_sheets` executes; HTML wrap-up; Writer session restored | **OK / Landed** |
+| **E12** | CI | Calc doc, `list sheets` | `open_calc_document` + Calc deck send | Calc tools advertised; `get_sheet_summary` (or `list_sheets` if specialized is on the wire); HTML wrap-up; Writer session restored | **OK / Landed** |
 | **E13** | CI | `add_comment` with mock tool delay | Call `press_stop()` during tool execution | Partial/no mutation; not stuck busy; no UI freeze; `next_hello_ok()` | **OK / Landed** |
 | **E14** | CI | `outline this` | Run delegate twice in succession | Nested agent functions repeatedly without stale session leaks; `next_hello_ok()` | **OK / Landed** |
 | **E15** | CI | `insert filler` | Stop after tool result queued, before HTML | Mutation applied; UI returns to idle; no double drain; `next_hello_ok()` | **OK / Landed** |

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -150,12 +150,14 @@ def _read_debug_snapshot() -> dict[str, Any]:
 
 
 def handle_debug_sidebar_command(command: str) -> None:
-    """Run inside soffice (protocol handler). Packet G URP FSM ops.
+    """Run inside soffice (protocol handler). Packet G URP FSM ops + OPEN_CALC.
 
     ``DispatchHandler`` runs on the URP thread. ``WRITERAGENT_TESTING=1`` makes
     ``QueueExecutor.post`` inline, so Stop Rec used to start ``_do_send`` off
     the VCL thread and freeze on ``Getting document...``. Marshal FSM work onto
     the listener's executor (VCL) before StartSendEffect posts the drain.
+    ``OPEN_CALC`` uses the same post-to-VCL rule: factory ``scalc`` over URP
+    after a Writer deck never returns.
     """
     _require_debug()
     adopt_runtime_send_listeners()
@@ -163,6 +165,12 @@ def handle_debug_sidebar_command(command: str) -> None:
     op = (rest or "SNAPSHOT").upper().replace("-", "_")
     sl = _listener_with_slash_popup(send_listener())
     if op == "SNAPSHOT":
+        _write_debug_snapshot(sl)
+        return
+    # Factory scalc over URP after a Writer deck never returns (Dummy-thread
+    # load vs VCL). Post the load onto soffice VCL; the URP client polls.
+    if op == "OPEN_CALC":
+        _post_to_soffice_vcl(_load_visible_calc_factory, sl=sl)
         _write_debug_snapshot(sl)
         return
     # Slash ops only touch the Ask ListBox. Run inline like SNAPSHOT —
@@ -358,6 +366,137 @@ def desktop_from_ctx(ctx: Any) -> Any:
 def current_component(ctx: Any) -> Any:
     _require_debug()
     return desktop_from_ctx(ctx).getCurrentComponent()
+
+
+def component_is_calc(doc: Any) -> bool:
+    """``supportsService`` over URP. Do not use ``is_calc`` (``@main_thread_only``)."""
+    _require_debug()
+    if doc is None:
+        return False
+    try:
+        return bool(doc.supportsService("com.sun.star.sheet.SpreadsheetDocument"))
+    except Exception:
+        return False
+
+
+def iter_desktop_components(ctx: Any) -> list[Any]:
+    """Open models from ``XDesktop.getComponents()`` (URP-safe enumeration)."""
+    _require_debug()
+    desktop = desktop_from_ctx(ctx)
+    comps = getattr(desktop, "getComponents", lambda: None)()
+    if comps is None or not hasattr(comps, "createEnumeration"):
+        return []
+    enum = comps.createEnumeration()
+    out: list[Any] = []
+    while True:
+        try:
+            if not enum.hasMoreElements():
+                break
+            out.append(enum.nextElement())
+        except Exception:
+            break
+    return out
+
+
+def find_calc_component(ctx: Any) -> Any:
+    """First open Calc model, or None. Does not load a document."""
+    _require_debug()
+    for doc in iter_desktop_components(ctx):
+        if component_is_calc(doc):
+            return doc
+    return None
+
+
+def close_component(doc: Any) -> None:
+    """Close *doc* if it is still alive. Swallows dispose-after-close."""
+    _require_debug()
+    if doc is None:
+        return
+    try:
+        if hasattr(doc, "close"):
+            doc.close(True)
+        elif hasattr(doc, "dispose"):
+            doc.dispose()
+    except Exception:
+        pass
+
+
+def _load_visible_calc_factory() -> None:
+    """Create a visible Calc on soffice VCL. ``_blank`` keeps the Writer window.
+
+    URP ``loadComponentFromURL('private:factory/scalc')`` after a Writer deck
+    never returns (120s watchdog; File→New Spreadsheet on VCL is fine). This
+    job must run via :func:`_post_to_soffice_vcl`, not on the Dummy URP thread.
+    """
+    from plugin.framework.uno_context import get_ctx, get_desktop
+
+    try:
+        desktop = get_desktop(get_ctx())
+        desktop.loadComponentFromURL("private:factory/scalc", "_blank", 0, ())
+        log.info("OPEN_CALC: loaded factory/scalc _blank on VCL")
+    except Exception:
+        log.exception("OPEN_CALC: factory/scalc _blank failed")
+        raise
+
+
+def _post_to_soffice_vcl(fn: Callable[[], None], *, sl: Any = None) -> None:
+    """Enqueue *fn* on soffice VCL. Do not run it inline on the URP Dummy thread.
+
+    ``WRITERAGENT_TESTING=1`` makes ``QueueExecutor.post`` inline. Force-marshal
+    so AsyncCallback runs the work on VCL. ``execute()`` from URP dispatch
+    deadlocks (office idle, tests wait forever) — same as Packet G FSM ops.
+    """
+    qe = getattr(sl, "queue_executor", None) if sl is not None else None
+    if qe is None:
+        from plugin.framework.queue_executor import default_executor
+
+        qe = default_executor
+    from plugin.framework.queue_executor import set_force_marshal_mode
+
+    set_force_marshal_mode(True)
+    try:
+        qe.post(fn)
+    finally:
+        set_force_marshal_mode(False)
+
+
+def open_calc_document(ctx: Any, *, timeout: float = 30.0) -> Any:
+    """Open a visible Calc after a Writer deck without blocking URP on factory/scalc.
+
+    Dual-peer / E12 / G17 recipe: keep Writer open, call this, then
+    :func:`adopt_chat_sidebar` on the returned model. Never call
+    ``desktop.loadComponentFromURL('private:factory/scalc', …)`` from the
+    URP test process after ``show_writeragent_chat_deck``.
+    """
+    _require_debug()
+    existing = find_calc_component(ctx)
+    if existing is not None:
+        return existing
+    execute_debug_sidebar_op("OPEN_CALC", ctx=ctx)
+    deadline = time.monotonic() + max(0.0, timeout)
+    while time.monotonic() <= deadline:
+        found = find_calc_component(ctx)
+        if found is not None:
+            return found
+        time.sleep(0.25)
+    raise RuntimeError(
+        "Calc did not appear after OPEN_CALC (factory/scalc was posted to VCL; "
+        "do not loadComponentFromURL factory/scalc over URP after a Writer deck)"
+    )
+
+
+def adopt_chat_sidebar(ctx: Any, doc: Any, *, timeout: float = 20.0) -> tuple[Any, Any]:
+    """Show WriterAgentDeck on *doc* and return ``(controls, send_listener)``."""
+    _require_debug()
+    controls = wait_for_chat_dialog_controls(ctx, timeout=timeout, doc=doc)
+    adopt_runtime_send_listeners()
+    frame = None
+    try:
+        if doc is not None:
+            frame = doc.getCurrentController().getFrame()
+    except Exception:
+        frame = None
+    return controls, send_listener(frame)
 
 
 def uno_click(control: Any) -> None:
@@ -670,8 +809,14 @@ def show_writeragent_chat_deck(ctx: Any, doc: Any) -> None:
     _activate_writeragent_deck(provider)
 
 
-def wait_for_chat_dialog_controls(ctx: Any, timeout: float = 20.0) -> dict[str, Any] | None:
-    """Show WriterAgentDeck until query+send exist. Does not pump VCL over URP."""
+def wait_for_chat_dialog_controls(
+    ctx: Any, timeout: float = 20.0, *, doc: Any = None
+) -> dict[str, Any] | None:
+    """Show WriterAgentDeck until query+send exist. Does not pump VCL over URP.
+
+    Pass *doc* to target a specific model (Calc after :func:`open_calc_document`).
+    Default is ``current_component``.
+    """
     global _HOOK_CTX
     _HOOK_CTX = ctx
     _require_debug()
@@ -679,9 +824,9 @@ def wait_for_chat_dialog_controls(ctx: Any, timeout: float = 20.0) -> dict[str, 
     last: dict[str, Any] | None = None
     while time.monotonic() <= deadline:
         try:
-            doc = current_component(ctx)
-            show_writeragent_chat_deck(ctx, doc)
-            last = chat_dialog_controls(ctx, doc)
+            target = doc if doc is not None else current_component(ctx)
+            show_writeragent_chat_deck(ctx, target)
+            last = chat_dialog_controls(ctx, target)
             if last is not None:
                 return last
         except Exception:
@@ -702,7 +847,9 @@ def control_enabled(control: Any) -> bool | None:
         return None
 
 
-def ensure_sidebar_chat_mode(controls: dict[str, Any] | None) -> None:
+def ensure_sidebar_chat_mode(
+    controls: dict[str, Any] | None, *, doc_type: str = "writer"
+) -> None:
     """Select main Chat (not Librarian) so Packet F hits the chat completions path."""
     _require_debug()
     if not controls:
@@ -715,7 +862,7 @@ def ensure_sidebar_chat_mode(controls: dict[str, Any] | None) -> None:
             sidebar_mode_flags_for_doc_type,
         )
 
-        set_selector_mode_with_flags(sel, CHAT_MODE_CHAT, sidebar_mode_flags_for_doc_type("writer"))
+        set_selector_mode_with_flags(sel, CHAT_MODE_CHAT, sidebar_mode_flags_for_doc_type(doc_type))
     sl = send_listener()
     if sl is not None:
         apply_fn = getattr(sl, "_apply_sidebar_mode_fn", None)

--- a/plugin/chatbot/sidebar_test_hooks.py
+++ b/plugin/chatbot/sidebar_test_hooks.py
@@ -161,7 +161,9 @@ def handle_debug_sidebar_command(command: str) -> None:
     """
     _require_debug()
     adopt_runtime_send_listeners()
-    rest = command[len(_DEBUG_SIDEBAR_PREFIX) :].lstrip(".")
+    # DispatchHandler joins Path+Query with ``.``, but LO often leaves the op
+    # in Path as ``chatbot.debug_sidebar?OPEN_CALC`` (Query empty). Strip both.
+    rest = command[len(_DEBUG_SIDEBAR_PREFIX) :].lstrip(".?")
     op = (rest or "SNAPSHOT").upper().replace("-", "_")
     sl = _listener_with_slash_popup(send_listener())
     if op == "SNAPSHOT":
@@ -170,6 +172,7 @@ def handle_debug_sidebar_command(command: str) -> None:
     # Factory scalc over URP after a Writer deck never returns (Dummy-thread
     # load vs VCL). Post the load onto soffice VCL; the URP client polls.
     if op == "OPEN_CALC":
+        log.info("debug_sidebar OPEN_CALC posting factory/scalc to VCL sl=%s", sl is not None)
         _post_to_soffice_vcl(_load_visible_calc_factory, sl=sl)
         _write_debug_snapshot(sl)
         return
@@ -451,6 +454,15 @@ def _post_to_soffice_vcl(fn: Callable[[], None], *, sl: Any = None) -> None:
         from plugin.framework.queue_executor import default_executor
 
         qe = default_executor
+    # force_marshal skips _get_async_callback inside post(); without a prior
+    # init, _poke_main_thread is a no-op and the factory load never runs
+    # (E12 2026-09-08: "poke skipped (no AsyncCallback)" after OPEN_CALC).
+    init_cb = getattr(qe, "_get_async_callback", None)
+    if callable(init_cb):
+        try:
+            init_cb()
+        except Exception:
+            log.exception("debug_sidebar: AsyncCallback init failed")
     from plugin.framework.queue_executor import set_force_marshal_mode
 
     set_force_marshal_mode(True)

--- a/scripts/mock_llm_server.py
+++ b/scripts/mock_llm_server.py
@@ -977,7 +977,10 @@ def _scenario_user_turn(
             turn,
         )
     if scenario == "list_sheets":
-        return _tool_or_html(tool_names, "list_sheets", {}, user_text, turn)
+        # list_sheets is specialized-tier (sheets domain). Main Calc chat
+        # advertises get_sheet_summary instead — E12 uses that fallback.
+        name = "list_sheets" if "list_sheets" in tool_names else "get_sheet_summary"
+        return _tool_or_html(tool_names, name, {}, user_text, turn)
     if scenario == "list_pages":
         return _tool_or_html(tool_names, "list_pages", {}, user_text, turn)
     if scenario == "tree":

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -1655,11 +1655,16 @@ def test_e12_calc_list_sheets(ctx):
         _send_and_wait("list sheets", timeout=60.0)
         snaps = _captures()
         decided: list[str] = []
+        advertised: list[str] = []
         for row in snaps:
             decided.extend(row.get("decided_tools") or [])
-        assert "list_sheets" in decided, (
-            "E12 expected list_sheets on Calc deck, decided=%r snaps=%r"
-            % (decided, snaps[-5:])
+            advertised.extend(row.get("advertised_tools") or [])
+        assert "write_formula_range" in advertised or "get_sheet_summary" in advertised, (
+            "E12 expected Calc-deck tools, advertised=%r" % advertised
+        )
+        # list_sheets is specialized-tier; main Calc chat uses get_sheet_summary.
+        assert "list_sheets" in decided or "get_sheet_summary" in decided, (
+            "E12 expected a Calc list tool, decided=%r snaps=%r" % (decided, snaps[-5:])
         )
         _hello_ok()
     finally:

--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -1607,13 +1607,63 @@ def test_e11_filler_then_comment_two_sends(ctx):
     _hello_ok()
 
 
+def _adopt_calc_sidebar(ctx, calc):
+    """Bind the Calc WriterAgent deck after :func:`open_calc_document`."""
+    from plugin.chatbot.sidebar_test_hooks import (
+        adopt_chat_sidebar,
+        ensure_sidebar_chat_mode,
+    )
+
+    controls, sl = adopt_chat_sidebar(ctx, calc)
+    if sl is None and controls is None:
+        raise AssertionError("Calc WriterAgent chat sidebar not wired after OPEN_CALC")
+    ensure_sidebar_chat_mode(controls, doc_type="calc")
+    assert _session is not None
+    _session.controls = controls
+    _session.listener = sl
+
+
+def _restore_writer_after_calc(ctx, writer, calc, saved_controls, saved_listener) -> None:
+    """Close the E12/G17 Calc window and point the shared session back at Writer."""
+    from plugin.chatbot.sidebar_test_hooks import (
+        adopt_runtime_send_listeners,
+        close_component,
+        wait_for_chat_dialog_controls,
+    )
+
+    close_component(calc)
+    if writer is not None:
+        wait_for_chat_dialog_controls(ctx, timeout=15.0, doc=writer)
+    adopt_runtime_send_listeners()
+    if _session is not None:
+        _session.controls = saved_controls
+        _session.listener = saved_listener
+
+
 @native_test
 def test_e12_calc_list_sheets(ctx):
-    # Isolated FILTER=e12 still hangs (2026-08-30): after setup's Writer deck,
-    # desktop.loadComponentFromURL("private:factory/scalc", "_default", …) never
-    # returns over URP (120s timeout; last mock log was GET /v1/models). Not a
-    # "two GUI windows" bug — File→New Spreadsheet by hand is a different path.
-    raise unittest.SkipTest("E12 URP hang on factory/scalc after Writer deck; isolate later")
+    from plugin.chatbot.sidebar_test_hooks import current_component, open_calc_document
+
+    _reset_mock_runtime()
+    writer = current_component(ctx)
+    saved_controls = getattr(_session, "controls", None)
+    saved_listener = getattr(_session, "listener", None)
+    calc = None
+    try:
+        calc = open_calc_document(ctx)
+        _adopt_calc_sidebar(ctx, calc)
+        _send_and_wait("list sheets", timeout=60.0)
+        snaps = _captures()
+        decided: list[str] = []
+        for row in snaps:
+            decided.extend(row.get("decided_tools") or [])
+        assert "list_sheets" in decided, (
+            "E12 expected list_sheets on Calc deck, decided=%r snaps=%r"
+            % (decided, snaps[-5:])
+        )
+        _hello_ok()
+    finally:
+        _restore_writer_after_calc(ctx, writer, calc, saved_controls, saved_listener)
 
 
 @native_test
@@ -2141,8 +2191,30 @@ def test_g16_second_take_replaces_audio(ctx):
 
 
 @native_test
-def test_g17_calc_deck_skipped(ctx):
-    raise unittest.SkipTest("G17 Calc deck: isolate like E12; do not open Calc from Packet G")
+def test_g17_calc_deck_native_audio(ctx):
+    from plugin.chatbot.sidebar_test_hooks import audio_status, current_component, open_calc_document
+
+    writer = current_component(ctx)
+    saved_controls = getattr(_session, "controls", None)
+    saved_listener = getattr(_session, "listener", None)
+    calc = None
+    try:
+        calc = open_calc_document(ctx)
+        _adopt_calc_sidebar(ctx, calc)
+        sl = _g_prep()
+        _g_record_and_stop(sl, _WAV_1S)
+        body = _transcript().lower()
+        assert "mock microphone" in body or "mock transcript" in body, (
+            "G17 expected canned transcript on Calc deck: %r" % _transcript()[-500:]
+        )
+        snaps = _captures()
+        assert any(row.get("has_input_audio") for row in snaps), (
+            "G17 expected input_audio on chat POST, snaps=%r" % snaps[-5:]
+        )
+        assert audio_status(listener=sl)["has_audio"] is False
+        _hello_ok()
+    finally:
+        _restore_writer_after_calc(ctx, writer, calc, saved_controls, saved_listener)
 
 
 @native_test

--- a/tests/chatbot/test_sidebar_test_hooks.py
+++ b/tests/chatbot/test_sidebar_test_hooks.py
@@ -876,6 +876,43 @@ def test_handle_debug_sidebar_open_calc_posts_to_queue(fake_listener, monkeypatc
     assert loaded == [True]
 
 
+def test_handle_debug_sidebar_open_calc_accepts_query_form(fake_listener, monkeypatch) -> None:
+    """LO often delivers Path as ``chatbot.debug_sidebar?OPEN_CALC`` (Query empty)."""
+    posted: list = []
+    fake_listener.queue_executor = SimpleNamespace(post=lambda fn, *a, **k: posted.append(fn))
+    loaded: list[bool] = []
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.adopt_runtime_send_listeners", lambda: 0)
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.send_listener", lambda frame=None: fake_listener
+    )
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks._load_visible_calc_factory",
+        lambda: loaded.append(True),
+    )
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks._write_debug_snapshot", lambda sl: {}
+    )
+    handle_debug_sidebar_command("chatbot.debug_sidebar?OPEN_CALC")
+    assert posted
+    posted[0]()
+    assert loaded == [True]
+
+
+def test_post_to_soffice_vcl_inits_async_callback(monkeypatch) -> None:
+    inited: list[bool] = []
+    posted: list = []
+    qe = SimpleNamespace(
+        _get_async_callback=lambda: inited.append(True),
+        post=lambda fn, *a, **k: posted.append(fn),
+    )
+    sl = SimpleNamespace(queue_executor=qe)
+    from plugin.chatbot.sidebar_test_hooks import _post_to_soffice_vcl
+
+    _post_to_soffice_vcl(lambda: None, sl=sl)
+    assert inited == [True]
+    assert posted
+
+
 def test_adopt_chat_sidebar_shows_deck_on_doc(monkeypatch) -> None:
     doc = SimpleNamespace(
         getCurrentController=lambda: SimpleNamespace(getFrame=lambda: "calc-frame")

--- a/tests/chatbot/test_sidebar_test_hooks.py
+++ b/tests/chatbot/test_sidebar_test_hooks.py
@@ -25,7 +25,6 @@ from plugin.chatbot.sidebar_state import SidebarCompositeState
 from plugin.chatbot.sidebar_test_hooks import (
     approval_active,
     audio_status,
-    handle_debug_sidebar_command,
     chat_dialog_controls,
     control_enabled,
     debug_hooks_available,
@@ -60,6 +59,12 @@ from plugin.chatbot.sidebar_test_hooks import (
     transcript_text,
     wait_controls_send_finished,
     wait_idle,
+    adopt_chat_sidebar,
+    close_component,
+    component_is_calc,
+    find_calc_component,
+    handle_debug_sidebar_command,
+    open_calc_document,
 )
 from tests.chatbot.mock_llm_harness import mock_config
 
@@ -772,3 +777,150 @@ def test_wait_controls_send_finished_wait_for_ignores_prior_turns(monkeypatch) -
         before=prior,
     )
     assert ok is False
+
+
+def test_component_is_calc_uses_supports_service() -> None:
+    calc = SimpleNamespace(
+        supportsService=lambda name: name == "com.sun.star.sheet.SpreadsheetDocument"
+    )
+    writer = SimpleNamespace(supportsService=lambda name: False)
+    assert component_is_calc(calc) is True
+    assert component_is_calc(writer) is False
+    assert component_is_calc(None) is False
+
+
+def test_find_calc_component_scans_desktop(monkeypatch) -> None:
+    calc = SimpleNamespace(
+        supportsService=lambda name: name == "com.sun.star.sheet.SpreadsheetDocument"
+    )
+    writer = SimpleNamespace(supportsService=lambda name: False)
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.iter_desktop_components",
+        lambda _ctx: [writer, calc],
+    )
+    assert find_calc_component(object()) is calc
+
+
+def test_open_calc_document_reuses_existing(monkeypatch) -> None:
+    calc = SimpleNamespace(
+        supportsService=lambda name: name == "com.sun.star.sheet.SpreadsheetDocument"
+    )
+    dispatched: list[str] = []
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.find_calc_component", lambda _ctx: calc
+    )
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.execute_debug_sidebar_op",
+        lambda op, ctx=None: dispatched.append(op),
+    )
+    assert open_calc_document(object()) is calc
+    assert dispatched == []
+
+
+def test_open_calc_document_posts_open_calc_and_polls(monkeypatch) -> None:
+    calc = SimpleNamespace(
+        supportsService=lambda name: name == "com.sun.star.sheet.SpreadsheetDocument"
+    )
+    calls = {"n": 0, "ops": []}
+
+    def fake_find(_ctx):
+        calls["n"] += 1
+        return calc if calls["n"] >= 2 else None
+
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.find_calc_component", fake_find)
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.execute_debug_sidebar_op",
+        lambda op, ctx=None: calls["ops"].append(op),
+    )
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.time.sleep", lambda _s: None)
+    assert open_calc_document(object(), timeout=5.0) is calc
+    assert calls["ops"] == ["OPEN_CALC"]
+
+
+def test_open_calc_document_times_out(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.find_calc_component", lambda _ctx: None
+    )
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.execute_debug_sidebar_op",
+        lambda op, ctx=None: {},
+    )
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.time.sleep", lambda _s: None)
+    times = iter([0.0, 0.0, 10.0])
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.time.monotonic",
+        lambda: next(times),
+    )
+    with pytest.raises(RuntimeError, match="OPEN_CALC"):
+        open_calc_document(object(), timeout=1.0)
+
+
+def test_handle_debug_sidebar_open_calc_posts_to_queue(fake_listener, monkeypatch) -> None:
+    posted: list = []
+    fake_listener.queue_executor = SimpleNamespace(post=lambda fn, *a, **k: posted.append(fn))
+    loaded: list[bool] = []
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.adopt_runtime_send_listeners", lambda: 0)
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.send_listener", lambda frame=None: fake_listener
+    )
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks._load_visible_calc_factory",
+        lambda: loaded.append(True),
+    )
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks._write_debug_snapshot", lambda sl: {}
+    )
+    handle_debug_sidebar_command("chatbot.debug_sidebar.OPEN_CALC")
+    assert posted
+    posted[0]()
+    assert loaded == [True]
+
+
+def test_adopt_chat_sidebar_shows_deck_on_doc(monkeypatch) -> None:
+    doc = SimpleNamespace(
+        getCurrentController=lambda: SimpleNamespace(getFrame=lambda: "calc-frame")
+    )
+    shown: list = []
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.wait_for_chat_dialog_controls",
+        lambda ctx, timeout=20.0, doc=None: shown.append(doc) or {"query": 1, "send": 1},
+    )
+    monkeypatch.setattr("plugin.chatbot.sidebar_test_hooks.adopt_runtime_send_listeners", lambda: 0)
+    monkeypatch.setattr(
+        "plugin.chatbot.sidebar_test_hooks.send_listener",
+        lambda frame=None: "sl-%s" % frame,
+    )
+    controls, sl = adopt_chat_sidebar(object(), doc)
+    assert shown == [doc]
+    assert controls == {"query": 1, "send": 1}
+    assert sl == "sl-calc-frame"
+
+
+def test_load_visible_calc_factory_uses_blank_target(monkeypatch) -> None:
+    """Dual-peer needs Writer to stay open — factory load must use ``_blank``."""
+    calls: list[tuple] = []
+
+    class _Desktop:
+        def loadComponentFromURL(self, url, target, _flags, _props):
+            calls.append((url, target))
+            return "calc"
+
+    monkeypatch.setattr(
+        "plugin.framework.uno_context.get_ctx", lambda: object()
+    )
+    monkeypatch.setattr(
+        "plugin.framework.uno_context.get_desktop", lambda _ctx: _Desktop()
+    )
+    from plugin.chatbot.sidebar_test_hooks import _load_visible_calc_factory
+
+    _load_visible_calc_factory()
+    assert calls == [("private:factory/scalc", "_blank")]
+
+
+def test_close_component_swallows_errors() -> None:
+    class _Boom:
+        def close(self, _unused: bool) -> None:
+            raise RuntimeError("disposed")
+
+    close_component(None)
+    close_component(_Boom())

--- a/tests/scripts/test_mock_llm_server.py
+++ b/tests/scripts/test_mock_llm_server.py
@@ -997,6 +997,14 @@ def test_mutate_and_calc_draw_thin_tools():
         cfg,
     )
     assert sheets.tool_name == "list_sheets"
+    sheets_core = decide_completion(
+        {
+            "messages": [{"role": "user", "content": "list sheets"}],
+            "tools": _tools("get_sheet_summary"),
+        },
+        cfg,
+    )
+    assert sheets_core.tool_name == "get_sheet_summary"
     pages = decide_completion(
         {"messages": [{"role": "user", "content": "list pages"}], "tools": _tools("list_pages")},
         cfg,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Packet E12 hung because `desktop.loadComponentFromURL("private:factory/scalc", "_default", …)` after a Writer deck never returns over URP (Dummy-thread VCL deadlock). File→New Spreadsheet starts on VCL and is fine.

This un-skips E12 and G17 with a **test-only** open path. No product chat/tool behavior change.

**Rebased onto `master` @ `0fd95b42` (#673).** The only conflict was `docs/chat/peer-messaging.md`: kept #673's specialized-inner wording and appended the E12 `OPEN_CALC` / `open_calc_document` recipe. **0 behind / 3 ahead.**

**CI:** [PR CI / Test & Typecheck](https://github.com/KeithCu/writeragent/actions/runs/34286230775) on `bd2dc639` is **SUCCESS** (typecheck, pytest, UNO, packaging). Default PR CI skips `make test-mock-sidebar` unless `test_mock_sidebar` is requested; E12/G17 were verified locally on this branch.

## What was wrong

Two stacked test-harness bugs:

1. **Dispatch op never matched.** LibreOffice logs `chatbot.debug_sidebar?OPEN_CALC` with `?` left in Path and empty Query. The hook only stripped `.`, so op was `?OPEN_CALC` and OPEN_CALC never ran.
2. **Force-marshal post was a no-op.** `WRITERAGENT_TESTING=1` makes `QueueExecutor.post` inline; `set_force_marshal_mode(True)` skips `_get_async_callback()`, so `_poke_main_thread` logged `poke skipped (no AsyncCallback)` and the factory load never ran.

## Fix (test harness only; `sidebar_test_hooks.py` is omitted from release OXTs)

- Parse debug ops with `.lstrip(".?")`.
- `OPEN_CALC`: `_post_to_soffice_vcl(_load_visible_calc_factory)` — init `qe._get_async_callback()` first, then `set_force_marshal_mode(True)` + `post`.
- Load `private:factory/scalc` with `_blank` (keeps Writer open for dual-peer).
- Client helpers: `open_calc_document`, `adopt_chat_sidebar`, `find_calc_component`, `close_component`.
- `wait_for_chat_dialog_controls(..., doc=)` optional target.
- Mock fallback: scenario `list_sheets` calls `get_sheet_summary` when `list_sheets` is not advertised (`list_sheets` is specialized-tier).

## Tests

- `test_e12_calc_list_sheets` — open Calc → adopt deck → send `list sheets` → assert Calc tools advertised + `get_sheet_summary` or `list_sheets` → `_hello_ok()`.
- `test_g17_calc_deck_native_audio` — same open path, then G1 native audio on Calc deck.

```bash
make cache   # required so soffice OXT has OPEN_CALC
make test-mock-sidebar FILTER=e12
make test-mock-sidebar FILTER=g17
```

## Dual-peer recipe

```python
calc = open_calc_document(ctx)   # never URP factory/scalc after Writer deck
controls, sl = adopt_chat_sidebar(ctx, calc)
```

## Docs

- `docs/tests/mock-llm-sidebar.md` — E12/G17 landed.
- `docs/chat/peer-messaging.md` — dual-peer UNO recipe (merged with #673).
- Makefile help mentions `e12 / g17`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b90a04b5-cb40-48f1-84e5-27a95dfd78d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b90a04b5-cb40-48f1-84e5-27a95dfd78d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

