### PR TITLE
Calc: re-apply CustomShape geometry after page.add (star24 paint)

### DIFF
--- a/plugin/draw/shapes.py
+++ b/plugin/draw/shapes.py
@@ -671,13 +671,17 @@ class UpsertShape(ToolDrawShapeBase):
             _try_writer_at_page_shape_finalize(ctx.doc, bridge, page, shape)
             _try_writer_reapply_position_after_anchor(ctx.doc, shape, position, size)
 
-            # Writer: re-apply EnhancedCustomShapeGeometry after AT_PAGE anchor (pre-#527
-            # upsert path). Before-add alone can leave handles-only / invisible on some LO.
+            # Re-apply EnhancedCustomShapeGeometry after add. Writer needs this after
+            # AT_PAGE anchor (pre-#527). Calc needs it too: pre-add Type alone stays
+            # Type-only (no Path/ViewBox) and CustomShapes do not paint on the sheet.
             if (
                 is_custom_shape
                 and custom_shape_type
                 and ctx.doc is not None
-                and ctx.doc.supportsService("com.sun.star.text.TextDocument")
+                and (
+                    ctx.doc.supportsService("com.sun.star.text.TextDocument")
+                    or ctx.doc.supportsService("com.sun.star.sheet.SpreadsheetDocument")
+                )
             ):
                 geometry_applied, geometry_error = _apply_enhanced_custom_shape_type(
                     shape, custom_shape_type

--- a/tests/draw/test_shapes.py
+++ b/tests/draw/test_shapes.py
@@ -167,3 +167,72 @@ def test_shape_upsert_edit_accepts_name_without_index():
     ok, err = tool.validate(action="edit", index=0)
     assert ok
     assert err is None
+
+
+def test_shape_upsert_calc_customshape_reapplies_geometry_after_page_add():
+    """Calc SpreadsheetDocument: re-apply EnhancedCustomShapeGeometry after page.add.
+
+    Pre-add Type alone leaves geometry Type-only (no Path) so CustomShapes do not
+    paint on the sheet; Writer already re-applies for TextDocument.
+    """
+    events: list = []
+    shape = _RecordingShape(events)
+
+    page = MagicMock()
+    page_shapes: list = []
+
+    def page_add(added):
+        events.append(("page.add",))
+        page_shapes.append(added)
+
+    page.add.side_effect = page_add
+    page.getCount.side_effect = lambda: len(page_shapes)
+    page.getByIndex.side_effect = lambda i: page_shapes[i]
+
+    pages = MagicMock()
+    pages.getCount.return_value = 1
+    pages.getByIndex.return_value = page
+
+    doc = MagicMock()
+
+    def supports(svc: str) -> bool:
+        return svc == "com.sun.star.sheet.SpreadsheetDocument"
+
+    doc.supportsService.side_effect = supports
+    doc.createInstance.side_effect = lambda _type: shape
+
+    ctx = MagicMock()
+    ctx.doc = doc
+    ctx.active_page_index = 0
+
+    with (
+        patch("plugin.draw.bridge.DrawBridge") as bridge_cls,
+        patch("uno.invoke", side_effect=_invoke_set_property),
+        patch("uno.Any", side_effect=lambda _type, value: value),
+    ):
+        bridge = bridge_cls.return_value
+        bridge.get_pages.return_value = pages
+        bridge.get_active_page_index.return_value = 0
+
+        result = UpsertShape().execute(
+            ctx,
+            action="create",
+            shape_type="star24",
+            x=2000,
+            y=5000,
+            width=4000,
+            height=4000,
+            fill_color="blue",
+        )
+
+    assert result["status"] == "ok"
+    assert result["geometry_applied"] is True
+
+    add_idx = next(i for i, ev in enumerate(events) if ev[0] == "page.add")
+    geom_idxs = [i for i, ev in enumerate(events) if ev[0] == "setPropertyValue" and ev[1] == "CustomShapeGeometry"]
+    engine_idxs = [i for i, ev in enumerate(events) if ev[0] == "setPropertyValue" and ev[1] == "CustomShapeEngine"]
+
+    assert any(i < add_idx for i in geom_idxs), events
+    assert any(i > add_idx for i in geom_idxs), events
+    assert any(i < add_idx for i in engine_idxs), events
+    assert any(i > add_idx for i in engine_idxs), events


### PR DESCRIPTION
## Summary
- Calc CustomShapes (`star24` / Universal Sample) create successfully (`shape_count=1`) but stay **Type-only** after pre-add geometry apply, so they do not paint on the sheet.
- Mirror Writer’s post-add `EnhancedCustomShapeGeometry` re-apply for `SpreadsheetDocument` so Path/ViewBox expand and the shape paints.
- Unit test: Calc path re-applies geometry after `page.add`; Draw path still pre-add only.

Orthogonal to #705 (Calc RPS status-dump skip).

## Test plan
- [x] `tests/draw/test_shapes.py` (4 passed locally)
- [ ] Headed Calc Universal Sample — star_visible yes (QA Engineer)
- [ ] CI green