### PR TITLE
UNO lifecycle breadcrumbs + Draw soak (no product fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ endif
         dev-deploy dev-deploy-remove \
         lo-start lo-start-full lo-kill lo-restart \
         clean-cache nuke-cache nuke-cache-force unbundle \
-        log log-tail lo-log test pytest test-uno test-mock-sidebar test-run test-durations slowtests vhs test-visible lo-test-threadguard lo-test-threadguard-visible typecheck typecheck-full check-ext check-setup deploy ensure-uno _check-lo-python \
+        log log-tail lo-log test pytest test-uno test-uno-soak test-mock-sidebar test-run test-durations slowtests vhs test-visible lo-test-threadguard lo-test-threadguard-visible typecheck typecheck-full check-ext check-setup deploy ensure-uno _check-lo-python \
         verify crosshair-check crosshair-cover crosshair-check-all crosshair-check-all-deep \
         crosshair-cover-all crosshair-cover-all-deep \
         lo-start-log opengrep-lint opengrep-lint-advisory opengrep-rules-sync opengrep-rules-audit uno-thread-lint uno-thread-lint-advisory opengrep-install \
@@ -261,6 +261,7 @@ help:
 	@echo "  make mock-llm               Fake OpenAI chat server on :18766 (sidebar soak: scroll, tools, Stop, errors)"
 	@echo "  make test-uno               UNO tests only via testing_runner (serial live soffice)"
 	@echo "  make test-uno FILTER=…      Same; FILTER=path or test_* name (native runner)"
+	@echo "  make test-uno-soak          Repeat Draw UNO (or FILTER=) in one soffice; REPEAT=20"
 	@echo "  make test-mock-sidebar      Packet F+B+C+D+E+G+P mock-LLM sidebar (visible soffice, your user profile)"
 	@echo "  make test-mock-sidebar FILTER=E   Packet letter (B/C/D/E/F/G/P), case id (e12 / g17 / p1), or test_* name"
 	@echo "  make test-mock-sidebar FILTER=P   Dual Writer+Calc peer Packet (specialized-inner #673)"
@@ -800,6 +801,15 @@ _check-lo-python:
 test-uno: _check-lo-python
 	@$(MAKE) -C "$(PROJECT_ROOT)" lo-kill
 	PYTHONUNBUFFERED=1 $(LO_PYTHON_UNSET) $(LO_PYTHON_ENV) "$(LO_PYTHON)" -u -m plugin.testing_runner $(FILTER); EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
+
+# Same office process, N times: stress Draw factory-open / close (URP DisposedException flakes).
+# FILTER defaults to the Draw native suite; override to pair two tests, e.g.
+#   make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
+# See docs/framework/uno-test-lifecycle.md
+REPEAT ?= 20
+test-uno-soak: _check-lo-python
+	@$(MAKE) -C "$(PROJECT_ROOT)" lo-kill
+	PYTHONUNBUFFERED=1 $(LO_PYTHON_UNSET) $(LO_PYTHON_ENV) "$(LO_PYTHON)" -u -m plugin.testing_runner --repeat $(REPEAT) $(or $(FILTER),test_draw_uno); EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
 
 test-mock-sidebar: _check-lo-python
 	@$(MAKE) -C "$(PROJECT_ROOT)" lo-kill

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ help:
 	@echo "  make mock-llm               Fake OpenAI chat server on :18766 (sidebar soak: scroll, tools, Stop, errors)"
 	@echo "  make test-uno               UNO tests only via testing_runner (serial live soffice)"
 	@echo "  make test-uno FILTER=…      Same; FILTER=path or test_* name (native runner)"
-	@echo "  make test-uno-soak          Repeat Draw UNO (or FILTER=) in one soffice; REPEAT=20"
+	@echo "  make test-uno-soak          Repeat Draw UNO (or FILTER=/PAIR=) in one soffice; REPEAT=20"
 	@echo "  make test-mock-sidebar      Packet F+B+C+D+E+G+P mock-LLM sidebar (visible soffice, your user profile)"
 	@echo "  make test-mock-sidebar FILTER=E   Packet letter (B/C/D/E/F/G/P), case id (e12 / g17 / p1), or test_* name"
 	@echo "  make test-mock-sidebar FILTER=P   Dual Writer+Calc peer Packet (specialized-inner #673)"
@@ -803,13 +803,20 @@ test-uno: _check-lo-python
 	PYTHONUNBUFFERED=1 $(LO_PYTHON_UNSET) $(LO_PYTHON_ENV) "$(LO_PYTHON)" -u -m plugin.testing_runner $(FILTER); EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
 
 # Same office process, N times: stress Draw factory-open / close (URP DisposedException flakes).
-# FILTER defaults to the Draw native suite; override to pair two tests, e.g.
+# FILTER defaults to the Draw native suite. PAIR=tree-math | dup-move expands --pair.
+#   make test-uno-soak PAIR=tree-math REPEAT=50
 #   make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
 # See docs/framework/uno-test-lifecycle.md
 REPEAT ?= 20
+PAIR ?=
+ifeq ($(PAIR),)
+SOAK_FILTERS := $(or $(FILTER),test_draw_uno)
+else
+SOAK_FILTERS := --pair $(PAIR) $(FILTER)
+endif
 test-uno-soak: _check-lo-python
 	@$(MAKE) -C "$(PROJECT_ROOT)" lo-kill
-	PYTHONUNBUFFERED=1 $(LO_PYTHON_UNSET) $(LO_PYTHON_ENV) "$(LO_PYTHON)" -u -m plugin.testing_runner --repeat $(REPEAT) $(or $(FILTER),test_draw_uno); EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
+	PYTHONUNBUFFERED=1 $(LO_PYTHON_UNSET) $(LO_PYTHON_ENV) "$(LO_PYTHON)" -u -m plugin.testing_runner --repeat $(REPEAT) $(SOAK_FILTERS); EXIT_CODE=$$?; $(MAKE) -C "$(PROJECT_ROOT)" lo-kill; exit $$EXIT_CODE
 
 test-mock-sidebar: _check-lo-python
 	@$(MAKE) -C "$(PROJECT_ROOT)" lo-kill

--- a/docs/archive/test_architecture_analysis.md
+++ b/docs/archive/test_architecture_analysis.md
@@ -83,6 +83,8 @@ Windows unit pytest on GHA (33453184665) failed 10 cases after the hang was isol
 
 macOS `make test-uno` (33453203864) reached LibreOfficePython and a live soffice (final `lo-kill` PID 18456) but the URP bridge died while creating the keeper document (`Binary URP bridge disposed during call`). `SUITE` lines printed `soffice.bin=-` because `pgrep -x soffice.bin` misses the Darwin process name `soffice`. `testing_runner` now strips runner Python env on **both** bootstrap paths (`PYTHONPATH` / `PYTHONHOME` / `VIRTUAL_ENV` / `__PYVENV_LAUNCHER__`), prints `BOOTSTRAP` breadcrumbs (path, stripped keys, soffice command, pids/exit), and **aborts after the first URP dispose** instead of running 200+ dead suites. This does **not** claim Darwin UNO is green.
 
+Draw factory-open `DisposedException` (victim often `test_duplicate_rename_move_slide` or `test_insert_math_draw`) now names the **previous** TEST end on the FAIL line. See [uno-test-lifecycle.md](../framework/uno-test-lifecycle.md) (`LIFECYCLE`, `make test-uno-soak`). Not a product fix.
+
 Opt-in hang diagnostics (`WRITERAGENT_CI_DEBUG=1`, or PR CI `workflow_dispatch` `ci_debug`): per-worker `start`/`end` nodeid trail + faulthandler dump at 240s under `WRITERAGENT_CI_DEBUG_DIR`, and `--max-worker-restart=0` so xdist prints the crashitem nodeid instead of replacing the worker and wedging on re-collection (Windows CI 33447705893: gw3 vanished at 261s with no `Failed: Timeout`; pytest-timeout did not fire). `pytest_serial` sets `PYTEST_WORKERS=0`. This is instrumentation, not a hang fix.
 
 Profile hotspots without the LO native suite:

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -1,0 +1,111 @@
+# Native UNO test lifecycle (Draw flakes / URP `DisposedException`)
+
+**Not a product fix.** This page is the diagnostic contract for intermittent
+`DisposedException` on `desktop.loadComponentFromURL` in the native runner
+(`plugin/testing_runner.py`, `make test-uno`). Do not treat a green soak as
+proof that LibreOffice or WriterAgent is healthy.
+
+Related: [archive/test_architecture_analysis.md](../archive/test_architecture_analysis.md)
+(TEST start/end lines, Darwin URP abort, keeper document).
+
+## What the fixture actually does
+
+| Path | Reuse? | Open | Close |
+|------|--------|------|-------|
+| Calc `@with_native_doc` | Yes (wipe-and-reuse pool) | Factory only on first use / dead pool | Close only if reset fails |
+| Writer `@with_native_doc` | No (unless `reuse=True`) | Factory each test | `close_doc` (`gc.collect` then `close`) |
+| Draw / Impress | **Never** | Factory each test (`private:factory/sdraw`) | Always `close_doc` |
+
+`create_native_doc` is a thin `loadComponentFromURL`. Draw tests do **not**
+share a pooled document. A keeper hidden Writer is opened once in
+`run_all_tests` so Windows bootstraps do not shut down when a suite closes
+its last hidden Draw doc.
+
+`_ensure_live_ctx` only runs **between suites**, and only if
+`getServiceManager()` already fails. Inside a suite, the next
+`@with_native_doc` open is the first place a dead bridge is noticed.
+
+`close_doc` still swallows most errors (a failed close must not hide the
+test body). Dispose during close is now **logged** (`LIFECYCLE close_doc dispose`).
+After a non-pooled close, the harness probes `desktop.getComponents()` and
+prints `LIFECYCLE office dead after close` if URP is already gone. That is
+instrumentation, not a retry.
+
+## Hypothesis (unproven)
+
+CI flake on `test_duplicate_rename_move_slide` (Draw UNO, PR #685 victim):
+failure at `create_native_doc` / `loadComponentFromURL` with URP
+`DisposedException`. That pattern matches **“previous test toasted soffice /
+the bridge; this open is the named victim”** more than a bug inside
+duplicate/rename/move.
+
+Historical Arch glibc double-free: `test_get_draw_tree` still printed OK,
+then `test_insert_math_draw` died on the next factory load. Same class of
+gap: TEST end OK does not prove the office survived teardown.
+
+Math OLE (`insert_math` → `OLE2Shape` + Math CLSID) is a plausible *stressor*
+for that second pair. It does **not** explain a flake whose victim is
+`test_duplicate_rename_move_slide` (earlier in the file, before math).
+No skip/xfail and no office auto-restart: those would hide the killer.
+
+## What the breadcrumb prints
+
+On every native **FAIL**, stderr `TEST end … FAIL` includes:
+
+```
+previous=<suite.test> result=OK|FAIL|SKIP|- end_pids=<soffice at that end>
+current=<victim> start_pids=<soffice at TEST start> now_pids=<soffice now>
+```
+
+A URP dispose also prints a dedicated line:
+
+```
+LIFECYCLE URP dispose at <victim> previous=… result=… …
+```
+
+Factory open maps the same trail onto the exception message
+(`LIFECYCLE native_doc open FAIL` + `Binary URP bridge disposed during call`
+so the runner still aborts remaining suites).
+
+Grep: `LIFECYCLE` and `previous=`. The victim is `current=`; the likely
+killer is `previous=` (last successful TEST end when `result=OK`).
+
+Native tests do **not** run under pytest. There is no pytest hook for this
+trail; `record_test_start` / `record_test_end` / `format_lifecycle_breadcrumb`
+in `plugin/testing_runner.py` are the hook. Unit tests live in
+`tests/scripts/test_testing_runner_cli.py` and `tests/test_testing_utils.py`.
+
+## Soak / reproduce (same soffice, no new framework)
+
+Tight loop in **one** office process (this is the lifecycle under test):
+
+```bash
+# Full Draw UNO suite, 20 rounds (default)
+make test-uno-soak
+
+# More rounds
+make test-uno-soak REPEAT=50
+
+# Historical pair (tree → math OLE factory open)
+make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
+
+# CI victim + its predecessor in file order
+make test-uno-soak FILTER="test_duplicate_slide_copies_shapes test_duplicate_rename_move_slide" REPEAT=50
+```
+
+Equivalent without the Make target:
+
+```bash
+# env form
+WRITERAGENT_UNO_SOAK=20 make test-uno FILTER=test_draw_uno
+
+# runner CLI (LibreOffice Python)
+python -m plugin.testing_runner --repeat 20 test_draw_uno
+```
+
+Look for `SOAK iter i/N`, then the first `LIFECYCLE` / `previous=` on FAIL.
+Outer `for i in …; do make test-uno …; done` restarts soffice each time and
+is a **weaker** repro for “bridge died between two tests.”
+
+`test-uno-soak` is not in default CI. Invoke it from a CI note or a
+workflow_dispatch job when hunting this flake.

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -28,8 +28,14 @@ its last hidden Draw doc.
 `close_doc` still swallows most errors (a failed close must not hide the
 test body). Dispose during close is now **logged** (`LIFECYCLE close_doc dispose`).
 After a non-pooled close, the harness probes `desktop.getComponents()` and
-prints `LIFECYCLE office dead after close` if URP is already gone. That is
-instrumentation, not a retry.
+prints `LIFECYCLE office dead after close` if URP is already gone.
+
+**Harness-only attribution (same PR, not a product fix):** if a test body
+returns OK but `getServiceManager` is already disposed, the runner fails
+*that* test (`LIFECYCLE office dead after TEST returned`) instead of letting
+the next factory open be the named victim. `create_native_doc` probes before
+`loadComponentFromURL` (`pre_open=disposed` skips the load and still raises
+a URP-shaped error). No office auto-restart. No skip/xfail.
 
 ## Hypothesis (unproven)
 
@@ -54,26 +60,33 @@ On every native **FAIL**, stderr `TEST end … FAIL` includes:
 
 ```
 previous=<suite.test> result=OK|FAIL|SKIP|- end_pids=<soffice at that end>
-current=<victim> start_pids=<soffice at TEST start> now_pids=<soffice now>
+last_ok=<last successful TEST> dt_ms=<ms from that end to this start>
+current=<victim> start_pids=… now_pids=… pids_changed=0|1
+bridge=alive|disposed|no_probe|error:…
 ```
 
-A URP dispose also prints a dedicated line:
+`bridge=` is `ctx.getServiceManager()` at **TEST start** (same check as
+`_ensure_live_ctx`). Factory-open failures also include `pre_open=` from a
+probe immediately before `loadComponentFromURL`:
 
-```
-LIFECYCLE URP dispose at <victim> previous=… result=… …
-```
+- `pre_open=disposed` — office was already dead; the previous TEST end is the
+  killer (hypothesis confirmed for that fail).
+- `pre_open=alive` then dispose on load — died *during* this open (less like
+  “previous close toasted the bridge”).
 
-Factory open maps the same trail onto the exception message
-(`LIFECYCLE native_doc open FAIL` + `Binary URP bridge disposed during call`
-so the runner still aborts remaining suites).
+A URP dispose also prints `LIFECYCLE URP dispose at <victim> previous=…`.
+If a test body + `@with_native_doc` teardown **returns OK** but
+`getServiceManager` is already disposed, the runner **fails that test**
+(`LIFECYCLE office dead after TEST returned`) so the killer is named instead
+of the next open. That is harness attribution, not a product retry.
 
 Grep: `LIFECYCLE` and `previous=`. The victim is `current=`; the likely
-killer is `previous=` (last successful TEST end when `result=OK`).
+killer is `previous=` / `last_ok=` when `result=OK`.
 
-Native tests do **not** run under pytest. There is no pytest hook for this
-trail; `record_test_start` / `record_test_end` / `format_lifecycle_breadcrumb`
-in `plugin/testing_runner.py` are the hook. Unit tests live in
-`tests/scripts/test_testing_runner_cli.py` and `tests/test_testing_utils.py`.
+Native tests do **not** run under pytest. `format_lifecycle_breadcrumb` /
+`probe_uno_bridge` in `plugin/testing_runner.py` are the hook. Unit tests:
+`tests/framework/test_testing_runner.py`, `tests/scripts/test_testing_runner_cli.py`,
+`tests/test_testing_utils.py`.
 
 ## Soak / reproduce (same soffice, no new framework)
 
@@ -87,20 +100,21 @@ make test-uno-soak
 make test-uno-soak REPEAT=50
 
 # Historical pair (tree → math OLE factory open)
-make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
+make test-uno-soak PAIR=tree-math REPEAT=50
 
 # CI victim + its predecessor in file order
-make test-uno-soak FILTER="test_duplicate_slide_copies_shapes test_duplicate_rename_move_slide" REPEAT=50
+make test-uno-soak PAIR=dup-move REPEAT=50
+
+# Same pairs without the alias
+make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
 ```
 
 Equivalent without the Make target:
 
 ```bash
-# env form
 WRITERAGENT_UNO_SOAK=20 make test-uno FILTER=test_draw_uno
-
-# runner CLI (LibreOffice Python)
 python -m plugin.testing_runner --repeat 20 test_draw_uno
+python -m plugin.testing_runner --repeat 50 --pair tree-math
 ```
 
 Look for `SOAK iter i/N`, then the first `LIFECYCLE` / `previous=` on FAIL.

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -45,7 +45,7 @@ Start here by task.
 | Vision / OCR | Host runner + venv worker + `run_vision` | [`plugin/vision/`](../plugin/vision/), [`plugin/vision/venv/`](../plugin/vision/venv/), [`plugin/scripting/client.py`](../plugin/scripting/client.py), [`plugin/vision/vision_availability.py`](../plugin/vision/vision_availability.py) — [images/recognition.md](images/recognition.md) |
 | PPT-Master | Impress/Draw adapters and session | [`plugin/contrib/ppt_master/`](../plugin/contrib/ppt_master/) ([README](../plugin/contrib/ppt_master/README.md)), [`plugin/ppt_master/`](../plugin/ppt_master/), [`plugin/chatbot/ppt_master.py`](../plugin/chatbot/ppt_master.py) — [integration plan](archive/ppt-master-integration-plan.md#roadmap) |
 | Tests (unit pytest) | Headless pytest; no live soffice | `make pytest` — `-m "not slow and not integration" --ignore-glob='*_uno.py'` |
-| Tests (UNO runner) | Native UNO tests (`@native_test`, `ctx`) | [`plugin/testing_runner.py`](../plugin/testing_runner.py) (`make test-uno`; mock-LLM sidebar: `make test-mock-sidebar`; `make test-run` includes pytest) |
+| Tests (UNO runner) | Native UNO tests (`@native_test`, `ctx`) | [`plugin/testing_runner.py`](../plugin/testing_runner.py) (`make test-uno`; Draw lifecycle soak: `make test-uno-soak`; mock-LLM sidebar: `make test-mock-sidebar`; `make test-run` includes pytest) — [framework/uno-test-lifecycle.md](framework/uno-test-lifecycle.md) |
 | Eval / benchmarks | CLI eval harness and prompt optimization | [`scripts/benchmark.py`](../scripts/benchmark.py), [`scripts/prompt_optimization/`](../scripts/prompt_optimization/) |
 | Mock LLM (dev) | Fake OpenAI `/v1/chat/completions` for sidebar soak: HTML/scroll, research, Stop, empty replies, reasoning, delegate, parallel tools, HTTP fail/hang (`make mock-llm`, port 18766) | [`scripts/mock_llm_server.py`](../scripts/mock_llm_server.py) — [chat/rich-text-control-sidebar.md](chat/rich-text-control-sidebar.md#mock-llm-for-sidebar-soak) |
 | Extension packaging | OXT resources; register new components in manifest | [`extension/`](../extension/) (`Dialogs/`, `idl/`, `metadata/`), [`extension/META-INF/manifest.xml`](../extension/META-INF/manifest.xml) |
@@ -90,6 +90,7 @@ Start here by task.
 | Math / HTML import design | [writer/math-tex.md](writer/math-tex.md) |
 | Grammar pipeline (cache, queue) | [writer/grammar-checker-plan.md](writer/grammar-checker-plan.md) |
 | Test Architecture | [archive/test_architecture_analysis.md](archive/test_architecture_analysis.md) |
+| Native UNO lifecycle / URP dispose breadcrumbs | [framework/uno-test-lifecycle.md](framework/uno-test-lifecycle.md) |
 | Type checking | [framework/type-checking.md](framework/type-checking.md) |
 | UNO Dialogs & Wizards | [framework/uno-dialogs.md](framework/uno-dialogs.md) |
 | UNO exception policy (disposed vs leaf catches) | [framework/exception-policy.md](framework/exception-policy.md) |

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -152,62 +152,142 @@ def _fail_reason(exc: BaseException) -> str:
 
 # Last completed native test + soffice PIDs. A DisposedException on the *next*
 # factory open is often leftover from this test's close, not a bug in the victim.
-# Reset at the start of run_all_tests / run_module_suite.
+# Reset at the start of run_all_tests (not per suite — first test of suite N+1
+# may die because suite N's last close toasted URP).
 _lifecycle_last_qual: str = ""
 _lifecycle_last_result: str = ""
 _lifecycle_last_end_pids: str = ""
+_lifecycle_last_ok_qual: str = ""
+_lifecycle_last_end_mono: float = 0.0
 _lifecycle_current_qual: str = ""
 _lifecycle_current_start_pids: str = ""
+_lifecycle_current_start_mono: float = 0.0
+_lifecycle_current_bridge: str = ""
 
 # ``--repeat N`` / ``WRITERAGENT_UNO_SOAK``: re-run selected suites in one office.
 _soak_repeat: int = 1
 
+# Named Draw pairs for ``--pair`` / ``make test-uno-soak PAIR=…`` (same office).
+_SOAK_PAIRS: Dict[str, List[str]] = {
+    "tree-math": ["test_get_draw_tree", "test_insert_math_draw"],
+    "dup-move": [
+        "test_duplicate_slide_copies_shapes",
+        "test_duplicate_rename_move_slide",
+    ],
+}
+
 
 def reset_lifecycle_breadcrumb() -> None:
-    """Clear the previous/current TEST trail (start of a suite or unit test)."""
+    """Clear the previous/current TEST trail (start of a run or unit test)."""
     global _lifecycle_last_qual, _lifecycle_last_result, _lifecycle_last_end_pids
+    global _lifecycle_last_ok_qual, _lifecycle_last_end_mono
     global _lifecycle_current_qual, _lifecycle_current_start_pids
+    global _lifecycle_current_start_mono, _lifecycle_current_bridge
     _lifecycle_last_qual = ""
     _lifecycle_last_result = ""
     _lifecycle_last_end_pids = ""
+    _lifecycle_last_ok_qual = ""
+    _lifecycle_last_end_mono = 0.0
     _lifecycle_current_qual = ""
     _lifecycle_current_start_pids = ""
+    _lifecycle_current_start_mono = 0.0
+    _lifecycle_current_bridge = ""
 
 
-def record_test_start(qual: str) -> None:
-    """Remember the test about to run and soffice PIDs at TEST start."""
+def probe_uno_bridge(ctx: Any = None) -> str:
+    """Cheap URP liveness: ``alive``, ``disposed``, ``no_probe``, or ``error:Type``.
+
+    Uses ``ctx.getServiceManager()`` only (same check as ``_ensure_live_ctx``).
+    Unit-test ctx objects without that method are ``no_probe`` — not a fail.
+    """
+    if ctx is None:
+        return "no_probe"
+    getter = getattr(ctx, "getServiceManager", None)
+    if getter is None or not callable(getter):
+        return "no_probe"
+    try:
+        getter()
+    except Exception as exc:
+        if _is_uno_bridge_disposed(exc):
+            return "disposed"
+        return "error:%s" % type(exc).__name__
+    return "alive"
+
+
+def record_test_start(qual: str, ctx: Any = None) -> None:
+    """Remember the test about to run, soffice PIDs, and a cheap bridge probe."""
     global _lifecycle_current_qual, _lifecycle_current_start_pids
+    global _lifecycle_current_start_mono, _lifecycle_current_bridge
     _lifecycle_current_qual = qual
     _lifecycle_current_start_pids = _soffice_pids()
+    _lifecycle_current_start_mono = time.monotonic()
+    _lifecycle_current_bridge = probe_uno_bridge(ctx)
 
 
 def record_test_end(qual: str, result: str) -> None:
     """Promote the current test to 'previous' after TEST end (OK / FAIL / SKIP)."""
     global _lifecycle_last_qual, _lifecycle_last_result, _lifecycle_last_end_pids
+    global _lifecycle_last_ok_qual, _lifecycle_last_end_mono
     global _lifecycle_current_qual, _lifecycle_current_start_pids
+    global _lifecycle_current_start_mono, _lifecycle_current_bridge
     _lifecycle_last_qual = qual
     _lifecycle_last_result = result
     _lifecycle_last_end_pids = _soffice_pids()
+    _lifecycle_last_end_mono = time.monotonic()
+    if result == "OK":
+        _lifecycle_last_ok_qual = qual
     _lifecycle_current_qual = ""
     _lifecycle_current_start_pids = ""
+    _lifecycle_current_start_mono = 0.0
+    _lifecycle_current_bridge = ""
 
 
 def format_lifecycle_breadcrumb() -> str:
-    """One line naming the previous TEST end, current test, and soffice PIDs.
+    """One line naming the previous TEST end, last OK, current test, PIDs, bridge.
 
     Intermittent URP ``DisposedException`` on ``loadComponentFromURL`` usually
     names the *victim* (next ``@with_native_doc`` open). This string names the
-    last test that finished — the likely killer — plus PIDs at that end and now.
+    last test that finished — the likely killer — plus last successful TEST end,
+    elapsed ms since that end, whether soffice PIDs changed, and a cheap
+    getServiceManager probe.
     """
     prev = _lifecycle_last_qual or "-"
     prev_result = _lifecycle_last_result or "-"
     prev_pids = _lifecycle_last_end_pids or "-"
+    last_ok = _lifecycle_last_ok_qual or "-"
     current = _lifecycle_current_qual or "-"
     start_pids = _lifecycle_current_start_pids or "-"
+    now_pids = _soffice_pids()
+    dt_ms = "-"
+    if _lifecycle_last_end_mono and _lifecycle_current_start_mono:
+        dt_ms = str(int(round((_lifecycle_current_start_mono - _lifecycle_last_end_mono) * 1000)))
+    pids_changed = "0"
+    if start_pids not in ("", "-") and now_pids != start_pids:
+        pids_changed = "1"
+    elif prev_pids not in ("", "-") and now_pids != prev_pids:
+        pids_changed = "1"
+    bridge = _lifecycle_current_bridge or "no_probe"
     return (
-        "previous=%s result=%s end_pids=%s current=%s start_pids=%s now_pids=%s"
-        % (prev, prev_result, prev_pids, current, start_pids, _soffice_pids())
+        "previous=%s result=%s end_pids=%s last_ok=%s dt_ms=%s "
+        "current=%s start_pids=%s now_pids=%s pids_changed=%s bridge=%s"
+        % (
+            prev,
+            prev_result,
+            prev_pids,
+            last_ok,
+            dt_ms,
+            current,
+            start_pids,
+            now_pids,
+            pids_changed,
+            bridge,
+        )
     )
+
+
+def expand_soak_pair(name: str) -> List[str]:
+    """Return ``test_*`` names for a Draw soak pair alias, or empty if unknown."""
+    return list(_SOAK_PAIRS.get(str(name).strip().lower(), ()))
 
 
 def _fail_reason_with_lifecycle(exc: BaseException) -> str:
@@ -344,8 +424,9 @@ def _parse_cli_args(argv: Sequence[str]) -> list[str]:
     ``--user-profile`` into ``WRITERAGENT_UNO_USER_PROFILE`` as well.
 
     ``--repeat N`` (or ``WRITERAGENT_UNO_SOAK``) re-runs selected suites in the
-    same soffice process to stress native-doc open/close. See
-    ``docs/framework/uno-test-lifecycle.md``.
+    same soffice process to stress native-doc open/close. ``--pair tree-math``
+    / ``dup-move`` expands to the two Draw tests that historically sandwich a
+    URP death. See ``docs/framework/uno-test-lifecycle.md``.
     """
     global show_window, use_user_profile, _soak_repeat
     filters: list[str] = []
@@ -370,6 +451,20 @@ def _parse_cli_args(argv: Sequence[str]) -> list[str]:
         elif arg.startswith("--repeat="):
             _soak_repeat = _parse_positive_int(arg.split("=", 1)[1], default=1)
             soak_from_cli = True
+        elif arg == "--pair":
+            if i + 1 < len(argv):
+                names = expand_soak_pair(argv[i + 1])
+                if names:
+                    filters.extend(names)
+                else:
+                    filters.append(str(argv[i + 1]))
+                skip_next = True
+        elif arg.startswith("--pair="):
+            names = expand_soak_pair(arg.split("=", 1)[1])
+            if names:
+                filters.extend(names)
+            else:
+                filters.append(arg.split("=", 1)[1])
         else:
             filters.append(str(arg))
     if os.environ.get("WRITERAGENT_UNO_USER_PROFILE") == "1":
@@ -914,8 +1009,11 @@ def run_module_suite(ctx, module, name, doc_model=None):
         for test_func in selected:
             test_line = f"Running test: {test_func.__name__}"
             qual = f"{name}.{test_func.__name__}"
-            record_test_start(qual)
-            _progress(f"TEST start {qual} soffice={_lifecycle_current_start_pids}")
+            record_test_start(qual, ctx)
+            _progress(
+                "TEST start %s soffice=%s bridge=%s"
+                % (qual, _lifecycle_current_start_pids, _lifecycle_current_bridge or "-")
+            )
             # Per-test faulthandler abort (30s). Silent — TEST start/end is enough.
             _arm_native_test_watchdog(qual)
             try:
@@ -937,6 +1035,27 @@ def run_module_suite(ctx, module, name, doc_model=None):
                 else:
                     test_func()
                 _progress(f"TEST returned {qual}")
+                # Harness attribution (not a product fix): body + @with_native_doc
+                # teardown returned, but getServiceManager is already disposed.
+                # Name *this* test as the killer instead of the next factory open.
+                post_bridge = probe_uno_bridge(ctx)
+                if post_bridge == "disposed":
+                    dead_exc = RuntimeError(
+                        "Binary URP bridge disposed during call; office dead after "
+                        "TEST returned (teardown likely killed URP) %s"
+                        % format_lifecycle_breadcrumb()
+                    )
+                    total_failed += 1
+                    suite_log.append(f"{test_line} — FAIL ({dead_exc})")
+                    suite_log.append("LIFECYCLE %s" % format_lifecycle_breadcrumb())
+                    _progress(
+                        "LIFECYCLE office dead after TEST returned %s %s"
+                        % (qual, format_lifecycle_breadcrumb())
+                    )
+                    _progress(f"TEST end {qual} FAIL {_fail_reason_with_lifecycle(dead_exc)}")
+                    _mark_urp_dead(dead_exc, qual)
+                    record_test_end(qual, "FAIL")
+                    break
                 total_passed += 1
                 suite_log.append(f"{test_line} — OK")
                 record_test_end(qual, "OK")
@@ -1374,6 +1493,7 @@ def main() -> int:
         python -m plugin.testing_runner tests/chatbot/test_mock_llm_sidebar_uno.py E
         python -m plugin.testing_runner --user-profile …/test_mock_llm_sidebar_uno.py f3a
         python -m plugin.testing_runner --repeat 20 test_draw_uno
+        python -m plugin.testing_runner --repeat 50 --pair tree-math
 
     Extra tokens select tests: packet letter (``B``/``C``/``D``/``E``/``F``/``G``/``P``), case id
     (``f3a`` / ``p1``), or full ``test_*`` name. Prefer ``make test-mock-sidebar FILTER=P``
@@ -1383,6 +1503,7 @@ def main() -> int:
     same soffice process to stress native-doc open/close. Draw subset::
 
         make test-uno-soak
+        make test-uno-soak PAIR=tree-math REPEAT=50
         make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
 
     See ``docs/framework/uno-test-lifecycle.md``.

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1383,7 +1383,7 @@ def main() -> int:
     same soffice process to stress native-doc open/close. Draw subset::
 
         make test-uno-soak
-        make test-uno-soak FILTER=test_get_draw_tree,test_insert_math_draw REPEAT=50
+        make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
 
     See ``docs/framework/uno-test-lifecycle.md``.
 

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -10,6 +10,10 @@
 #
 # It aggregates existing in-LO tests (Writer/Calc, etc.) and returns
 # a JSON summary that external tools or agents can consume.
+#
+# URP DisposedException on the next factory open: FAIL lines include
+# previous=<last TEST end> (see format_lifecycle_breadcrumb). Soak:
+# --repeat N / make test-uno-soak. docs/framework/uno-test-lifecycle.md
 
 import logging
 import json
@@ -146,6 +150,87 @@ def _fail_reason(exc: BaseException) -> str:
     return text
 
 
+# Last completed native test + soffice PIDs. A DisposedException on the *next*
+# factory open is often leftover from this test's close, not a bug in the victim.
+# Reset at the start of run_all_tests / run_module_suite.
+_lifecycle_last_qual: str = ""
+_lifecycle_last_result: str = ""
+_lifecycle_last_end_pids: str = ""
+_lifecycle_current_qual: str = ""
+_lifecycle_current_start_pids: str = ""
+
+# ``--repeat N`` / ``WRITERAGENT_UNO_SOAK``: re-run selected suites in one office.
+_soak_repeat: int = 1
+
+
+def reset_lifecycle_breadcrumb() -> None:
+    """Clear the previous/current TEST trail (start of a suite or unit test)."""
+    global _lifecycle_last_qual, _lifecycle_last_result, _lifecycle_last_end_pids
+    global _lifecycle_current_qual, _lifecycle_current_start_pids
+    _lifecycle_last_qual = ""
+    _lifecycle_last_result = ""
+    _lifecycle_last_end_pids = ""
+    _lifecycle_current_qual = ""
+    _lifecycle_current_start_pids = ""
+
+
+def record_test_start(qual: str) -> None:
+    """Remember the test about to run and soffice PIDs at TEST start."""
+    global _lifecycle_current_qual, _lifecycle_current_start_pids
+    _lifecycle_current_qual = qual
+    _lifecycle_current_start_pids = _soffice_pids()
+
+
+def record_test_end(qual: str, result: str) -> None:
+    """Promote the current test to 'previous' after TEST end (OK / FAIL / SKIP)."""
+    global _lifecycle_last_qual, _lifecycle_last_result, _lifecycle_last_end_pids
+    global _lifecycle_current_qual, _lifecycle_current_start_pids
+    _lifecycle_last_qual = qual
+    _lifecycle_last_result = result
+    _lifecycle_last_end_pids = _soffice_pids()
+    _lifecycle_current_qual = ""
+    _lifecycle_current_start_pids = ""
+
+
+def format_lifecycle_breadcrumb() -> str:
+    """One line naming the previous TEST end, current test, and soffice PIDs.
+
+    Intermittent URP ``DisposedException`` on ``loadComponentFromURL`` usually
+    names the *victim* (next ``@with_native_doc`` open). This string names the
+    last test that finished — the likely killer — plus PIDs at that end and now.
+    """
+    prev = _lifecycle_last_qual or "-"
+    prev_result = _lifecycle_last_result or "-"
+    prev_pids = _lifecycle_last_end_pids or "-"
+    current = _lifecycle_current_qual or "-"
+    start_pids = _lifecycle_current_start_pids or "-"
+    return (
+        "previous=%s result=%s end_pids=%s current=%s start_pids=%s now_pids=%s"
+        % (prev, prev_result, prev_pids, current, start_pids, _soffice_pids())
+    )
+
+
+def _fail_reason_with_lifecycle(exc: BaseException) -> str:
+    """FAIL reason plus previous-test breadcrumb (never truncated off the crumb)."""
+    return "%s | %s" % (_fail_reason(exc), format_lifecycle_breadcrumb())
+
+
+def _parse_positive_int(raw: str, default: int = 1) -> int:
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _apply_soak_repeat_from_env() -> None:
+    """``WRITERAGENT_UNO_SOAK=N`` when CLI did not pass ``--repeat``."""
+    global _soak_repeat
+    raw = os.environ.get("WRITERAGENT_UNO_SOAK")
+    if not raw:
+        return
+    _soak_repeat = _parse_positive_int(raw, default=1)
+
+
 def _is_case_id(token: str) -> bool:
     """True for packet case ids like ``f3a``, ``b1a``, ``e9`` (not a lone packet letter)."""
     if len(token) < 2 or not token[0].isalpha():
@@ -257,21 +342,41 @@ def _parse_cli_args(argv: Sequence[str]) -> list[str]:
     ``python -m plugin.testing_runner`` runs as ``__main__``, so tests that
     ``import plugin.testing_runner`` would miss module-level flags. Mirror
     ``--user-profile`` into ``WRITERAGENT_UNO_USER_PROFILE`` as well.
+
+    ``--repeat N`` (or ``WRITERAGENT_UNO_SOAK``) re-runs selected suites in the
+    same soffice process to stress native-doc open/close. See
+    ``docs/framework/uno-test-lifecycle.md``.
     """
-    global show_window, use_user_profile
+    global show_window, use_user_profile, _soak_repeat
     filters: list[str] = []
-    for arg in argv:
+    _soak_repeat = 1
+    soak_from_cli = False
+    skip_next = False
+    for i, arg in enumerate(argv):
+        if skip_next:
+            skip_next = False
+            continue
         if arg in ("--visible", "--show-window"):
             show_window = True
         elif arg == "--user-profile":
             use_user_profile = True
             show_window = True
             os.environ["WRITERAGENT_UNO_USER_PROFILE"] = "1"
+        elif arg == "--repeat":
+            if i + 1 < len(argv):
+                _soak_repeat = _parse_positive_int(argv[i + 1], default=1)
+                soak_from_cli = True
+                skip_next = True
+        elif arg.startswith("--repeat="):
+            _soak_repeat = _parse_positive_int(arg.split("=", 1)[1], default=1)
+            soak_from_cli = True
         else:
             filters.append(str(arg))
     if os.environ.get("WRITERAGENT_UNO_USER_PROFILE") == "1":
         use_user_profile = True
         show_window = True
+    if not soak_from_cli:
+        _apply_soak_repeat_from_env()
     return filters
 
 
@@ -776,6 +881,8 @@ def run_module_suite(ctx, module, name, doc_model=None):
             except Exception as e:
                 return 0, 1, [f"EXCEPTION in {fallback_func_name}: {e}", traceback.format_exc()]
 
+    # Do not reset the lifecycle trail here: the first test of this suite may
+    # fail on factory open because the *previous suite's last test* killed URP.
     _progress(f"SUITE start {name} python_pid={os.getpid()} soffice.bin={_soffice_pids()}")
     name_filters = _test_function_filters(_cli_filters)
     if name_filters:
@@ -807,7 +914,8 @@ def run_module_suite(ctx, module, name, doc_model=None):
         for test_func in selected:
             test_line = f"Running test: {test_func.__name__}"
             qual = f"{name}.{test_func.__name__}"
-            _progress(f"TEST start {qual}")
+            record_test_start(qual)
+            _progress(f"TEST start {qual} soffice={_lifecycle_current_start_pids}")
             # Per-test faulthandler abort (30s). Silent — TEST start/end is enough.
             _arm_native_test_watchdog(qual)
             try:
@@ -831,35 +939,45 @@ def run_module_suite(ctx, module, name, doc_model=None):
                 _progress(f"TEST returned {qual}")
                 total_passed += 1
                 suite_log.append(f"{test_line} — OK")
-                _progress(f"TEST end {qual} OK")
+                record_test_end(qual, "OK")
+                _progress(f"TEST end {qual} OK soffice={_lifecycle_last_end_pids}")
             except ModuleNotFoundError as e:
                 # Some "native" tests attempt to use pytest.skip, but LibreOffice's
                 # Python may not have pytest installed.
                 if getattr(e, "name", None) == "pytest":
                     suite_log.append(f"{test_line} — SKIP (pytest not available)")
+                    record_test_end(qual, "SKIP")
                     _progress(f"TEST end {qual} SKIP")
                     continue
                 total_failed += 1
                 suite_log.append(f"{test_line} — FAIL (ModuleNotFoundError: {e})")
                 suite_log.append(traceback.format_exc())
-                _progress(f"TEST end {qual} FAIL {_fail_reason(e)}")
+                _progress(f"TEST end {qual} FAIL {_fail_reason_with_lifecycle(e)}")
+                record_test_end(qual, "FAIL")
             except unittest.SkipTest as e:
                 total_passed += 1
                 suite_log.append(f"{test_line} — OK (skipped) ({e})")
+                record_test_end(qual, "SKIP")
                 _progress(f"TEST end {qual} SKIP")
             except AssertionError as e:
                 total_failed += 1
                 suite_log.append(f"{test_line} — FAIL (AssertionError: {e})")
                 suite_log.append(traceback.format_exc())
-                _progress(f"TEST end {qual} FAIL {_fail_reason(e)}")
+                _progress(f"TEST end {qual} FAIL {_fail_reason_with_lifecycle(e)}")
+                record_test_end(qual, "FAIL")
             except Exception as e:
                 total_failed += 1
+                crumb = format_lifecycle_breadcrumb()
                 suite_log.append(f"{test_line} — FAIL ({type(e).__name__}: {e})")
+                suite_log.append(f"LIFECYCLE {crumb}")
                 suite_log.append(traceback.format_exc())
-                _progress(f"TEST end {qual} FAIL {_fail_reason(e)}")
+                _progress(f"TEST end {qual} FAIL {_fail_reason_with_lifecycle(e)}")
                 if _is_uno_bridge_disposed(e):
+                    _progress("LIFECYCLE URP dispose at %s %s" % (qual, crumb))
                     _mark_urp_dead(e, qual)
+                    record_test_end(qual, "FAIL")
                     break
+                record_test_end(qual, "FAIL")
             finally:
                 _disarm_native_test_watchdog(qual)
 
@@ -916,6 +1034,7 @@ def run_all_tests(ctx: Any) -> str:
     """
     global _urp_bridge_dead
     _urp_bridge_dead = False
+    reset_lifecycle_breadcrumb()
     # Mock doc.agent_edit_review_mode during tests to default to "off"
     # and only track its test-specific overrides in memory.
     import plugin.framework.config
@@ -1125,65 +1244,77 @@ def run_all_tests(ctx: Any) -> str:
                     if _module_matches_filters(full_path, filename, filter_strs):
                         test_candidates.append(full_path)
 
-        for module_path in sorted(test_candidates):
+        soak_rounds = max(1, _soak_repeat)
+        if soak_rounds > 1:
+            _progress(
+                "SOAK start rounds=%s suites=%s filter=%s"
+                % (soak_rounds, len(test_candidates), filter_strs or "-")
+            )
+        for soak_i in range(soak_rounds):
+            if soak_rounds > 1:
+                _progress("SOAK iter %s/%s" % (soak_i + 1, soak_rounds))
             if _urp_bridge_dead:
-                _progress("SUITE skip remaining: URP already disposed")
+                _progress("SOAK stop: URP already disposed")
                 break
-            ctx = _ensure_live_ctx(ctx)
-            if _urp_bridge_dead:
-                _progress("SUITE skip remaining: URP already disposed")
-                break
-            filename = os.path.basename(module_path)
-            module_name = filename[:-3]
-            
-            # Construct a unique module name for sys.modules to avoid collisions
-            # during the recursive walk.
-            rel_path = os.path.relpath(module_path, tests_root)
-            sys_module_name = "plugin.tests." + rel_path[:-3].replace(os.sep, ".")
+            for module_path in sorted(test_candidates):
+                if _urp_bridge_dead:
+                    _progress("SUITE skip remaining: URP already disposed")
+                    break
+                ctx = _ensure_live_ctx(ctx)
+                if _urp_bridge_dead:
+                    _progress("SUITE skip remaining: URP already disposed")
+                    break
+                filename = os.path.basename(module_path)
+                module_name = filename[:-3]
+                
+                # Construct a unique module name for sys.modules to avoid collisions
+                # during the recursive walk.
+                rel_path = os.path.relpath(module_path, tests_root)
+                sys_module_name = "plugin.tests." + rel_path[:-3].replace(os.sep, ".")
 
-            restore_snapshot: Dict[str, Any] | None = None
-            try:
-                restore_snapshot = {k: sys.modules.get(k, _MISSING) for k in NATIVE_TEST_SYS_MODULE_SNAPSHOT_KEYS}
-                spec = importlib.util.spec_from_file_location(sys_module_name, module_path)
-                if spec is None or spec.loader is None:
-                    continue
-                test_module = importlib.util.module_from_spec(spec)
-                sys.modules[sys_module_name] = test_module
-                spec.loader.exec_module(test_module)
+                restore_snapshot: Dict[str, Any] | None = None
+                try:
+                    restore_snapshot = {k: sys.modules.get(k, _MISSING) for k in NATIVE_TEST_SYS_MODULE_SNAPSHOT_KEYS}
+                    spec = importlib.util.spec_from_file_location(sys_module_name, module_path)
+                    if spec is None or spec.loader is None:
+                        continue
+                    test_module = importlib.util.module_from_spec(spec)
+                    sys.modules[sys_module_name] = test_module
+                    spec.loader.exec_module(test_module)
 
-                # Menu-only facade (e.g. calc ``test_calc_uno``): aggregates other UNO
-                # modules via ``run_calc_tests`` / ``run_integration_tests`` and must not
-                # run here — ``'_uno.py' in filename`` matches it, but it has no
-                # ``@native_test`` and the generic fallback name would not map to those runners.
-                if getattr(test_module, "SKIP_NATIVE_RUN_ALL", False):
-                    continue
+                    # Menu-only facade (e.g. calc ``test_calc_uno``): aggregates other UNO
+                    # modules via ``run_calc_tests`` / ``run_integration_tests`` and must not
+                    # run here — ``'_uno.py' in filename`` matches it, but it has no
+                    # ``@native_test`` and the generic fallback name would not map to those runners.
+                    if getattr(test_module, "SKIP_NATIVE_RUN_ALL", False):
+                        continue
 
-                doc_to_pass = None
-                if "writer" in module_name or "format" in module_name:
-                    # Writer core tests mutate the document and assume an empty starting state,
-                    # so we pass None to force it to create its own hidden temporary document.
-                    if "test_writer" not in module_name or module_name == "test_writer_uno":
-                        doc_to_pass = writer_doc
-                elif "calc" in module_name:
-                    doc_to_pass = calc_doc
-                elif "draw" in module_name or "impress" in module_name:
-                    doc_to_pass = draw_doc
+                    doc_to_pass = None
+                    if "writer" in module_name or "format" in module_name:
+                        # Writer core tests mutate the document and assume an empty starting state,
+                        # so we pass None to force it to create its own hidden temporary document.
+                        if "test_writer" not in module_name or module_name == "test_writer_uno":
+                            doc_to_pass = writer_doc
+                    elif "calc" in module_name:
+                        doc_to_pass = calc_doc
+                    elif "draw" in module_name or "impress" in module_name:
+                        doc_to_pass = draw_doc
 
-                p, f = _run_suite(ctx, suites, sys_module_name.replace("plugin.tests.", ""), test_module, doc_to_pass)
-                total_passed += p
-                total_failed += f
-            except ImportError as e:
-                print(f"Skipping {filename} due to ImportError: {e}")
-            except Exception as e:
-                print(f"Error loading {filename}: {e}")
-            finally:
-                # Prevent sys.modules mocking from polluting later native tests.
-                if restore_snapshot is not None:
-                    for k, v in restore_snapshot.items():
-                        if v is _MISSING:
-                            sys.modules.pop(k, None)
-                        else:
-                            sys.modules[k] = v
+                    p, f = _run_suite(ctx, suites, sys_module_name.replace("plugin.tests.", ""), test_module, doc_to_pass)
+                    total_passed += p
+                    total_failed += f
+                except ImportError as e:
+                    print(f"Skipping {filename} due to ImportError: {e}")
+                except Exception as e:
+                    print(f"Error loading {filename}: {e}")
+                finally:
+                    # Prevent sys.modules mocking from polluting later native tests.
+                    if restore_snapshot is not None:
+                        for k, v in restore_snapshot.items():
+                            if v is _MISSING:
+                                sys.modules.pop(k, None)
+                            else:
+                                sys.modules[k] = v
 
         if keeper_doc is not None:
             try:
@@ -1242,10 +1373,19 @@ def main() -> int:
         python -m plugin.testing_runner
         python -m plugin.testing_runner tests/chatbot/test_mock_llm_sidebar_uno.py E
         python -m plugin.testing_runner --user-profile …/test_mock_llm_sidebar_uno.py f3a
+        python -m plugin.testing_runner --repeat 20 test_draw_uno
 
     Extra tokens select tests: packet letter (``B``/``C``/``D``/``E``/``F``/``G``/``P``), case id
     (``f3a`` / ``p1``), or full ``test_*`` name. Prefer ``make test-mock-sidebar FILTER=P``
     for the dual-sidebar peer Packet.
+
+    ``--repeat N`` (or ``WRITERAGENT_UNO_SOAK=N``) re-runs selected suites in the
+    same soffice process to stress native-doc open/close. Draw subset::
+
+        make test-uno-soak
+        make test-uno-soak FILTER=test_get_draw_tree,test_insert_math_draw REPEAT=50
+
+    See ``docs/framework/uno-test-lifecycle.md``.
 
     The import of officehelper/uno is done lazily so that this module
     can still be imported inside LibreOffice without pulling them in.

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -16,7 +16,9 @@ from plugin.testing_runner import (
     _is_case_id,
     _module_matches_filters,
     _test_function_filters,
+    expand_soak_pair,
     format_lifecycle_breadcrumb,
+    probe_uno_bridge,
     record_test_end,
     record_test_start,
     reset_lifecycle_breadcrumb,
@@ -121,7 +123,59 @@ def test_lifecycle_breadcrumb_names_previous_and_current(monkeypatch) -> None:
     assert "previous=draw.test_draw_uno.test_get_draw_tree" in crumb
     assert "result=OK" in crumb
     assert "end_pids=4242" in crumb
+    assert "last_ok=draw.test_draw_uno.test_get_draw_tree" in crumb
     assert "current=draw.test_draw_uno.test_insert_math_draw" in crumb
+    assert "pids_changed=0" in crumb
+    assert "dt_ms=" in crumb
+
+
+def test_lifecycle_breadcrumb_marks_pid_change_and_last_ok(monkeypatch) -> None:
+    pids = ["11"]
+
+    def fake_pids() -> str:
+        return pids[0]
+
+    monkeypatch.setattr("plugin.testing_runner._soffice_pids", fake_pids)
+    reset_lifecycle_breadcrumb()
+    record_test_end("suite.test_ok", "OK")
+    pids[0] = "-"
+    record_test_start("suite.test_victim")
+    crumb = format_lifecycle_breadcrumb()
+    assert "last_ok=suite.test_ok" in crumb
+    assert "pids_changed=1" in crumb
+    assert "now_pids=-" in crumb
+
+
+def test_probe_uno_bridge_states() -> None:
+    assert probe_uno_bridge(None) == "no_probe"
+    assert probe_uno_bridge(object()) == "no_probe"
+
+    class _Alive:
+        def getServiceManager(self) -> object:
+            return object()
+
+    assert probe_uno_bridge(_Alive()) == "alive"
+
+    class _Dead:
+        def getServiceManager(self) -> None:
+            raise RuntimeError("Binary URP bridge disposed during call")
+
+    assert probe_uno_bridge(_Dead()) == "disposed"
+
+    class _Boom:
+        def getServiceManager(self) -> None:
+            raise ValueError("no desktop")
+
+    assert probe_uno_bridge(_Boom()) == "error:ValueError"
+
+
+def test_expand_soak_pair_aliases() -> None:
+    assert expand_soak_pair("tree-math") == ["test_get_draw_tree", "test_insert_math_draw"]
+    assert expand_soak_pair("dup-move") == [
+        "test_duplicate_slide_copies_shapes",
+        "test_duplicate_rename_move_slide",
+    ]
+    assert expand_soak_pair("unknown") == []
 
 
 def test_fail_reason_with_lifecycle_keeps_crumb_after_cap() -> None:

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -10,10 +10,16 @@ from pathlib import Path
 
 from plugin.testing_runner import (
     _cli_filters,
+    _fail_reason,
+    _fail_reason_with_lifecycle,
     _function_name_matches,
     _is_case_id,
     _module_matches_filters,
     _test_function_filters,
+    format_lifecycle_breadcrumb,
+    record_test_end,
+    record_test_start,
+    reset_lifecycle_breadcrumb,
 )
 
 
@@ -94,3 +100,37 @@ def test_module_matches_filters_by_packet_letter(tmp_path: Path) -> None:
 
 def test_cli_filters_default_empty() -> None:
     assert isinstance(_cli_filters, list)
+
+
+def test_lifecycle_breadcrumb_names_previous_and_current(monkeypatch) -> None:
+    """DisposedException on the next open must name the last TEST end, not only the victim."""
+    monkeypatch.setattr("plugin.testing_runner._soffice_pids", lambda: "4242")
+    reset_lifecycle_breadcrumb()
+    assert "previous=-" in format_lifecycle_breadcrumb()
+    assert "current=-" in format_lifecycle_breadcrumb()
+
+    record_test_start("draw.test_draw_uno.test_get_draw_tree")
+    crumb = format_lifecycle_breadcrumb()
+    assert "current=draw.test_draw_uno.test_get_draw_tree" in crumb
+    assert "start_pids=4242" in crumb
+    assert "now_pids=4242" in crumb
+
+    record_test_end("draw.test_draw_uno.test_get_draw_tree", "OK")
+    record_test_start("draw.test_draw_uno.test_insert_math_draw")
+    crumb = format_lifecycle_breadcrumb()
+    assert "previous=draw.test_draw_uno.test_get_draw_tree" in crumb
+    assert "result=OK" in crumb
+    assert "end_pids=4242" in crumb
+    assert "current=draw.test_draw_uno.test_insert_math_draw" in crumb
+
+
+def test_fail_reason_with_lifecycle_keeps_crumb_after_cap() -> None:
+    reset_lifecycle_breadcrumb()
+    record_test_end("suite.test_ok", "OK")
+    record_test_start("suite.test_victim")
+    long_exc = AssertionError("n" * 500)
+    out = _fail_reason_with_lifecycle(long_exc)
+    assert _fail_reason(long_exc).endswith("...")
+    assert "previous=suite.test_ok" in out
+    assert "result=OK" in out
+    assert "current=suite.test_victim" in out

--- a/tests/scripts/test_testing_runner_cli.py
+++ b/tests/scripts/test_testing_runner_cli.py
@@ -275,6 +275,66 @@ def test_is_uno_bridge_disposed() -> None:
     assert not tr._is_uno_bridge_disposed(RuntimeError("no desktop"))
 
 
+def test_parse_cli_repeat_and_soak_env(monkeypatch) -> None:
+    monkeypatch.setattr(tr, "use_user_profile", False)
+    monkeypatch.setattr(tr, "show_window", False)
+    monkeypatch.delenv("WRITERAGENT_UNO_USER_PROFILE", raising=False)
+    monkeypatch.delenv("WRITERAGENT_UNO_SOAK", raising=False)
+    rest = tr._parse_cli_args(["--repeat", "7", "test_draw_uno"])
+    assert rest == ["test_draw_uno"]
+    assert tr._soak_repeat == 7
+
+    rest = tr._parse_cli_args(["--repeat=3", "test_get_draw_tree"])
+    assert rest == ["test_get_draw_tree"]
+    assert tr._soak_repeat == 3
+
+    monkeypatch.setenv("WRITERAGENT_UNO_SOAK", "11")
+    rest = tr._parse_cli_args(["test_draw_uno"])
+    assert rest == ["test_draw_uno"]
+    assert tr._soak_repeat == 11
+
+    rest = tr._parse_cli_args(["--repeat", "2", "test_draw_uno"])
+    assert tr._soak_repeat == 2
+
+    rest = tr._parse_cli_args(["--repeat", "nope", "test_draw_uno"])
+    assert tr._soak_repeat == 1
+
+
+def test_run_module_suite_fail_names_previous_test(capsys, monkeypatch) -> None:
+    """URP dispose on the second test must print previous=<first> result=OK."""
+    monkeypatch.setattr(tr, "_soffice_pids", lambda: "99")
+    tr.reset_lifecycle_breadcrumb()
+
+    def test_ok(ctx=None):
+        return None
+
+    def test_victim(ctx=None):
+        raise RuntimeError("Binary URP bridge disposed during call")
+
+    test_ok._is_test = True
+    test_victim._is_test = True
+
+    class _Mod:
+        pass
+
+    module = _Mod()
+    module.test_ok = test_ok
+    module.test_victim = test_victim
+
+    tr._urp_bridge_dead = False
+    passed, failed, suite_log = tr.run_module_suite(object(), module, "draw.crumb")
+    assert passed == 1
+    assert failed == 1
+    err = capsys.readouterr().err
+    assert "previous=draw.crumb.test_ok" in err
+    assert "result=OK" in err
+    assert "current=draw.crumb.test_victim" in err
+    assert "LIFECYCLE URP dispose at draw.crumb.test_victim" in err
+    assert any("LIFECYCLE" in line and "previous=draw.crumb.test_ok" in line for line in suite_log)
+    tr._urp_bridge_dead = False
+    tr.reset_lifecycle_breadcrumb()
+
+
 def test_run_module_suite_stops_after_urp_dispose() -> None:
     ran: list[str] = []
 

--- a/tests/scripts/test_testing_runner_cli.py
+++ b/tests/scripts/test_testing_runner_cli.py
@@ -299,6 +299,15 @@ def test_parse_cli_repeat_and_soak_env(monkeypatch) -> None:
     rest = tr._parse_cli_args(["--repeat", "nope", "test_draw_uno"])
     assert tr._soak_repeat == 1
 
+    rest = tr._parse_cli_args(["--pair", "tree-math", "--repeat", "4"])
+    assert rest == ["test_get_draw_tree", "test_insert_math_draw"]
+    assert tr._soak_repeat == 4
+    rest = tr._parse_cli_args(["--pair=dup-move"])
+    assert rest == [
+        "test_duplicate_slide_copies_shapes",
+        "test_duplicate_rename_move_slide",
+    ]
+
 
 def test_run_module_suite_fail_names_previous_test(capsys, monkeypatch) -> None:
     """URP dispose on the second test must print previous=<first> result=OK."""
@@ -331,6 +340,50 @@ def test_run_module_suite_fail_names_previous_test(capsys, monkeypatch) -> None:
     assert "current=draw.crumb.test_victim" in err
     assert "LIFECYCLE URP dispose at draw.crumb.test_victim" in err
     assert any("LIFECYCLE" in line and "previous=draw.crumb.test_ok" in line for line in suite_log)
+    tr._urp_bridge_dead = False
+    tr.reset_lifecycle_breadcrumb()
+
+
+def test_run_module_suite_fails_ok_test_when_bridge_dies_after_return(capsys) -> None:
+    """Harness attribution: TEST returned OK but getServiceManager is already disposed."""
+    tr.reset_lifecycle_breadcrumb()
+    ran: list[str] = []
+
+    class _Ctx:
+        dead = False
+
+        def getServiceManager(self) -> object:
+            if self.dead:
+                raise RuntimeError("Binary URP bridge disposed during call")
+            return object()
+
+    def test_ok(ctx=None):
+        ran.append("ok")
+        ctx.dead = True
+
+    def test_second(ctx=None):
+        ran.append("second")
+
+    test_ok._is_test = True
+    test_second._is_test = True
+
+    class _Mod:
+        pass
+
+    module = _Mod()
+    module.test_ok = test_ok
+    module.test_second = test_second
+
+    ctx = _Ctx()
+    tr._urp_bridge_dead = False
+    passed, failed, suite_log = tr.run_module_suite(ctx, module, "draw.teardown")
+    assert ran == ["ok"]
+    assert passed == 0
+    assert failed == 1
+    assert tr._urp_bridge_dead is True
+    err = capsys.readouterr().err
+    assert "LIFECYCLE office dead after TEST returned draw.teardown.test_ok" in err
+    assert any("office dead after TEST returned" in line for line in suite_log)
     tr._urp_bridge_dead = False
     tr.reset_lifecycle_breadcrumb()
 

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -254,6 +254,7 @@ def test_reraise_native_open_failure_names_previous_test(capsys, monkeypatch):
         except RuntimeError as exc:
             _reraise_native_open_failure(exc, "private:factory/sdraw")
     assert "create_native_doc loadComponentFromURL(private:factory/sdraw)" in str(caught.value)
+    assert "pre_open=" in str(caught.value)
     assert "Binary URP bridge" in str(caught.value)
     err = capsys.readouterr().err
     assert "LIFECYCLE native_doc open FAIL" in err
@@ -269,6 +270,33 @@ def test_reraise_native_open_failure_passthrough_non_urp():
             raise ValueError("not a bridge")
         except ValueError as exc:
             _reraise_native_open_failure(exc, "private:factory/sdraw")
+
+
+def test_create_native_doc_skips_load_when_bridge_already_dead(monkeypatch):
+    from unittest.mock import MagicMock, patch
+
+    import plugin.testing_runner as tr
+    from plugin.tests.testing_utils import TestingFactory
+
+    tr.reset_lifecycle_breadcrumb()
+    tr.record_test_end("draw.test_draw_uno.test_duplicate_slide_copies_shapes", "OK")
+    tr.record_test_start("draw.test_draw_uno.test_duplicate_rename_move_slide")
+
+    class _DeadCtx:
+        def getServiceManager(self) -> None:
+            raise RuntimeError("Binary URP bridge disposed during call")
+
+    desktop = MagicMock()
+    with (
+        patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+        patch("uno.createUnoStruct", return_value=MagicMock()),
+        pytest.raises(RuntimeError, match="pre_open=disposed") as caught,
+    ):
+        TestingFactory.create_native_doc(_DeadCtx(), "draw")
+    assert "already disposed before loadComponentFromURL" in str(caught.value)
+    assert "previous=draw.test_draw_uno.test_duplicate_slide_copies_shapes" in str(caught.value)
+    desktop.loadComponentFromURL.assert_not_called()
+    tr.reset_lifecycle_breadcrumb()
 
 
 def test_create_native_doc_wraps_disposed_exception(monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -238,6 +238,102 @@ def test_clear_writeragent_udprops_skips_set_document_scripts():
     assert written["WriterAgentSessionID"] == ""
 
 
+def test_reraise_native_open_failure_names_previous_test(capsys, monkeypatch):
+    """Factory-open DisposedException must name the previous TEST end in the message."""
+    import plugin.testing_runner as tr
+    from plugin.tests.testing_utils import _reraise_native_open_failure
+
+    monkeypatch.setattr(tr, "_soffice_pids", lambda: "7")
+    tr.reset_lifecycle_breadcrumb()
+    tr.record_test_end("draw.test_draw_uno.test_duplicate_slide_copies_shapes", "OK")
+    tr.record_test_start("draw.test_draw_uno.test_duplicate_rename_move_slide")
+
+    with pytest.raises(RuntimeError, match="previous=draw.test_draw_uno.test_duplicate_slide_copies_shapes") as caught:
+        try:
+            raise RuntimeError("Binary URP bridge disposed during call")
+        except RuntimeError as exc:
+            _reraise_native_open_failure(exc, "private:factory/sdraw")
+    assert "create_native_doc loadComponentFromURL(private:factory/sdraw)" in str(caught.value)
+    assert "Binary URP bridge" in str(caught.value)
+    err = capsys.readouterr().err
+    assert "LIFECYCLE native_doc open FAIL" in err
+    assert "previous=draw.test_draw_uno.test_duplicate_slide_copies_shapes" in err
+    tr.reset_lifecycle_breadcrumb()
+
+
+def test_reraise_native_open_failure_passthrough_non_urp():
+    from plugin.tests.testing_utils import _reraise_native_open_failure
+
+    with pytest.raises(ValueError, match="not a bridge"):
+        try:
+            raise ValueError("not a bridge")
+        except ValueError as exc:
+            _reraise_native_open_failure(exc, "private:factory/sdraw")
+
+
+def test_create_native_doc_wraps_disposed_exception(monkeypatch):
+    from unittest.mock import MagicMock, patch
+
+    import plugin.testing_runner as tr
+    from plugin.tests.testing_utils import TestingFactory
+
+    tr.reset_lifecycle_breadcrumb()
+    tr.record_test_end("draw.test_draw_uno.test_get_draw_tree", "OK")
+    tr.record_test_start("draw.test_draw_uno.test_insert_math_draw")
+
+    desktop = MagicMock()
+    desktop.loadComponentFromURL.side_effect = RuntimeError("Binary URP bridge disposed during call")
+    with (
+        patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+        patch("uno.createUnoStruct", return_value=MagicMock()),
+        pytest.raises(RuntimeError, match="previous=draw.test_draw_uno.test_get_draw_tree"),
+    ):
+        TestingFactory.create_native_doc(object(), "draw")
+    tr.reset_lifecycle_breadcrumb()
+
+
+def test_log_close_doc_failure_and_office_health(capsys, monkeypatch):
+    from unittest.mock import MagicMock, patch
+
+    import plugin.testing_runner as tr
+    from plugin.tests.testing_utils import _log_close_doc_failure, _log_office_health_after_close
+
+    monkeypatch.setattr(tr, "_soffice_pids", lambda: "-")
+    tr.reset_lifecycle_breadcrumb()
+    tr.record_test_end("draw.test_draw_uno.test_get_draw_tree", "OK")
+
+    _log_close_doc_failure(RuntimeError("Binary URP bridge disposed during call"))
+    err = capsys.readouterr().err
+    assert "LIFECYCLE close_doc dispose" in err
+    assert "previous=draw.test_draw_uno.test_get_draw_tree" in err
+
+    desktop = MagicMock()
+    desktop.getComponents.side_effect = RuntimeError("Binary URP bridge disposed during call")
+    with patch("plugin.framework.uno_context.get_desktop", return_value=desktop):
+        _log_office_health_after_close(object(), "draw")
+    err = capsys.readouterr().err
+    assert "LIFECYCLE office dead after close doc_type=draw" in err
+    assert "previous=draw.test_draw_uno.test_get_draw_tree" in err
+    tr.reset_lifecycle_breadcrumb()
+
+
+def test_close_doc_logs_urp_dispose(capsys, monkeypatch):
+    from unittest.mock import MagicMock
+
+    import plugin.testing_runner as tr
+    from plugin.tests.testing_utils import TestingFactory
+
+    monkeypatch.setattr(tr, "_soffice_pids", lambda: "8")
+    tr.reset_lifecycle_breadcrumb()
+    tr.record_test_start("draw.test_draw_uno.test_get_draw_tree")
+    doc = MagicMock()
+    doc.close.side_effect = RuntimeError("Binary URP bridge disposed during call")
+    TestingFactory.close_doc(doc)
+    err = capsys.readouterr().err
+    assert "LIFECYCLE close_doc dispose" in err
+    tr.reset_lifecycle_breadcrumb()
+
+
 def test_testing_factory_execute_tool_unknown_name():
     from unittest.mock import MagicMock, patch
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -800,13 +800,16 @@ def _native_teardown_progress(msg: str) -> None:
     _progress(msg)
 
 
-def _reraise_native_open_failure(exc: BaseException, factory_url: str) -> None:
+def _reraise_native_open_failure(
+    exc: BaseException, factory_url: str, pre_open: str = "no_probe"
+) -> None:
     """Re-raise factory-open failures with the previous-test breadcrumb attached.
 
     URP ``DisposedException`` on ``loadComponentFromURL`` usually means the
     *previous* ``@with_native_doc`` close killed soffice/the bridge. Keep
     ``Binary URP bridge`` in the message so ``_is_uno_bridge_disposed`` still
-    matches and the runner aborts remaining suites.
+    matches and the runner aborts remaining suites. ``pre_open`` is the cheap
+    getServiceManager probe taken *before* load (alive vs already disposed).
     """
     from plugin.testing_runner import (
         _is_uno_bridge_disposed,
@@ -818,7 +821,8 @@ def _reraise_native_open_failure(exc: BaseException, factory_url: str) -> None:
     if _is_uno_bridge_disposed(exc):
         msg = (
             "create_native_doc loadComponentFromURL(%s) DisposedException / URP dead "
-            "(%s: %s) %s" % (factory_url, type(exc).__name__, exc, crumb)
+            "pre_open=%s (%s: %s) %s"
+            % (factory_url, pre_open, type(exc).__name__, exc, crumb)
         )
         _progress("LIFECYCLE native_doc open FAIL %s" % msg)
         raise RuntimeError("Binary URP bridge disposed during call; %s" % msg) from exc
@@ -1242,10 +1246,21 @@ class TestingFactory:
                 "impress": "private:factory/simpress"
             }.get(doc_type, "private:factory/swriter")
 
+        from plugin.testing_runner import probe_uno_bridge
+
+        # Distinguish "bridge already dead" (previous test) from "died during load".
+        pre_open = probe_uno_bridge(ctx)
+        if pre_open == "disposed":
+            _reraise_native_open_failure(
+                RuntimeError("Binary URP bridge already disposed before loadComponentFromURL"),
+                factory_url,
+                pre_open=pre_open,
+            )
+            raise
         try:
             doc = desktop.loadComponentFromURL(factory_url, "_blank", 0, tuple(props))
         except Exception as exc:
-            _reraise_native_open_failure(exc, factory_url)
+            _reraise_native_open_failure(exc, factory_url, pre_open=pre_open)
             raise
         return doc
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -800,6 +800,75 @@ def _native_teardown_progress(msg: str) -> None:
     _progress(msg)
 
 
+def _reraise_native_open_failure(exc: BaseException, factory_url: str) -> None:
+    """Re-raise factory-open failures with the previous-test breadcrumb attached.
+
+    URP ``DisposedException`` on ``loadComponentFromURL`` usually means the
+    *previous* ``@with_native_doc`` close killed soffice/the bridge. Keep
+    ``Binary URP bridge`` in the message so ``_is_uno_bridge_disposed`` still
+    matches and the runner aborts remaining suites.
+    """
+    from plugin.testing_runner import (
+        _is_uno_bridge_disposed,
+        _progress,
+        format_lifecycle_breadcrumb,
+    )
+
+    crumb = format_lifecycle_breadcrumb()
+    if _is_uno_bridge_disposed(exc):
+        msg = (
+            "create_native_doc loadComponentFromURL(%s) DisposedException / URP dead "
+            "(%s: %s) %s" % (factory_url, type(exc).__name__, exc, crumb)
+        )
+        _progress("LIFECYCLE native_doc open FAIL %s" % msg)
+        raise RuntimeError("Binary URP bridge disposed during call; %s" % msg) from exc
+    raise
+
+
+def _log_close_doc_failure(exc: BaseException) -> None:
+    """Log (do not re-raise) a dispose during ``close_doc`` so the trail is named."""
+    from plugin.testing_runner import (
+        _is_uno_bridge_disposed,
+        _progress,
+        _soffice_pids,
+        format_lifecycle_breadcrumb,
+    )
+
+    if not (_is_uno_bridge_disposed(exc) or type(exc).__name__ == "DisposedException"):
+        return
+    _progress(
+        "LIFECYCLE close_doc dispose pids=%s %s"
+        % (_soffice_pids(), format_lifecycle_breadcrumb())
+    )
+
+
+def _log_office_health_after_close(ctx, doc_type: str) -> None:
+    """Harness-only: probe the desktop after close; log if the office is already dead.
+
+    Draw/Impress never reuse a pooled doc, so each test closes. If that close
+    (or a delayed crash) kills URP, the next factory open is the named victim.
+    This probe prints at close time. It does not restart office or skip tests.
+    """
+    from plugin.testing_runner import (
+        _is_uno_bridge_disposed,
+        _progress,
+        _soffice_pids,
+        format_lifecycle_breadcrumb,
+    )
+
+    try:
+        from plugin.framework.uno_context import get_desktop
+
+        desktop = get_desktop(ctx)
+        desktop.getComponents()
+    except Exception as exc:
+        if _is_uno_bridge_disposed(exc) or type(exc).__name__ == "DisposedException":
+            _progress(
+                "LIFECYCLE office dead after close doc_type=%s pids=%s %s"
+                % (doc_type, _soffice_pids(), format_lifecycle_breadcrumb())
+            )
+
+
 def _default_native_doc_reuse(doc_type: str) -> bool:
     return doc_type == "calc"
 
@@ -1148,7 +1217,13 @@ class TestingFactory:
 
     @staticmethod
     def create_native_doc(ctx, doc_type="writer", hidden=True):
-        """Creates a real hidden document in LibreOffice."""
+        """Creates a real hidden document in LibreOffice.
+
+        On URP ``DisposedException``, logs the previous native test (and PIDs)
+        then re-raises a ``RuntimeError`` that still matches
+        ``_is_uno_bridge_disposed`` so the runner names the *previous* test,
+        not only this factory open. See ``docs/framework/uno-test-lifecycle.md``.
+        """
         from plugin.framework.uno_context import get_desktop
         import uno
 
@@ -1167,7 +1242,11 @@ class TestingFactory:
                 "impress": "private:factory/simpress"
             }.get(doc_type, "private:factory/swriter")
 
-        doc = desktop.loadComponentFromURL(factory_url, "_blank", 0, tuple(props))
+        try:
+            doc = desktop.loadComponentFromURL(factory_url, "_blank", 0, tuple(props))
+        except Exception as exc:
+            _reraise_native_open_failure(exc, factory_url)
+            raise
         return doc
 
     @staticmethod
@@ -1194,8 +1273,10 @@ class TestingFactory:
                 doc.close(True)
             elif hasattr(doc, "dispose"):
                 doc.dispose()
-        except Exception:
-            pass
+        except Exception as exc:
+            # Harness-only: close used to swallow DisposedException, so the
+            # *next* factory open became the named victim. Log the trail here.
+            _log_close_doc_failure(exc)
 
 
     @staticmethod
@@ -1262,6 +1343,9 @@ class TestingFactory:
             else:
                 _native_teardown_progress("native_doc: teardown close_doc start")
                 TestingFactory.close_doc(doc)
+                # Harness probe (not a product fix): if close toasted URP, name
+                # it now instead of waiting for the next loadComponentFromURL.
+                _log_office_health_after_close(ctx, doc_type)
                 _native_teardown_progress("native_doc: teardown close_doc done")
 
 
@@ -1333,7 +1417,8 @@ def with_native_doc(doc_type="writer", hidden=True, reuse=None):
 
     Calc: experimental wipe-and-reuse of one hidden spreadsheet (faster than factory+close).
     Writer: factory load/close by default (reuse leaks HTML/CharWeight). Pass reuse=True to try pooling.
-    Draw/Impress never reuse.
+    Draw/Impress never reuse. Factory-open DisposedException is annotated with
+    the previous native test (docs/framework/uno-test-lifecycle.md).
     """
     def decorator(func):
         import functools


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

Diagnostic harness for intermittent URP `DisposedException` on Draw/UNO factory open (CI flake on #685 at `test_duplicate_rename_move_slide` / `create_native_doc` / `loadComponentFromURL`). **Not a product fix.** Breadcrumbs + soak stay in this **one** PR.

## What I found about lifecycle

- Draw/Impress **never** reuse a pooled doc. Each `@with_native_doc("draw")` is factory `loadComponentFromURL` + `close_doc` (`gc.collect` then `close`).
- A keeper hidden Writer stays open for the whole `run_all_tests` so closing the last Draw doc does not shut down Windows bootstraps.
- `_ensure_live_ctx` only runs **between suites**, and only after `getServiceManager()` already fails. Inside a suite the next factory open is the first place a dead bridge is noticed.
- `close_doc` swallowed dispose, so a teardown crash still printed `TEST end … OK` and the **next** open became the named victim. That matches “previous test toasted soffice/the bridge” more than a bug inside duplicate/rename/move.
- Historical Arch glibc double-free (`test_get_draw_tree` OK → `test_insert_math_draw` factory load) is the same class of gap. Math OLE is a plausible stressor for *that* pair; it does **not** explain a victim that is `test_duplicate_rename_move_slide` (earlier in the file). Unproven either way.

## What the breadcrumb prints

On every native **FAIL**, stderr `TEST end … FAIL` appends:

```
previous=<suite.test> result=OK|FAIL|SKIP|- end_pids=<pids at that end>
last_ok=<last successful TEST> dt_ms=<ms from that end to this start>
current=<victim> start_pids=… now_pids=… pids_changed=0|1
bridge=alive|disposed|no_probe|error:…
```

`bridge=` is `ctx.getServiceManager()` at TEST start. Factory open also prints `pre_open=`:

- `pre_open=disposed` — already dead; load is skipped; previous TEST end is the killer for that fail.
- `pre_open=alive` then dispose on load — died *during* this open.

URP dispose also prints `LIFECYCLE URP dispose at <victim> previous=…`. If a test **returns OK** but `getServiceManager` is already disposed, the runner fails *that* test (`LIFECYCLE office dead after TEST returned`) so the killer is named instead of the next open. Grep `LIFECYCLE` / `previous=` / `pre_open=`. Native tests do not run under pytest; `format_lifecycle_breadcrumb` / `probe_uno_bridge` in `plugin/testing_runner.py` are the hook.

Unit coverage: `tests/framework/test_testing_runner.py`, `tests/scripts/test_testing_runner_cli.py`, `tests/test_testing_utils.py` (75 passed).

## How to run the soak

Same soffice process (this is the lifecycle under test):

```bash
make test-uno-soak
make test-uno-soak REPEAT=50
make test-uno-soak PAIR=tree-math REPEAT=50
make test-uno-soak PAIR=dup-move REPEAT=50
make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
```

`PAIR=tree-math` → `test_get_draw_tree` + `test_insert_math_draw`. `PAIR=dup-move` → `test_duplicate_slide_copies_shapes` + `test_duplicate_rename_move_slide`. Or `python -m plugin.testing_runner --repeat 50 --pair tree-math`. Look for `SOAK iter i/N` then the first `LIFECYCLE` line. Outer `make test-uno` loops restart soffice and are a weaker repro. Not in default CI.

Topic doc: [`docs/framework/uno-test-lifecycle.md`](docs/framework/uno-test-lifecycle.md).

## Hardening included? Why / why not

**Included (harness only, clearly labeled, not a product fix):**

- Log `LIFECYCLE close_doc dispose` instead of swallowing URP errors silently in `close_doc`.
- After a non-pooled close, probe `desktop.getComponents()` → `LIFECYCLE office dead after close`.
- After TEST returned OK, if `getServiceManager` is disposed, **fail that test** (name the killer).
- `create_native_doc` probes before load; `pre_open=disposed` skips `loadComponentFromURL` and still raises a URP-shaped error with the trail.

**Not included:**

- No office auto-restart on dispose (would hide the killer).
- No skip/xfail of math OLE or Draw tests.
- No product `loadComponentFromURL` retry.

Cause is still unproven until a soak/CI fail shows `previous=` / `pre_open=` on the FAIL line.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b66c7783-f174-413f-b93f-9ce5a9e1ee14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b66c7783-f174-413f-b93f-9ce5a9e1ee14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

