### PR TITLE
Keep eval gold/prompt files LF on Windows checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Gold / eval-2 prompt copies are compared as bytes against the HF tree
+# and task.json "prompt" (LF). Windows checkout with core.autocrlf must
+# not rewrite these as CRLF or test_gold_prompt_is_byte_copy_of_hf_tree fails.
+docs/eval/gdpval/**/prompt.txt text eol=lf
+docs/eval/eval-2/**/prompt.gdpval.txt text eol=lf

--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -4,6 +4,11 @@
 `docs/eval/gdpval/` gold trees except by **adding** a new untouched gold
 id. A multi-model benchmark comes later, when ~10 siblings exist.
 
+`test_gold_prompt_is_byte_copy_of_hf_tree` compares `prompt.txt` and
+`prompt.gdpval.txt` as bytes to the HF `task.json` `prompt` (LF).
+`.gitattributes` pins those files to `eol=lf` so Windows checkout does
+not rewrite them as CRLF.
+
 Living headed autopsy (product bar + peer polarity + next experiments): [`headed-failure-autopsy.md`](headed-failure-autopsy.md).
 
 Each subdirectory is one experiment. **Ready** means headed helper +

--- a/tests/scripts/test_eval_2_debug_log.py
+++ b/tests/scripts/test_eval_2_debug_log.py
@@ -90,15 +90,18 @@ def test_snapshot_debug_log_warns_when_missing(tmp_path: Path) -> None:
 
 def test_snapshot_debug_log_returns_dest(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     live = tmp_path / "live.log"
-    live.write_text("trace\n", encoding="utf-8")
+    # Binary write: Path.write_text("trace\n") becomes 7 bytes on Windows (CRLF).
+    body = b"trace\n"
+    live.write_bytes(body)
     dest_dir = tmp_path / "stamp"
     result = snapshot_debug_log(dest_dir, source=live)
     assert result == dest_dir / DEBUG_LOG_FILENAME
     assert result is not None
-    assert result.read_text(encoding="utf-8") == "trace\n"
+    assert result.read_bytes() == body
     printed = capsys.readouterr().out
     assert str(live) in printed
-    assert "6 bytes" in printed
+    assert f"{len(body)} bytes" in printed
+
 
 
 def test_save_eval2_debug_log_helper_prints_source_and_size(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Windows CI `Test & Typecheck` failed 8 tests on `windows-latest` ([run 34411555292](https://github.com/KeithCu/writeragent/actions/runs/34411555292) @ `440924ec`). Mock-sidebar was skipped after pytest failed.

Root cause is CRLF checkout, not prompt drift:

1. **Seven `test_gold_prompt_is_byte_copy_of_hf_tree` tests** compare `docs/eval/gdpval/<id>/prompt.txt` and `docs/eval/eval-2/<exp>/prompt.gdpval.txt` with `read_bytes()`, then decode and match `task.json` `"prompt"`. The HF / JSON prompt is LF. Windows runners default to `core.autocrlf=true`, so those text files check out as CRLF. `rstrip("\n")` leaves a trailing `\r` per line (`assert '…\r' == '…'`).

2. **`test_snapshot_debug_log_returns_dest`** wrote `"trace\n"` via `Path.write_text` and asserted the snapshot message contained `6 bytes`. On Windows, text mode writes `trace\r\n` (7 bytes).

## Change

- Add `.gitattributes` with `text eol=lf` for the compared paths:
  - `docs/eval/gdpval/**/prompt.txt`
  - `docs/eval/eval-2/**/prompt.gdpval.txt`
- Harden the debug-log test: write/read binary and assert the printed size from the file, not a hardcoded LF byte count.
- Note the Windows checkout rule in `docs/eval/eval-2/README.md`.

No gold/prompt file rewrites. Existing LF bytes in the repo are unchanged.

## Test plan

- `pytest` on the seven gold-prompt modules, `test_eval_2_debug_log.py`, and `test_eval_2_stub_index.py` (57 passed).
- `make typecheck` passed.
- Local CRLF simulation: LF gold still matches `task.json`; the same bytes with `\n` → `\r\n` reproduce the `'…\r' == '…'` failure. `write_bytes(b"trace\n")` stays 6 bytes.

Windows `workflow_dispatch` of PR CI should pass these 8 after checkout honors `.gitattributes`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01330314-1eaa-41a9-afdf-09149c35e366?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01330314-1eaa-41a9-afdf-09149c35e366&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

