### PR TITLE
Diagnostic: fail-closed on Unspecified Application Error (SalAbort)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -806,6 +806,7 @@ test-uno: _check-lo-python
 # FILTER defaults to the Draw native suite. PAIR=tree-math | dup-move expands --pair.
 #   make test-uno-soak PAIR=tree-math REPEAT=50
 #   make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
+# FILTER prefix-matches (test_get_draw_tree also selects the blank/label test). PAIR= is exact.
 # See docs/framework/uno-test-lifecycle.md
 REPEAT ?= 20
 PAIR ?=

--- a/docs/framework/salabort-svxshape-close.md
+++ b/docs/framework/salabort-svxshape-close.md
@@ -1,0 +1,68 @@
+# SalAbort during SvxShape / SdrRectObj teardown (gdb)
+
+**Not a product fix.** Box QA catch on PR `#694` branch
+(`cursor/uno-application-error-diag-6477`), 2026-09-08 evening (America/Detroit).
+Raw dump: captured as `/workspace/draw-urp-soak/gdb/native-stack.txt` on the QA box
+(not committed). Summary for morning review.
+
+## Catch
+
+| Item | Value |
+|------|--------|
+| LO | 25.2.3.2 520(Build:2) |
+| Method | Attach `gdb -p` to soak `soffice.bin` after `connected=True`; break `Application::Abort` |
+| Trigger soak | `make test-uno-soak FILTER="test_duplicate_slide_copies_shapes" REPEAT=40` |
+| When | After TEST returned OK → stderr `Unspecified Application Error` → `soffice_exit=134` |
+| Symbols | Partial dynamic only (no `libreoffice-*-dbgsym` in apt on the box) |
+
+## Faulting thread (`cppu_threadpool`)
+
+SEGV (or equivalent) during Draw shape teardown → signal handler → empty-text
+`Application::Abort` → VCL `SalAbort` prints **Unspecified Application Error**
+→ `abort()` (soak uses `--norestore`).
+
+```
+#0  Application::Abort(rtl::OUString const&)     libmergedlo.so
+#1  ??                                           libmergedlo.so
+#2  ??                                           libmergedlo.so
+#3  ??                                           libuno_sal.so.3
+#4  <signal handler called>
+#5  ??                                           libmergedlo.so
+#6  SfxItemSet::ClearSingleItem_PrepareRemove(SfxPoolItem const*)
+#7  SfxItemSet::ClearAllItemsImpl()
+#8  SfxItemSet::~SfxItemSet()
+#9–10 ??                                         libmergedlo.so
+#11 SdrObject::~SdrObject()
+#12 SdrRectObj::~SdrRectObj()
+#13 SvxShape::~SvxShape()
+#14 ??                                           libmergedlo.so
+#15 cppu::OWeakAggObject::release()
+… uno_Environment_invoke / binaryurp / cppu_threadpool
+```
+
+Main thread was idle in `Application::Execute` / `ImplSVMain`.
+
+## Reading
+
+1. The stderr string is VCL `SalAbort` with **empty** abort text (see
+   `uno-test-lifecycle.md`) — office is dying, not a WriterAgent log line.
+2. Death is on a **URP / cppu_threadpool** thread releasing an `SvxShape` that
+   wraps an `SdrRectObj`, while clearing an `SfxItemSet` (item pool).
+3. Fits the QA timeline: Python `doc.close(True)` **returns**, then async
+   shape/model teardown aborts soffice; the next open sees
+   `Binary URP bridge already disposed`.
+4. **Kinship with the octagon Draw abort:** same general family —
+   `SfxItemPool` / item-set destruction while destroying a rect/shape
+   (`SfxItemPool::unregisterNameOrIndex` on octagon vs
+   `SfxItemSet::ClearSingleItem_PrepareRemove` here). Not proven identical
+   root cause without dbgsyms / LO source line mapping.
+5. Hottest harness repro remains solo
+   `test_duplicate_slide_copies_shapes` (rectangle + text then
+   `duplicate_slide`). Blank/label TextShape soak also fires SalAbort at a
+   lower rate — not exclusive to `duplicate_slide`, but that path is hottest.
+
+## Morning next steps (parked until Chief/Keith pick)
+
+- Optional: install LO dbgsyms and re-catch for resolved `??` frames.
+- Product / harness hardening (e.g. `close_doc` drain, shape-proxy release
+  order) — **do not start** until explicitly asked after reviewing this stack.

--- a/docs/framework/salabort-svxshape-close.md
+++ b/docs/framework/salabort-svxshape-close.md
@@ -2,67 +2,84 @@
 
 **Not a product fix.** Box QA catch on PR `#694` branch
 (`cursor/uno-application-error-diag-6477`), 2026-09-08 evening (America/Detroit).
-Raw dump: captured as `/workspace/draw-urp-soak/gdb/native-stack.txt` on the QA box
-(not committed). Summary for morning review.
+Raw dump: `/workspace/draw-urp-soak/gdb/native-stack.txt` on the QA box (not committed).
+dbgsym resolve: `/workspace/draw-urp-soak/gdb-dbgsym/STACK-DBGSYM.md` (local).
 
 ## Catch
 
 | Item | Value |
 |------|--------|
-| LO | 25.2.3.2 520(Build:2) |
-| Method | Attach `gdb -p` to soak `soffice.bin` after `connected=True`; break `Application::Abort` |
+| LO | 25.2.3.2 520(Build:2) (`libreoffice-core` 4:25.2.3-2+deb13u6) |
+| Method | Attach `gdb -p` after `connected=True`; break `Application::Abort` |
 | Trigger soak | `make test-uno-soak FILTER="test_duplicate_slide_copies_shapes" REPEAT=40` |
 | When | After TEST returned OK → stderr `Unspecified Application Error` → `soffice_exit=134` |
-| Symbols | Partial dynamic only (no `libreoffice-*-dbgsym` in apt on the box) |
+| First catch symbols | Partial dynamic only |
+| Follow-up | Installed Debian `trixie-debug` `libreoffice-*-dbgsym`; offline `addr2line` on the saved stack (live gdb+DWARF freezes the soak) |
 
-## Faulting thread (`cppu_threadpool`)
+## Faulting thread (`cppu_threadpool`) — resolved with dbgsyms
 
-SEGV (or equivalent) during Draw shape teardown → signal handler → empty-text
+SEGV during Draw shape teardown → VCL signal hook → empty-text
 `Application::Abort` → VCL `SalAbort` prints **Unspecified Application Error**
 → `abort()` (soak uses `--norestore`).
 
 ```
-#0  Application::Abort(rtl::OUString const&)     libmergedlo.so
-#1  ??                                           libmergedlo.so
-#2  ??                                           libmergedlo.so
-#3  ??                                           libuno_sal.so.3
+#0  Application::Abort(rtl::OUString const&)
+#1  desktop::Desktop::Exception(ExceptionCategory)
+#2  VCLExceptionSignal_impl(void*, oslSignalInfo*)
+#3  (SAL signal trampoline)
 #4  <signal handler called>
-#5  ??                                           libmergedlo.so
+#5  SfxItemPool::unregisterNameOrIndex(SfxPoolItem const&) [clone .cold]   ← SEGV site
 #6  SfxItemSet::ClearSingleItem_PrepareRemove(SfxPoolItem const*)
 #7  SfxItemSet::ClearAllItemsImpl()
 #8  SfxItemSet::~SfxItemSet()
-#9–10 ??                                         libmergedlo.so
+#9  sdr::properties::AttributeProperties::~AttributeProperties()
+#10 sdr::properties::RectangleProperties::~RectangleProperties()
 #11 SdrObject::~SdrObject()
 #12 SdrRectObj::~SdrRectObj()
 #13 SvxShape::~SvxShape()
-#14 ??                                           libmergedlo.so
+#14 SvxShapeRect::~SvxShapeRect()
 #15 cppu::OWeakAggObject::release()
 … uno_Environment_invoke / binaryurp / cppu_threadpool
 ```
 
 Main thread was idle in `Application::Execute` / `ImplSVMain`.
 
+Debian LO dbgsyms give solid **function** names; `file:line` is mostly unavailable (LTO).
+
 ## Reading
 
 1. The stderr string is VCL `SalAbort` with **empty** abort text (see
    `uno-test-lifecycle.md`) — office is dying, not a WriterAgent log line.
-2. Death is on a **URP / cppu_threadpool** thread releasing an `SvxShape` that
-   wraps an `SdrRectObj`, while clearing an `SfxItemSet` (item pool).
-3. Fits the QA timeline: Python `doc.close(True)` **returns**, then async
+2. Death is on a **URP / cppu_threadpool** thread releasing an **`SvxShapeRect`**
+   (rectangle shape UNO wrapper → `SdrRectObj`), while clearing the shape's
+   `SfxItemSet` / item pool.
+3. The faulting frame is **`SfxItemPool::unregisterNameOrIndex` (.cold)** —
+   same family as the historical octagon Draw abort (previously only
+   hypothesized for this path).
+4. Fits the QA timeline: Python `doc.close(True)` **returns**, then async
    shape/model teardown aborts soffice; the next open sees
    `Binary URP bridge already disposed`.
-4. **Kinship with the octagon Draw abort:** same general family —
-   `SfxItemPool` / item-set destruction while destroying a rect/shape
-   (`SfxItemPool::unregisterNameOrIndex` on octagon vs
-   `SfxItemSet::ClearSingleItem_PrepareRemove` here). Not proven identical
-   root cause without dbgsyms / LO source line mapping.
 5. Hottest harness repro remains solo
    `test_duplicate_slide_copies_shapes` (rectangle + text then
    `duplicate_slide`). Blank/label TextShape soak also fires SalAbort at a
    lower rate — not exclusive to `duplicate_slide`, but that path is hottest.
 
+## dbgsyms on Debian trixie (box note)
+
+`main` alone has no `*-dbgsym`. Add:
+
+```
+Types: deb
+URIs: http://deb.debian.org/debian-debug
+Suites: trixie-debug
+Components: main
+```
+
+then `apt-get install libreoffice-core-dbgsym libreoffice-draw-dbgsym ure-dbgsym uno-libs-private-dbgsym`
+(~588 MB). Prefer offline `addr2line` against the `.build-id` debug file rather
+than attaching gdb with full DWARF during a soak.
+
 ## Morning next steps (parked until Chief/Keith pick)
 
-- Optional: install LO dbgsyms and re-catch for resolved `??` frames.
 - Product / harness hardening (e.g. `close_doc` drain, shape-proxy release
   order) — **do not start** until explicitly asked after reviewing this stack.

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -45,7 +45,7 @@ Headless/user-profile bootstrap now `PIPE`s soffice **stderr** and drains it
 on a dedicated thread so the SalAbort line is not only inherited onto the
 terminal. `TEST end … OK` also prints `exit=` (`-` while the child lives).
 
-## Findings: Unspecified Application Error (still unproven LO cause)
+## Findings: Unspecified Application Error
 
 QA soak (`make test-uno-soak PAIR=dup-move REPEAT=20`): mid
 `test_duplicate_slide_copies_shapes` stderr prints `Unspecified Application
@@ -66,10 +66,27 @@ if (rErrorText.isEmpty())
     std::fprintf(stderr, "Unspecified Application Error\n");
 ```
 
-So the Error **is** office death (empty-text SalAbort). Why Draw UNO trips
-`Application::Abort("")` / `SalAbort` is still **unknown**. `#687`'s
-post-OK `getServiceManager` probe can miss this: SalAbort can print while
-URP still answers, then the process exits before the next open.
+So the Error **is** office death (empty-text SalAbort).
+
+### gdb catch (box QA on this branch)
+
+Attached gdb to soak `soffice.bin` during solo
+`FILTER=test_duplicate_slide_copies_shapes`. Faulting `cppu_threadpool`
+thread:
+
+`Application::Abort` ← signal handler ← `SfxItemSet::ClearSingleItem_PrepareRemove`
+← `ClearAllItemsImpl` / `~SfxItemSet` ← `~SdrObject` ← `~SdrRectObj` ←
+`~SvxShape` ← `OWeakAggObject::release` ← URP / `uno_Environment_invoke`.
+
+**Reading:** SalAbort during **SvxShape / SdrRectObj destruction** while
+clearing an `SfxItemSet` on a URP release thread after close — same general
+family as the historical octagon `SfxItemPool::unregisterNameOrIndex` abort
+on rect teardown. Exact LO invariant still needs dbgsyms / source mapping;
+product fixes are parked until Chief/Keith pick next steps.
+
+Full write-up: [salabort-svxshape-close.md](salabort-svxshape-close.md).
+`#687`'s post-OK `getServiceManager` probe can miss the race: SalAbort can
+print while URP still answers, then the process exits before the next open.
 
 ### Ranked hypotheses
 

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -81,7 +81,9 @@ thread:
 **Reading:** SalAbort during **SvxShape / SdrRectObj destruction** while
 clearing an `SfxItemSet` on a URP release thread after close — same general
 family as the historical octagon `SfxItemPool::unregisterNameOrIndex` abort
-on rect teardown. Exact LO invariant still needs dbgsyms / source mapping;
+on rect teardown. dbgsym offline resolve confirmed `#5` is that same
+`unregisterNameOrIndex` (.cold) under `SvxShapeRect` teardown (see
+`salabort-svxshape-close.md`); file:line still thin under LTO;
 product fixes are parked until Chief/Keith pick next steps.
 
 Full write-up: [salabort-svxshape-close.md](salabort-svxshape-close.md).

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -30,29 +30,88 @@ test body). Dispose during close is now **logged** (`LIFECYCLE close_doc dispose
 After a non-pooled close, the harness probes `desktop.getComponents()` and
 prints `LIFECYCLE office dead after close` if URP is already gone.
 
-**Harness-only attribution (same PR, not a product fix):** if a test body
-returns OK but `getServiceManager` is already disposed, the runner fails
-*that* test (`LIFECYCLE office dead after TEST returned`) instead of letting
-the next factory open be the named victim. `create_native_doc` probes before
-`loadComponentFromURL` (`pre_open=disposed` skips the load and still raises
-a URP-shaped error). No office auto-restart. No skip/xfail.
+**Harness-only attribution (not a product fix):** if a test body returns OK
+but the office already aborted, the runner fails *that* test instead of
+letting the next factory open be the named victim:
 
-## Hypothesis (unproven)
+- `Unspecified Application Error` on office/Python stderr (VCL `SalAbort`)
+- harness soffice `Popen.poll()` already exited
+- `getServiceManager` disposed (`LIFECYCLE office dead after TEST returned`)
 
-CI flake on `test_duplicate_rename_move_slide` (Draw UNO, PR #685 victim):
-failure at `create_native_doc` / `loadComponentFromURL` with URP
-`DisposedException`. That pattern matches **“previous test toasted soffice /
-the bridge; this open is the named victim”** more than a bug inside
-duplicate/rename/move.
+`create_native_doc` probes before load (`pre_open=disposed` skips the load
+and still raises a URP-shaped error). No office auto-restart. No skip/xfail.
 
-Historical Arch glibc double-free: `test_get_draw_tree` still printed OK,
-then `test_insert_math_draw` died on the next factory load. Same class of
-gap: TEST end OK does not prove the office survived teardown.
+Headless/user-profile bootstrap now `PIPE`s soffice **stderr** and drains it
+on a dedicated thread so the SalAbort line is not only inherited onto the
+terminal. `TEST end … OK` also prints `exit=` (`-` while the child lives).
 
-Math OLE (`insert_math` → `OLE2Shape` + Math CLSID) is a plausible *stressor*
-for that second pair. It does **not** explain a flake whose victim is
-`test_duplicate_rename_move_slide` (earlier in the file, before math).
-No skip/xfail and no office auto-restart: those would hide the killer.
+## Findings: Unspecified Application Error (still unproven LO cause)
+
+QA soak (`make test-uno-soak PAIR=dup-move REPEAT=20`): mid
+`test_duplicate_slide_copies_shapes` stderr prints `Unspecified Application
+Error`, the test still returns OK, then `test_duplicate_rename_move_slide`
+fails `Binary URP bridge already disposed` (pids gone). `PAIR=tree-math`:
+same Error during `test_get_draw_tree_marks_blank_and_label_hint` (OK), then
+the next soak iter dies at `_ensure_live_ctx`.
+
+**This is not a Draw assertion flake.** Python finished the killer; soffice
+did not.
+
+The exact string is **not** a WriterAgent message. LibreOffice VCL
+`SalAbort` (`vcl/source/app/salplug.cxx`) prints it when the abort text is
+empty, then `abort()` or `_exit(1)`:
+
+```
+if (rErrorText.isEmpty())
+    std::fprintf(stderr, "Unspecified Application Error\n");
+```
+
+So the Error **is** office death (empty-text SalAbort). Why Draw UNO trips
+`Application::Abort("")` / `SalAbort` is still **unknown**. `#687`'s
+post-OK `getServiceManager` probe can miss this: SalAbort can print while
+URP still answers, then the process exits before the next open.
+
+### Ranked hypotheses
+
+1. **VCL SalAbort during Draw UNO or `close_doc`, URP lags** (best fit).
+   Confirm: fail-closed names the killer; `soffice_exit=` is `1`; stderr
+   tail has `terminate called after…` or a real abort text; pids gone at
+   that TEST end.
+2. **`XDrawPageDuplicator.duplicate` (`doc.duplicate`) headless crash**
+   (`PAIR=dup-move` body). Confirm: isolate `duplicate_slide` only; Error
+   during the tool call vs during teardown; `activate=False` vs `True`.
+   Does **not** explain the blank/label killer.
+3. **Draw `TextShape` create / empty `getString` / `get_draw_tree` property
+   walk** (`test_get_draw_tree_marks_blank_and_label_hint`). Confirm: soak
+   that test alone; Error during `shape_upsert` vs `get_draw_tree` vs close.
+4. **`--pair tree-math` prefix bleed** (harness fact, now fixed). Filter
+   `test_get_draw_tree` also matched `test_get_draw_tree_marks_blank_and_label_hint`.
+   QA’s tree-math Error on the blank test may be that extra test, not
+   `test_get_draw_tree` → math OLE. `--pair` is now exact; `FILTER=` still
+   prefix-matches.
+5. **`close_doc` / `gc.collect` + Draw model teardown** (shared by both
+   killers: factory `sdraw` + always-close). Confirm: Error after body
+   return / `LIFECYCLE close_doc` vs during the tool call.
+6. **Use-after-close or stale page/shape proxy** (weaker). Confirm: Error
+   only when the body still holds `page.getByIndex` / `getString` across
+   duplicate; not when the body is a no-op close.
+7. **Headless VCL / hidden controller (`setCurrentPage`)** (weaker; would
+   be more deterministic). Confirm: `--visible` soak vs headless.
+8. **Heap corruption / delayed abort** (historical Arch glibc
+   `test_get_draw_tree` → math). Confirm: malloc/`terminate` line before
+   SalAbort; Arch-only. Do not require Arch to hunt this.
+
+What the two killer tests do (no product change):
+
+- `test_duplicate_slide_copies_shapes`: `shape_upsert` rectangle + text,
+  `duplicate_slide(page=0, activate=False)` → `DrawBridge.duplicate_slide`
+  → `self.doc.duplicate(source)`, then `getString` on the copy.
+- `test_duplicate_rename_move_slide` (usual victim): `duplicate_slide`
+  (activate default True), `rename_slide`, `move_slide` (`remove` +
+  `insertByIndex`).
+- `test_get_draw_tree_marks_blank_and_label_hint`: two `TextShape`s
+  (label + empty named blank), `get_draw_tree` → `build_shape_tree`
+  (`getString`, geometry, `FillColor` / `CustomShapeGeometry`).
 
 ## What the breadcrumb prints
 
@@ -75,18 +134,19 @@ probe immediately before `loadComponentFromURL`:
   “previous close toasted the bridge”).
 
 A URP dispose also prints `LIFECYCLE URP dispose at <victim> previous=…`.
-If a test body + `@with_native_doc` teardown **returns OK** but
-`getServiceManager` is already disposed, the runner **fails that test**
-(`LIFECYCLE office dead after TEST returned`) so the killer is named instead
-of the next open. That is harness attribution, not a product retry.
+SalAbort / child exit after an OK body prints
+`LIFECYCLE application error after TEST returned` (or
+`office death before TEST call` for the gap). That is harness attribution,
+not a product retry.
 
-Grep: `LIFECYCLE` and `previous=`. The victim is `current=`; the likely
-killer is `previous=` / `last_ok=` when `result=OK`.
+Grep: `LIFECYCLE`, `previous=`, `Unspecified Application Error`, `soffice_exit=`.
+The victim is `current=`; the likely killer is `previous=` / `last_ok=` when
+`result=OK`.
 
 Native tests do **not** run under pytest. `format_lifecycle_breadcrumb` /
-`probe_uno_bridge` in `plugin/testing_runner.py` are the hook. Unit tests:
-`tests/framework/test_testing_runner.py`, `tests/scripts/test_testing_runner_cli.py`,
-`tests/test_testing_utils.py`.
+`probe_uno_bridge` / `collect_post_test_death` in `plugin/testing_runner.py`
+are the hook. Unit tests: `tests/framework/test_testing_runner.py`,
+`tests/scripts/test_testing_runner_cli.py`, `tests/test_testing_utils.py`.
 
 ## Soak / reproduce (same soffice, no new framework)
 
@@ -99,13 +159,14 @@ make test-uno-soak
 # More rounds
 make test-uno-soak REPEAT=50
 
-# Historical pair (tree → math OLE factory open)
+# Historical pair (tree → math OLE factory open). Exact names only.
 make test-uno-soak PAIR=tree-math REPEAT=50
 
 # CI victim + its predecessor in file order
 make test-uno-soak PAIR=dup-move REPEAT=50
 
-# Same pairs without the alias
+# FILTER still prefix-matches: test_get_draw_tree also selects
+# test_get_draw_tree_marks_blank_and_label_hint. Prefer PAIR= for isolation.
 make test-uno-soak FILTER="test_get_draw_tree test_insert_math_draw" REPEAT=50
 ```
 
@@ -117,9 +178,10 @@ python -m plugin.testing_runner --repeat 20 test_draw_uno
 python -m plugin.testing_runner --repeat 50 --pair tree-math
 ```
 
-Look for `SOAK iter i/N`, then the first `LIFECYCLE` / `previous=` on FAIL.
-Outer `for i in …; do make test-uno …; done` restarts soffice each time and
-is a **weaker** repro for “bridge died between two tests.”
+Look for `SOAK iter i/N`, then the first `LIFECYCLE` / `previous=` /
+`application error` on FAIL. Outer `for i in …; do make test-uno …; done`
+restarts soffice each time and is a **weaker** repro for “bridge died
+between two tests.”
 
 `test-uno-soak` is not in default CI. Invoke it from a CI note or a
 workflow_dispatch job when hunting this flake.

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -13,7 +13,9 @@
 #
 # URP DisposedException on the next factory open: FAIL lines include
 # previous=<last TEST end> (see format_lifecycle_breadcrumb). Soak:
-# --repeat N / make test-uno-soak. docs/framework/uno-test-lifecycle.md
+# --repeat N / make test-uno-soak. SalAbort empty-text
+# ("Unspecified Application Error") fail-closes the OK test.
+# docs/framework/uno-test-lifecycle.md
 
 import logging
 import json
@@ -22,6 +24,7 @@ import secrets
 import shutil
 import subprocess
 import sys
+import threading
 import time
 import traceback
 import unittest
@@ -176,6 +179,30 @@ _SOAK_PAIRS: Dict[str, List[str]] = {
     ],
 }
 
+# ``--pair`` uses exact function names. Prefix match on ``test_get_draw_tree``
+# also selected ``test_get_draw_tree_marks_blank_and_label_hint`` (QA soak).
+_cli_exact_function_names: list[str] = []
+
+# VCL SalAbort empty-text fallback (LibreOffice vcl/source/app/salplug.cxx):
+# fprintf(stderr, "Unspecified Application Error\n") then abort()/_exit(1).
+# Not a Draw assertion. The office is dying; URP death is the next symptom.
+_APPLICATION_ERROR_MARKER = "Unspecified Application Error"
+_OFFICE_STDERR_TAIL = 30
+_soffice_proc: Any = None
+_office_stderr_lock = threading.Lock()
+_office_stderr_application_error = False
+_office_stderr_tail: list[str] = []
+
+
+def reset_office_death_signals(*, clear_proc: bool = False) -> None:
+    """Clear SalAbort / stderr flags. Does not drop the live soffice Popen unless asked."""
+    global _soffice_proc, _office_stderr_application_error, _office_stderr_tail
+    with _office_stderr_lock:
+        _office_stderr_application_error = False
+        _office_stderr_tail = []
+    if clear_proc:
+        _soffice_proc = None
+
 
 def reset_lifecycle_breadcrumb() -> None:
     """Clear the previous/current TEST trail (start of a run or unit test)."""
@@ -192,6 +219,151 @@ def reset_lifecycle_breadcrumb() -> None:
     _lifecycle_current_start_pids = ""
     _lifecycle_current_start_mono = 0.0
     _lifecycle_current_bridge = ""
+    reset_office_death_signals()
+
+
+def note_office_stderr_line(line: str, *, echo: bool = False) -> None:
+    """Record one office/Python stderr line; set the SalAbort flag if the marker appears.
+
+    ``echo=True`` reprints on the real stderr (soffice PIPE drain). The TEST-call
+    tee already wrote the line, so it only marks.
+    """
+    global _office_stderr_application_error
+    text = line.rstrip("\r\n")
+    if not text:
+        return
+    if echo:
+        print(text, file=sys.__stderr__, flush=True)
+    with _office_stderr_lock:
+        _office_stderr_tail.append(text)
+        if len(_office_stderr_tail) > _OFFICE_STDERR_TAIL:
+            del _office_stderr_tail[0 : len(_office_stderr_tail) - _OFFICE_STDERR_TAIL]
+        if _APPLICATION_ERROR_MARKER in text:
+            _office_stderr_application_error = True
+
+
+def consume_application_error() -> bool:
+    """Return-and-clear whether Unspecified Application Error was seen since last consume."""
+    global _office_stderr_application_error
+    with _office_stderr_lock:
+        seen = _office_stderr_application_error
+        _office_stderr_application_error = False
+        return seen
+
+
+def office_stderr_tail() -> list[str]:
+    with _office_stderr_lock:
+        return list(_office_stderr_tail)
+
+
+def soffice_exit_code() -> int | None:
+    """``Popen.poll()`` of the harness soffice, or None if still running / no child."""
+    proc = _soffice_proc
+    if proc is None:
+        return None
+    try:
+        return proc.poll()
+    except Exception:
+        return None
+
+
+def attach_soffice_proc(proc: Any) -> None:
+    """Keep the bootstrap Popen and drain its stderr (must be PIPE)."""
+    global _soffice_proc
+    _soffice_proc = proc
+    stream = getattr(proc, "stderr", None)
+    if stream is None:
+        return
+    # Harness-only: bootstrap is before plugin worker_pool. Dedicated daemon so
+    # a full stderr pipe cannot deadlock soffice (AGENTS.md pipe-drain rule).
+    thread = threading.Thread(
+        target=_drain_soffice_stderr,
+        args=(stream,),
+        name="soffice-stderr-drain",
+        daemon=True,
+    )
+    thread.start()
+
+
+def _drain_soffice_stderr(stream: Any) -> None:
+    try:
+        while True:
+            line = stream.readline()
+            if not line:
+                break
+            note_office_stderr_line(line, echo=True)
+    except Exception:
+        pass
+    finally:
+        try:
+            stream.close()
+        except Exception:
+            pass
+
+
+class _StderrMarkerTee:
+    """Wrap ``sys.stderr`` during a TEST call so in-process SalAbort text is flagged."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    def write(self, data: Any) -> int:
+        if isinstance(data, bytes):
+            text = data.decode("utf-8", "replace")
+        else:
+            text = data if isinstance(data, str) else str(data)
+        if text and _APPLICATION_ERROR_MARKER in text:
+            note_office_stderr_line(text, echo=False)
+        return self._inner.write(data)
+
+    def flush(self) -> None:
+        return self._inner.flush()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def collect_post_test_death(ctx: Any = None) -> str | None:
+    """Fail-closed reason if the office aborted during this TEST, else None.
+
+    QA: killer printed Unspecified Application Error and still returned OK;
+    the next open saw Binary URP already disposed. getServiceManager can lag
+    SalAbort. Treat the stderr marker or a child exit as URP death.
+    """
+    app_err = consume_application_error()
+    exit_code = soffice_exit_code()
+    pids = _soffice_pids()
+    bridge = probe_uno_bridge(ctx)
+    crumb = format_lifecycle_breadcrumb()
+    tail = office_stderr_tail()
+    tail_note = ""
+    if tail:
+        tail_note = " stderr_tail=%s" % " | ".join(tail[-5:])
+    if app_err:
+        return (
+            "Binary URP bridge disposed during call; Unspecified Application Error "
+            "on office stderr (VCL SalAbort) soffice_exit=%s pids=%s bridge=%s %s%s"
+            % (
+                "-" if exit_code is None else exit_code,
+                pids,
+                bridge,
+                crumb,
+                tail_note,
+            )
+        )
+    if exit_code is not None:
+        return (
+            "Binary URP bridge disposed during call; soffice exited %s during TEST "
+            "pids=%s bridge=%s %s%s"
+            % (exit_code, pids, bridge, crumb, tail_note)
+        )
+    if bridge == "disposed":
+        return (
+            "Binary URP bridge disposed during call; office dead after "
+            "TEST returned (teardown likely killed URP) %s"
+            % crumb
+        )
+    return None
 
 
 def probe_uno_bridge(ctx: Any = None) -> str:
@@ -428,9 +600,10 @@ def _parse_cli_args(argv: Sequence[str]) -> list[str]:
     / ``dup-move`` expands to the two Draw tests that historically sandwich a
     URP death. See ``docs/framework/uno-test-lifecycle.md``.
     """
-    global show_window, use_user_profile, _soak_repeat
+    global show_window, use_user_profile, _soak_repeat, _cli_exact_function_names
     filters: list[str] = []
     _soak_repeat = 1
+    _cli_exact_function_names = []
     soak_from_cli = False
     skip_next = False
     for i, arg in enumerate(argv):
@@ -456,6 +629,7 @@ def _parse_cli_args(argv: Sequence[str]) -> list[str]:
                 names = expand_soak_pair(argv[i + 1])
                 if names:
                     filters.extend(names)
+                    _cli_exact_function_names = list(names)
                 else:
                     filters.append(str(argv[i + 1]))
                 skip_next = True
@@ -463,6 +637,7 @@ def _parse_cli_args(argv: Sequence[str]) -> list[str]:
             names = expand_soak_pair(arg.split("=", 1)[1])
             if names:
                 filters.extend(names)
+                _cli_exact_function_names = list(names)
             else:
                 filters.append(arg.split("=", 1)[1])
         else:
@@ -815,7 +990,14 @@ def _bootstrap_user_profile_gui(officehelper_module: Any) -> Any:
         cmd,
         env=child_env,
         start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
     )
+    attach_soffice_proc(proc)
     # GUI + extension OnStartApp is slower than headless.
     return _connect_uno_accept(proc, accept, path_label="user-profile")
 
@@ -865,7 +1047,14 @@ def _bootstrap_office(officehelper_module: Any) -> Any:
             cmd,
             env=child_env,
             start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
         )
+        attach_soffice_proc(proc)
         # Headless usually connects faster than GUI; keep the same retry budget.
         ctx = _connect_uno_accept(
             proc,
@@ -980,11 +1169,14 @@ def run_module_suite(ctx, module, name, doc_model=None):
     # fail on factory open because the *previous suite's last test* killed URP.
     _progress(f"SUITE start {name} python_pid={os.getpid()} soffice.bin={_soffice_pids()}")
     name_filters = _test_function_filters(_cli_filters)
-    if name_filters:
+    if _cli_exact_function_names:
+        exact = set(_cli_exact_function_names)
+        selected = [tf for tf in test_funcs if tf.__name__ in exact]
+    elif name_filters:
         selected = [tf for tf in test_funcs if _function_name_matches(tf.__name__, name_filters)]
     else:
         selected = list(test_funcs)
-    if name_filters and not selected:
+    if (name_filters or _cli_exact_function_names) and not selected:
         msg = f"No tests matched filters {name_filters!r} in {name}"
         _progress(f"SUITE filter miss {name}: {name_filters}")
         _progress(f"SUITE end {name} passed=0 failed=1")
@@ -1027,31 +1219,56 @@ def run_module_suite(ctx, module, name, doc_model=None):
                     accepts_ctx = "ctx" in sig.parameters
                 except Exception:
                     accepts_ctx = True
-                # GHA 33703959362: execute-done then 20min silence, no TEST end.
-                # call vs returned splits body hang from post-return bookkeeping.
-                _progress(f"TEST call {qual}")
-                if accepts_ctx:
-                    test_func(ctx=ctx)
-                else:
-                    test_func()
-                _progress(f"TEST returned {qual}")
-                # Harness attribution (not a product fix): body + @with_native_doc
-                # teardown returned, but getServiceManager is already disposed.
-                # Name *this* test as the killer instead of the next factory open.
-                post_bridge = probe_uno_bridge(ctx)
-                if post_bridge == "disposed":
-                    dead_exc = RuntimeError(
-                        "Binary URP bridge disposed during call; office dead after "
-                        "TEST returned (teardown likely killed URP) %s"
-                        % format_lifecycle_breadcrumb()
-                    )
+                # SalAbort can print after the previous TEST end OK. Fail-closed
+                # here so we do not open another Draw factory on a dying office.
+                gap_death = collect_post_test_death(ctx)
+                if gap_death:
+                    dead_exc = RuntimeError(gap_death)
                     total_failed += 1
                     suite_log.append(f"{test_line} — FAIL ({dead_exc})")
                     suite_log.append("LIFECYCLE %s" % format_lifecycle_breadcrumb())
                     _progress(
-                        "LIFECYCLE office dead after TEST returned %s %s"
-                        % (qual, format_lifecycle_breadcrumb())
+                        "LIFECYCLE office death before TEST call %s soffice_exit=%s %s"
+                        % (qual, soffice_exit_code(), format_lifecycle_breadcrumb())
                     )
+                    _progress(f"TEST end {qual} FAIL {_fail_reason_with_lifecycle(dead_exc)}")
+                    _mark_urp_dead(dead_exc, qual)
+                    record_test_end(qual, "FAIL")
+                    break
+                # GHA 33703959362: execute-done then 20min silence, no TEST end.
+                # call vs returned splits body hang from post-return bookkeeping.
+                _progress(f"TEST call {qual}")
+                # In-process SalAbort text hits Python stderr; soffice PIPE drain
+                # catches the same marker from the child (Popen inherits no longer).
+                old_err = sys.stderr
+                sys.stderr = _StderrMarkerTee(old_err)
+                try:
+                    if accepts_ctx:
+                        test_func(ctx=ctx)
+                    else:
+                        test_func()
+                finally:
+                    sys.stderr = old_err
+                _progress(f"TEST returned {qual}")
+                # Harness attribution (not a product fix): body + @with_native_doc
+                # teardown returned, but SalAbort already printed, soffice exited,
+                # or getServiceManager is disposed. Name *this* test as the killer.
+                death = collect_post_test_death(ctx)
+                if death:
+                    dead_exc = RuntimeError(death)
+                    total_failed += 1
+                    suite_log.append(f"{test_line} — FAIL ({dead_exc})")
+                    suite_log.append("LIFECYCLE %s" % format_lifecycle_breadcrumb())
+                    if _APPLICATION_ERROR_MARKER in death:
+                        _progress(
+                            "LIFECYCLE application error after TEST returned %s soffice_exit=%s %s"
+                            % (qual, soffice_exit_code(), format_lifecycle_breadcrumb())
+                        )
+                    else:
+                        _progress(
+                            "LIFECYCLE office dead after TEST returned %s %s"
+                            % (qual, format_lifecycle_breadcrumb())
+                        )
                     _progress(f"TEST end {qual} FAIL {_fail_reason_with_lifecycle(dead_exc)}")
                     _mark_urp_dead(dead_exc, qual)
                     record_test_end(qual, "FAIL")
@@ -1059,7 +1276,11 @@ def run_module_suite(ctx, module, name, doc_model=None):
                 total_passed += 1
                 suite_log.append(f"{test_line} — OK")
                 record_test_end(qual, "OK")
-                _progress(f"TEST end {qual} OK soffice={_lifecycle_last_end_pids}")
+                exit_code = soffice_exit_code()
+                _progress(
+                    "TEST end %s OK soffice=%s exit=%s"
+                    % (qual, _lifecycle_last_end_pids, "-" if exit_code is None else exit_code)
+                )
             except ModuleNotFoundError as e:
                 # Some "native" tests attempt to use pytest.skip, but LibreOffice's
                 # Python may not have pytest installed.

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -274,15 +274,12 @@ def attach_soffice_proc(proc: Any) -> None:
     stream = getattr(proc, "stderr", None)
     if stream is None:
         return
-    # Harness-only: bootstrap is before plugin worker_pool. Dedicated daemon so
-    # a full stderr pipe cannot deadlock soffice (AGENTS.md pipe-drain rule).
-    thread = threading.Thread(
-        target=_drain_soffice_stderr,
-        args=(stream,),
-        name="soffice-stderr-drain",
-        daemon=True,
-    )
-    thread.start()
+    from plugin.framework.worker_pool import run_in_background
+
+    def _loop() -> None:
+        _drain_soffice_stderr(stream)
+
+    run_in_background(_loop, name="soffice-stderr-drain", dedicated=True)
 
 
 def _drain_soffice_stderr(stream: Any) -> None:

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from plugin.testing_runner import (
+    _APPLICATION_ERROR_MARKER,
     _cli_filters,
     _fail_reason,
     _fail_reason_with_lifecycle,
@@ -16,12 +17,17 @@ from plugin.testing_runner import (
     _is_case_id,
     _module_matches_filters,
     _test_function_filters,
+    collect_post_test_death,
+    consume_application_error,
     expand_soak_pair,
     format_lifecycle_breadcrumb,
+    note_office_stderr_line,
     probe_uno_bridge,
     record_test_end,
     record_test_start,
     reset_lifecycle_breadcrumb,
+    reset_office_death_signals,
+    soffice_exit_code,
 )
 
 
@@ -176,6 +182,56 @@ def test_expand_soak_pair_aliases() -> None:
         "test_duplicate_rename_move_slide",
     ]
     assert expand_soak_pair("unknown") == []
+
+
+def test_function_name_matches_draw_tree_prefix_bleed() -> None:
+    """FILTER=test_get_draw_tree also selects the blank/label test; --pair must not."""
+    assert _function_name_matches(
+        "test_get_draw_tree_marks_blank_and_label_hint",
+        ["test_get_draw_tree"],
+    ) is True
+    assert "test_get_draw_tree_marks_blank_and_label_hint" not in expand_soak_pair("tree-math")
+
+
+def test_note_office_stderr_line_sets_salabort_flag() -> None:
+    reset_office_death_signals(clear_proc=True)
+    assert consume_application_error() is False
+    note_office_stderr_line("warn: something else")
+    assert consume_application_error() is False
+    note_office_stderr_line("  %s  " % _APPLICATION_ERROR_MARKER)
+    assert consume_application_error() is True
+    assert consume_application_error() is False
+    reset_office_death_signals(clear_proc=True)
+
+
+def test_collect_post_test_death_application_error() -> None:
+    reset_lifecycle_breadcrumb()
+    reset_office_death_signals(clear_proc=True)
+    note_office_stderr_line(_APPLICATION_ERROR_MARKER)
+    reason = collect_post_test_death(None)
+    assert reason is not None
+    assert "Unspecified Application Error" in reason
+    assert "Binary URP bridge" in reason
+    assert "VCL SalAbort" in reason
+    reset_office_death_signals(clear_proc=True)
+
+
+def test_collect_post_test_death_soffice_exit() -> None:
+    import plugin.testing_runner as tr
+
+    class _DeadProc:
+        def poll(self) -> int:
+            return 1
+
+    reset_lifecycle_breadcrumb()
+    reset_office_death_signals(clear_proc=True)
+    tr._soffice_proc = _DeadProc()
+    assert soffice_exit_code() == 1
+    reason = collect_post_test_death(None)
+    assert reason is not None
+    assert "soffice exited 1" in reason
+    assert "Binary URP bridge" in reason
+    reset_office_death_signals(clear_proc=True)
 
 
 def test_fail_reason_with_lifecycle_keeps_crumb_after_cap() -> None:

--- a/tests/scripts/test_testing_runner_cli.py
+++ b/tests/scripts/test_testing_runner_cli.py
@@ -307,6 +307,90 @@ def test_parse_cli_repeat_and_soak_env(monkeypatch) -> None:
         "test_duplicate_slide_copies_shapes",
         "test_duplicate_rename_move_slide",
     ]
+    assert tr._cli_exact_function_names == [
+        "test_duplicate_slide_copies_shapes",
+        "test_duplicate_rename_move_slide",
+    ]
+    rest = tr._parse_cli_args(["--pair", "tree-math"])
+    assert rest == ["test_get_draw_tree", "test_insert_math_draw"]
+    assert tr._cli_exact_function_names == ["test_get_draw_tree", "test_insert_math_draw"]
+    assert "test_get_draw_tree_marks_blank_and_label_hint" not in tr._cli_exact_function_names
+    tr._cli_exact_function_names = []
+
+
+def test_run_module_suite_pair_exact_skips_draw_tree_prefix_bleed() -> None:
+    """--pair tree-math must not run test_get_draw_tree_marks_blank_and_label_hint."""
+    tr.reset_lifecycle_breadcrumb()
+    tr._cli_exact_function_names = ["test_get_draw_tree", "test_insert_math_draw"]
+    ran: list[str] = []
+
+    def test_get_draw_tree(ctx=None):
+        ran.append("tree")
+
+    def test_get_draw_tree_marks_blank_and_label_hint(ctx=None):
+        ran.append("blank")
+
+    def test_insert_math_draw(ctx=None):
+        ran.append("math")
+
+    test_get_draw_tree._is_test = True
+    test_get_draw_tree_marks_blank_and_label_hint._is_test = True
+    test_insert_math_draw._is_test = True
+
+    class _Mod:
+        pass
+
+    module = _Mod()
+    module.test_get_draw_tree = test_get_draw_tree
+    module.test_get_draw_tree_marks_blank_and_label_hint = test_get_draw_tree_marks_blank_and_label_hint
+    module.test_insert_math_draw = test_insert_math_draw
+
+    tr._urp_bridge_dead = False
+    passed, failed, _suite_log = tr.run_module_suite(object(), module, "draw.pair")
+    assert ran == ["tree", "math"]
+    assert passed == 2
+    assert failed == 0
+    tr._cli_exact_function_names = []
+    tr._urp_bridge_dead = False
+    tr.reset_lifecycle_breadcrumb()
+
+
+def test_run_module_suite_fails_ok_test_on_application_error(capsys) -> None:
+    """Harness attribution: TEST returned OK but SalAbort already printed."""
+    tr.reset_lifecycle_breadcrumb()
+    tr.reset_office_death_signals(clear_proc=True)
+    tr._cli_exact_function_names = []
+    ran: list[str] = []
+
+    def test_ok(ctx=None):
+        ran.append("ok")
+        print(tr._APPLICATION_ERROR_MARKER, file=sys.stderr)
+
+    def test_second(ctx=None):
+        ran.append("second")
+
+    test_ok._is_test = True
+    test_second._is_test = True
+
+    class _Mod:
+        pass
+
+    module = _Mod()
+    module.test_ok = test_ok
+    module.test_second = test_second
+
+    tr._urp_bridge_dead = False
+    passed, failed, suite_log = tr.run_module_suite(object(), module, "draw.salabort")
+    assert ran == ["ok"]
+    assert passed == 0
+    assert failed == 1
+    assert tr._urp_bridge_dead is True
+    err = capsys.readouterr().err
+    assert "LIFECYCLE application error after TEST returned draw.salabort.test_ok" in err
+    assert any("Unspecified Application Error" in line for line in suite_log)
+    tr._urp_bridge_dead = False
+    tr.reset_office_death_signals(clear_proc=True)
+    tr.reset_lifecycle_breadcrumb()
 
 
 def test_run_module_suite_fail_names_previous_test(capsys, monkeypatch) -> None:
@@ -331,6 +415,7 @@ def test_run_module_suite_fail_names_previous_test(capsys, monkeypatch) -> None:
     module.test_victim = test_victim
 
     tr._urp_bridge_dead = False
+    tr._cli_exact_function_names = []
     passed, failed, suite_log = tr.run_module_suite(object(), module, "draw.crumb")
     assert passed == 1
     assert failed == 1
@@ -376,6 +461,7 @@ def test_run_module_suite_fails_ok_test_when_bridge_dies_after_return(capsys) ->
 
     ctx = _Ctx()
     tr._urp_bridge_dead = False
+    tr._cli_exact_function_names = []
     passed, failed, suite_log = tr.run_module_suite(ctx, module, "draw.teardown")
     assert ran == ["ok"]
     assert passed == 0
@@ -409,6 +495,7 @@ def test_run_module_suite_stops_after_urp_dispose() -> None:
     module.test_second = test_second
 
     tr._urp_bridge_dead = False
+    tr._cli_exact_function_names = []
     passed, failed, suite_log = tr.run_module_suite(object(), module, "fake.urp")
     assert ran == ["first"]
     assert passed == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

Follow-up diagnostic on #687. **Not a product fix.** Product hardening is parked until explicitly asked.

QA: `make test-uno-soak PAIR=dup-move REPEAT=20` prints `Unspecified Application Error` mid `test_duplicate_slide_copies_shapes` (still OK), then `test_duplicate_rename_move_slide` dies `Binary URP bridge already disposed` (pids gone). Same Error during `test_get_draw_tree_marks_blank_and_label_hint` on the tree-math soak, then the next iter dies at `_ensure_live_ctx`.

## What the string actually is

Not WriterAgent, not a Draw assertion. LibreOffice VCL `SalAbort` (`vcl/source/app/salplug.cxx`) prints `Unspecified Application Error` when the abort text is **empty**, then `abort()` / `_exit(1)`. The office is dying. `#687`’s post-OK `getServiceManager` probe can still look alive for a moment.

## gdb + dbgsym catch (box QA on this branch)

Solo `FILTER=test_duplicate_slide_copies_shapes` soak, `soffice_exit=134`. Faulting `cppu_threadpool` thread, resolved offline with Debian `libreoffice-core-dbgsym`:

`Application::Abort` ← `Desktop::Exception` ← VCL signal hook ← **`SfxItemPool::unregisterNameOrIndex` (.cold)** ← `SfxItemSet::ClearSingleItem_PrepareRemove` ← `~AttributeProperties` / `~RectangleProperties` ← `~SdrRectObj` ← `~SvxShape` / **`~SvxShapeRect`** ← `OWeakAggObject::release` ← URP.

**Reading:** async rectangle-shape teardown after Python `doc.close(True)` returns. This is the **same function** as the historical octagon Draw abort (`unregisterNameOrIndex` on item-pool teardown). `file:line` still thin under LTO. Write-up: [`docs/framework/salabort-svxshape-close.md`](docs/framework/salabort-svxshape-close.md).

## Ranked hypotheses

1. **`SfxItemPool::unregisterNameOrIndex` during `SvxShapeRect` release on URP after close** — confirmed by dbgsym stack. Fail-closed names the killer + `soffice_exit=134`.
2. **`XDrawPageDuplicator.duplicate` as hottest stressor** — solo duplicate-slide soak is hottest; not exclusive (blank/label TextShape also fires, lower rate).
3. **`TextShape` create / empty `getString` / `get_draw_tree` property walk** — blank/label test.
4. **`--pair tree-math` prefix bleed** (harness fact, fixed here). Filter `test_get_draw_tree` also selected `test_get_draw_tree_marks_blank_and_label_hint`.
5. **`close_doc` / `gc.collect` + Draw teardown** — gdb puts the abort *after* close returns.
6. Stale page/shape proxy after duplicate (weaker; gdb is destructor, not a later getString).
7. Headless VCL / hidden `setCurrentPage` (weaker).
8. Heap corruption / delayed abort (historical Arch; the dbgsym stack is a specific item-pool SEGV, not a generic glibc double-free).

Full write-up: [`docs/framework/uno-test-lifecycle.md`](docs/framework/uno-test-lifecycle.md).

## Harness change (diagnostic only)

- PIPE + drain soffice stderr; flag `Unspecified Application Error`.
- Capture harness `Popen.poll()` (`TEST end … OK exit=`).
- Fail-closed after Error / child exit / disposed bridge so the **killer** is named, then abort remaining suites.
- `--pair` is exact-name; `FILTER=` still prefix-matches (documented).

No office auto-restart. No skip/xfail. No product Draw/API change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64298b67-02c0-48c4-981b-7eadf3446477?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64298b67-02c0-48c4-981b-7eadf3446477&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

