### PR TITLE
Harness: raw-close Windows Impress so the next Writer factory load is not wedged

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -66,17 +66,23 @@ Peer tests: POSIX closes Writer first, then `close_draw_family_doc`
 (`setModified(False)`, GC, pre-close settle, `close(True)`). **Windows
 keeps Writer open** and uses a bare Impress `close(True)` (no pre-close
 GC/sleep — the only close that returned, `#710` / 34419828920), drops
-the proxy, `settle_after_draw_family_close`, re-activates Writer
-(`setActiveFrame`, `#707`), then closes Writer. Breadcrumbs:
+the proxy, `settle_after_draw_family_close`, and re-activates Writer
+(`setActiveFrame`, `#707`). Do **not** then `close_doc` that Writer:
+GHA 34540353452 (`c511aab7`) raw-closed Impress in ~25 ms, settle +
+`writer reactivated` printed, then `TestingFactory.close_doc` hung 30s
+at Writer `close(True)` (office still alive; `kill-libreoffice.ps1`
+then killed soffice). Leftover Writer is not the poison (the keeper
+Writer already exists); leftover Impress is. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
-`peer_message_uno: writer reactivated`. Do **not** fold Draw-family
-settle into `close_doc`. Not a product fix.
+`peer_message_uno: writer reactivated`,
+`peer_message_uno: skip writer close after impress`. Do **not** fold
+Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for both peer Impress
-tests finishing (`TEST end … OK`) and the next `swriter` load
-(`test_peer_missing_deck_is_clear_error`) starting after post-close
-settle. Ubuntu PR CI is the automatic gate; this cloud agent cannot run
+tests finishing (`TEST end … OK`) after `skip writer close after impress`,
+then the next `swriter` load (`test_peer_missing_deck_is_clear_error`)
+starting. Ubuntu PR CI is the automatic gate; this cloud agent cannot run
 `windows-latest`.
 
 **Harness-only attribution (not a product fix):** if a test body returns OK

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -55,13 +55,29 @@ printed `peer_message_uno: load start/done` for `swriter` then `simpress`.
 
 GHA 34532953982 hung at `close(True)` after Writer-first + 0.75s settle.
 GHA 34535868114 hung the same way at `dispose() start` (office still
-alive; `kill-libreoffice.ps1` then killed soffice). Peer tests close the
-Writer sibling first, then `close_draw_family_doc` (`setModified(False)`,
-GC, Windows-longer settle). POSIX then `close(True)`. **Windows skips
-`close` and `dispose`**, drops the Python proxy, and relies on suite-end
-office kill. Then `settle_after_draw_family_close`. Breadcrumb to look
-for: `close_draw_family: skip uno teardown`. Do **not** fold Draw-family
+alive; `kill-libreoffice.ps1` then killed soffice). GHA 34537826720
+(`9adff169`, skip-teardown) printed `close_draw_family: skip uno teardown`
+and the first Impress test ended OK, then
+`test_peer_catalog_draw_label_is_not_enough_for_impress` hung 30s on
+`private:factory/swriter` load — leftover Impress poisons later Writer
+factory loads (same family as `#710`).
+
+Peer tests: POSIX closes Writer first, then `close_draw_family_doc`
+(`setModified(False)`, GC, pre-close settle, `close(True)`). **Windows
+keeps Writer open** and uses a bare Impress `close(True)` (no pre-close
+GC/sleep — the only close that returned, `#710` / 34419828920), drops
+the proxy, `settle_after_draw_family_close`, re-activates Writer
+(`setActiveFrame`, `#707`), then closes Writer. Breadcrumbs:
+`close_draw_family: raw close(True) start/done`,
+`peer_message_uno: writer reactivated`. Do **not** fold Draw-family
 settle into `close_doc`. Not a product fix.
+
+**Windows proof** still needs a `workflow_dispatch` of PR CI on the
+branch: `os=windows-latest`, `ci_debug=true`. Look for both peer Impress
+tests finishing (`TEST end … OK`) and the next `swriter` load
+(`test_peer_missing_deck_is_clear_error`) starting after post-close
+settle. Ubuntu PR CI is the automatic gate; this cloud agent cannot run
+`windows-latest`.
 
 **Harness-only attribution (not a product fix):** if a test body returns OK
 but the office already aborted, the runner fails *that* test instead of

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -17,6 +17,7 @@ from plugin.framework.uno_context import get_desktop, get_runtime_uid
 from plugin.testing_runner import _progress, native_test
 from plugin.tests.testing_utils import (
     TestingFactory,
+    _draw_family_raw_close,
     close_draw_family_doc,
     settle_after_draw_family_close,
 )
@@ -78,9 +79,8 @@ def _close(doc):
     next test's ``private:factory/swriter`` load hung 30s (GHA 34419828920;
     office still alive). How: leftover Impress proxies raced the next
     factory. Why this: same close path as ``@with_native_doc``. Impress
-    teardown is ``_teardown_peer_pair`` (Writer first, then
-    ``close_draw_family_doc`` + ``settle_after_draw_family_close``) — not
-    this helper. Do not fold Draw-family settle into ``close_doc``.
+    teardown is ``_teardown_peer_pair`` — not this helper. Do not fold
+    Draw-family settle into ``close_doc``.
     """
     if doc is None:
         return None
@@ -88,27 +88,65 @@ def _close(doc):
     return None
 
 
-def _teardown_peer_pair(writer, impress):
-    """Close the sibling Writer before Impress.
+def _reactivate_writer_after_impress(ctx, writer):
+    """Point the desktop back at Writer after Impress close.
+
+    Closing another app can leave ``getCurrentComponent()`` empty even
+    while Writer remains open (box UNO proof; ``_restore_writer_after_calc``
+    / #707). Re-activate before the next ``private:factory/swriter`` load
+    so the factory is not racing a wedged Impress current component.
+    Hidden docs may have no container window; ``setActiveFrame`` is the
+    important call.
+    """
+    if ctx is None or writer is None:
+        return
+    try:
+        frame = writer.getCurrentController().getFrame()
+        try:
+            win = frame.getContainerWindow()
+            if win is not None:
+                win.toFront()
+        except Exception:
+            pass
+        get_desktop(ctx).setActiveFrame(frame)
+        _progress("peer_message_uno: writer reactivated")
+    except Exception as exc:
+        _progress(
+            "peer_message_uno: writer reactivate skipped err=%s" % type(exc).__name__
+        )
+
+
+def _teardown_peer_pair(writer, impress, ctx=None):
+    """Close the Writer+Impress peer pair without poisoning the next load.
 
     What was wrong: GHA 34518091151 hung 30s in ``TestingFactory.close_doc``
     at ``doc.close(True)`` while this suite closed Impress with Writer still
-    open (``test_peer_impress_rejected_on_resolved_model`` finally). Both
-    factory loads had succeeded. #710's ``settle_after_draw_family_close``
-    never ran — that settle is *after* close.
+    open. #710's ``settle_after_draw_family_close`` never ran. Later
+    Writer-first + GC/sleep then close/dispose also hung (34532953982 /
+    34535868114). Skipping close (34537826720) unblocked the first test
+    then hung the next ``private:factory/swriter`` load — leftover Impress
+    wedges later Writer factory loads (same family as #710).
 
-    How: Windows ``XCloseable.close(True)`` on Impress can block when a
-    Writer sibling is still open, and ``close_doc`` GCs leftover
-    ``resolve_document_by_url`` wrappers then close()s after only 50 ms.
-
-    Why this: close Writer first (generic ``close_doc``), then the
-    Draw-family path (``setModified(False)`` + longer settle). POSIX
-    ``close(True)``. Windows skips ``close``/``dispose`` (both hung 30s
-    in 34532953982 / 34535868114) and drops the proxy; suite-end kill
-    reaps soffice. Then the existing post-close settle. Not a product
-    fix.
+    Why this: Windows keeps Writer open and uses a bare Impress
+    ``close(True)`` (the only close that returned, #710 / 34419828920),
+    drops the proxy, post-close settles, re-activates Writer (#707), then
+    closes Writer. POSIX still closes Writer first, then the Draw-family
+    path (setModified + pre-close settle + ``close(True)``) and the same
+    post-close settle. Not a product fix.
     """
     had_impress = impress is not None
+    if had_impress and _draw_family_raw_close():
+        _progress("peer_message_uno: close impress start")
+        close_draw_family_doc(impress)
+        impress = None
+        _progress("peer_message_uno: close impress done")
+        settle_after_draw_family_close()
+        _progress("peer_message_uno: impress post-close settle done")
+        _reactivate_writer_after_impress(ctx, writer)
+        _progress("peer_message_uno: close writer start")
+        writer = _close(writer)
+        _progress("peer_message_uno: close writer done")
+        return None, None
     _progress("peer_message_uno: close writer start")
     writer = _close(writer)
     _progress("peer_message_uno: close writer done")
@@ -143,7 +181,7 @@ def test_peer_impress_rejected_on_resolved_model(ctx):
         assert code == "PEER_UNSUPPORTED"
         assert "Impress" in msg
     finally:
-        writer, impress = _teardown_peer_pair(writer, impress)
+        writer, impress = _teardown_peer_pair(writer, impress, ctx)
         reset_peer_queues()
         reset_live_panels()
 
@@ -168,7 +206,7 @@ def test_peer_catalog_draw_label_is_not_enough_for_impress(ctx):
         peers = list_v1_peers(ctx, writer)
         assert all(p.get("uid") != impress_uid for p in peers)
     finally:
-        writer, impress = _teardown_peer_pair(writer, impress)
+        writer, impress = _teardown_peer_pair(writer, impress, ctx)
 
 
 @native_test

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -129,10 +129,14 @@ def _teardown_peer_pair(writer, impress, ctx=None):
 
     Why this: Windows keeps Writer open and uses a bare Impress
     ``close(True)`` (the only close that returned, #710 / 34419828920),
-    drops the proxy, post-close settles, re-activates Writer (#707), then
-    closes Writer. POSIX still closes Writer first, then the Draw-family
-    path (setModified + pre-close settle + ``close(True)``) and the same
-    post-close settle. Not a product fix.
+    drops the proxy, post-close settles, and re-activates Writer (#707).
+    Do **not** then ``close_doc`` the sibling Writer — GHA 34540353452
+    raw-closed Impress in ~25 ms, settle + ``setActiveFrame`` returned,
+    then ``TestingFactory.close_doc`` hung 30s at Writer ``close(True)``.
+    Leftover Writer is not the poison (keeper Writer already exists);
+    leftover Impress is. POSIX still closes Writer first, then the
+    Draw-family path (setModified + pre-close settle + ``close(True)``)
+    and the same post-close settle. Not a product fix.
     """
     had_impress = impress is not None
     if had_impress and _draw_family_raw_close():
@@ -143,9 +147,8 @@ def _teardown_peer_pair(writer, impress, ctx=None):
         settle_after_draw_family_close()
         _progress("peer_message_uno: impress post-close settle done")
         _reactivate_writer_after_impress(ctx, writer)
-        _progress("peer_message_uno: close writer start")
-        writer = _close(writer)
-        _progress("peer_message_uno: close writer done")
+        # Drop the proxy only. close_doc hung 30s here (34540353452).
+        _progress("peer_message_uno: skip writer close after impress")
         return None, None
     _progress("peer_message_uno: close writer start")
     writer = _close(writer)

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -577,8 +577,8 @@ def test_teardown_peer_pair_closes_writer_before_impress(monkeypatch):
     ]
 
 
-def test_teardown_peer_pair_windows_closes_impress_then_writer(monkeypatch):
-    """GHA 34537826720: skip-teardown left Impress alive; next swriter hung."""
+def test_teardown_peer_pair_windows_closes_impress_skips_writer(monkeypatch):
+    """GHA 34540353452: Impress raw close returned; Writer close_doc hung."""
     from unittest.mock import MagicMock
 
     from tests.chatbot.test_peer_message_uno import _teardown_peer_pair
@@ -613,7 +613,6 @@ def test_teardown_peer_pair_windows_closes_impress_then_writer(monkeypatch):
         ("close_draw_family", impress),
         "post_settle",
         ("reactivate", ctx, writer),
-        ("close_doc", writer),
     ]
 
 

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -428,7 +428,7 @@ def test_close_draw_family_doc_setmodified_gc_settle_then_close(monkeypatch):
     monkeypatch.setattr("gc.collect", lambda: order.append("gc"))
     monkeypatch.setattr("time.sleep", lambda seconds: order.append(("sleep", seconds)))
     monkeypatch.setattr(
-        "plugin.tests.testing_utils._draw_family_skip_uno_teardown",
+        "plugin.tests.testing_utils._draw_family_raw_close",
         lambda: False,
     )
 
@@ -453,33 +453,35 @@ def test_close_draw_family_doc_setmodified_gc_settle_then_close(monkeypatch):
     doc.dispose.assert_not_called()
 
 
-def test_close_draw_family_doc_windows_skips_close_and_dispose(monkeypatch):
-    """GHA 34535868114: dispose() hung the same way as close(True)."""
+def test_close_draw_family_doc_windows_raw_close_skips_pre_close_gc(monkeypatch):
+    """GHA 34537826720: skip left Impress alive; #710 raw close returned."""
     from unittest.mock import MagicMock
 
-    from plugin.tests.testing_utils import (
-        _DRAW_FAMILY_PRE_CLOSE_SETTLE_S,
-        close_draw_family_doc,
-    )
+    from plugin.tests.testing_utils import close_draw_family_doc
 
     order = []
-    monkeypatch.setattr("gc.collect", lambda: order.append("gc"))
-    monkeypatch.setattr("time.sleep", lambda seconds: order.append(("sleep", seconds)))
+
+    def _fail_gc():
+        raise AssertionError("Windows raw close must not gc.collect before close")
+
+    def _fail_sleep(_seconds):
+        raise AssertionError("Windows raw close must not sleep before close")
+
+    monkeypatch.setattr("gc.collect", _fail_gc)
+    monkeypatch.setattr("time.sleep", _fail_sleep)
     monkeypatch.setattr(
-        "plugin.tests.testing_utils._draw_family_skip_uno_teardown",
+        "plugin.tests.testing_utils._draw_family_raw_close",
         lambda: True,
     )
     doc = MagicMock()
     doc.supportsService.side_effect = lambda svc: svc.endswith("PresentationDocument")
     doc.RuntimeUID = "impress-uid"
     doc.setModified.side_effect = lambda _modified: order.append("setModified")
+    doc.close.side_effect = lambda _save: order.append("close")
     close_draw_family_doc(doc)
-    assert order == [
-        "setModified",
-        "gc",
-        ("sleep", _DRAW_FAMILY_PRE_CLOSE_SETTLE_S),
-    ]
-    doc.close.assert_not_called()
+    assert order == ["close"]
+    doc.setModified.assert_not_called()
+    doc.close.assert_called_once_with(True)
     doc.dispose.assert_not_called()
 
 
@@ -501,7 +503,7 @@ def test_close_draw_family_doc_logs_svc_and_steps(capsys, monkeypatch):
     monkeypatch.setattr("gc.collect", lambda: None)
     monkeypatch.setattr("time.sleep", lambda _seconds: None)
     monkeypatch.setattr(
-        "plugin.tests.testing_utils._draw_family_skip_uno_teardown",
+        "plugin.tests.testing_utils._draw_family_raw_close",
         lambda: False,
     )
     doc = MagicMock()
@@ -515,15 +517,13 @@ def test_close_draw_family_doc_logs_svc_and_steps(capsys, monkeypatch):
     assert "close_draw_family: close(True) done svc=impress uid=uid-9" in err
 
 
-def test_close_draw_family_doc_windows_logs_skip(capsys, monkeypatch):
+def test_close_draw_family_doc_windows_logs_raw_close(capsys, monkeypatch):
     from unittest.mock import MagicMock
 
     from plugin.tests.testing_utils import close_draw_family_doc
 
-    monkeypatch.setattr("gc.collect", lambda: None)
-    monkeypatch.setattr("time.sleep", lambda _seconds: None)
     monkeypatch.setattr(
-        "plugin.tests.testing_utils._draw_family_skip_uno_teardown",
+        "plugin.tests.testing_utils._draw_family_raw_close",
         lambda: True,
     )
     doc = MagicMock()
@@ -531,18 +531,122 @@ def test_close_draw_family_doc_windows_logs_skip(capsys, monkeypatch):
     doc.RuntimeUID = "uid-9"
     close_draw_family_doc(doc)
     err = capsys.readouterr().err
-    assert "close_draw_family: skip uno teardown svc=impress uid=uid-9" in err
-    assert "close(True) start" not in err
-    assert "dispose() start" not in err
+    assert "close_draw_family: start svc=impress uid=uid-9" in err
+    assert "close_draw_family: raw close(True) start svc=impress uid=uid-9" in err
+    assert "close_draw_family: raw close(True) done svc=impress uid=uid-9" in err
+    assert "skip uno teardown" not in err
+    assert "setModified" not in err
+    doc.close.assert_called_once_with(True)
 
 
 def test_teardown_peer_pair_closes_writer_before_impress(monkeypatch):
-    """GHA 34518091151: Impress close hung while Writer was still open."""
+    """POSIX: Writer first, then Impress (GHA 34518091151)."""
     from unittest.mock import MagicMock
 
     from tests.chatbot.test_peer_message_uno import _teardown_peer_pair
 
     order = []
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._draw_family_raw_close",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._close",
+        lambda doc: order.append(("close_doc", doc)) or None,
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno.close_draw_family_doc",
+        lambda doc: order.append(("close_draw_family", doc)),
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno.settle_after_draw_family_close",
+        lambda: order.append("post_settle"),
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._reactivate_writer_after_impress",
+        lambda ctx, doc: order.append(("reactivate", ctx, doc)),
+    )
+    writer = MagicMock(name="writer")
+    impress = MagicMock(name="impress")
+    out_writer, out_impress = _teardown_peer_pair(writer, impress)
+    assert out_writer is None and out_impress is None
+    assert order == [
+        ("close_doc", writer),
+        ("close_draw_family", impress),
+        "post_settle",
+    ]
+
+
+def test_teardown_peer_pair_windows_closes_impress_then_writer(monkeypatch):
+    """GHA 34537826720: skip-teardown left Impress alive; next swriter hung."""
+    from unittest.mock import MagicMock
+
+    from tests.chatbot.test_peer_message_uno import _teardown_peer_pair
+
+    order = []
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._draw_family_raw_close",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._close",
+        lambda doc: order.append(("close_doc", doc)) or None,
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno.close_draw_family_doc",
+        lambda doc: order.append(("close_draw_family", doc)),
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno.settle_after_draw_family_close",
+        lambda: order.append("post_settle"),
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._reactivate_writer_after_impress",
+        lambda ctx, doc: order.append(("reactivate", ctx, doc)),
+    )
+    writer = MagicMock(name="writer")
+    impress = MagicMock(name="impress")
+    ctx = MagicMock(name="ctx")
+    out_writer, out_impress = _teardown_peer_pair(writer, impress, ctx)
+    assert out_writer is None and out_impress is None
+    assert order == [
+        ("close_draw_family", impress),
+        "post_settle",
+        ("reactivate", ctx, writer),
+        ("close_doc", writer),
+    ]
+
+
+def test_reactivate_writer_after_impress_sets_active_frame(monkeypatch):
+    from unittest.mock import MagicMock, patch
+
+    from tests.chatbot.test_peer_message_uno import _reactivate_writer_after_impress
+
+    frame = MagicMock()
+    writer = MagicMock()
+    writer.getCurrentController.return_value.getFrame.return_value = frame
+    desktop = MagicMock()
+    ctx = MagicMock()
+    with patch(
+        "tests.chatbot.test_peer_message_uno.get_desktop",
+        return_value=desktop,
+    ) as get_desktop:
+        _reactivate_writer_after_impress(ctx, writer)
+    get_desktop.assert_called_once_with(ctx)
+    desktop.setActiveFrame.assert_called_once_with(frame)
+    frame.getContainerWindow.return_value.toFront.assert_called_once_with()
+
+
+def test_teardown_peer_pair_windows_no_impress_just_closes_writer(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from tests.chatbot.test_peer_message_uno import _teardown_peer_pair
+
+    order = []
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._draw_family_raw_close",
+        lambda: True,
+    )
     monkeypatch.setattr(
         "tests.chatbot.test_peer_message_uno._close",
         lambda doc: order.append(("close_doc", doc)) or None,
@@ -556,14 +660,20 @@ def test_teardown_peer_pair_closes_writer_before_impress(monkeypatch):
         lambda: order.append("post_settle"),
     )
     writer = MagicMock(name="writer")
-    impress = MagicMock(name="impress")
-    out_writer, out_impress = _teardown_peer_pair(writer, impress)
+    out_writer, out_impress = _teardown_peer_pair(writer, None, MagicMock())
     assert out_writer is None and out_impress is None
-    assert order == [
-        ("close_doc", writer),
-        ("close_draw_family", impress),
-        "post_settle",
-    ]
+    assert order == [("close_doc", writer)]
+
+
+def test_reactivate_writer_after_impress_skips_when_missing():
+    from unittest.mock import MagicMock, patch
+
+    from tests.chatbot.test_peer_message_uno import _reactivate_writer_after_impress
+
+    with patch("tests.chatbot.test_peer_message_uno.get_desktop") as get_desktop:
+        _reactivate_writer_after_impress(None, MagicMock())
+        _reactivate_writer_after_impress(MagicMock(), None)
+    get_desktop.assert_not_called()
 
 
 def test_testing_factory_execute_tool_unknown_name():

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -895,17 +895,29 @@ _CLOSE_DOC_URP_SETTLE_S = 0.05
 # ``doc.close(True)`` (faulthandler 30s; office still alive). close_doc GCs
 # leftover ``resolve_document_by_url`` wrappers then close()s after only
 # 50 ms — too tight on Windows Draw-family. Pre-close settle uses the same
-# Windows-longer budget; still not inside close_doc.
+# Windows-longer budget; still not inside close_doc. POSIX only: Windows
+# Draw-family close is a bare ``close(True)`` (see ``_draw_family_raw_close``).
 _DRAW_FAMILY_POST_CLOSE_SETTLE_S = 0.75 if sys.platform == "win32" else 0.15
 _DRAW_FAMILY_PRE_CLOSE_SETTLE_S = _DRAW_FAMILY_POST_CLOSE_SETTLE_S
 
 
-def _draw_family_skip_uno_teardown() -> bool:
-    """True when Impress close *and* dispose block the Windows UI thread.
+def _draw_family_raw_close() -> bool:
+    """True when Impress must be closed with a bare ``close(True)``.
 
-    GHA 34532953982: ``close(True)`` hung 30s after Writer-first + settle.
-    GHA 34535868114: ``dispose()`` hung the same way (``dispose() start``,
-    office still alive). Do not call either API on win32.
+    What the breadcrumbs showed:
+    - GHA 34419828920 / #710: raw ``doc.close(True)`` (no pre-close GC)
+      *returned* on Windows; the *next* Writer factory load then hung
+      until ``settle_after_draw_family_close`` was added.
+    - GHA 34518091151: ``close_doc`` (GC + 50 ms + ``close``) hung 30s
+      *inside* Impress close.
+    - GHA 34532953982 / 34535868114: GC + pre-close settle then
+      ``close(True)`` / ``dispose()`` hung the same way.
+    - GHA 34537826720: skipping close/dispose left Impress alive; the
+      next ``private:factory/swriter`` load hung 30s.
+
+    Skip is not a fix. Pre-close GC/sleep before close is the hung path.
+    Raw close + post-close settle is the only sequence that both returned
+    and (with #710's settle) was meant to unwedge the next Writer load.
     """
     return sys.platform == "win32"
 
@@ -932,19 +944,23 @@ def close_draw_family_doc(doc):
     at ``doc.close(True)`` while tearing down Impress in
     ``test_peer_impress_rejected_on_resolved_model`` (Writer still open;
     both factory loads had succeeded). #710's post-close settle never ran.
+    Skipping close/dispose (34537826720) unblocked that teardown, then the
+    *next* ``private:factory/swriter`` load hung 30s — leftover Impress
+    poisons later Writer factory loads (same family as #710).
 
     How: ``close_doc`` GCs leftover peer-resolve wrappers then close()s
-    after 50 ms. On Windows that races URP release of the same model and
-    can block ``XCloseable.close(True)`` until faulthandler kills the
-    suite. A sibling Writer still open in the same soffice makes that
-    worse.
+    after 50 ms. On Windows, GC + sleep *immediately before* ``close`` /
+    ``dispose`` blocks the UI thread (34532953982 / 34535868114). A bare
+    ``close(True)`` with no pre-close GC is the only Impress close that
+    has returned on Windows (#710 / 34419828920).
 
-    Why this: mark unmodified, GC, then the Draw-family pre-close settle.
-    POSIX then ``close(True)``. Windows skips ``close`` *and* ``dispose``
-    — both blocked 30s (34532953982 / 34535868114). Drop the Python
-    proxy; suite-end ``kill-libreoffice`` reaps soffice. Callers close
-    any Writer sibling first and ``settle_after_draw_family_close`` after
-    dropping the local. Logs svc/uid and each step. Not a product fix.
+    Why this: Windows calls ``close(True)`` with no setModified / GC /
+    sleep in front of it, then callers drop the proxy and
+    ``settle_after_draw_family_close``. POSIX still marks unmodified, GC,
+    pre-close settle, then ``close(True)``. Peer tests keep Writer open
+    across the Windows raw close (the #710 returning order) and
+    re-activate it before closing Writer. Logs svc/uid and each step.
+    Not a product fix.
     """
     if not doc:
         return
@@ -957,6 +973,23 @@ def close_draw_family_doc(doc):
     except Exception:
         uid = "?"
     _progress("close_draw_family: start svc=%s uid=%s" % (svc, uid))
+    if _draw_family_raw_close():
+        # Do not GC or sleep here — that is the hung close/dispose path.
+        _progress("close_draw_family: raw close(True) start svc=%s uid=%s" % (svc, uid))
+        try:
+            if hasattr(doc, "close"):
+                doc.close(True)
+            elif hasattr(doc, "dispose"):
+                doc.dispose()
+        except Exception as exc:
+            _log_close_doc_failure(exc)
+            _progress(
+                "close_draw_family: raw close failed svc=%s uid=%s err=%s"
+                % (svc, uid, type(exc).__name__)
+            )
+        else:
+            _progress("close_draw_family: raw close(True) done svc=%s uid=%s" % (svc, uid))
+        return
     try:
         if hasattr(doc, "setModified"):
             doc.setModified(False)
@@ -975,10 +1008,6 @@ def close_draw_family_doc(doc):
         % (_DRAW_FAMILY_PRE_CLOSE_SETTLE_S, svc, uid)
     )
     time.sleep(_DRAW_FAMILY_PRE_CLOSE_SETTLE_S)
-    if _draw_family_skip_uno_teardown():
-        # Do not call close/dispose — both hang the native-test 30s watchdog.
-        _progress("close_draw_family: skip uno teardown svc=%s uid=%s" % (svc, uid))
-        return
     _progress("close_draw_family: close(True) start svc=%s uid=%s" % (svc, uid))
     try:
         if hasattr(doc, "close"):
@@ -998,10 +1027,11 @@ def close_draw_family_doc(doc):
 def settle_after_draw_family_close() -> None:
     """Harness-only: GC + sleep after closing Impress/Draw before the next factory load.
 
-    Call after ``close_draw_family_doc`` / ``TestingFactory.close_doc`` *and*
-    after dropping the local reference. The next ``loadComponentFromURL`` is
-    the hang site if this settle is skipped
-    (see ``tests/chatbot/test_peer_message_uno.py``).
+    Call after ``close_draw_family_doc`` *and* after dropping the local
+    reference. The next ``loadComponentFromURL`` is the hang site if this
+    settle is skipped *or* if Impress was never actually closed
+    (GHA 34537826720 skip-teardown; see
+    ``tests/chatbot/test_peer_message_uno.py``).
     """
     import gc
     import time


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Harness-only follow-up after #716. No product behavior change. Pint / `uv.lock` freeze stays as already on master.

## What is still red

#716 merged skip-Windows-Impress-teardown to master (`9a884cde`). That unblocked the first peer Impress test, then **poisoned the next Writer factory load**.

- Master hang (close *inside* Impress teardown): [34518091151](https://github.com/KeithCu/writeragent/actions/runs/34518091151) on `e01439f1` — `test_peer_impress_rejected_on_resolved_model` hung 30s in `TestingFactory.close_doc` at `doc.close(True)`. Office stayed alive.
- After skip: [34537826720](https://github.com/KeithCu/writeragent/actions/runs/34537826720) on `9adff169` — `close_draw_family: skip uno teardown` printed, first test ended OK, then `test_peer_catalog_draw_label_is_not_enough_for_impress` hung 30s on `_load("private:factory/swriter")`. Office stayed alive.
- This PR, first attempt (`c511aab7`): [34540353452](https://github.com/KeithCu/writeragent/actions/runs/34540353452) — **raw Impress `close(True)` returned in ~25 ms**. Settle + `writer reactivated` printed. Then `TestingFactory.close_doc` hung 30s at **Writer** `close(True)`. Office stayed alive.

Same family as #710 (close-then-next-`swriter` hang), except skip never actually closes Impress, so `#710`'s `settle_after_draw_family_close` has nothing to settle.

## What the breadcrumbs showed (verified, not assumed)

| Run | Sequence | Result |
|-----|----------|--------|
| 34419828920 / #710 | raw `doc.close(True)` (no pre-close GC) | close **returned**; next `swriter` hung until post-close settle |
| 34518091151 | `close_doc` = GC + 50 ms + `close` | hung 30s **inside** Impress close |
| 34532953982 | Writer-first + GC + 0.75s + `close(True)` | hung 30s at `close(True) start` |
| 34535868114 | same + `dispose()` | hung 30s at `dispose() start` |
| 34537826720 | skip `close`/`dispose` | first test OK; **next** `swriter` hung 30s |
| 34540353452 | raw Impress close + settle + `setActiveFrame` + Writer `close_doc` | Impress close **returned**; Writer `close_doc` hung 30s |

Skip is not a fix. Pre-close GC/sleep then close/dispose is the hung path. Combining the two Impress tests is not enough: leftover Impress can wedge *any* later Writer factory load in the same office. After a successful Impress close, `close_doc` on the sibling Writer is the new hang site — leftover Writer is not the poison (the keeper Writer already exists).

## This PR (`8efbe30a`)

Windows peer teardown:

1. Keep Writer open.
2. Bare Impress `close(True)` — no `setModified` / GC / sleep in front of it (returned in 34540353452).
3. Drop the Python proxy, then `settle_after_draw_family_close`.
4. Re-activate Writer (`setActiveFrame` / `#707` pattern).
5. **Do not** `close_doc` that Writer (34540353452 hung there). Drop the proxy only.

POSIX path is unchanged (Writer first, then Draw-family `setModified` + pre-close settle + `close(True)` + post-close settle).

Breadcrumbs to look for on Windows: `close_draw_family: raw close(True) start/done`, `peer_message_uno: writer reactivated`, `peer_message_uno: skip writer close after impress`, both peer Impress tests `TEST end … OK`, then `peer_message_uno: load start private:factory/swriter` for `test_peer_missing_deck_is_clear_error`.

## Windows re-dispatch (this agent cannot run `windows-latest`)

Ubuntu PR CI is the automatic gate and was green on `c511aab7`. Windows proof still needs a manual dispatch **on the new head** (`8efbe30a`):

1. Actions → **PR CI** → **Run workflow**.
2. Use branch `cursor/windows-impress-next-load-hang-a0c4` (not master).
3. `os` = `windows-latest`.
4. `ci_debug` = `true`.
5. Leave `test_mock_sidebar` / `pytest_serial` off.

Success: the full `test_peer_message_uno` suite finishes (both Impress tests + later Writer/Calc peer tests) and the job is not cancelled by the 30s faulthandler on a factory load or Writer close. Artifact `ci-debug-windows-latest-<run_id>` if it still hangs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca57e514-eea3-42e1-988b-3f8407cda0c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca57e514-eea3-42e1-988b-3f8407cda0c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

