### PR TITLE
Save full writeragent_debug.log on every eval-2 headed run

### DIFF
--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -32,6 +32,19 @@ Do not hand-edit `writeragent.json`. Do not open `fixtures/` or the task
 directory — `--launch` stages a clean trial dir so `document_research`
 cannot list prompt/rubric/gold.
 
+**Debug log (standing rule):** every headed run must keep a **full**
+copy of `writeragent_debug.log`. LO restart for the next trial re-inits
+logging (`Debug log active`) and can reset the live profile file —
+Floorstand Gemini `20260909-1748` lost its tool-call trace that way.
+`--launch` snapshots the live log on Enter / Ctrl-C into `--run-dir`
+(typically `docs/eval/eval-2/<task>/runs/<stamp>/writeragent_debug.log`)
+or an auto-stamp `YYYYMMDD-HHMM` under that task’s `runs/`. Mid-stall,
+**before** restarting LibreOffice:
+
+```bash
+.venv/bin/python scripts/save_eval2_debug_log.py docs/eval/eval-2/<task>/runs/<stamp>
+```
+
 Slot **7 stays PARKED** and is **not wired** into `--task` / `--launch` /
 `--score`. Do not invent helper flags for it. See that stub `run.md`.
 

--- a/docs/eval/eval-2/headed-failure-autopsy.md
+++ b/docs/eval/eval-2/headed-failure-autopsy.md
@@ -118,7 +118,7 @@ Paths (box): `docs/eval/eval-2/writer-calc-peer-write/runs/…` under Scrolly’
 - Observer: peer asks were **fill/write**, not extract/JSON — polarity telemetry **HIT**.
 - UI shots (`fs3-sent` / `fs3-calc`): sidebar **Thinking…** with **blank chat transcript** and blank email (0 words); later `fs3-final`: **Ready**, still blank email, chat UI empty. Calc still in taskbar.
 - computerUse: hard-stall **>3 min** after send → stopped; did not create `*_SAVED` copies (scored live trial files).
-- Debug log for this run was **rotated away** at `17:48:34` when LO restarted into Calc-primary Gemini (`Debug log active` resets the file). Floorstand tool-call trace is **not** in the live `writeragent_debug.log` — reconstruct from notes + shots only. (Do not confuse post-17:48 Calc-primary `Raw Data` / `peer_count=0` lines with Floorstand.)
+- Debug log for this run was **rotated away** at `17:48:34` when LO restarted into Calc-primary Gemini (`Debug log active` resets the file). Floorstand tool-call trace is **not** in the live `writeragent_debug.log` — reconstruct from notes + shots only. (Do not confuse post-17:48 Calc-primary `Raw Data` / `peer_count=0` lines with Floorstand.) **Standing rule:** save the full debug log for every headed run — `--launch` exit snapshots it; mid-stall use `scripts/save_eval2_debug_log.py DEST_DIR` before restart. See [§ Debug log snapshot](#debug-log-snapshot-standing-rule).
 
 #### Ranked causes — why fill polarity still left empty sheets + blank email + stall
 
@@ -154,7 +154,17 @@ Paths (box): `docs/eval/eval-2/writer-calc-peer-write/runs/…` under Scrolly’
 4. **DO — Stall plumbing (separate from polarity)** — fail-loud / timeout when peer drain or LLM stream hangs >N minutes; preserve debug log across LO restarts for headed trials. Not an eval cheat.  
 5. **Don’t** add gold dollar totals to `prompt.writeragent.txt`. **Don’t** wait on gpt-oss polarity for Gemini gating. **Don’t** fight Scrolly’s `writeragent-master` deploy while Calc-primary Gemini runs.
 
-**Next Gemini headed:** same private patches + value-payload peer teaching; expect nonempty Cost Comparison **and** nonempty email; capture `thinking_and_tools` + avoid log rotate before notes.
+**Next Gemini headed:** same private patches + value-payload peer teaching; expect nonempty Cost Comparison **and** nonempty email; capture `thinking_and_tools` + a full `writeragent_debug.log` in the stamp dir (do not rely on the live profile file after the next LO restart).
+
+---
+
+## Debug log snapshot (standing rule)
+
+Keith: **save off the full `writeragent_debug.log` for every headed / eval-2 run.** The live file lives next to `writeragent.json` in the LibreOffice user profile. A later LO restart re-inits logging (`Debug log active`) and can reset that file — that is how Floorstand Gemini `1748` lost its tool-call trace.
+
+- **`--launch` exit:** Enter / Ctrl-C after the trial copies the live log via `shutil.copy2` into `--run-dir/writeragent_debug.log`, or (if `--run-dir` is omitted) `docs/eval/eval-2/<task>/runs/<YYYYMMDD-HHMM>/writeragent_debug.log`. A missing live log warns; config restore still runs.
+- **Mid-stall (before restart):** `.venv/bin/python scripts/save_eval2_debug_log.py DEST_DIR` — prints the source path and dest size; exits non-zero if the live log is missing.
+- Discovery is shared with `scripts/analyze_tool_call_timing.py` (`eval_2_debug_log.py`; same profile dirs as `writeragent.json` / `DEBUG_LOG_FILENAME`). Do not change live-log format or truncate behavior.
 
 ---
 

--- a/scripts/analyze_tool_call_timing.py
+++ b/scripts/analyze_tool_call_timing.py
@@ -18,6 +18,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from eval_2_debug_log import debug_log_candidates, find_debug_log
+
 
 # Debug log line format: "YYYY-MM-DD HH:MM:SS.mmm | [Context] msg"
 LOG_LINE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) \| (.+)$")
@@ -37,17 +39,12 @@ def parse_timestamp(s):
 
 
 def find_log_path():
-    """Default log locations (extension writes to user config, sometimes under config/)."""
-    candidates = [
-        Path.home() / ".config" / "libreoffice" / "4" / "user" / "config" / "writeragent_debug.log",
-        Path.home() / ".config" / "libreoffice" / "4" / "user" / "writeragent_debug.log",
-        Path.home() / ".config" / "libreoffice" / "24" / "user" / "config" / "writeragent_debug.log",
-        Path.home() / ".config" / "libreoffice" / "24" / "user" / "writeragent_debug.log",
-    ]
-    for p in candidates:
-        if p.exists():
-            return p
-    return candidates[0]  # return first as default for "not found" message
+    """Default log locations (shared with eval_2_debug_log / writeragent.json)."""
+    found = find_debug_log()
+    if found is not None:
+        return found
+    candidates = debug_log_candidates()
+    return candidates[0]  # first candidate for the "not found" message
 
 
 def analyze(log_path):

--- a/scripts/eval_2_debug_log.py
+++ b/scripts/eval_2_debug_log.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# WriterAgent - snapshot writeragent_debug.log for eval-2 headed runs
+"""Discover and copy the live LibreOffice-user writeragent_debug.log.
+
+LO restart for the next headed trial re-inits logging (``Debug log
+active``). That can reset the live profile file, so Floorstand Gemini
+``20260909-1748`` lost its tool-call trace. Copy the full file with
+``shutil.copy2`` before restart.
+
+Candidate dirs match ``eval_2_headed.writeragent_json_candidates`` (same
+profile locations as the live log next to ``writeragent.json``). The
+filename matches ``plugin.framework.logging.DEBUG_LOG_FILENAME``. Outside
+LibreOffice, filesystem candidates are enough — ``get_debug_log_path``
+is only set after ``init_logging(ctx)``.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import TextIO
+
+# Keep in lockstep with plugin.framework.logging.DEBUG_LOG_FILENAME.
+# Scripts stay importable without loading the plugin logging stack.
+DEBUG_LOG_FILENAME = "writeragent_debug.log"
+
+
+def lo_user_profile_dirs() -> list[Path]:
+    """LibreOffice user-profile dirs that may hold writeragent.json / the debug log."""
+    if os.name == "nt":
+        return [Path(os.environ.get("APPDATA", "")) / "LibreOffice" / "4" / "user"]
+    if sys.platform == "darwin":
+        return [Path("~/Library/Application Support/LibreOffice/4/user").expanduser()]
+    return [
+        Path("~/.config/libreoffice/4/user/config").expanduser(),
+        Path("~/.config/libreoffice/4/user").expanduser(),
+        Path("~/.config/libreoffice/24/user/config").expanduser(),
+        Path("~/.config/libreoffice/24/user").expanduser(),
+    ]
+
+
+def debug_log_candidates() -> list[Path]:
+    """Same profile locations as analyze_tool_call_timing / writeragent.json."""
+    return [directory / DEBUG_LOG_FILENAME for directory in lo_user_profile_dirs()]
+
+
+def find_debug_log(
+    explicit: Path | None = None,
+    candidates: list[Path] | None = None,
+) -> Path | None:
+    """Return the first existing debug log, or None if none exist."""
+    if explicit is not None:
+        return explicit if explicit.is_file() else None
+    search = debug_log_candidates() if candidates is None else candidates
+    for path in search:
+        if path.is_file():
+            return path
+    return None
+
+
+def copy_debug_log(
+    dest_dir: Path,
+    *,
+    source: Path | None = None,
+    candidates: list[Path] | None = None,
+) -> tuple[Path, Path]:
+    """Copy the live debug log into ``dest_dir/writeragent_debug.log``.
+
+    Raises ``FileNotFoundError`` when no live log exists. Does not change
+    the live file (no truncate / no format change).
+    """
+    found = find_debug_log(source, candidates)
+    if found is None:
+        searched = [source] if source is not None else (candidates or debug_log_candidates())
+        raise FileNotFoundError(
+            "Could not find writeragent_debug.log. Looked in: "
+            + ", ".join(str(path) for path in searched)
+        )
+    dest_dir = dest_dir.expanduser()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / DEBUG_LOG_FILENAME
+    if dest.resolve() != found.resolve():
+        shutil.copy2(found, dest)
+    return found, dest
+
+
+def snapshot_debug_log(
+    dest_dir: Path,
+    *,
+    source: Path | None = None,
+    candidates: list[Path] | None = None,
+    file: TextIO | None = None,
+) -> Path | None:
+    """Copy the live log for a headed trial. Warn and return None on failure.
+
+    Headed ``--launch`` must not fail the restore-config path if the log
+    is missing or unreadable.
+    """
+    out = sys.stderr if file is None else file
+    try:
+        found, dest = copy_debug_log(dest_dir, source=source, candidates=candidates)
+    except FileNotFoundError as exc:
+        print(f"Warning: {exc}", file=out)
+        return None
+    except OSError as exc:
+        print(f"Warning: could not snapshot writeragent_debug.log: {exc}", file=out)
+        return None
+    size = dest.stat().st_size
+    print(f"Saved {DEBUG_LOG_FILENAME} from {found} -> {dest} ({size} bytes)")
+    return dest

--- a/scripts/eval_2_headed.py
+++ b/scripts/eval_2_headed.py
@@ -54,9 +54,16 @@ PDF is **not** the write target. Writer is optional/absent.
 
 Do not open ``fixtures/`` or the task folder.
 
+``--launch`` copies the live LO-user ``writeragent_debug.log`` when the
+trial ends (Enter / Ctrl-C). Pass ``--run-dir`` to write it under that
+stamp; otherwise a ``YYYYMMDD-HHMM`` folder is created under the task
+``runs/`` dir. Mid-stall, before restarting LO, use
+``scripts/save_eval2_debug_log.py DEST_DIR``.
+
 Usage:
   .venv/bin/python scripts/eval_2_headed.py
   .venv/bin/python scripts/eval_2_headed.py --launch
+  .venv/bin/python scripts/eval_2_headed.py --launch --run-dir docs/eval/eval-2/afc-sample-83d10b06/runs/<stamp>
   .venv/bin/python scripts/eval_2_headed.py --launch --trial-dir /tmp/my-afc
   .venv/bin/python scripts/eval_2_headed.py --task tenant-retention --launch
   .venv/bin/python scripts/eval_2_headed.py --task cadaver-proposal --launch
@@ -88,8 +95,11 @@ import sys
 import tempfile
 import zipfile
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+from eval_2_debug_log import lo_user_profile_dirs, snapshot_debug_log
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MAX_TOOL_ROUNDS_KEY = "chatbot.max_tool_rounds"
@@ -203,17 +213,8 @@ TASK_CHOICES = (
 
 
 def writeragent_json_candidates() -> list[Path]:
-    """Same profile locations as bench_embeddings / strip_lru / bench_warm_numpy."""
-    if os.name == "nt":
-        return [Path(os.environ.get("APPDATA", "")) / "LibreOffice" / "4" / "user" / "writeragent.json"]
-    if sys.platform == "darwin":
-        return [Path("~/Library/Application Support/LibreOffice/4/user/writeragent.json").expanduser()]
-    return [
-        Path("~/.config/libreoffice/4/user/config/writeragent.json").expanduser(),
-        Path("~/.config/libreoffice/4/user/writeragent.json").expanduser(),
-        Path("~/.config/libreoffice/24/user/config/writeragent.json").expanduser(),
-        Path("~/.config/libreoffice/24/user/writeragent.json").expanduser(),
-    ]
+    """Same profile locations as bench_embeddings / strip_lru / the debug log."""
+    return [directory / "writeragent.json" for directory in lo_user_profile_dirs()]
 
 
 def find_writeragent_json(
@@ -332,6 +333,33 @@ def task_max_tool_rounds(task: str) -> int:
     if task in {TASK_GMP, TASK_WRITER_CALC, TASK_REVERSE}:
         return EVAL_2_GMP_MAX_TOOL_ROUNDS
     return EVAL_2_MAX_TOOL_ROUNDS
+
+
+def task_doc_dir(task: str) -> Path:
+    """Task folder under docs/eval/eval-2/ (holds fixtures/ + runs/)."""
+    return {
+        TASK_AFC: _AFC_DIR,
+        TASK_TENANT: _TENANT_DIR,
+        TASK_CADAVER: _CADAVER_DIR,
+        TASK_GMP: _GMP_DIR,
+        TASK_WRITER_CALC: _FLOORSTAND_DIR,
+        TASK_CALC_PRIMARY: _CALC_PRIMARY_DIR,
+        TASK_REVERSE: _REVERSE_DIR,
+        TASK_LONG: _LONG_DIR,
+        TASK_DRAW: _DRAW_DIR,
+    }[task]
+
+
+def default_eval2_run_dir(task: str, *, now: datetime | None = None) -> Path:
+    """Durable stamp dir for headed artifacts (debug log, later notes/ods)."""
+    stamp = (now or datetime.now()).strftime("%Y%m%d-%H%M")
+    return task_doc_dir(task) / "runs" / stamp
+
+
+def resolve_headed_run_dir(task: str, run_dir: Path | None, *, now: datetime | None = None) -> Path:
+    if run_dir is not None:
+        return run_dir
+    return default_eval2_run_dir(task, now=now)
 
 
 def default_eval2_trial_dir(task: str = TASK_AFC) -> Path:
@@ -909,6 +937,16 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--run-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Durable stamp dir that receives writeragent_debug.log on "
+            "--launch exit (typically docs/eval/eval-2/<task>/runs/<stamp>). "
+            "Default: auto-stamp YYYYMMDD-HHMM under that task's runs/"
+        ),
+    )
+    parser.add_argument(
         "--score",
         type=Path,
         default=None,
@@ -1028,6 +1066,8 @@ def main(argv: list[str] | None = None) -> int:
                 print(str(exc), file=sys.stderr)
                 return 1
             _wait_for_finish(rounds)
+            # Copy before the next trial's LO restart resets the live log.
+            snapshot_debug_log(resolve_headed_run_dir(args.task, args.run_dir))
         else:
             _wait_for_finish(rounds)
     print(f"Restored previous {MAX_TOOL_ROUNDS_KEY} in {config_path}")

--- a/scripts/save_eval2_debug_log.py
+++ b/scripts/save_eval2_debug_log.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# WriterAgent - one-shot save of writeragent_debug.log for eval-2
+"""Copy the live LibreOffice-user debug log into DEST_DIR.
+
+Use this mid-stall, *before* restarting LibreOffice for the next trial.
+``eval_2_headed.py --launch`` also snapshots on Enter / Ctrl-C; this
+helper is for saving while the hang is still on disk.
+
+Usage:
+  .venv/bin/python scripts/save_eval2_debug_log.py DEST_DIR
+  .venv/bin/python scripts/save_eval2_debug_log.py docs/eval/eval-2/writer-calc-peer-write/runs/20260909-1748
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from eval_2_debug_log import copy_debug_log
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dest_dir",
+        type=Path,
+        help="Directory that will receive writeragent_debug.log",
+    )
+    args = parser.parse_args(argv)
+    try:
+        source, dest = copy_debug_log(args.dest_dir)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"Could not copy writeragent_debug.log: {exc}", file=sys.stderr)
+        return 1
+    print(f"source: {source}")
+    print(f"dest: {dest} ({dest.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_eval_2_debug_log.py
+++ b/tests/scripts/test_eval_2_debug_log.py
@@ -1,0 +1,139 @@
+# WriterAgent tests for scripts/eval_2_debug_log.py / save_eval2_debug_log.py
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from eval_2_debug_log import (  # noqa: E402
+    DEBUG_LOG_FILENAME,
+    copy_debug_log,
+    debug_log_candidates,
+    find_debug_log,
+    lo_user_profile_dirs,
+    snapshot_debug_log,
+)
+from eval_2_headed import writeragent_json_candidates  # noqa: E402
+from save_eval2_debug_log import main as save_main  # noqa: E402
+
+
+def test_filename_matches_plugin_logging() -> None:
+    from plugin.framework.logging import DEBUG_LOG_FILENAME as plugin_name
+
+    assert DEBUG_LOG_FILENAME == plugin_name == "writeragent_debug.log"
+
+
+def test_debug_log_candidates_share_json_profile_dirs() -> None:
+    json_parents = [path.parent for path in writeragent_json_candidates()]
+    log_parents = [path.parent for path in debug_log_candidates()]
+    assert json_parents == log_parents == lo_user_profile_dirs()
+    assert all(path.name == DEBUG_LOG_FILENAME for path in debug_log_candidates())
+
+
+def test_find_debug_log_prefers_first_existing(tmp_path: Path) -> None:
+    missing = tmp_path / "missing" / DEBUG_LOG_FILENAME
+    first = tmp_path / "first" / DEBUG_LOG_FILENAME
+    second = tmp_path / "second" / DEBUG_LOG_FILENAME
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_text("FIRST\n", encoding="utf-8")
+    second.write_text("SECOND\n", encoding="utf-8")
+    assert find_debug_log(candidates=[missing, first, second]) == first
+    assert find_debug_log(explicit=second) == second
+    assert find_debug_log(explicit=missing) is None
+    assert find_debug_log(candidates=[missing]) is None
+
+
+def test_copy_debug_log_writes_full_file(tmp_path: Path) -> None:
+    live = tmp_path / "live" / DEBUG_LOG_FILENAME
+    live.parent.mkdir()
+    body = "Debug log active: /tmp/live\nround 1 sending\n"
+    live.write_text(body, encoding="utf-8")
+    dest_dir = tmp_path / "runs" / "20260909-1748"
+    source, dest = copy_debug_log(dest_dir, source=live)
+    assert source == live
+    assert dest == dest_dir / DEBUG_LOG_FILENAME
+    assert dest.read_text(encoding="utf-8") == body
+    # Live file is unchanged (no truncate).
+    assert live.read_text(encoding="utf-8") == body
+
+
+def test_copy_debug_log_missing_raises(tmp_path: Path) -> None:
+    missing = tmp_path / "nope" / DEBUG_LOG_FILENAME
+    with pytest.raises(FileNotFoundError, match="writeragent_debug.log"):
+        copy_debug_log(tmp_path / "dest", source=missing)
+
+
+def test_copy_debug_log_same_path_is_noop(tmp_path: Path) -> None:
+    live = tmp_path / DEBUG_LOG_FILENAME
+    live.write_text("same\n", encoding="utf-8")
+    source, dest = copy_debug_log(tmp_path, source=live)
+    assert source == dest == live
+    assert live.read_text(encoding="utf-8") == "same\n"
+
+
+def test_snapshot_debug_log_warns_when_missing(tmp_path: Path) -> None:
+    buf = io.StringIO()
+    missing = tmp_path / "nope.log"
+    result = snapshot_debug_log(tmp_path / "dest", source=missing, file=buf)
+    assert result is None
+    assert not (tmp_path / "dest" / DEBUG_LOG_FILENAME).exists()
+    assert "Warning:" in buf.getvalue()
+    assert "writeragent_debug.log" in buf.getvalue()
+
+
+def test_snapshot_debug_log_returns_dest(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    live = tmp_path / "live.log"
+    live.write_text("trace\n", encoding="utf-8")
+    dest_dir = tmp_path / "stamp"
+    result = snapshot_debug_log(dest_dir, source=live)
+    assert result == dest_dir / DEBUG_LOG_FILENAME
+    assert result is not None
+    assert result.read_text(encoding="utf-8") == "trace\n"
+    printed = capsys.readouterr().out
+    assert str(live) in printed
+    assert "6 bytes" in printed
+
+
+def test_save_eval2_debug_log_helper_prints_source_and_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    live = tmp_path / "profile" / DEBUG_LOG_FILENAME
+    live.parent.mkdir()
+    live.write_text("stall-trace\n", encoding="utf-8")
+    dest_dir = tmp_path / "run"
+    monkeypatch.setattr("eval_2_debug_log.debug_log_candidates", lambda: [live])
+    assert save_main([str(dest_dir)]) == 0
+    out = capsys.readouterr().out
+    dest = dest_dir / DEBUG_LOG_FILENAME
+    assert f"source: {live}" in out
+    assert f"dest: {dest} ({dest.stat().st_size} bytes)" in out
+    assert dest.read_text(encoding="utf-8") == "stall-trace\n"
+
+
+def test_save_eval2_debug_log_helper_exits_nonzero_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "eval_2_debug_log.debug_log_candidates",
+        lambda: [tmp_path / "absent.log"],
+    )
+    assert save_main([str(tmp_path / "dest")]) == 1
+    err = capsys.readouterr().err
+    assert "Could not find writeragent_debug.log" in err
+    assert not (tmp_path / "dest" / DEBUG_LOG_FILENAME).exists()
+
+
+def test_analyze_tool_call_timing_uses_shared_finder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from analyze_tool_call_timing import find_log_path
+
+    live = tmp_path / DEBUG_LOG_FILENAME
+    live.write_text("x\n", encoding="utf-8")
+    monkeypatch.setattr("eval_2_debug_log.debug_log_candidates", lambda: [live])
+    assert find_log_path() == live

--- a/tests/scripts/test_eval_2_headed.py
+++ b/tests/scripts/test_eval_2_headed.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import sys
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
+from eval_2_debug_log import DEBUG_LOG_FILENAME  # noqa: E402
 from eval_2_headed import (  # noqa: E402
     CADAVER_BUDGET_XLSX_NAME,
     CADAVER_PROPOSAL_NAME,
@@ -39,6 +41,7 @@ from eval_2_headed import (  # noqa: E402
     RAW_DATA_ODS_NAME,
     ROSTER_XLSX_NAME,
     SURVEY_XLSX_NAME,
+    TASK_AFC,
     TASK_CALC_PRIMARY,
     TASK_CADAVER,
     TASK_DRAW,
@@ -59,9 +62,13 @@ from eval_2_headed import (  # noqa: E402
     _REVERSE_DIR,
     _TENANT_DIR,
     apply_max_tool_rounds,
+    default_eval2_run_dir,
     default_eval2_trial_dir,
     find_writeragent_json,
+    main as headed_main,
     read_max_tool_rounds,
+    resolve_headed_run_dir,
+    task_doc_dir,
     restore_max_tool_rounds,
     stage_calc_primary_trial,
     stage_cadaver_trial,
@@ -451,3 +458,70 @@ def test_stage_draw_primary_trial_contains_only_canvas(tmp_path: Path) -> None:
 def test_stage_draw_primary_trial_refuses_real_task_dir() -> None:
     with pytest.raises(ValueError, match="protected"):
         stage_draw_primary_trial(_DRAW_DIR)
+
+
+def test_default_eval2_run_dir_uses_task_runs_stamp() -> None:
+    now = datetime(2026, 9, 9, 17, 48)
+    path = default_eval2_run_dir(TASK_WRITER_CALC, now=now)
+    assert path == _FLOORSTAND_DIR / "runs" / "20260909-1748"
+    assert resolve_headed_run_dir(TASK_AFC, None, now=now) == _AFC_DIR / "runs" / "20260909-1748"
+    explicit = Path("/tmp/my-stamp")
+    assert resolve_headed_run_dir(TASK_AFC, explicit) == explicit
+    assert task_doc_dir(TASK_AFC) == _AFC_DIR
+
+
+def test_launch_exit_snapshots_debug_log_into_run_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = tmp_path / "writeragent.json"
+    config.write_text("{}\n", encoding="utf-8")
+    live = tmp_path / "profile" / DEBUG_LOG_FILENAME
+    live.parent.mkdir()
+    live.write_text("Tool loop round 1: sending\n", encoding="utf-8")
+    run_dir = tmp_path / "runs" / "20260909-1748"
+    trial_dir = tmp_path / "trial"
+    monkeypatch.setattr("eval_2_debug_log.debug_log_candidates", lambda: [live])
+    monkeypatch.setattr("eval_2_headed.launch_calc", lambda fixture: None)
+    monkeypatch.setattr("eval_2_headed._wait_for_finish", lambda rounds=50: None)
+    assert headed_main([
+        "--config",
+        str(config),
+        "--launch",
+        "--trial-dir",
+        str(trial_dir),
+        "--run-dir",
+        str(run_dir),
+    ]) == 0
+    dest = run_dir / DEBUG_LOG_FILENAME
+    assert dest.is_file()
+    assert dest.read_text(encoding="utf-8") == "Tool loop round 1: sending\n"
+    assert "Restored previous" in capsys.readouterr().out
+    assert MAX_TOOL_ROUNDS_KEY not in json.loads(config.read_text(encoding="utf-8"))
+
+
+def test_launch_exit_warns_when_debug_log_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = tmp_path / "writeragent.json"
+    config.write_text("{}\n", encoding="utf-8")
+    missing = tmp_path / "absent.log"
+    run_dir = tmp_path / "runs" / "stamp"
+    trial_dir = tmp_path / "trial"
+    monkeypatch.setattr("eval_2_debug_log.debug_log_candidates", lambda: [missing])
+    monkeypatch.setattr("eval_2_headed.launch_calc", lambda fixture: None)
+    monkeypatch.setattr("eval_2_headed._wait_for_finish", lambda rounds=50: None)
+    assert headed_main([
+        "--config",
+        str(config),
+        "--launch",
+        "--trial-dir",
+        str(trial_dir),
+        "--run-dir",
+        str(run_dir),
+    ]) == 0
+    assert not (run_dir / DEBUG_LOG_FILENAME).exists()
+    captured = capsys.readouterr()
+    assert "Warning:" in captured.err
+    assert "Restored previous" in captured.out
+    assert MAX_TOOL_ROUNDS_KEY not in json.loads(config.read_text(encoding="utf-8"))
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Floorstand Gemini headed run `20260909-1748` lost its tool-call trace. LibreOffice restart for the next trial re-inited logging (`Debug log active`) and reset the live profile `writeragent_debug.log`. Autopsy had to reconstruct from notes + shots only. Keith rule: save off the full debug log for every headed / eval-2 run.

## What

- **`--launch` exit** (Enter / Ctrl-C after `_wait_for_finish`) copies the live LO-user log with `shutil.copy2` into `--run-dir/writeragent_debug.log`, or an auto-stamp `docs/eval/eval-2/<task>/runs/<YYYYMMDD-HHMM>/writeragent_debug.log` when `--run-dir` is omitted. A missing live log warns; config restore still runs.
- **One-shot helper** `scripts/save_eval2_debug_log.py DEST_DIR` for mid-stall saves *before* restart. Prints source path and dest size; exits non-zero if the live log is missing.
- Shared discovery in `scripts/eval_2_debug_log.py` (same profile dirs as `writeragent.json` / `analyze_tool_call_timing.py`; filename matches `plugin.framework.logging.DEBUG_LOG_FILENAME`). Live log format and truncate behavior are unchanged.
- Docs: standing rule in `docs/eval/eval-2/README.md` and `headed-failure-autopsy.md` (Floorstand `1748` rotate lesson).

## Tests

Unit tests cover copy/discovery with temp files (no live LibreOffice). Headed `--launch` exit is mocked through staging + snapshot.

```
.venv/bin/python -m pytest tests/scripts/test_eval_2_debug_log.py tests/scripts/test_eval_2_headed.py -q
make typecheck
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b58bb9e2-91dc-4452-8ea4-d06b59915b91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b58bb9e2-91dc-4452-8ea4-d06b59915b91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

