### PR TITLE
Calc RPS: skip shape upsert status dump into cells

### DIFF
--- a/plugin/scripting/python_runner.py
+++ b/plugin/scripting/python_runner.py
@@ -186,6 +186,12 @@ def insert_result_into_calc(doc: Any, uno_ctx: Any, result: Any) -> None:
     try:
         if result is None:
             return
+        if is_shape_tool_status_result(result):
+            log.debug(
+                "Skipping Calc result insert for shape tool status dict (keys=%s)",
+                sorted(result.keys()) if isinstance(result, dict) else type(result).__name__,
+            )
+            return
 
         # Determine anchor cell from selection
         controller = doc.getCurrentController() if doc else None
@@ -491,7 +497,13 @@ def execute_and_insert_result(
                     return post
 
             if is_calc(doc):
-                insert_result_into_calc(doc, ctx, result_data)
+                if is_shape_tool_status_result(result_data):
+                    log.debug(
+                        "Skipping Calc result insert for shape tool status dict (keys=%s)",
+                        sorted(result_data.keys()) if isinstance(result_data, dict) else type(result_data).__name__,
+                    )
+                else:
+                    insert_result_into_calc(doc, ctx, result_data)
             elif is_writer(doc):
                 if is_shape_tool_status_result(result_data):
                     log.debug(

--- a/tests/scripting/test_python_runner_formatting.py
+++ b/tests/scripting/test_python_runner_formatting.py
@@ -218,5 +218,27 @@ def test_insert_result_into_calc_exception_shows_msgbox():
     box.assert_called_once()
     assert "Failed to insert result into Calc" in box.call_args[0][2]
 
+
+
+def test_insert_result_into_calc_skips_shape_status_dict():
+    from unittest.mock import MagicMock, patch
+    from plugin.scripting.python_runner import insert_result_into_calc
+
+    doc = MagicMock()
+    with patch("plugin.calc.rich_html.insert_cell_html_rich") as rich:
+        insert_result_into_calc(
+            doc,
+            MagicMock(),
+            {
+                "status": "ok",
+                "message": "Created star24",
+                "index": 0,
+                "page": 0,
+                "shape_count_after": 1,
+                "geometry_applied": True,
+            },
+        )
+    rich.assert_not_called()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Mirror Writer's `is_shape_tool_status_result` skip for Calc RPS result insert
- Guard both `execute_and_insert_result` Calc branch and `insert_result_into_calc`
- Unit test: shape status dict does not call `insert_cell_html_rich`

Keith: Universal Sample in Calc reported success but status/success wording appeared in the sheet. Writer already skipped these dicts on #704; Calc did not.

## Test plan
- [x] unit test for Calc skip
- [x] `make typecheck`
- [ ] headed Universal Sample in Calc (sheet + dialog shots)
- [ ] confirm whether star24 paints (separate from dump)