### PR TITLE
Expose get_image page screenshots to Draw and Impress

### DIFF
--- a/docs/draw/impress-specialized-toolsets.md
+++ b/docs/draw/impress-specialized-toolsets.md
@@ -43,6 +43,7 @@ These tools are **always available** to the main agent for Draw/Impress document
 | `read_slide_text` | `pages.py` | Drawing+Presentation | Extract text from all shapes on a page |
 | `get_presentation_info` | `pages.py` | Drawing+Presentation | Metadata: slide count, dimensions, masters |
 | `get_draw_tree` | `tree.py` | Drawing+Presentation | JSON DOM of shapes and layout; `fillable` blanks + ControlShape value/state |
+| `get_image` | `writer/get_image.py` | Text+Drawing+Presentation | Vision: embedded graphic, selection, or `page=N` (1-based) PNG of the rendered page. Complements `get_draw_tree`; does not replace it. |
 | `list_placeholders` | `placeholders.py` | Presentation | List placeholder shapes (title, subtitle, body) |
 | `get_placeholder_text` | `placeholders.py` | Presentation | Get text from a placeholder |
 | `set_placeholder_text` | `placeholders.py` | Presentation | Set text in a placeholder |

--- a/docs/images/recognition-multimodal-LLMs.md
+++ b/docs/images/recognition-multimodal-LLMs.md
@@ -75,9 +75,9 @@ Implemented in [`response_normalizers.py`](../../plugin/framework/client/respons
 
 | Item | Location | Notes |
 |------|----------|-------|
-| `GetImage` core tool | [`get_image.py`](../../plugin/writer/get_image.py) | `tier="core"`, Writer `TextDocument` only |
+| `GetImage` core tool | [`get_image.py`](../../plugin/writer/get_image.py) | `tier="core"`, Writer `TextDocument` + Draw `DrawingDocument` + Impress `PresentationDocument` |
 | Modes | same | `image=<name>`, `selection=true` (or implicit when no name), `page=<n>` (1-based whole-page PNG) |
-| Page render | `_render_page_png` | Native `writer_png_Export` after `jumpToPage`; XRenderable abandoned (BUG-5: `getRendererCount` reports 1 page on multi-page docs). View cursor saved/restored best-effort. Fail-loud — never returns empty PNG. |
+| Page render | `_render_page_png` | Writer: native `writer_png_Export` after `jumpToPage` (XRenderable abandoned — BUG-5). Draw/Impress: `GraphicExportFilter` on the `XDrawPage` (`MediaType=image/png`; same bytes as `draw_png_Export` / `impress_png_Export` after `setCurrentPage`, without a view jump). Fail-loud — never returns empty PNG. |
 | Wire marker | same | Returns `{"status":"ok","source":...,"_mcp_image":{"data":"<b64>","mimeType":"image/png"}}` |
 | Schema gating | [`vision_availability.py`](../../plugin/vision/vision_availability.py) `filter_get_image_for_text_only_model` | On **openai** schema path only: drops `get_image` when `has_native_vision` is false. Fail-open on lookup errors. MCP path always exposes it (client assumed vision-capable). Hook in [`tool.py`](../../plugin/framework/tool.py) `get_schemas`. |
 
@@ -104,7 +104,8 @@ MCP vision clients receive the picture itself, not base64 pasted as text.
 | `normalize_multimodal_messages` per provider | [`tests/framework/test_client_llm.py`](../../tests/framework/test_client_llm.py), [`tests/framework/client/test_response_normalizers.py`](../../tests/framework/client/test_response_normalizers.py) |
 | `filter_get_image_for_text_only_model` | [`tests/vision/test_vision_availability.py`](../../tests/vision/test_vision_availability.py) |
 | `call_tool_result_image` | [`tests/mcp/test_wire_types.py`](../../tests/mcp/test_wire_types.py) |
-| `_render_page_png` error/control-flow | [`tests/writer/test_get_image_render.py`](../../tests/writer/test_get_image_render.py) |
+| `_render_page_png` error/control-flow | [`tests/writer/test_get_image_render.py`](../../tests/writer/test_get_image_render.py) (Writer + Draw/Impress) |
+| Draw/Impress `page=N` PNG (live) | [`tests/writer/test_get_image_uno.py`](../../tests/writer/test_get_image_uno.py) |
 | `_resolve_crop_edges`, `_resolve_orient` | [`tests/writer/images/test_crop_edges.py`](../../tests/writer/images/test_crop_edges.py), [`tests/writer/images/test_images.py`](../../tests/writer/images/test_images.py) |
 
 Host capability table row: [recognition.md §6](recognition.md).
@@ -265,7 +266,7 @@ Normalization belongs in the `LlmClient` layer (`make_chat_request`) so all chat
 - **Not all vision models support tools** on local stacks.
 - **Send-path selection:** Raster images in Writer/Calc selection only; Draw/Impress vectors use other paths.
 - **Main chat model only** for send-path attachment; sub-agents/delegates have separate rules.
-- **`get_image` Writer-only** for now; Calc has specialized list/info/set but not core fetch (see follow-up §4).
+- **`get_image`** is on Writer, Draw, and Impress. Calc still has specialized list/info/set but not core fetch (see follow-up §4). Draw/Impress `page=N` is a screenshot; `get_draw_tree` stays the structure read.
 - **Complementary OCR:** Use `domain=vision` + `extract_structure_from_image` for text and structure + insert; use native multimodal for visual reasoning.
 
 ---

--- a/docs/images/recognition.md
+++ b/docs/images/recognition.md
@@ -367,7 +367,7 @@ Extended [`test_vision.py`](../../tests/scripting/test_vision.py), [`test_vision
 | Alt text from visible text | `extract_text` → description (**later**) | optional |
 | Find logos / UI elements | `detect_objects` (Phase 4) | same |
 | “What does this diagram *mean*?” | — | LLM vision ([§18](#18-llm-access-deferred)) |
-| Draw/Impress **vector** slides | LO-DOM [`get_draw_tree`](../writer/lo-dom-semantic-tree.md) | not raster CV |
+| Draw/Impress **vector** slides | LO-DOM [`get_draw_tree`](../writer/lo-dom-semantic-tree.md) | structure; layout QA uses [`get_image`](../../plugin/writer/get_image.py) `page=N` (vision screenshot, not a tree replacement) |
 
 ---
 
@@ -381,7 +381,7 @@ Extended [`test_vision.py`](../../tests/scripting/test_vision.py), [`test_vision
 | Export by graphic name | [`resolve_vision_image_bytes`](plugin/vision/vision_runner.py) + [`_get_graphic_object`](plugin/writer/images/images.py) |
 | List in-document graphics | [`image_list`](../../plugin/writer/images/images.py) |
 | Metadata | [`image_get_info`](../../plugin/writer/images/images.py) |
-| Return a viewable image to the model | [`get_image`](../../plugin/writer/get_image.py) — an embedded graphic by name, the current selection, or `page=<n>` to render a whole page as PNG (native `writer_png_Export`) |
+| Return a viewable image to the model | [`get_image`](../../plugin/writer/get_image.py) — an embedded graphic by name, the current selection, or `page=<n>` to render a whole page as PNG (Writer: `writer_png_Export`; Draw/Impress: `GraphicExportFilter` on the draw page) |
 | Insert / replace / delete | [`image_tools.py`](../../plugin/writer/images/image_tools.py) |
 | Remote **generation** | [`image_generate`](../../plugin/writer/images/images.py) |
 

--- a/docs/writer/lo-dom-semantic-tree.md
+++ b/docs/writer/lo-dom-semantic-tree.md
@@ -16,7 +16,7 @@ LibreOffice maintains a rigorous structural hierarchy of its documents via the U
 
 ### Draw and Impress (Draw Tree)
 
-The `get_draw_tree` tool extracts the hierarchical structure of a Draw page or Impress slide. It translates raw UNO objects (`com.sun.star.drawing.RectangleShape`) into semantic JSON nodes.
+The `get_draw_tree` tool extracts the hierarchical structure of a Draw page or Impress slide. It translates raw UNO objects (`com.sun.star.drawing.RectangleShape`) into semantic JSON nodes. Vision-capable chat can also call `get_image page=N` (1-based) for a PNG of that page — a screenshot for layout QA, not a substitute for this tree.
 
 **Features of the Draw Tree:**
 * **Hierarchy:** Grouped shapes become parent nodes with nested children.

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -622,6 +622,7 @@ READ:
 - read_slide_text: Extract text content and speaker notes from a slide.
 - get_presentation_info: Slide count, dimensions, master slide names, and Impress status.
 - get_draw_tree: Semantic tree (DOM) of shapes, layout, and hierarchy on a page. Empty/near-empty text boxes are fill targets (fillable, label_hint, name); ControlShapes include type/name/value/state. Address by name. Do not spawn ControlShapes to fill paper-form blanks.
+- get_image: page=N (1-based; first page is 1, unlike 0-based get_draw_tree) renders that page as a PNG so a vision model can see the layout. Use alongside get_draw_tree, not instead of it. image= / selection= fetch an embedded GraphicObjectShape.
 - list_placeholders: List text placeholders (title, subtitle, body) on a slide (Impress).
 - get_placeholder_text: Get text from a slide placeholder by role or index.
 

--- a/plugin/writer/get_image.py
+++ b/plugin/writer/get_image.py
@@ -9,6 +9,7 @@ b64 is stripped from get_document_content by default, so a model never pays visi
 When it actually needs to SEE one image, it calls get_image, which returns that single picture as a
 native MCP image content block (only then are vision tokens spent). One self-documenting tool, by
 graphic name, by the current selection, or page=<n> to render a whole page (_render_page_png below).
+On Draw/Impress, page=N is the vision screenshot; get_draw_tree remains the structure read.
 """
 
 import base64
@@ -17,7 +18,33 @@ from plugin.framework.tool import ToolBase
 from plugin.writer.images.image_tools import export_graphic_object_to_bytes, get_selected_image_base64
 
 
-def _render_page_png(ctx, doc, page):
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_TEXT_DOCUMENT = "com.sun.star.text.TextDocument"
+_DRAW_DOCUMENT = "com.sun.star.drawing.DrawingDocument"
+_IMPRESS_DOCUMENT = "com.sun.star.presentation.PresentationDocument"
+
+
+def _supports_service(doc, service):
+    try:
+        return bool(doc.supportsService(service))
+    except Exception:
+        return False
+
+
+def _is_draw_family(doc):
+    """True for Draw or Impress. Check PresentationDocument first: Impress also supports DrawingDocument."""
+    return _supports_service(doc, _IMPRESS_DOCUMENT) or _supports_service(doc, _DRAW_DOCUMENT)
+
+
+def _read_png_or_reason(tmp_path, page):
+    with open(tmp_path, "rb") as f:
+        png = f.read()
+    if not png or png[:8] != _PNG_MAGIC:
+        return None, "could not render page %d: the PNG export produced no valid image." % page
+    return png, None
+
+
+def _render_writer_page_png(doc, page):
     """Render 1-based *page* of a Writer doc to PNG bytes, or (None, reason).
 
     NATIVE LibreOffice path ONLY — the writer_png_Export graphic filter, targeted per page with the
@@ -67,11 +94,7 @@ def _render_page_png(ctx, doc, page):
             uno.systemPathToFileUrl(tmp_path),
             (PropertyValue(Name="FilterName", Value="writer_png_Export"),),
         )
-        with open(tmp_path, "rb") as f:
-            png = f.read()
-        if not png or png[:8] != b"\x89PNG\r\n\x1a\n":
-            return None, "could not render page %d: the PNG export produced no valid image." % page
-        return png, None
+        return _read_png_or_reason(tmp_path, page)
     except Exception as e:
         return None, "could not render page %d: %s" % (page, e)
     finally:
@@ -87,15 +110,79 @@ def _render_page_png(ctx, doc, page):
                 pass
 
 
+def _render_draw_page_png(ctx, doc, page):
+    """Render 1-based *page* of a Draw/Impress doc to PNG bytes, or (None, reason).
+
+    Native ``com.sun.star.drawing.GraphicExportFilter`` with the XDrawPage as source (MediaType
+    image/png). Verified live 2026-09-09: this yields a valid PNG and different pages produce
+    different bytes. ``setCurrentPage`` + ``storeToURL(draw_png_Export / impress_png_Export)``
+    produces the same image but mutates the view; FilterData PageNumber on the document model
+    does not work (filter returns false). Fail-loud — never a silent empty image.
+    """
+    import os
+    import tempfile
+
+    try:
+        pages = doc.getDrawPages()
+        total = int(pages.getCount())
+    except Exception as e:
+        return None, "could not render page %d: no draw pages available (%s)" % (page, e)
+
+    if page < 1 or page > total:
+        return None, "could not render page %d: page not found (document has %d page(s))." % (page, total)
+
+    tmp_path = None
+    try:
+        import uno
+        from com.sun.star.beans import PropertyValue
+
+        if ctx is None:
+            return None, "could not render page %d: no component context for GraphicExportFilter." % page
+        smgr = getattr(ctx, "ServiceManager", None)
+        if smgr is None:
+            smgr = ctx.getServiceManager()
+        filt = smgr.createInstanceWithContext("com.sun.star.drawing.GraphicExportFilter", ctx)
+        if filt is None:
+            return None, "could not render page %d: GraphicExportFilter is unavailable." % page
+        # setSourceDocument accepts XDrawPage here (not only XModel) — that is how a specific
+        # slide is targeted without a controller page jump.
+        filt.setSourceDocument(pages.getByIndex(page - 1))
+        fd, tmp_path = tempfile.mkstemp(prefix="wa_page_render_", suffix=".png")
+        os.close(fd)
+        ok = filt.filter((
+            PropertyValue(Name="URL", Value=uno.systemPathToFileUrl(tmp_path)),
+            PropertyValue(Name="MediaType", Value="image/png"),
+        ))
+        if not ok:
+            return None, "could not render page %d: GraphicExportFilter returned false." % page
+        return _read_png_or_reason(tmp_path, page)
+    except Exception as e:
+        return None, "could not render page %d: %s" % (page, e)
+    finally:
+        if tmp_path:
+            try:
+                os.remove(tmp_path)
+            except Exception:
+                pass
+
+
+def _render_page_png(ctx, doc, page):
+    """Render 1-based *page* of Writer, Draw, or Impress to PNG bytes, or (None, reason)."""
+    if _is_draw_family(doc):
+        return _render_draw_page_png(ctx, doc, page)
+    return _render_writer_page_png(doc, page)
+
+
 class GetImage(ToolBase):
     name = "get_image"
     tier = "core"
     description = (
         "Return an image so you can SEE it (vision-capable models). One of: image=<the graphic's name "
         "from image_list / get_page_objects> for an embedded picture; selection=true for the image "
-        "currently selected; or page=<n> to render that whole PAGE as an image (layout/what-it-looks-like). "
-        "Returns the picture itself, not a description. b64 is stripped from normal reads, so use this "
-        "when you actually need to look."
+        "currently selected; or page=<n> (1-based) to render that whole PAGE as an image "
+        "(Writer/Draw/Impress layout). On Draw/Impress, get_draw_tree is the shape tree — use page= "
+        "here when you need to see the rendered page. Returns the picture itself, not a description. "
+        "b64 is stripped from normal reads, so use this when you actually need to look."
     )
     parameters = {
         "type": "object",
@@ -106,7 +193,8 @@ class GetImage(ToolBase):
         },
         "required": [],
     }
-    uno_services = ["com.sun.star.text.TextDocument"]
+    # Impress also supports DrawingDocument; list both so execution accepts either service set.
+    uno_services = [_TEXT_DOCUMENT, _DRAW_DOCUMENT, _IMPRESS_DOCUMENT]
 
     def execute(self, ctx, **kwargs):
         doc = ctx.doc
@@ -128,9 +216,14 @@ class GetImage(ToolBase):
                     return self._tool_error("No image selected. Select an image in the document, or pass image=<name> (see image_list).")
                 source = "selection"
             else:
-                if not hasattr(doc, "getGraphicObjects") or not doc.getGraphicObjects().hasByName(name):
+                # visual_helpers walks Writer GraphicObjects and Draw/Impress GraphicObjectShapes.
+                # Do not call getGraphicObjects() here — that Writer-only API is missing on Draw
+                # and would look like a successful miss ("no such name") instead of a real lookup.
+                from plugin.doc.visual_helpers import get_graphic_object_by_name
+
+                obj = get_graphic_object_by_name(doc, name)
+                if obj is None:
                     return self._tool_error(f"No embedded image named '{name}'. Call image_list to see the available names.")
-                obj = doc.getGraphicObjects().getByName(name)
                 raw = export_graphic_object_to_bytes(ctx.ctx, obj)
                 if not raw:
                     return self._tool_error(f"Could not export image '{name}'.")

--- a/tests/writer/test_get_image_render.py
+++ b/tests/writer/test_get_image_render.py
@@ -2,19 +2,24 @@
 # Copyright (c) 2026 KeithCu
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""R4/BUG-5: page render via the writer_png_Export filter — pure control-flow tests with fakes.
+"""Page-render control flow for get_image — Writer jumpToPage + Draw GraphicExportFilter.
 
 The old XRenderable/DIB math was removed with that route (its getRendererCount reports 1 page on
 real multi-page docs; see BUG-5). What is testable without LibreOffice is the control flow of
-_render_page_png: the no-view error, the page-not-found error (jumpToPage clamps; the message must
-report the real total), and that the view cursor is restored best-effort on the way out. The happy
-path (storeToURL + PNG bytes) is validated live."""
+_render_page_png: Writer no-view / page-not-found (jumpToPage clamps; the message must report the
+real total) and view-cursor restore; Draw/Impress page-not-found from getDrawPages().getCount()
+(no silent empty image). The happy path (storeToURL / GraphicExportFilter + PNG bytes) is
+validated live."""
+import base64
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from plugin.tests.testing_utils import setup_uno_mocks
 setup_uno_mocks()
 
-from plugin.writer.get_image import _render_page_png
+from plugin.framework.tool import ToolContext
+from plugin.writer.get_image import GetImage, _is_draw_family, _render_page_png
 
 
 class FakeViewCursor:
@@ -93,3 +98,125 @@ def test_out_of_range_never_renders(bad_page):
     doc = FakeDoc(page_count=20)
     png, reason = _render_page_png(object(), doc, bad_page)
     assert png is None and "page not found" in reason
+
+
+class FakeDrawPages:
+    def __init__(self, page_count):
+        self.page_count = page_count
+        self.pages = [object() for _unused in range(page_count)]
+
+    def getCount(self):
+        return self.page_count
+
+    def getByIndex(self, index):
+        return self.pages[index]
+
+
+class FakeDrawDoc:
+    def __init__(self, page_count=2, services=None, pages_error=None):
+        self.page_count = page_count
+        self.services = services or ("com.sun.star.drawing.DrawingDocument",)
+        self.pages_error = pages_error
+        self._pages = FakeDrawPages(page_count)
+
+    def supportsService(self, service):
+        return service in self.services
+
+    def getDrawPages(self):
+        if self.pages_error is not None:
+            raise RuntimeError(self.pages_error)
+        return self._pages
+
+    def getGraphicObjects(self):
+        raise AssertionError("Draw must not use Writer getGraphicObjects()")
+
+
+def test_draw_family_detects_impress_before_drawing_service():
+    impress = FakeDrawDoc(services=("com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"))
+    draw = FakeDrawDoc(services=("com.sun.star.drawing.DrawingDocument",))
+    writer = FakeDoc()
+    assert _is_draw_family(impress) is True
+    assert _is_draw_family(draw) is True
+    assert _is_draw_family(writer) is False
+
+
+def test_draw_page_not_found_reports_real_total():
+    png, reason = _render_page_png(object(), FakeDrawDoc(page_count=2), 9)
+    assert png is None
+    assert "page not found" in reason
+    assert "2 page(s)" in reason
+
+
+def test_draw_no_pages_is_a_clear_error():
+    png, reason = _render_page_png(object(), FakeDrawDoc(pages_error="no pages"), 1)
+    assert png is None
+    assert "could not render page 1" in reason
+    assert "no draw pages available" in reason
+
+
+def test_impress_uses_draw_page_path_not_writer_view_cursor():
+    """Impress supports DrawingDocument too; must not fall through to jumpToPage."""
+    doc = FakeDrawDoc(
+        page_count=1,
+        services=("com.sun.star.drawing.DrawingDocument", "com.sun.star.presentation.PresentationDocument"),
+    )
+    png, reason = _render_page_png(object(), doc, 4)
+    assert png is None
+    assert "page not found" in reason
+    assert "1 page(s)" in reason
+
+
+def test_get_image_registers_draw_and_impress():
+    assert "com.sun.star.text.TextDocument" in GetImage.uno_services
+    assert "com.sun.star.drawing.DrawingDocument" in GetImage.uno_services
+    assert "com.sun.star.presentation.PresentationDocument" in GetImage.uno_services
+
+
+def _tctx(doc, doc_type="draw"):
+    return ToolContext(doc=doc, ctx=object(), doc_type=doc_type, services={}, caller="test")
+
+
+def test_execute_draw_page_error_is_tool_error():
+    res = GetImage().execute(_tctx(FakeDrawDoc(page_count=2)), page=9)
+    assert res["status"] == "error"
+    assert "page not found" in res["message"]
+    assert "2 page(s)" in res["message"]
+
+
+def test_execute_draw_page_success_returns_mcp_image():
+    png = b"\x89PNG\r\n\x1a\n" + b"draw-page"
+    with patch("plugin.writer.get_image._render_page_png", return_value=(png, None)):
+        res = GetImage().execute(_tctx(FakeDrawDoc()), page=1)
+    assert res["status"] == "ok"
+    assert res["source"] == "page 1"
+    assert res["_mcp_image"]["mimeType"] == "image/png"
+    assert base64.b64decode(res["_mcp_image"]["data"]) == png
+
+
+def test_execute_named_image_uses_visual_helpers_not_graphic_objects():
+    doc = FakeDrawDoc()
+    raw = b"\x89PNG\r\n\x1a\nimg"
+    with (
+        patch("plugin.doc.visual_helpers.get_graphic_object_by_name", return_value=object()) as lookup,
+        patch("plugin.writer.get_image.export_graphic_object_to_bytes", return_value=raw),
+    ):
+        res = GetImage().execute(_tctx(doc), image="Logo")
+    lookup.assert_called_once_with(doc, "Logo")
+    assert res["status"] == "ok"
+    assert res["source"] == "Logo"
+    assert base64.b64decode(res["_mcp_image"]["data"]) == raw
+
+
+def test_execute_named_image_missing_is_clear_error():
+    with patch("plugin.doc.visual_helpers.get_graphic_object_by_name", return_value=None):
+        res = GetImage().execute(_tctx(FakeDrawDoc()), image="Missing")
+    assert res["status"] == "error"
+    assert "Missing" in res["message"]
+    assert "image_list" in res["message"]
+
+
+def test_execute_selection_none_is_clear_error():
+    with patch("plugin.writer.get_image.get_selected_image_base64", return_value=None):
+        res = GetImage().execute(_tctx(FakeDrawDoc()), selection=True)
+    assert res["status"] == "error"
+    assert "No image selected" in res["message"]

--- a/tests/writer/test_get_image_render.py
+++ b/tests/writer/test_get_image_render.py
@@ -11,7 +11,7 @@ real total) and view-cursor restore; Draw/Impress page-not-found from getDrawPag
 (no silent empty image). The happy path (storeToURL / GraphicExportFilter + PNG bytes) is
 validated live."""
 import base64
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/writer/test_get_image_uno.py
+++ b/tests/writer/test_get_image_uno.py
@@ -1,0 +1,81 @@
+# WriterAgent - AI Writing Assistant for LibreOffice
+# Copyright (c) 2026 KeithCu
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Live get_image page=N on Draw and Impress (GraphicExportFilter on XDrawPage)."""
+import base64
+
+from plugin.testing_runner import native_test
+from plugin.tests.testing_utils import with_native_doc
+
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def _add_rect(doc, page, color, x=1000, y=1000):
+    from com.sun.star.awt import Point, Size
+
+    shape = doc.createInstance("com.sun.star.drawing.RectangleShape")
+    shape.setPosition(Point(x, y))
+    shape.setSize(Size(8000, 5000))
+    shape.setPropertyValue("FillColor", color)
+    shape.setPropertyValue("FillStyle", 1)  # SOLID
+    page.add(shape)
+
+
+def _two_pages(doc):
+    pages = doc.getDrawPages()
+    if pages.getCount() < 2:
+        pages.insertNewByIndex(1)
+    _add_rect(doc, pages.getByIndex(0), 0xFF0000)
+    _add_rect(doc, pages.getByIndex(1), 0x0000FF, x=12000, y=8000)
+    return pages
+
+
+def _exec(doc, ctx, doc_type, **kwargs):
+    from plugin.framework.tool import ToolContext
+    from plugin.writer.get_image import GetImage
+
+    tctx = ToolContext(doc, ctx, doc_type, {}, "test")
+    return GetImage().execute(tctx, **kwargs)
+
+
+def _assert_png_result(res, source):
+    assert res.get("status") == "ok", res
+    assert res.get("source") == source
+    blob = res.get("_mcp_image") or {}
+    raw = base64.b64decode(blob.get("data") or "")
+    assert raw[:8] == _PNG_MAGIC, "get_image must return a real PNG, not an empty placeholder"
+    assert blob.get("mimeType") == "image/png"
+    return raw
+
+
+@native_test
+@with_native_doc("draw")
+def test_get_image_draw_page_png(ctx, doc):
+    _two_pages(doc)
+    page1 = _assert_png_result(_exec(doc, ctx, "draw", page=1), "page 1")
+    page2 = _assert_png_result(_exec(doc, ctx, "draw", page=2), "page 2")
+    assert page1 != page2, "page=1 and page=2 must render different Draw pages"
+
+    missing = _exec(doc, ctx, "draw", page=9)
+    assert missing.get("status") == "error"
+    assert "page not found" in missing.get("message", "")
+    assert "2 page(s)" in missing.get("message", "")
+
+    unnamed = _exec(doc, ctx, "draw", image="NoSuchGraphic")
+    assert unnamed.get("status") == "error"
+    assert "NoSuchGraphic" in unnamed.get("message", "")
+
+    no_sel = _exec(doc, ctx, "draw", selection=True)
+    assert no_sel.get("status") == "error"
+    assert "No image selected" in no_sel.get("message", "")
+
+
+@native_test
+@with_native_doc("impress")
+def test_get_image_impress_page_png(ctx, doc):
+    _two_pages(doc)
+    page1 = _assert_png_result(_exec(doc, ctx, "impress", page=1), "page 1")
+    page2 = _assert_png_result(_exec(doc, ctx, "impress", page=2), "page 2")
+    assert page1 != page2, "page=1 and page=2 must render different Impress slides"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Vision-capable chat models can now look at a Draw or Impress page the same way they look at a Writer page: `get_image page=N` (1-based) returns a PNG.

## Approach
- Register `GetImage` on `DrawingDocument` and `PresentationDocument` as well as `TextDocument`.
- Draw/Impress page render uses native `com.sun.star.drawing.GraphicExportFilter` with the **XDrawPage** as source (`MediaType=image/png`). Live probe confirmed:
  - this produces a valid PNG
  - page 1 and page 2 differ
  - `setCurrentPage` + `storeToURL(draw_png_Export / impress_png_Export)` yields the same bytes but mutates the view
  - `FilterData PageNumber` on the document model does **not** work
- Named graphics use `visual_helpers.get_graphic_object_by_name` (Writer GraphicObjects **and** Draw/Impress GraphicObjectShapes). Do not call Writer-only `getGraphicObjects()` on Draw.
- Selection uses the existing `get_selected_image_base64` path (GraphicObjectShape). Clear errors when nothing is selected or the name is missing.
- Draw chat prompt notes `get_image page=N` alongside `get_draw_tree` (tree stays the structure read; this is the screenshot).

## Still Writer-only
- Writer page render is still `jumpToPage` + `writer_png_Export` (view-cursor save/restore).
- Calc is unchanged (no `get_image` there).
- `get_draw_tree` is unchanged.

## Tests
- Unit: Draw/Impress page-not-found / no-pages control flow; execute mocks for page / named / selection. `15 passed`.
- Native UNO: two-page Draw and Impress docs, assert real PNGs that differ; missing name / no selection errors on Draw. `2 passed`.
- `make typecheck` passed.

Live `GetImage.execute(page=1|2)` on a two-page Draw doc:

[Draw page 1 (red rectangle)](https://cursor.com/agents/bc-8fe06b2b-0372-4884-8e90-f2dd7c2c8d98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdraw_page_1_red.png)
[Draw page 2 (blue rectangle)](https://cursor.com/agents/bc-8fe06b2b-0372-4884-8e90-f2dd7c2c8d98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdraw_page_2_blue.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fe06b2b-0372-4884-8e90-f2dd7c2c8d98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fe06b2b-0372-4884-8e90-f2dd7c2c8d98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

