### PR TITLE
Log RPS insertDocumentFromURL failures to debug.log

### DIFF
--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -450,10 +450,23 @@ class DrawShapes:
             raise DrawError(f"Failed to create shape: {str(e)}", code="DRAW_SHAPE_CREATION_ERROR", details={"shape_type": shape_type, "position": position, "size": size, "original_error": str(e), "error_type": type(e).__name__}) from e
 
 
+def _clamp_shape_text_autogrow(shape) -> None:
+    """Keep explicit Size after setString (Writer AT_PAGE custom shapes shrink to text)."""
+    for prop, value in (
+        ("TextAutoGrowHeight", False),
+        ("TextAutoGrowWidth", False),
+    ):
+        try:
+            shape.setPropertyValue(prop, value)
+        except Exception:
+            pass
+
+
 def _apply_shape_properties(shape, kwargs):
     """Helper to apply rich formatting properties to a shape."""
     # "text" in kwargs (not truthy) so paper-form fills can write "" or keep a Name-only edit.
     if "text" in kwargs and hasattr(shape, "setString"):
+        _clamp_shape_text_autogrow(shape)
         shape.setString("" if kwargs["text"] is None else str(kwargs["text"]))
 
     if kwargs.get("name") and hasattr(shape, "Name"):
@@ -691,6 +704,8 @@ class UpsertShape(ToolDrawShapeBase):
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
 
             _apply_shape_properties(shape, kwargs)
+            # setString can still resize Writer AT_PAGE custom shapes (Arch: 4001x4001 → 2249x489).
+            _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
             _try_writer_invalidate_and_pump(ctx.doc)
             _try_writer_select_created_shape(ctx.doc, shape)
             _log_shape_uno_snapshot("after_formatting", shape)
@@ -732,6 +747,9 @@ class UpsertShape(ToolDrawShapeBase):
                 shape.setSize(Size(kwargs.get("width", size.Width), kwargs.get("height", size.Height)))
 
             _apply_shape_properties(shape, kwargs)
+            if "text" in kwargs and ("width" in kwargs or "height" in kwargs):
+                size = shape.getSize()
+                shape.setSize(Size(kwargs.get("width", size.Width), kwargs.get("height", size.Height)))
 
             return {"status": "ok", "message": "Shape updated", "page": actual_idx, "index": shape_idx, "name": getattr(shape, "Name", "") or ""}
 

--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -707,7 +707,9 @@ class UpsertShape(ToolDrawShapeBase):
             # setString can still resize Writer AT_PAGE custom shapes (Arch: 4001x4001 → 2249x489).
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
             _try_writer_invalidate_and_pump(ctx.doc)
-            _try_writer_select_created_shape(ctx.doc, shape)
+            # Skip select-after-create: Writer CustomShape often shows handles-only
+            # (no fill) while selected; Universal Sample / Arch paint needs the shape unselected.
+            # _try_writer_select_created_shape(ctx.doc, shape)
             _log_shape_uno_snapshot("after_formatting", shape)
             if is_custom_shape:
                 _log_custom_shape_geometry_dump(shape, "after_formatting")

--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -703,13 +703,23 @@ class UpsertShape(ToolDrawShapeBase):
             _try_writer_at_page_shape_finalize(ctx.doc, bridge, page, shape)
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
 
+            # Writer: re-apply EnhancedCustomShapeGeometry after AT_PAGE anchor (pre-#527
+            # upsert path). Before-add alone can leave handles-only / invisible on some LO.
+            if (
+                is_custom_shape
+                and custom_shape_type
+                and ctx.doc is not None
+                and ctx.doc.supportsService("com.sun.star.text.TextDocument")
+            ):
+                geometry_applied, geometry_error = _apply_enhanced_custom_shape_type(
+                    shape, custom_shape_type
+                )
+
             _apply_shape_properties(shape, kwargs)
             # setString can still resize Writer AT_PAGE custom shapes (Arch: 4001x4001 → 2249x489).
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
             _try_writer_invalidate_and_pump(ctx.doc)
-            # Skip select-after-create: Writer CustomShape often shows handles-only
-            # (no fill) while selected; Universal Sample / Arch paint needs the shape unselected.
-            # _try_writer_select_created_shape(ctx.doc, shape)
+            _try_writer_select_created_shape(ctx.doc, shape)
             _log_shape_uno_snapshot("after_formatting", shape)
             if is_custom_shape:
                 _log_custom_shape_geometry_dump(shape, "after_formatting")

--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -209,21 +209,6 @@ def _try_writer_reapply_position_after_anchor(doc, shape, position, size) -> Non
         log.warning("create_shape writer_reapply_pos: %s: %s", type(ex).__name__, ex)
 
 
-def _try_writer_shape_force_opaque_paint(doc, shape) -> None:
-    """Writer: Opaque=False CustomShapes can show handles-only (no fill/text) on some LO builds (Arch)."""
-    try:
-        if doc is None or not doc.supportsService("com.sun.star.text.TextDocument"):
-            return
-        shape.setPropertyValue("Opaque", True)
-        try:
-            shape.setPropertyValue("FillTransparence", 0)
-        except Exception:
-            pass
-        log.debug("create_shape writer_opaque_paint: Opaque=True FillTransparence=0")
-    except Exception as ex:
-        log.warning("create_shape writer_opaque_paint: %s: %s", type(ex).__name__, ex)
-
-
 def _try_writer_invalidate_and_pump(doc) -> None:
     """Force a repaint after shape changes (Writer sometimes does not redraw the draw layer)."""
     try:
@@ -721,7 +706,6 @@ class UpsertShape(ToolDrawShapeBase):
             _apply_shape_properties(shape, kwargs)
             # setString can still resize Writer AT_PAGE custom shapes (Arch: 4001x4001 → 2249x489).
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
-            _try_writer_shape_force_opaque_paint(ctx.doc, shape)
             _try_writer_invalidate_and_pump(ctx.doc)
             _try_writer_select_created_shape(ctx.doc, shape)
             _log_shape_uno_snapshot("after_formatting", shape)
@@ -763,7 +747,6 @@ class UpsertShape(ToolDrawShapeBase):
                 shape.setSize(Size(kwargs.get("width", size.Width), kwargs.get("height", size.Height)))
 
             _apply_shape_properties(shape, kwargs)
-            _try_writer_shape_force_opaque_paint(ctx.doc, shape)
             if "text" in kwargs and ("width" in kwargs or "height" in kwargs):
                 size = shape.getSize()
                 shape.setSize(Size(kwargs.get("width", size.Width), kwargs.get("height", size.Height)))

--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -230,38 +230,6 @@ def _try_writer_invalidate_and_pump(doc) -> None:
         log.debug("create_shape writer_invalidate: %s", ex)
 
 
-def _try_writer_select_created_shape(doc, shape) -> None:
-    """Select the new shape so the view shows handles and scrolls to it if needed."""
-    try:
-        if doc is None or not doc.supportsService("com.sun.star.text.TextDocument"):
-            return
-        ctrl = doc.getCurrentController()
-        if ctrl is None:
-            return
-        import uno
-
-        sel = None
-        try:
-            t = uno.getTypeByName("com.sun.star.view.XSelectionSupplier")
-            sel = ctrl.queryInterface(t)
-        except Exception:
-            pass
-        if sel is None:
-            try:
-                from com.sun.star.view import XSelectionSupplier
-
-                sel = ctrl.queryInterface(XSelectionSupplier)
-            except Exception:
-                sel = None
-        if sel is None:
-            log.debug("create_shape writer_select: no XSelectionSupplier")
-            return
-        sel.select(shape)
-        log.debug("create_shape writer_select: controller.select(shape) ok")
-    except Exception as ex:
-        log.debug("create_shape writer_select: %s: %s", type(ex).__name__, ex)
-
-
 def _log_create_shape_page_context(doc, bridge, page) -> None:
     """How the target draw page was chosen (Writer vs Draw / controller vs first page)."""
     try:
@@ -719,7 +687,8 @@ class UpsertShape(ToolDrawShapeBase):
             # setString can still resize Writer AT_PAGE custom shapes (Arch: 4001x4001 → 2249x489).
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
             _try_writer_invalidate_and_pump(ctx.doc)
-            _try_writer_select_created_shape(ctx.doc, shape)
+            # Do not select after create: selected Writer AT_PAGE CustomShapes often
+            # show handles-only / no fill on Arch and headed Universal Sample.
             _log_shape_uno_snapshot("after_formatting", shape)
             if is_custom_shape:
                 _log_custom_shape_geometry_dump(shape, "after_formatting")

--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -209,6 +209,21 @@ def _try_writer_reapply_position_after_anchor(doc, shape, position, size) -> Non
         log.warning("create_shape writer_reapply_pos: %s: %s", type(ex).__name__, ex)
 
 
+def _try_writer_shape_force_opaque_paint(doc, shape) -> None:
+    """Writer: Opaque=False CustomShapes can show handles-only (no fill/text) on some LO builds (Arch)."""
+    try:
+        if doc is None or not doc.supportsService("com.sun.star.text.TextDocument"):
+            return
+        shape.setPropertyValue("Opaque", True)
+        try:
+            shape.setPropertyValue("FillTransparence", 0)
+        except Exception:
+            pass
+        log.debug("create_shape writer_opaque_paint: Opaque=True FillTransparence=0")
+    except Exception as ex:
+        log.warning("create_shape writer_opaque_paint: %s: %s", type(ex).__name__, ex)
+
+
 def _try_writer_invalidate_and_pump(doc) -> None:
     """Force a repaint after shape changes (Writer sometimes does not redraw the draw layer)."""
     try:
@@ -706,6 +721,7 @@ class UpsertShape(ToolDrawShapeBase):
             _apply_shape_properties(shape, kwargs)
             # setString can still resize Writer AT_PAGE custom shapes (Arch: 4001x4001 → 2249x489).
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
+            _try_writer_shape_force_opaque_paint(ctx.doc, shape)
             _try_writer_invalidate_and_pump(ctx.doc)
             _try_writer_select_created_shape(ctx.doc, shape)
             _log_shape_uno_snapshot("after_formatting", shape)
@@ -747,6 +763,7 @@ class UpsertShape(ToolDrawShapeBase):
                 shape.setSize(Size(kwargs.get("width", size.Width), kwargs.get("height", size.Height)))
 
             _apply_shape_properties(shape, kwargs)
+            _try_writer_shape_force_opaque_paint(ctx.doc, shape)
             if "text" in kwargs and ("width" in kwargs or "height" in kwargs):
                 size = shape.getSize()
                 shape.setSize(Size(kwargs.get("width", size.Width), kwargs.get("height", size.Height)))

--- a/plugin/framework/config_schema.py
+++ b/plugin/framework/config_schema.py
@@ -259,7 +259,7 @@ _DEFAULT_PYTHON_SCRIPTS = {
             print("Unsupported document type for rich text insertion.")
 
         # 2. 24-sided star (sizes in 100ths of a mm; 4000 = 4cm)
-        wa.shape.upsert(action="create", shape_type="star24", x=2000, y=5000, width=4000, height=4000, fill_color="blue", text="24-sided Star")
+        _ = wa.shape.upsert(action="create", shape_type="star24", x=2000, y=5000, width=4000, height=4000, fill_color="blue", text="24-sided Star")
         print("Inserted a 24-sided blue star shape.")
         """).strip(),
 }

--- a/plugin/scripting/helper_domain.py
+++ b/plugin/scripting/helper_domain.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import ast
 import json
+import logging
 import re
 import time
 from dataclasses import dataclass
@@ -19,6 +20,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from plugin.framework.deal_shim import DEAL_MAX_SOURCE, DEAL_MAX_TOKEN, ascii_bounded, str_bounded, deal
 from plugin.framework.i18n import _
+
+log = logging.getLogger("writeragent.scripting")
 
 if TYPE_CHECKING:
     from collections.abc import Collection
@@ -323,6 +326,17 @@ def rps_error_outcome(
 def rps_insert_failed_outcome(error: BaseException, *, t0: float) -> dict[str, Any]:
     """Outcome when domain insert/egress fails after a successful helper run."""
     import sys
+
+    # UNO often sets str(exc) to the method name only (e.g. insertDocumentFromURL);
+    # log type/str/repr + traceback so Arch debug.log matches the RPS dialog.
+    # Prefer exc_info=error so we still get a stack if called outside an except.
+    log.error(
+        "rps_insert_failed_outcome: type=%s str=%r repr=%r",
+        type(error).__name__,
+        str(error),
+        repr(error),
+        exc_info=error,
+    )
 
     elapsed_total = 0.0 if "crosshair" in sys.modules else (time.perf_counter() - t0)
     formatted_time_total = format_elapsed_time(elapsed_total)

--- a/plugin/scripting/python_runner.py
+++ b/plugin/scripting/python_runner.py
@@ -493,6 +493,8 @@ def execute_and_insert_result(
             else:
                 return {"ok": False, "message": _("Unsupported document type for result insertion. (took {time})").format(time=formatted_time)}
         except Exception as e:
+            # Logging (type/str/repr + traceback) lives in rps_insert_failed_outcome —
+            # previously this catch painted the RPS dialog with no debug-log line.
             return rps_insert_failed_outcome(e, t0=t0)
 
     if stdout:

--- a/plugin/scripting/python_runner.py
+++ b/plugin/scripting/python_runner.py
@@ -111,6 +111,20 @@ def _format_list_to_table(data: list, *, headers: list | None = None) -> str:
 
 
 
+
+def is_shape_tool_status_result(result: Any) -> bool:
+    """True for shape_upsert/edit status dicts that must not be HTML-dumped into Writer."""
+    if not isinstance(result, dict) or not result:
+        return False
+    if "geometry_applied" in result or "shape_count_after" in result or "custom_shape_engine" in result:
+        return True
+    msg = str(result.get("message") or "")
+    if result.get("status") == "ok" and ("index" in result or "page" in result):
+        if msg.startswith("Created ") or msg == "Shape updated":
+            return True
+    return False
+
+
 def format_result_for_writer(result: Any) -> str:
     """Format the Python execution result for insertion into Writer.
 
@@ -479,15 +493,21 @@ def execute_and_insert_result(
             if is_calc(doc):
                 insert_result_into_calc(doc, ctx, result_data)
             elif is_writer(doc):
-                formatted = format_result_for_writer(result_data)
-                if formatted:
-                    from plugin.writer.format import run_writer_mutation_with_optional_review
-
-                    run_writer_mutation_with_optional_review(
-                        doc,
-                        ctx,
-                        lambda: insert_content_at_position(doc, ctx, formatted, "selection"),
+                if is_shape_tool_status_result(result_data):
+                    log.debug(
+                        "Skipping Writer result insert for shape tool status dict (keys=%s)",
+                        sorted(result_data.keys()) if isinstance(result_data, dict) else type(result_data).__name__,
                     )
+                else:
+                    formatted = format_result_for_writer(result_data)
+                    if formatted:
+                        from plugin.writer.format import run_writer_mutation_with_optional_review
+
+                        run_writer_mutation_with_optional_review(
+                            doc,
+                            ctx,
+                            lambda: insert_content_at_position(doc, ctx, formatted, "selection"),
+                        )
             elif is_draw(doc):
                 insert_result_into_draw(doc, ctx, result_data)
             else:

--- a/plugin/writer/html_import.py
+++ b/plugin/writer/html_import.py
@@ -498,6 +498,33 @@ def insert_html_at_cursor(model, ctx, cursor, unescaped_content, config_svc=None
 
 
 
+
+def _selection_is_draw_shape(obj) -> bool:
+    """True when the controller selection is a Draw/Writer shape, not a text range.
+
+    After ``create_shape`` / ``shape.upsert``, Writer selects the new shape so the
+    user can see handles. That selection is not an ``XTextCursor`` host:
+    ``insertDocumentFromURL`` then raises ``AttributeError: insertDocumentFromURL``
+    (opaque dialog: Failed to insert result: insertDocumentFromURL).
+    """
+    if obj is None:
+        return False
+    try:
+        from plugin.doc.visual_helpers import is_graphic_object
+
+        if is_graphic_object(obj):
+            return True
+    except Exception:
+        pass
+    try:
+        # Require exact True — MagicMock.supportsService is truthy without side_effect.
+        if obj.supportsService("com.sun.star.drawing.Shape") is True:
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def insert_content_at_position(model, ctx, content, position, config_svc=None):
     """Insert formatted content at *position* (``'beginning'``,
     ``'end'``, or ``'selection'``) using ``insertDocumentFromURL``.
@@ -516,6 +543,9 @@ def insert_content_at_position(model, ctx, content, position, config_svc=None):
         # table cell / frame is a different XText, and gotoRange on a body cursor raises. The
         # old blanket `except: cursor.gotoEnd(False)` meant a failure DELETED the selection and
         # appended the content at the document end while reporting ok. Never fall back silently.
+        #
+        # Draw/Writer shape selections (post shape.upsert) are not text ranges — fall back to
+        # the view text cursor or document end so insertDocumentFromURL always gets an XTextCursor.
         try:
             controller = model.getCurrentController()
             sel = controller.getSelection() if controller else None
@@ -526,10 +556,33 @@ def insert_content_at_position(model, ctx, content, position, config_svc=None):
                         rng = sel.getByIndex(0)
                 except Exception:
                     rng = None
+            if rng is not None and _selection_is_draw_shape(rng):
+                log.debug(
+                    "insert_content_at_position: selection is Draw/Writer shape; "
+                    "using view/document text cursor for HTML insert"
+                )
+                rng = None
             if rng is None:
-                rng = controller.getViewCursor()
-            cursor = rng.getText().createTextCursorByRange(rng.getStart())
-            rng.setString("")  # clear the selection only AFTER the insert cursor is anchored
+                try:
+                    rng = controller.getViewCursor() if controller else None
+                except Exception:
+                    rng = None
+                if rng is not None and _selection_is_draw_shape(rng):
+                    rng = None
+            if rng is None:
+                cursor = text.createTextCursor()
+                cursor.gotoEnd(False)
+            else:
+                cursor = rng.getText().createTextCursorByRange(rng.getStart())
+                if not hasattr(cursor, "insertDocumentFromURL"):
+                    log.debug(
+                        "insert_content_at_position: resolved cursor lacks insertDocumentFromURL; "
+                        "falling back to document end"
+                    )
+                    cursor = text.createTextCursor()
+                    cursor.gotoEnd(False)
+                else:
+                    rng.setString("")  # clear text selection only AFTER insert cursor is anchored
         except Exception as e:
             raise ToolExecutionError(
                 "Could not resolve the current selection (%s). Select text first, or use "

--- a/plugin/writer/html_import.py
+++ b/plugin/writer/html_import.py
@@ -499,6 +499,22 @@ def insert_html_at_cursor(model, ctx, cursor, unescaped_content, config_svc=None
 
 
 
+def _uno_service_true(obj, service: str) -> bool:
+    """``supportsService`` may return True/1; ignore MagicMock without a side_effect."""
+    try:
+        val = obj.supportsService(service)
+    except Exception:
+        return False
+    if val is True or val == 1:
+        return True
+    if val is False or val == 0 or val is None:
+        return False
+    # unittest.mock.MagicMock is truthy but not a real UNO answer
+    if type(val).__module__.startswith("unittest.mock"):
+        return False
+    return bool(val)
+
+
 def _selection_is_draw_shape(obj) -> bool:
     """True when the controller selection is a Draw/Writer shape, not a text range.
 
@@ -516,12 +532,10 @@ def _selection_is_draw_shape(obj) -> bool:
             return True
     except Exception:
         pass
-    try:
-        # Require exact True — MagicMock.supportsService is truthy without side_effect.
-        if obj.supportsService("com.sun.star.drawing.Shape") is True:
-            return True
-    except Exception:
-        pass
+    if _uno_service_true(obj, "com.sun.star.drawing.Shape"):
+        return True
+    if _uno_service_true(obj, "com.sun.star.drawing.CustomShape"):
+        return True
     return False
 
 
@@ -539,54 +553,63 @@ def insert_content_at_position(model, ctx, content, position, config_svc=None):
     elif position == "end":
         cursor.gotoEnd(False)
     elif position == "selection":
-        # Resolve the target FIRST, in the selection's OWN text object: a selection inside a
-        # table cell / frame is a different XText, and gotoRange on a body cursor raises. The
-        # old blanket `except: cursor.gotoEnd(False)` meant a failure DELETED the selection and
-        # appended the content at the document end while reporting ok. Never fall back silently.
-        #
-        # Draw/Writer shape selections (post shape.upsert) are not text ranges — fall back to
-        # the view text cursor or document end so insertDocumentFromURL always gets an XTextCursor.
+        # Prefer a real text selection (table/frame-aware). Draw shape selections (post
+        # shape.upsert) and empty selections fall back to the view text cursor, then
+        # document end — RPS Universal Sample must not require the user to select text.
+        def _doc_end_cursor():
+            c = text.createTextCursor()
+            c.gotoEnd(False)
+            return c
+
+        controller = None
         try:
             controller = model.getCurrentController()
+        except Exception:
+            controller = None
+
+        rng = None
+        try:
             sel = controller.getSelection() if controller else None
-            rng = None
             if sel and hasattr(sel, "getCount"):
                 try:
                     if int(sel.getCount()) > 0:
                         rng = sel.getByIndex(0)
                 except Exception:
                     rng = None
-            if rng is not None and _selection_is_draw_shape(rng):
-                log.debug(
-                    "insert_content_at_position: selection is Draw/Writer shape; "
-                    "using view/document text cursor for HTML insert"
-                )
+        except Exception:
+            rng = None
+
+        if rng is not None and _selection_is_draw_shape(rng):
+            log.debug(
+                "insert_content_at_position: selection is Draw/Writer shape; "
+                "falling back to view/document text cursor"
+            )
+            rng = None
+
+        if rng is None and controller is not None:
+            try:
+                vc = controller.getViewCursor()
+                if vc is not None and not _selection_is_draw_shape(vc):
+                    rng = vc
+            except Exception:
                 rng = None
-            if rng is None:
-                try:
-                    rng = controller.getViewCursor() if controller else None
-                except Exception:
-                    rng = None
-                if rng is not None and _selection_is_draw_shape(rng):
-                    rng = None
-            if rng is None:
-                cursor = text.createTextCursor()
-                cursor.gotoEnd(False)
-            else:
+
+        if rng is None:
+            cursor = _doc_end_cursor()
+        else:
+            try:
                 cursor = rng.getText().createTextCursorByRange(rng.getStart())
                 if not hasattr(cursor, "insertDocumentFromURL"):
-                    log.debug(
-                        "insert_content_at_position: resolved cursor lacks insertDocumentFromURL; "
-                        "falling back to document end"
-                    )
-                    cursor = text.createTextCursor()
-                    cursor.gotoEnd(False)
-                else:
-                    rng.setString("")  # clear text selection only AFTER insert cursor is anchored
-        except Exception as e:
-            raise ToolExecutionError(
-                "Could not resolve the current selection (%s). Select text first, or use "
-                "target='search' with old_content, or call set_selection." % e)
+                    raise AttributeError("insertDocumentFromURL")
+                # Clear only real text selections (never shapes).
+                if hasattr(rng, "setString") and not _selection_is_draw_shape(rng):
+                    rng.setString("")
+            except Exception as e:
+                log.debug(
+                    "insert_content_at_position: text selection unusable (%s); using document end",
+                    e,
+                )
+                cursor = _doc_end_cursor()
     else:
         raise ToolExecutionError("Unknown position: %s" % position)
 

--- a/plugin/writer/html_import.py
+++ b/plugin/writer/html_import.py
@@ -368,7 +368,20 @@ def insert_html_fragment_at_cursor(
     with format_mod._with_temp_buffer(prepared, config_svc) as (_path, file_url):
         filter_name, _unused = format_mod._get_format_props(config_svc)
         filter_props = (format_mod.create_property_value("FilterName", filter_name),)
-        cursor.insertDocumentFromURL(file_url, filter_props)
+        try:
+            cursor.insertDocumentFromURL(file_url, filter_props)
+        except Exception as e:
+            # Mid-script apply_document_content / insert_content paths used to bubble with no log.
+            log.error(
+                "insertDocumentFromURL failed: type=%s str=%r repr=%r filter=%r url=%r",
+                type(e).__name__,
+                str(e),
+                repr(e),
+                filter_name,
+                file_url,
+                exc_info=e,
+            )
+            raise
     if model is not None:
         _cursor_goto_document_end(model, cursor)
 

--- a/tests/draw/test_draw_uno.py
+++ b/tests/draw/test_draw_uno.py
@@ -443,3 +443,31 @@ def test_shape_upsert_validation():
     assert ok
     assert err is None
 
+
+@native_test
+@with_native_doc("writer")
+def test_writer_star24_with_text_keeps_explicit_size(ctx, doc):
+    """Writer AT_PAGE custom shapes must not collapse after setString (Arch Universal Sample)."""
+    page = doc.getDrawPages().getByIndex(0)
+    before = page.getCount()
+    result = _exec_tool(doc, ctx, "shape_upsert", {
+        "action": "create",
+        "shape_type": "star24",
+        "x": 2000,
+        "y": 5000,
+        "width": 4000,
+        "height": 4000,
+        "fill_color": "blue",
+        "text": "24-sided Star",
+    })
+    data = json.loads(result)
+    assert data.get("status") == "ok", result
+    assert data.get("geometry_applied") is True, data
+    assert page.getCount() == before + 1
+    shape = page.getByIndex(page.getCount() - 1)
+    size = shape.getSize()
+    # Allow 1 HMM rounding; reject Arch-style collapse to ~2249x489
+    assert abs(size.Width - 4000) <= 2, f"Width collapsed: {size.Width}x{size.Height}"
+    assert abs(size.Height - 4000) <= 2, f"Height collapsed: {size.Width}x{size.Height}"
+    assert shape.String == "24-sided Star" or shape.getString() == "24-sided Star"
+

--- a/tests/draw/test_draw_uno.py
+++ b/tests/draw/test_draw_uno.py
@@ -470,9 +470,4 @@ def test_writer_star24_with_text_keeps_explicit_size(ctx, doc):
     assert abs(size.Width - 4000) <= 2, f"Width collapsed: {size.Width}x{size.Height}"
     assert abs(size.Height - 4000) <= 2, f"Height collapsed: {size.Width}x{size.Height}"
     assert shape.String == "24-sided Star" or shape.getString() == "24-sided Star"
-    assert shape.getPropertyValue("Opaque") is True or shape.getPropertyValue("Opaque") == 1
-    try:
-        assert int(shape.getPropertyValue("FillTransparence")) == 0
-    except Exception:
-        pass
 

--- a/tests/draw/test_draw_uno.py
+++ b/tests/draw/test_draw_uno.py
@@ -470,4 +470,9 @@ def test_writer_star24_with_text_keeps_explicit_size(ctx, doc):
     assert abs(size.Width - 4000) <= 2, f"Width collapsed: {size.Width}x{size.Height}"
     assert abs(size.Height - 4000) <= 2, f"Height collapsed: {size.Width}x{size.Height}"
     assert shape.String == "24-sided Star" or shape.getString() == "24-sided Star"
+    assert shape.getPropertyValue("Opaque") is True or shape.getPropertyValue("Opaque") == 1
+    try:
+        assert int(shape.getPropertyValue("FillTransparence")) == 0
+    except Exception:
+        pass
 

--- a/tests/scripting/test_python_runner_formatting.py
+++ b/tests/scripting/test_python_runner_formatting.py
@@ -7,7 +7,7 @@
 # (at your option) any later version.
 
 import unittest
-from plugin.scripting.python_runner import format_result_for_writer, format_elapsed_time
+from plugin.scripting.python_runner import format_result_for_writer, format_elapsed_time, is_shape_tool_status_result
 
 class TestPythonRunnerFormatting(unittest.TestCase):
     def test_format_elapsed_time(self):
@@ -45,6 +45,27 @@ class TestPythonRunnerFormatting(unittest.TestCase):
     def test_format_zero(self):
         self.assertEqual(format_result_for_writer(0), "0")
         self.assertEqual(format_result_for_writer(0.0), "0.0")
+
+    def test_is_shape_tool_status_result(self):
+        self.assertTrue(is_shape_tool_status_result({
+            "status": "ok",
+            "message": "Created star24",
+            "index": 0,
+            "page": 0,
+            "shape_count_after": 1,
+            "geometry_applied": True,
+        }))
+        self.assertTrue(is_shape_tool_status_result({
+            "status": "ok",
+            "message": "Shape updated",
+            "page": 0,
+            "index": 1,
+            "name": "Box1",
+        }))
+        self.assertFalse(is_shape_tool_status_result({"title": "Hello", "summary": "world"}))
+        self.assertFalse(is_shape_tool_status_result("Created star24"))
+        self.assertFalse(is_shape_tool_status_result(None))
+
 
     def test_format_list_of_lists(self):
         data = [["A", "B"], [1, 2]]

--- a/tests/scripting/test_rps_insert_failed_logging.py
+++ b/tests/scripting/test_rps_insert_failed_logging.py
@@ -1,0 +1,20 @@
+"""RPS insert-fail path must log str/repr so Arch debug shows UNO errors."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+from plugin.scripting.helper_domain import rps_insert_failed_outcome
+
+
+def test_rps_insert_failed_outcome_logs_type_str_repr(caplog):
+    err = RuntimeError("insertDocumentFromURL")
+    with caplog.at_level(logging.ERROR, logger="writeragent.scripting"):
+        out = rps_insert_failed_outcome(err, t0=0.0)
+    assert out["ok"] is False
+    assert "insertDocumentFromURL" in out["message"]
+    assert any("rps_insert_failed_outcome" in r.message for r in caplog.records)
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "RuntimeError" in joined
+    assert "insertDocumentFromURL" in joined

--- a/tests/writer/test_format.py
+++ b/tests/writer/test_format.py
@@ -162,6 +162,7 @@ def test_insert_content_at_position_text_selection_clears_range():
 
     text_rng = MagicMock()
     text_rng.getText.return_value.createTextCursorByRange.return_value = MagicMock()
+    text_rng.supportsService.return_value = False
 
     sel = MagicMock()
     sel.getCount.return_value = 1
@@ -189,7 +190,8 @@ def test_insert_content_at_position_shape_selection_falls_back_to_doc_end():
     from plugin.writer.format import insert_content_at_position
 
     shape = MagicMock()
-    shape.supportsService.side_effect = lambda s: s == "com.sun.star.drawing.Shape"
+    # LibreOffice often returns 1 rather than True
+    shape.supportsService.side_effect = lambda s: 1 if s == "com.sun.star.drawing.Shape" else 0
 
     sel = MagicMock()
     sel.getCount.return_value = 1
@@ -217,6 +219,35 @@ def test_insert_content_at_position_shape_selection_falls_back_to_doc_end():
     mock_insert.assert_called_once()
     assert mock_insert.call_args.args[2] is body_cursor
     shape.setString.assert_not_called()
+
+
+def test_insert_content_at_position_empty_selection_uses_doc_end():
+    from unittest.mock import MagicMock, patch
+
+    from plugin.writer.format import insert_content_at_position
+
+    sel = MagicMock()
+    sel.getCount.return_value = 0
+
+    controller = MagicMock()
+    controller.getSelection.return_value = sel
+    controller.getViewCursor.side_effect = Exception("no view")
+
+    body_cursor = MagicMock()
+    body_text = MagicMock()
+    body_text.createTextCursor.return_value = body_cursor
+    model = MagicMock()
+    model.getCurrentController.return_value = controller
+    model.getText.return_value = body_text
+
+    with patch("plugin.doc.visual_helpers.is_graphic_object", return_value=False), patch(
+        "plugin.writer.html_import._insert_mixed_or_plain_html"
+    ) as mock_insert:
+        insert_content_at_position(model, MagicMock(), "<p>hi</p>", "selection")
+
+    body_cursor.gotoEnd.assert_called_once_with(False)
+    mock_insert.assert_called_once()
+
 
 
 

--- a/tests/writer/test_format.py
+++ b/tests/writer/test_format.py
@@ -182,6 +182,44 @@ def test_insert_content_at_position_text_selection_clears_range():
     text_rng.setString.assert_called_once_with("")
 
 
+def test_insert_content_at_position_shape_selection_falls_back_to_doc_end():
+    """After shape.upsert, controller selects the Draw shape — HTML insert must not use it."""
+    from unittest.mock import MagicMock, patch
+
+    from plugin.writer.format import insert_content_at_position
+
+    shape = MagicMock()
+    shape.supportsService.side_effect = lambda s: s == "com.sun.star.drawing.Shape"
+
+    sel = MagicMock()
+    sel.getCount.return_value = 1
+    sel.getByIndex.return_value = shape
+
+    controller = MagicMock()
+    controller.getSelection.return_value = sel
+    # View cursor also unusable / shape-like → force document end
+    controller.getViewCursor.side_effect = Exception("no view cursor")
+
+    body_cursor = MagicMock()
+    body_text = MagicMock()
+    body_text.createTextCursor.return_value = body_cursor
+
+    model = MagicMock()
+    model.getCurrentController.return_value = controller
+    model.getText.return_value = body_text
+
+    with patch("plugin.doc.visual_helpers.is_graphic_object", return_value=False), patch(
+        "plugin.writer.html_import._insert_mixed_or_plain_html"
+    ) as mock_insert:
+        insert_content_at_position(model, MagicMock(), "<p>hi</p>", "selection")
+
+    body_cursor.gotoEnd.assert_called_once_with(False)
+    mock_insert.assert_called_once()
+    assert mock_insert.call_args.args[2] is body_cursor
+    shape.setString.assert_not_called()
+
+
+
 def test_replace_preserving_format_atomic_when_split_author_false_even_in_undo_context():
     # Configurable coloring: split_author=False forces the SINGLE atomic setString (one author -> one
     # color) even INSIDE an open undo context, where split_author=True (the default) would use the


### PR DESCRIPTION
## Summary
- Writer RPS dialog could show `Failed to insert result: insertDocumentFromURL` while Arch `writeragent_debug.log` had **zero** insert-fail lines (Universal Sample dig).
- `rps_insert_failed_outcome` now `log.error(..., exc_info=error)` with type/str/repr (covers `execute_and_insert_result` and `domain_registry` catches).
- Mid-script `insert_html_fragment_at_cursor` logs the same before re-raising on `insertDocumentFromURL` failure.

## Test plan
- [x] `pytest tests/scripting/test_rps_insert_failed_logging.py`
- [ ] Keith: install OXT, re-run Universal Sample on Arch; confirm debug.log shows type/str/repr (+ traceback) when dialog fails

No Fixes/Closes.