### PR TITLE
mock-sidebar: re-activate Writer after e12/G17 Calc close

### DIFF
--- a/tests/chatbot/test_mock_llm_sidebar_uno.py
+++ b/tests/chatbot/test_mock_llm_sidebar_uno.py
@@ -1624,16 +1624,36 @@ def _adopt_calc_sidebar(ctx, calc):
 
 
 def _restore_writer_after_calc(ctx, writer, calc, saved_controls, saved_listener) -> None:
-    """Close the E12/G17 Calc window and point the shared session back at Writer."""
+    """Close the E12/G17 Calc window and point the shared session back at Writer.
+
+    Closing Calc leaves ``desktop.getCurrentComponent()`` None even while Writer
+    remains open (box UNO proof). Re-activate Writer like peer ``_focus_doc`` so
+    e13+ ``_set_writer_body`` / Packet G ``execute_debug_sidebar_op`` still see a
+    current document and frame.
+    """
     from plugin.chatbot.sidebar_test_hooks import (
         adopt_runtime_send_listeners,
         close_component,
+        current_component,
+        desktop_from_ctx,
         wait_for_chat_dialog_controls,
     )
 
     close_component(calc)
     if writer is not None:
+        try:
+            frame = writer.getCurrentController().getFrame()
+            try:
+                frame.getContainerWindow().toFront()
+            except Exception:
+                pass
+            desktop_from_ctx(ctx).setActiveFrame(frame)
+        except Exception:
+            pass
         wait_for_chat_dialog_controls(ctx, timeout=15.0, doc=writer)
+        assert current_component(ctx) is not None, (
+            "after closing Calc, Writer was not re-activated as current component"
+        )
     adopt_runtime_send_listeners()
     if _session is not None:
         _session.controls = saved_controls


### PR DESCRIPTION
## Summary
- After e12 closes Calc, LibreOffice leaves **no current component** even though Writer is still open (local UNO proof: Writer+Calc → close Calc → `current=None` → `setActiveFrame(writer)` restores Writer).
- That matches Ubuntu mock-sidebar RED: e12 OK, then e13+ `no current document` and Packet G `no frame for executeDispatch`.
- `_restore_writer_after_calc` now mirrors peer `_focus_doc` (`toFront` + `setActiveFrame`) and asserts current is non-None.

Harness-only. Not a product Calc/shape issue.

Proof (QA box): `/workspace/mock-sidebar-e12/PROOF.md`

## Test plan
- [ ] CI mock-sidebar green (e12 then e13… / Packet G)
- [x] Local UNO proof of current-after-close + setActiveFrame restore