### PR TITLE
Widen GMP eval-2 form-cite aliases for prompt Request wording

### DIFF
--- a/docs/eval/eval-2/gmp-change-control-58ac1cc5/notes.md
+++ b/docs/eval/eval-2/gmp-change-control-58ac1cc5/notes.md
@@ -58,6 +58,10 @@ do **not** change `prompt.writeragent.txt`):
 6. Identity ids fold hyphen-like characters (U+2010, U+2011, U+2212, NBSP)
    to ASCII before the RMS-3333 / QY-GEL checks. Do **not** drop the
    RMS-3333 requirement — only the encoding false-red.
+7. Form-cite aliases include prompt wording (Change Control Request / CCR /
+   completed … change control), not only tracking form / filled form /
+   Form-920. Still fail if the memo never acknowledges the form-side
+   deliverable.
 
 ## Not changed
 

--- a/docs/eval/eval-2/gmp-change-control-58ac1cc5/rubric.eval2.md
+++ b/docs/eval/eval-2/gmp-change-control-58ac1cc5/rubric.eval2.md
@@ -24,7 +24,7 @@ fails. Extract ODT `text:h` and `text:p`; Draw `draw:frame` text by
 | 4 | Endotoxin mismatch: **Report Result** and **`< 1` EU** (aliases: less than 1 / below 1) | Prompt + COA / RMS | Either anchor missing |
 | 5 | Discrepancy / mismatch / non-conforming | Prompt | Theme missing |
 | 6 | Quarantine / hold + RMS update / change control | Prompt §1 | Either theme missing |
-| 7 | Memo **cites** the filled form (change-control form / Form-920 / draft change control) | Writer prompt §4 | No form cite in the memo |
+| 7 | Memo **cites** the filled form (change-control form / Form-920 / Change Control Request / CCR / draft or completed change control) | Writer prompt §4 | No form cite in the memo |
 | 8 | QA escalation email section + deviation **or** requalification ask | Writer prompt §2 | Missing section or ask |
 | 9 | Internal / Teams / status summary | Writer prompt §3 | Missing note |
 | 10 | Vendor notification (two months / report only / vendor memo); departed employee; centralized tracking; SOP | Writer prompt §4 | Any of those four themes missing |

--- a/scripts/eval_2_gmp_oracle.py
+++ b/scripts/eval_2_gmp_oracle.py
@@ -64,11 +64,18 @@ _RMS_UPDATE_RE = re.compile(
     r"update.{0,24}rms|rms.{0,24}update|change\s+control|form[\s\-]*920",
     re.I,
 )
+# Prompt names the Draw deliverable a Change Control Request; headed
+# HAPPY memos cite that / CCR / "completed … change control" instead of
+# "tracking form" / Form-920. Keep a form-side cite — "change control"
+# alone is the RMS-update theme, not this check.
 _FORM_CITE_RE = re.compile(
     r"change\s+control(?:\s+tracking)?\s+form"
     r"|filled\s+form"
-    r"|draft\s+change\s+control"
-    r"|form[\s\-]*920",
+    r"|draft(?:ed)?(?:\s+a)?\s+change\s+control"
+    r"|change\s+control\s+request"
+    r"|completed.{0,40}change\s+control"
+    r"|form[\s\-]*920"
+    r"|\bCCR\b",
     re.I,
 )
 _QA_EMAIL_RE = re.compile(

--- a/tests/scripts/test_eval_2_gmp_oracle.py
+++ b/tests/scripts/test_eval_2_gmp_oracle.py
@@ -15,6 +15,7 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from eval_2_gmp_oracle import (  # noqa: E402
+    _FORM_CITE_RE,
     main as oracle_main,
     normalize_hyphen_like,
     read_odg_frames,
@@ -225,6 +226,67 @@ def test_synonym_sections_pass() -> None:
         filled_chars=120,
     )
     assert result.passed, result.failures
+
+
+_CITE_SENTENCE = (
+    "A draft change control\n"
+    "request is on the filled Change Control Tracking Form. "
+)
+
+
+def _memo_without_form_cite() -> str:
+    """Keep change-control theme; drop form / request / Form-920 cites."""
+    stripped = _padded().replace(_CITE_SENTENCE, "")
+    assert "Change Control Request" not in stripped
+    assert "filled Change Control Tracking Form" not in stripped
+    assert "draft change control" not in stripped.lower()
+    return stripped
+
+
+def test_form_cite_accepts_change_control_request_alias() -> None:
+    """Headed HAPPY (20260909-0225) used prompt wording, not tracking form."""
+    happy_phrases = (
+        "Change Control Request",
+        "Change Control Request completed",
+        "drafted a Change Control Request",
+        "completed the change control",
+        "CCR filed for RMS-3333",
+    )
+    for phrase in happy_phrases:
+        assert _FORM_CITE_RE.search(phrase), phrase
+    # Theme-only "change control" is the RMS-update check, not a form cite.
+    assert not _FORM_CITE_RE.search("change control initiated")
+    assert not _FORM_CITE_RE.search("formal change control")
+    assert not _FORM_CITE_RE.search("ACCRINT")
+    text = _memo_without_form_cite() + " I drafted a Change Control Request."
+    result = score_pair(
+        text,
+        "Change Title: RMS-3333 QY-GEL CompCello Report Result < 1 EU/ml hold",
+        para_count=16,
+        filled_fields=9,
+        filled_chars=1497,
+    )
+    assert result.passed, result.failures
+    assert not any("cite" in item for item in result.failures)
+
+
+def test_form_cite_still_fails_without_deliverable_cite() -> None:
+    result = score_pair(
+        _memo_without_form_cite(),
+        "Change Title: RMS-3333 QY-GEL CompCello Report Result < 1 EU/ml hold",
+        para_count=16,
+        filled_fields=9,
+        filled_chars=1497,
+    )
+    assert not result.passed
+    assert any("cite the filled change-control form" in item for item in result.failures)
+    # Form fill / identity / husk bands are unchanged — only the cite fails.
+    assert result.filled_fields == 9
+    assert result.filled_chars == 1497
+    assert not any("RMS-3333" in item for item in result.failures)
+    assert not any("CompCello" in item for item in result.failures)
+    assert not any("husk" in item for item in result.failures)
+    assert not any("substantially filled" in item for item in result.failures)
 
 
 def test_resolve_sibling_form(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A headed GMP HAPPY run (`20260909-0225-gpt-oss-120b`) filled the Draw stand-in (`filled_fields=9` / `filled_chars=1497`) but the oracle failed only on:

`memo does not cite the filled change-control form`

The memo used the Writer prompt’s own wording — “Change Control Request”, “Change Control Request completed”, “drafted a Change Control Request” — not the regex’s `change control tracking form` / `filled form` / `form-920`. The run directory is not in-repo; confirmation is the unit test with that phrasing.

## Change

Widen `_FORM_CITE_RE` in `scripts/eval_2_gmp_oracle.py` to also accept:

- `change control request`
- word-ish `CCR` (`\bCCR\b`, not substrings such as `ACCRINT`)
- `drafted a change control` and `completed … change control`

Existing tracking-form / filled-form / Form-920 needles stay. A bare “change control” theme still fails this check (that remains the RMS-update criterion). Form-fill thresholds, RMS-3333, CompCello, endotoxin anchors, and the husk ban are unchanged.

`rubric.eval2.md` row 7 and `notes.md` softness item 7 document the extra aliases.

## Tests

`tests/scripts/test_eval_2_gmp_oracle.py` — 15 passed, including:

- Request / HAPPY phrasing passes the cite check (`filled_fields=9`, `filled_chars=1497`)
- Memo with no form-side deliverable cite still fails that one criterion

`make typecheck` passed.

[gmp_oracle_happy_cite_phrases.log](https://cursor.com/agents/bc-62999a53-95e4-4c1d-b5cb-98b9872cb32c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgmp_oracle_happy_cite_phrases.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62999a53-95e4-4c1d-b5cb-98b9872cb32c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62999a53-95e4-4c1d-b5cb-98b9872cb32c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

