### PR TITLE
Marshal specialized peer catalog off the async tool worker

### DIFF
--- a/docs/chat/peer-messaging.md
+++ b/docs/chat/peer-messaging.md
@@ -381,7 +381,7 @@ Concrete touch points so this is implementable without rediscovering the review.
 | MCP hide | [`plugin/mcp/mcp_protocol.py`](../../plugin/mcp/mcp_protocol.py) | Add `"chat"` to both MCP exclude frozensets. |
 | Extracted send | `SendButtonListener` / `ToolCallingMixin` | New method: set peer busy FSM + **new** `SendCancellation` + `agent_session`; `refresh_document_context`; `add_user_message` **once** (or skip append if already injected); `_append_response` user line; force chat-with-tools; **do not** read/clear Ask, `setFocus`, or route librarian/image (error if peer mode is not chat). |
 | Pending start | [`async_drain_guard.py`](../../plugin/framework/async_drain_guard.py) or drain `finally` | When depth hits 0, start next scheduled extracted send. Never `post(_run_send_drain)` while owned. |
-| Prompts | [`plugin/framework/prompts.py`](../../plugin/framework/prompts.py) | Outer: thin `PEER_OUTER_DELEGATE_HINT`. Inner: short `PEER_INNER_CHOICE_RULES`. No #672 PEER SIDEBARS dump on main. |
+| Prompts | [`plugin/framework/prompts.py`](../../plugin/framework/prompts.py) | Outer: thin `PEER_OUTER_DELEGATE_HINT`. Inner: short `PEER_INNER_CHOICE_RULES`. No #672 PEER SIDEBARS dump on main. Inner catalog (`list_v1_peers` / `getRuntimeUID`) is gathered on the UI thread before the async specialize worker builds the smol prompt (`specialized_base._fetch_domain_tools`); `get_peer_inner_choice_block` also marshals if called off-main. |
 | Errors | `self._tool_error(...)` | Codes in [§4.4](#44-addressing). |
 
 **Tests (required):**

--- a/docs/framework/uno-thread-safety.md
+++ b/docs/framework/uno-thread-safety.md
@@ -280,7 +280,7 @@ All UNO objects must be wrapped at birth using `guard_uno(obj)` or obtained via 
 ## 9. Specialized Sub-Agents & Tools Threading
 
 Specialized sub-agents (`plugin/doc/specialized_base.py`) run `DelegateToSpecializedBase.execute` on background worker threads when `is_async()` is True.
-- **Scaffolding**: `get_tools(doc=...)`, shapes canvas, and open-documents enumeration must marshal through `execute_on_main_thread()`.
+- **Scaffolding**: `get_tools(doc=...)`, shapes canvas, open-documents enumeration, and the document_research workflow hint (peer catalog via `list_v1_peers` / `getRuntimeUID`) must marshal through `execute_on_main_thread()`.
 - **Sync Domain Tools**: Run via `SmolToolAdapter` which marshals tool execution to the main thread by default.
 - **Async Domain Tools** (`image_generate`, `delegate_read_document`): Run on caller worker threads and must marshal PyUNO access internally inside their own `execute_safe()` methods. Verified in [`tests/doc/test_specialized_delegation_threading.py`](../../tests/doc/test_specialized_delegation_threading.py).
 

--- a/plugin/doc/document_research.py
+++ b/plugin/doc/document_research.py
@@ -109,7 +109,12 @@ def guess_doc_type_from_path(path: str) -> DocTypeGuess:
 
 
 def get_document_research_workflow_hint(ctx=None, doc=None) -> str:
-    """Outer document_research sub-agent workflow text."""
+    """Outer document_research sub-agent workflow text.
+
+    The peer-choice suffix calls ``list_v1_peers`` (RuntimeUID / desktop).
+    Specialized execute gathers this on the main thread; the suffix also
+    marshals if invoked off-main.
+    """
     from plugin.framework.constants import folder_search_enabled
     from plugin.framework.prompts import get_peer_inner_choice_block
 

--- a/plugin/doc/peer_message.py
+++ b/plugin/doc/peer_message.py
@@ -178,10 +178,16 @@ def format_peer_catalog(peers: list[dict[str, str]]) -> str:
 
 
 def list_v1_peers(uno_ctx: Any, self_doc: Any) -> list[dict[str, str]]:
-    """Resolvable other v1 peers (distinct uid, supported model, addressable)."""
+    """Resolvable other v1 peers (distinct uid, supported model, addressable).
+
+    Desktop catalog + RuntimeUID. Callers marshal to the main thread
+    (specialized scaffolding / ``get_peer_inner_choice_block``) or this asserts.
+    """
     from plugin.doc.document_research import get_open_documents
+    from plugin.framework.thread_guard import assert_main_thread
     from plugin.framework.uno_context import get_runtime_uid, resolve_document_by_url
 
+    assert_main_thread("peer_message.list_v1_peers")
     self_uid = ""
     if self_doc is not None:
         try:

--- a/plugin/doc/specialized_base.py
+++ b/plugin/doc/specialized_base.py
@@ -30,7 +30,6 @@ from plugin.framework.prompts import DELEGATE_SPECIALIZED_TASK_PARAM_HINT, pytho
 from plugin.framework.i18n import _
 from plugin.chatbot.smol_agent import build_toolcalling_agent, SmolAgentExecutor, SmolToolAdapter
 from plugin.chatbot.smol_examples import get_examples_block
-from plugin.doc.document_research import get_document_research_workflow_hint
 from plugin.doc.specialized_shapes_context import format_shapes_canvas_context
 from plugin.framework import queue_executor
 
@@ -194,8 +193,12 @@ class DelegateToSpecializedBase(ToolBase):
                 ctx=ctx.ctx,
             )
             peer_catalog = ""
+            document_research_hint = ""
             if domain == "document_research":
-                from plugin.doc.document_research import filter_document_research_discovery_tools
+                from plugin.doc.document_research import (
+                    filter_document_research_discovery_tools,
+                    get_document_research_workflow_hint,
+                )
                 from plugin.doc.peer_message import (
                     PEER_TOOL_NAME,
                     filter_peer_tools_for_specialized,
@@ -207,10 +210,18 @@ class DelegateToSpecializedBase(ToolBase):
                 tools = filter_peer_tools_for_specialized(tools, ctx.ctx, ctx.doc)
                 if any(getattr(t, "name", None) == PEER_TOOL_NAME for t in tools):
                     peer_catalog = format_peer_catalog(list_v1_peers(ctx.ctx, ctx.doc))
-            return tools, peer_catalog
+                # #673 added list_v1_peers / getRuntimeUID to this hint. Specialized
+                # execute is async: gather the catalog here with get_tools, not on
+                # the tool-async worker.
+                document_research_hint = get_document_research_workflow_hint(
+                    ctx.ctx, getattr(ctx, "doc", None)
+                )
+            return tools, peer_catalog, document_research_hint
 
         # get_tools(doc=...) calls doc.supportsService — must not run on the sub-agent worker.
-        domain_tools, peer_catalog = queue_executor.execute_on_main_thread(_fetch_domain_tools)
+        domain_tools, peer_catalog, document_research_hint = queue_executor.execute_on_main_thread(
+            _fetch_domain_tools
+        )
 
         if not domain_tools:
             return self._tool_error(f"No specialized tools found for domain '{domain}'. Ensure the tools are implemented and registered.")
@@ -263,11 +274,6 @@ class DelegateToSpecializedBase(ToolBase):
                 except Exception as e:
                     log.warning("Failed to get Calc context for sub-agent: %s", e)
 
-            document_research_hint = (
-                get_document_research_workflow_hint(ctx.ctx, getattr(ctx, "doc", None))
-                if domain == "document_research"
-                else ""
-            )
             open_docs_context = ""
             if domain == "document_research":
                 try:

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -607,16 +607,29 @@ def get_peer_messaging_prompt_block(model, ctx) -> str:
 
 
 def get_peer_inner_choice_block(uno_ctx, doc) -> str:
-    """Short inner read-vs-peer rules plus catalog. Empty when no v1 peer is open."""
+    """Short inner read-vs-peer rules plus catalog. Empty when no v1 peer is open.
+
+    ``list_v1_peers`` reads RuntimeUID and the desktop catalog (UNO). Specialized
+    execute runs on a tool-async worker, so this marshals when called off-main.
+    """
     if uno_ctx is None:
         return ""
-    try:
+
+    def _build() -> str:
         from plugin.doc.peer_message import format_peer_catalog, list_v1_peers
 
         peers = list_v1_peers(uno_ctx, doc)
         if not peers:
             return ""
         return PEER_INNER_CHOICE_RULES + "\n" + format_peer_catalog(peers)
+
+    try:
+        from plugin.framework.queue_executor import execute_on_main_thread
+        from plugin.framework.thread_guard import on_main_thread
+
+        if on_main_thread():
+            return _build()
+        return execute_on_main_thread(_build)
     except Exception:
         return ""
 

--- a/tests/doc/test_specialized_delegation_threading.py
+++ b/tests/doc/test_specialized_delegation_threading.py
@@ -14,8 +14,12 @@ from plugin.calc.sheets import ListSheets
 from plugin.calc.specialized import DelegateToSpecializedCalc
 from plugin.chatbot.smol_agent import SmolToolAdapter
 from plugin.contrib.smolagents.memory import FinalAnswerStep
+from plugin.doc.document_research import get_document_research_workflow_hint
+from plugin.doc.peer_message import SendPeerMessage
 from plugin.framework import thread_guard as tg
+from plugin.framework.prompts import get_peer_inner_choice_block
 from plugin.framework.tool import ToolBase, ToolContext, ToolRegistry
+from plugin.framework.uno_context import get_runtime_uid
 from plugin.framework.worker_pool import run_in_background
 from plugin.tests.testing_utils import setup_uno_mocks
 from plugin.writer.specialized.footnotes import FootnotesList
@@ -334,12 +338,157 @@ def test_writer_delegate_marshals_document_research_scaffolding(
 
     assert result["status"] == "ok"
     mock_enqueue_index.assert_called_once_with(ctx.ctx, ctx.services, mock_doc)
-    # Open-docs context plus list_v1_peers (peer catalog / inner PEER vs READ hint).
+    # Open-docs context plus list_v1_peers (peer catalog / inner PEER vs READ hint),
+    # both gathered on the main thread with get_tools.
     assert mock_get_open_docs.call_count >= 1
     mock_get_open_docs.assert_called_with(ctx.ctx, mock_doc)
     instructions = mock_agent_class.call_args.kwargs["instructions"]
     assert "[OPEN DOCUMENTS CONTEXT]" in instructions
     assert "/tmp/a.odt" in instructions
+
+
+_PEER_HINT_PEERS = [{"name": "Budget.ods", "uid": "u2", "url": "", "type": "calc"}]
+
+
+def _list_v1_peers_touching_runtime_uid(uno_ctx, self_doc):
+    """Stand-in for list_v1_peers that reproduces the #673 UNO touch."""
+    get_runtime_uid(self_doc)
+    return list(_PEER_HINT_PEERS)
+
+
+def test_document_research_hint_off_main_does_not_touch_runtime_uid():
+    """Regression: get_peer_inner_choice_block called getRuntimeUID on the specialize worker."""
+    session = start_uno_thread_safety_session()
+    was_guard = tg.GUARD_ON
+    tg.GUARD_ON = True
+    err: BaseException | None = None
+    hint: str | None = None
+    inner: str | None = None
+    try:
+        raw_doc = MagicMock()
+        raw_doc.getRuntimeUID.return_value = "uid-self"
+        doc = session.make_mock(raw_doc, name="writer-doc")
+        uno_ctx = MagicMock()
+
+        def worker():
+            nonlocal err, hint, inner
+            try:
+                with patch(
+                    "plugin.doc.peer_message.list_v1_peers",
+                    side_effect=_list_v1_peers_touching_runtime_uid,
+                ):
+                    hint = get_document_research_workflow_hint(uno_ctx, doc)
+                    inner = get_peer_inner_choice_block(uno_ctx, doc)
+            except BaseException as e:
+                err = e
+
+        t = run_in_background(
+            worker, name="tool-async-delegate_to_specialized_writer_toolset", daemon=False
+        )
+        t.join(timeout=5.0)
+    finally:
+        tg.GUARD_ON = was_guard
+        session.close()
+
+    assert err is None, f"UNO touch from worker: {err}"
+    assert hint and "Budget.ods" in hint
+    assert "send_peer_message" in hint
+    assert "PEER vs READ" in hint
+    assert inner and "Budget.ods" in inner
+    assert "uid=u2" in inner
+
+
+@patch("plugin.doc.specialized_base.USE_SUB_AGENT", True)
+@patch(
+    "plugin.chatbot.smol_agent.get_config_int",
+    side_effect=lambda key: 25 if key == "chatbot.max_tool_rounds" else 1024,
+)
+@patch("plugin.chatbot.smol_agent.get_api_config", create=True, return_value={"model": "test/model"})
+@patch("plugin.chatbot.smol_agent.ToolCallingAgent")
+@patch("plugin.chatbot.smol_agent.WriterAgentSmolModel")
+@patch("plugin.chatbot.smol_agent.LlmClient")
+@patch("plugin.doc.document_research.get_open_documents")
+@patch("plugin.embeddings.embeddings_indexer.enqueue_folder_index")
+def test_document_research_delegate_off_main_does_not_touch_runtime_uid(
+    mock_enqueue_index,
+    mock_get_open_docs,
+    _mock_llm,
+    _mock_smol_model,
+    mock_agent_class,
+    _mock_get_config,
+    _mock_get_config_int,
+):
+    """Regression: specialized execute built the #673 peer catalog on the async worker.
+
+    Writer/Calc/Draw gateways share DelegateToSpecializedBase.execute.
+    """
+    mock_get_open_docs.return_value = []
+    mock_agent_instance = MagicMock()
+    mock_agent_instance.run.return_value = [FinalAnswerStep(output="done")]
+    mock_agent_class.return_value = mock_agent_instance
+
+    registry = ToolRegistry(MagicMock())
+    registry.register(_DummyDocResearchTool())
+    registry.register(SendPeerMessage())
+    registry.register(DelegateToSpecializedWriter())
+
+    session = start_uno_thread_safety_session()
+    was_guard = tg.GUARD_ON
+    tg.GUARD_ON = True
+    err: BaseException | None = None
+    result: dict | None = None
+    try:
+        raw_doc = MagicMock()
+        raw_doc.supportsService.return_value = True
+        raw_doc.getRuntimeUID.return_value = "uid-self"
+        proxied_doc = tg._UnoThreadGuardProxy(raw_doc)
+
+        ctx = MagicMock()
+        ctx.services = {"tools": registry}
+        ctx.doc = proxied_doc
+        ctx.ctx = MagicMock()
+        ctx.doc_type = "writer"
+        ctx.stop_checker = lambda: False
+        ctx.active_domain = None
+
+        gateway = registry.get("delegate_to_specialized_writer_toolset")
+        with patch.object(tg, "_notify_thread_violation"):
+            with patch(
+                "plugin.doc.peer_message.list_v1_peers",
+                side_effect=_list_v1_peers_touching_runtime_uid,
+            ):
+
+                def worker():
+                    nonlocal err, result
+                    try:
+                        result = gateway.execute_safe(
+                            ctx, domain="document_research", task="Get Q4 from the open budget"
+                        )
+                    except BaseException as e:
+                        err = e
+
+                t = run_in_background(
+                    worker,
+                    name="tool-async-delegate_to_specialized_writer_toolset",
+                    daemon=False,
+                )
+                t.join(timeout=5.0)
+    finally:
+        tg.GUARD_ON = was_guard
+        session.close()
+
+    assert err is None, f"UNO touch from worker: {err}"
+    assert result is not None and result.get("status") == "ok"
+    instructions = mock_agent_class.call_args.kwargs["instructions"]
+    assert "Budget.ods" in instructions
+    assert "send_peer_message" in instructions
+    assert "PEER vs READ" in instructions
+    smol_tools = mock_agent_class.call_args.kwargs.get("tools", [])
+    names = {t.name for t in smol_tools}
+    assert "send_peer_message" in names
+    peer_adapter = next(t for t in smol_tools if t.name == "send_peer_message")
+    assert "Budget.ods" in peer_adapter.description
+    mock_enqueue_index.assert_called_once()
 
 
 def test_writer_smol_adapter_marshals_sync_footnotes_tool():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#673 put `list_v1_peers` / `getRuntimeUID` on the document_research specialized inner prompt. `DelegateToSpecializedBase.execute` is async, so that catalog was built on `tool-async-delegate_to_specialized_*` and tripped the viral UNO thread guard.

## Cause
`get_document_research_workflow_hint` used to be config-only (`folder_search_enabled`) and was safe on the specialize worker. The specialized-inner experiment appended `get_peer_inner_choice_block` → `list_v1_peers` → `get_runtime_uid(self_doc)`. Writer/Calc/Draw gateways share this `execute` path.

Other UNO scaffolding in the same method (`get_tools`, peer-tool filter, open-docs list) was already marshaled. The hint call was not.

## Fix
- Gather the workflow hint (and therefore the peer catalog) inside `_fetch_domain_tools` on the main thread, next to `get_tools`.
- `get_peer_inner_choice_block` marshals via `execute_on_main_thread` when invoked off-main (covers `find_tools` and any later caller).
- `list_v1_peers` asserts main thread, same contract as `get_open_documents`.
- Guard is not weakened. `send_peer_message` stays off the outer chat wire.

Peers still appear in the specialized prompt: catalog text is a plain string after the main-thread hop, then appended to the smol instructions and the `send_peer_message` tool description on the worker.

## Tests
`tests/doc/test_specialized_delegation_threading.py`:
- off-main `get_document_research_workflow_hint` / `get_peer_inner_choice_block` with a thread-affine doc whose `getRuntimeUID` would fire
- off-main Writer `document_research` specialize (shared `execute` for Calc/Draw) asserting the catalog still lands in instructions

Local: `make typecheck` green; targeted pytest 62 passed, including the new regression tests.

No Fixes/Closes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1ed44a2-0936-4b86-a504-7dc54032ec1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1ed44a2-0936-4b86-a504-7dc54032ec1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

