### PR TITLE
Windows pytest: import plugin.doc before Layer B guard worker

### DIFF
--- a/docs/framework/uno-thread-safety.md
+++ b/docs/framework/uno-thread-safety.md
@@ -166,6 +166,7 @@ For fast CI tests where LibreOffice is not running:
 - `test_yellow_context_allows_inline_when_on_main_thread`: Asserts GUI formula evaluation on main thread executes inline without errors.
 - `test_notify_thread_violation_never_blocks`: Asserts guard violation reporting uses non-blocking `post_to_main_thread`.
 - `test_charts_process_events_regression_must_marshal`: Prevents regressions of the chart event loop hang (commit `0cfc6891`).
+- `test_guarded_getter_from_background_fails_with_marshal_fixture`: Asserts `@main_thread_only` on `doc_type.get_document_type` still raises from `run_in_background` under the Layer B pump. Import `plugin.doc` on the test thread before spawning — first import on the worker hung Windows xdist (GHA 34423268523: `join` timed out with only "Starting task" logged).
 
 ---
 

--- a/tests/framework/test_thread_affinity.py
+++ b/tests/framework/test_thread_affinity.py
@@ -128,27 +128,54 @@ def test_direct_affine_access_from_run_in_background_fails(uno_thread_safety):
 
 def test_guarded_getter_from_background_fails_with_marshal_fixture(uno_thread_safety, monkeypatch):
     """doc_type entrypoints call assert_main_thread even on mocks."""
+    from plugin.doc import doc_type
     from plugin.framework.errors import UnoObjectError
 
+    # What was wrong (GHA 34423268523, Windows xdist gw2): the worker did
+    # ``from plugin.doc import doc_type`` after ``run_in_background`` started.
+    # ``join(timeout=3)`` returned with ``err`` still None; captured log had
+    # only worker_pool "Starting task" — no completion, no violation. How:
+    # first import of ``plugin.doc`` (package ``__init__`` → CommonModule) ran
+    # on the dedicated worker while the Layer B pump was live, so the getter
+    # never reached ``assert_main_thread`` before the timeout. Why this: load
+    # the module on the test thread; the worker only calls the getter. Event +
+    # liveness / unexpected-exception notes so a future miss names the cause
+    # (alive thread vs wrong type vs GUARD_ON / designated-main).
     monkeypatch.setattr(tg, "GUARD_ON", True)
+    done = threading.Event()
     err: BaseException | None = None
+    notes: dict[str, object] = {}
 
-    def worker():
+    def worker() -> None:
         nonlocal err
         try:
-            from plugin.doc import doc_type
-
+            notes["guard_on"] = tg.GUARD_ON
+            notes["on_main_thread"] = tg.on_main_thread()
+            designated = tg.get_designated_main_thread()
+            notes["designated_name"] = None if designated is None else designated.name
+            notes["current_name"] = threading.current_thread().name
+            notes["task_name"] = tg.get_background_task_name()
             doc_type.get_document_type(MagicMock())
-        except (RuntimeError, UnoObjectError) as e:
-            err = e
+            notes["returned"] = True
+        except BaseException as exc:
+            err = exc
+            notes["exc_type"] = type(exc).__name__
+        finally:
+            done.set()
 
     t = run_in_background(worker, name="run_get_doc_type", daemon=False)
-    t.join(timeout=3.0)
-    assert err is not None
+    finished = done.wait(timeout=3.0)
+    t.join(timeout=1.0)
+    state = (
+        f"finished={finished} alive={t.is_alive()} notes={notes!r} "
+        f"GUARD_ON={tg.GUARD_ON} designated={tg.get_designated_main_thread()!r}"
+    )
+    assert finished, f"worker did not finish; {state}"
+    assert err is not None, f"guard did not raise; {state}"
     msg = str(err)
     if isinstance(err, UnoObjectError) and err.__cause__ is not None:
         msg = str(err.__cause__)
-    assert "UNO thread violation" in msg
+    assert "UNO thread violation" in msg, f"unexpected {type(err).__name__}: {err!r}; {state}"
 
 
 def test_charts_process_events_regression_must_marshal(uno_thread_safety, monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Master Windows CI failed after #710 on pytest, not UNO:

- Run: https://github.com/KeithCu/writeragent/actions/runs/34423268523
- Job: Test & Typecheck (windows-latest)
- Case: `tests/framework/test_thread_affinity.py::test_guarded_getter_from_background_fails_with_marshal_fixture`
- Assertion: `assert err is not None` (line 147)
- Log: only `worker_pool` `Starting task run_get_doc_type` — no completion, no `UNO thread violation`

## Cause

Not a Layer A guard regression and not caused by the #710 harness settle (that diff is UNO peer-close only).

The worker imported `plugin.doc` *after* `run_in_background` started. On Windows xdist that first import (`plugin.doc` package `__init__` → `CommonModule`) ran on the dedicated thread next to the Layer B pump. `join(timeout=3)` returned while the worker was still in import, so `err` stayed `None`. Other affinity tests in the same file import on the test thread (or do not import a new package in the worker) and passed.

Hunches checked:

1. Join race / worker still running — **yes**. Missing “completed successfully” / “Task failed” next to “Starting task” means the dedicated thread had not finished.
2. Guard not firing (`on_main_thread()` true / `GUARD_ON` missed) — **no evidence**. That path would finish quickly and log completion.
3. Wrong exception type — **no evidence**. That would log completion or `Task failed`.

## Fix

- Import `plugin.doc.doc_type` on the test thread; the worker only calls `get_document_type(MagicMock())`.
- Wait on a `done` Event; on failure report thread liveness, `GUARD_ON`, designated-main, and the actual exception type.
- Note the GHA in `docs/framework/uno-thread-safety.md` B3.

No product `thread_guard` / `worker_pool` change.

## Verification

- `make typecheck` clean
- `tests/framework/test_thread_affinity.py`: 13 passed
- Targeted case repeated 10× locally (Linux)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e4c3825-2735-4be4-b660-353744a48b45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e4c3825-2735-4be4-b660-353744a48b45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

