### PR TITLE
Harness: settle after peer Impress close before next Writer factory load

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -37,6 +37,18 @@ proof LibreOffice is healthy. If SalAbort still prints, `#698` fail-closed
 still names that test. Details and soak rates:
 [salabort-svxshape-close.md](salabort-svxshape-close.md).
 
+**Peer Impress → next Writer factory (Windows):** GHA 34419828920 hung 30s
+in `tests/chatbot/test_peer_message_uno.py` at `_load("private:factory/swriter")`
+(line 109), immediately after `test_peer_impress_rejected_on_resolved_model`
+passed. That predecessor used a local `doc.close(True)` and skipped
+`close_doc`. Office stayed alive (`kill-libreoffice.ps1` still found PIDs).
+Peer tests now close through `TestingFactory.close_doc`, drop the Impress
+local, then `settle_after_draw_family_close` (GC + 0.75s Windows / 0.15s
+else) before the next factory load. `_load` prints
+`peer_message_uno: load start <url>` so a later faulthandler dump names
+swriter vs simpress. Do **not** fold that post-close sleep into
+`close_doc` (would tax every Writer/Calc close). Not a product fix.
+
 **Harness-only attribution (not a product fix):** if a test body returns OK
 but the office already aborted, the runner fails *that* test instead of
 letting the next factory open be the named victim:

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -14,7 +14,8 @@ from plugin.doc.peer_message import (
 from plugin.framework.async_drain_guard import drain_owner_scope, reset_sentry_state
 from plugin.framework.tool import ToolContext
 from plugin.framework.uno_context import get_desktop, get_runtime_uid
-from plugin.testing_runner import native_test
+from plugin.testing_runner import _progress, native_test
+from plugin.tests.testing_utils import TestingFactory, settle_after_draw_family_close
 
 
 class _Listener:
@@ -55,17 +56,32 @@ def _hidden_prop():
 
 
 def _load(ctx, factory_url):
+    # Name the factory on stderr so a 30s faulthandler dump shows swriter vs
+    # simpress. GHA 34419828920 hung at line 109 — Writer after a raw Impress
+    # close, not the Impress load itself (that would be the next _load line).
+    _progress("peer_message_uno: load start %s" % factory_url)
     desktop = get_desktop(ctx)
-    return desktop.loadComponentFromURL(factory_url, "_blank", 0, (_hidden_prop(),))
+    doc = desktop.loadComponentFromURL(factory_url, "_blank", 0, (_hidden_prop(),))
+    _progress("peer_message_uno: load done %s" % factory_url)
+    return doc
 
 
 def _close(doc):
+    """Close via harness ``close_doc`` (GC + 50 ms, then ``doc.close``).
+
+    What was wrong: local ``doc.close(True)`` skipped that settle. After
+    ``test_peer_impress_rejected_on_resolved_model`` raw-closed Impress, the
+    next test's ``private:factory/swriter`` load hung 30s (GHA 34419828920;
+    office still alive). How: leftover Impress proxies raced the next
+    factory. Why this: same close path as ``@with_native_doc``. Impress
+    callers then drop the local ref and call
+    ``settle_after_draw_family_close`` (not inside ``close_doc`` — that
+    would tax every Writer/Calc close).
+    """
     if doc is None:
-        return
-    try:
-        doc.close(True)
-    except Exception:
-        pass
+        return None
+    TestingFactory.close_doc(doc)
+    return None
 
 
 def _tool_ctx(ctx, doc):
@@ -90,8 +106,11 @@ def test_peer_impress_rejected_on_resolved_model(ctx):
         assert code == "PEER_UNSUPPORTED"
         assert "Impress" in msg
     finally:
-        _close(impress)
-        _close(writer)
+        had_impress = impress is not None
+        impress = _close(impress)
+        if had_impress:
+            settle_after_draw_family_close()
+        writer = _close(writer)
         reset_peer_queues()
         reset_live_panels()
 
@@ -116,8 +135,11 @@ def test_peer_catalog_draw_label_is_not_enough_for_impress(ctx):
         peers = list_v1_peers(ctx, writer)
         assert all(p.get("uid") != impress_uid for p in peers)
     finally:
-        _close(impress)
-        _close(writer)
+        had_impress = impress is not None
+        impress = _close(impress)
+        if had_impress:
+            settle_after_draw_family_close()
+        writer = _close(writer)
 
 
 @native_test

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -388,6 +388,31 @@ def test_close_doc_none_skips_settle(monkeypatch):
     TestingFactory.close_doc(None)
 
 
+def test_settle_after_draw_family_close_gcs_then_sleeps(monkeypatch):
+    """Post-Impress settle must GC after the caller drops the closed proxy."""
+    from plugin.tests.testing_utils import (
+        _DRAW_FAMILY_POST_CLOSE_SETTLE_S,
+        settle_after_draw_family_close,
+    )
+
+    order = []
+    monkeypatch.setattr("gc.collect", lambda: order.append("gc"))
+    monkeypatch.setattr("time.sleep", lambda seconds: order.append(("sleep", seconds)))
+    settle_after_draw_family_close()
+    assert order == ["gc", ("sleep", _DRAW_FAMILY_POST_CLOSE_SETTLE_S)]
+
+
+def test_settle_after_draw_family_close_windows_longer_than_posix():
+    """Windows is the hang host (GHA 34419828920); POSIX stays a short drain."""
+    from plugin.tests import testing_utils as tu
+
+    assert tu._DRAW_FAMILY_POST_CLOSE_SETTLE_S > tu._CLOSE_DOC_URP_SETTLE_S
+    if tu.sys.platform == "win32":
+        assert tu._DRAW_FAMILY_POST_CLOSE_SETTLE_S == 0.75
+    else:
+        assert tu._DRAW_FAMILY_POST_CLOSE_SETTLE_S == 0.15
+
+
 def test_testing_factory_execute_tool_unknown_name():
     from unittest.mock import MagicMock, patch
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -882,6 +882,31 @@ def _default_native_doc_reuse(doc_type: str) -> bool:
 # the SfxItemPool path. Measured 0/80 on the killer; post-close wait did not help.
 _CLOSE_DOC_URP_SETTLE_S = 0.05
 
+# GHA 34419828920 (master bf6c2ea2): peer test_peer_impress_rejected_on_resolved_model
+# raw-closed Impress via doc.close(True), then the *next* test hung 30s in
+# private:factory/swriter load (test_peer_message_uno.py:109). Office stayed
+# alive (kill-libreoffice.ps1 still found soffice PIDs). close_doc's 50 ms is
+# pre-close (release proxies before teardown). This is post-close: drop the
+# closed Impress/Draw proxy, GC, then let URP finish before the next factory
+# load. Do not put this inside close_doc — that would tax every Writer/Calc
+# close. Windows needs longer; POSIX is a short drain. Not a product fix.
+_DRAW_FAMILY_POST_CLOSE_SETTLE_S = 0.75 if sys.platform == "win32" else 0.15
+
+
+def settle_after_draw_family_close() -> None:
+    """Harness-only: GC + sleep after closing Impress/Draw before the next factory load.
+
+    Call after ``TestingFactory.close_doc`` *and* after dropping the local
+    reference. The next ``loadComponentFromURL`` is the hang site if this
+    settle is skipped (see ``tests/chatbot/test_peer_message_uno.py``).
+    """
+    import gc
+    import time
+
+    gc.collect()
+    time.sleep(_DRAW_FAMILY_POST_CLOSE_SETTLE_S)
+
+
 # offapi/com/sun/star/sheet/CellFlags.idl — VALUE|DATETIME|STRING|ANNOTATION|FORMULA|HARDATTR|STYLES|OBJECTS|EDITATTR|FORMATTED
 _CALC_CLEAR_ALL = 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 | 512
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Windows `workflow_dispatch` PR CI is red on the Impress-close → next factory-load hang. This PR is that hang only. It does not reopen the bootstrap connect/retry work from #709.

## Evidence (which `_load` hung)

Both Windows dispatches hang the same way. Prior Impress test in the suite **passes**; the next factory load hangs.

| Run | SHA | Notes |
| --- | --- | --- |
| https://github.com/KeithCu/writeragent/actions/runs/34415961088 | `2b64081` (pre-#709, bootstrap OK) | Twin breadcrumb |
| https://github.com/KeithCu/writeragent/actions/runs/34419828920 | `bf6c2ea` (post-#709) | Master tip that stayed red |

- `test_peer_impress_rejected_on_resolved_model` loaded `swriter` + `simpress`, raw-closed both via local `doc.close(True)`, and **passed**.
- Next test `test_peer_catalog_draw_label_is_not_enough_for_impress` timed out at 30s.
- Faulthandler: `test_peer_message_uno.py` line 109 → line 59 `_load` → `desktop.loadComponentFromURL`.
- On those SHAs, **line 109 is `writer = _load(ctx, "private:factory/swriter")`**. Line 110 is `simpress`. The hung load is Writer after a raw Impress close, not the Impress factory itself.
- After timeout on 34419828920, `kill-libreoffice.ps1` still found soffice PIDs — office was alive and stuck in load.

## Fix (harness / this suite only)

Peer tests were bypassing `TestingFactory.close_doc` (`gc.collect` + 50 ms + `close`), the path `@with_native_doc` already uses for Draw/Impress.

1. Route `_close` through `close_doc`.
2. After an Impress close, drop the local ref and call `settle_after_draw_family_close` (GC + 0.75s Windows / 0.15s else) before the next factory load.
3. `_load` prints `peer_message_uno: load start <url>` so a later dump names swriter vs simpress.

No product change. Extra settle is **not** folded into `close_doc` (that would tax every Writer/Calc close). No Windows skip.

## Validation here

- `make typecheck` green
- `pytest tests/test_testing_utils.py` — 25 passed (including settle helper)
- `make test-uno FILTER=test_peer_message_uno` — 6 passed (Linux; hang is Windows-only)
- Soak 8× the two Impress-then-Writer tests in one soffice — 16 passed

This cloud agent cannot run `windows-latest`. Automatic `pull_request` CI is Ubuntu-only.

## How to re-run the red job

`workflow_dispatch` **PR CI** on this branch with `os=windows-latest` (same as the red master / twin dispatches).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67754813-ebfa-4844-b930-f6ac0d35a6c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67754813-ebfa-4844-b930-f6ac0d35a6c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

