### PR TITLE
Windows UNO bootstrap: longer connect budget, retry, fail logging

### DIFF
--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -924,6 +924,18 @@ def _uno_resolver_for_local_ctx() -> Any:
     )
 
 
+def _headless_connect_delays() -> tuple[float, ...]:
+    """Connect poll budget for headless ``make test-uno``.
+
+    Windows GHA sometimes needs longer than the Linux ~21.5s budget before the
+    named pipe accepts (same SHA: connected in ~5s vs miss at ~22s).
+    """
+    if sys.platform.startswith("win"):
+        # ~44.5s — enough for the slow-accept twin of the intermittent flake.
+        return (0.5, 1, 1, 2, 2, 3, 5, 8, 10, 12)
+    return (0.5, 1, 1, 2, 2, 3, 5, 7)
+
+
 def _connect_uno_accept(
     proc: Any,
     accept: str,
@@ -937,8 +949,11 @@ def _connect_uno_accept(
     resolver = _uno_resolver_for_local_ctx()
     url = "uno:%sStarOffice.ComponentContext" % accept
     last_exc: BaseException | None = None
-    for delay in delays:
+    t0 = time.monotonic()
+    n = len(delays)
+    for i, delay in enumerate(delays, start=1):
         time.sleep(delay)
+        elapsed = time.monotonic() - t0
         code = proc.poll()
         if code is not None:
             raise RuntimeError(
@@ -948,15 +963,20 @@ def _connect_uno_accept(
         try:
             ctx = resolver.resolve(url)
             _progress(
-                "BOOTSTRAP path=%s connected=True soffice_exit=%s pids=%s"
-                % (path_label, proc.poll(), _soffice_pids())
+                "BOOTSTRAP path=%s connected=True attempt=%s/%s elapsed=%.1fs soffice_exit=%s pids=%s"
+                % (path_label, i, n, elapsed, proc.poll(), _soffice_pids())
             )
             return ctx
         except NoConnectException as exc:
             last_exc = exc
+            _progress(
+                "BOOTSTRAP path=%s attempt=%s/%s elapsed=%.1fs no_connect=%s pids=%s"
+                % (path_label, i, n, elapsed, exc, _soffice_pids())
+            )
+    tail = office_stderr_tail()
     _progress(
-        "BOOTSTRAP path=%s connected=False soffice_exit=%s pids=%s last=%s"
-        % (path_label, proc.poll(), _soffice_pids(), last_exc)
+        "BOOTSTRAP path=%s connected=False soffice_exit=%s pids=%s last=%s stderr_tail=%r"
+        % (path_label, proc.poll(), _soffice_pids(), last_exc, tail[-30:])
     )
     raise RuntimeError("could not connect to %s soffice: %s" % (path_label, last_exc))
 
@@ -1006,6 +1026,26 @@ def _accept_from_soffice_argv(cmd: list[str]) -> str:
     raise RuntimeError("soffice argv missing --accept=...")
 
 
+
+def _terminate_bootstrap_soffice() -> None:
+    """Best-effort kill of the harness soffice Popen before a bootstrap retry."""
+    proc = _soffice_proc
+    if proc is None:
+        return
+    try:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+
 def _bootstrap_office(officehelper_module: Any) -> Any:
     """Start soffice without leaking the test runner's Python env into the child.
 
@@ -1039,37 +1079,71 @@ def _bootstrap_office(officehelper_module: Any) -> Any:
             resolved,
         )
     )
-    try:
-        proc = subprocess.Popen(
-            cmd,
-            env=child_env,
-            start_new_session=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            bufsize=1,
-        )
-        attach_soffice_proc(proc)
-        # Headless usually connects faster than GUI; keep the same retry budget.
-        ctx = _connect_uno_accept(
-            proc,
-            _accept_from_soffice_argv(cmd),
-            path_label="headless",
-            delays=(0.5, 1, 1, 2, 2, 3, 5, 7),
-        )
-        _progress(
-            "BOOTSTRAP path=headless returned=%s pids=%s leftover_PYTHONPATH=%s"
-            % (ctx is not None, _soffice_pids(), os.environ.get("PYTHONPATH"))
-        )
-        return ctx
-    except Exception as exc:
-        _progress(
-            "BOOTSTRAP path=headless error=%s:%s pids=%s"
-            % (type(exc).__name__, exc, _soffice_pids())
-        )
-        raise
+    # Windows GHA: intermittent pipe miss while soffice stays alive — longer
+    # budget plus one full restart. Linux keeps the shorter single attempt.
+    attempts = 2 if sys.platform.startswith("win") else 1
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        if attempt > 1:
+            cmd = _soffice_bootstrap_command(officehelper_module)
+            if cmd is None:
+                raise RuntimeError(
+                    "soffice not found (PATH, officehelper dir, or common install paths)"
+                )
+            _progress(
+                "BOOTSTRAP path=headless retry=%s/%s after pipe miss; new profile"
+                % (attempt, attempts)
+            )
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                env=child_env,
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+            )
+            attach_soffice_proc(proc)
+            ctx = _connect_uno_accept(
+                proc,
+                _accept_from_soffice_argv(cmd),
+                path_label="headless",
+                delays=_headless_connect_delays(),
+            )
+            _progress(
+                "BOOTSTRAP path=headless returned=%s attempt=%s/%s pids=%s leftover_PYTHONPATH=%s"
+                % (
+                    ctx is not None,
+                    attempt,
+                    attempts,
+                    _soffice_pids(),
+                    os.environ.get("PYTHONPATH"),
+                )
+            )
+            return ctx
+        except Exception as exc:
+            last_exc = exc
+            _progress(
+                "BOOTSTRAP path=headless error=%s:%s attempt=%s/%s pids=%s stderr_tail=%r"
+                % (
+                    type(exc).__name__,
+                    exc,
+                    attempt,
+                    attempts,
+                    _soffice_pids(),
+                    office_stderr_tail()[-30:],
+                )
+            )
+            _terminate_bootstrap_soffice()
+            if attempt >= attempts:
+                raise
+            # Brief pause so Windows releases the named pipe / process handles.
+            time.sleep(2.0)
+    assert last_exc is not None
+    raise last_exc
 
 
 

--- a/tests/scripts/test_testing_runner_cli.py
+++ b/tests/scripts/test_testing_runner_cli.py
@@ -780,3 +780,64 @@ def test_geometric_leftover_525_skips_locally(monkeypatch) -> None:
         )
         is True
     )
+
+
+def test_headless_connect_delays_windows_longer(monkeypatch) -> None:
+    """Windows headless budget exceeds the intermittent ~22s pipe-miss window."""
+    import plugin.testing_runner as tr
+
+    monkeypatch.setattr(tr.sys, "platform", "win32")
+    win = tr._headless_connect_delays()
+    monkeypatch.setattr(tr.sys, "platform", "linux")
+    linux = tr._headless_connect_delays()
+    assert sum(win) > sum(linux)
+    assert sum(win) >= 40.0
+
+
+def test_connect_uno_accept_logs_stderr_tail_on_miss(monkeypatch) -> None:
+    """Connect-fail path surfaces soffice stderr_tail for Windows GHA digs."""
+    import plugin.testing_runner as tr
+
+    class _Proc:
+        def poll(self):
+            return None
+
+    class _NoConnect(Exception):
+        pass
+
+    # Mimic com.sun.star.connection.NoConnectException name used in except.
+    import types
+    import sys
+
+    fake_mod = types.ModuleType("com.sun.star.connection")
+    fake_mod.NoConnectException = type("NoConnectException", (Exception,), {})
+    # Build nested com.sun.star.connection
+    com = types.ModuleType("com")
+    sun = types.ModuleType("com.sun")
+    star = types.ModuleType("com.sun.star")
+    conn = fake_mod
+    sys.modules["com"] = com
+    sys.modules["com.sun"] = sun
+    sys.modules["com.sun.star"] = star
+    sys.modules["com.sun.star.connection"] = conn
+
+    logs: list[str] = []
+    monkeypatch.setattr(tr, "_progress", lambda msg: logs.append(msg))
+    monkeypatch.setattr(tr, "_uno_resolver_for_local_ctx", lambda: types.SimpleNamespace(
+        resolve=lambda url: (_ for _ in ()).throw(conn.NoConnectException("pipe miss"))
+    ))
+    monkeypatch.setattr(tr, "_soffice_pids", lambda: "1,2")
+    monkeypatch.setattr(tr, "office_stderr_tail", lambda: ["prefix warn", "still starting"])
+    monkeypatch.setattr(tr.time, "sleep", lambda _d: None)
+
+    try:
+        tr._connect_uno_accept(_Proc(), "pipe,name=x;urp;", path_label="headless", delays=(0.1, 0.1))
+        raise AssertionError("expected RuntimeError")
+    except RuntimeError as exc:
+        assert "could not connect" in str(exc)
+
+    joined = "\n".join(logs)
+    assert "attempt=1/2" in joined
+    assert "connected=False" in joined
+    assert "stderr_tail=" in joined
+    assert "still starting" in joined


### PR DESCRIPTION
## Summary
- Connect-fail logging: per-attempt elapsed + `stderr_tail` when the named pipe never accepts.
- Windows headless: longer delay schedule (~44.5s) and **one** full bootstrap retry after a pipe miss (new throwaway profile).
- Linux budget unchanged (single attempt).

Harness-only. No product changes. No socket A/B in this PR.

Dig: intermittent slow accept on Windows GHA (same SHA twin: connected ~5s vs miss ~22s). `/workspace/win-uno-bootstrap/REPORT.md` on QA box.

## Test plan
- [x] Unit: `test_headless_connect_delays_windows_longer`, `test_connect_uno_accept_logs_stderr_tail_on_miss`
- [ ] CI / optional Windows workflow_dispatch re-check