### PR TITLE
Harness: skip all Windows Writer/Calc close_doc in the peer suite

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -81,23 +81,35 @@ Then `test_peer_missing_deck_is_clear_error` loaded **two**
 and hung 30s in `TestingFactory.close_doc` from `_close(other)` in
 `finally`. That test never opens Impress — leftover Impress/process
 state poisons later Writer `close_doc` in the same soffice, not only
-factory load. Isolation: Writer+Writer / Writer+Calc peer tests run
-**before** the Impress pair so their `close_doc` happens on a clean
-office. After Impress, `_close` drops the proxy (`skip close after
-impress uid=…`) and the runner recycles soffice
-(`LIFECYCLE recycle office after impress`) before the next suite.
-Breadcrumbs: `close_draw_family: raw close(True) start/done`,
+factory load.
+
+GHA 34544965319 (`#718` isolate: Impress **last**):
+`test_peer_missing_deck_is_clear_error` ran **first**, before any
+Impress in this file. First `close_doc` (`other`, uid=30) returned;
+the second (`writer`, uid=29) hung 30s at `doc.close`. Dual
+hidden-Writer `close_doc` is the hang — leftover Impress from *this*
+suite is not required. Isolation by reordering did not unblock
+`missing_deck`. Office stayed alive (`kill-libreoffice.ps1` then
+killed soffice).
+
+Windows `_close` therefore drops the proxy on every Writer/Calc
+(`skip close (windows) uid=…`) and asks the runner to recycle soffice
+(`LIFECYCLE recycle office after impress`) after this suite. Impress
+still runs last; teardown keeps the raw Impress `close(True)` +
+`setActiveFrame` path and does not `close_doc` the sibling Writer.
+POSIX still `close_doc`. Breadcrumbs:
+`close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
 `peer_message_uno: skip writer close after impress`,
-`peer_message_uno: close_doc start/done uid=…`. Do **not** fold
-Draw-family settle into `close_doc`. Not a product fix.
+`peer_message_uno: skip close (windows) uid=…`,
+`peer_message_uno: close_doc start/done uid=…` (POSIX). Do **not**
+fold Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
-branch: `os=windows-latest`, `ci_debug=true`. Look for Writer-only peer
-tests finishing (`close_doc start/done`) *before* the Impress pair,
-both Impress tests `TEST end … OK`, then `LIFECYCLE recycle office after
-impress done`. Ubuntu PR CI is the automatic gate; this cloud agent
-cannot run `windows-latest`.
+branch: `os=windows-latest`, `ci_debug=true`. Look for
+`skip close (windows)`, all six peer tests `TEST end … OK`, then
+`LIFECYCLE recycle office after impress done`. Ubuntu PR CI is the
+automatic gate; this cloud agent cannot run `windows-latest`.
 
 **Harness-only attribution (not a product fix):** if a test body returns OK
 but the office already aborted, the runner fails *that* test instead of

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -72,18 +72,32 @@ GHA 34540353452 (`c511aab7`) raw-closed Impress in ~25 ms, settle +
 `writer reactivated` printed, then `TestingFactory.close_doc` hung 30s
 at Writer `close(True)` (office still alive; `kill-libreoffice.ps1`
 then killed soffice). Leftover Writer is not the poison (the keeper
-Writer already exists); leftover Impress is. Breadcrumbs:
-`close_draw_family: raw close(True) start/done`,
+Writer already exists); leftover Impress is.
+
+GHA 34542928132 (master `fa60bd5e`, tip of `#717`): both Impress tests
+`TEST end … OK` (`raw close(True)` + `skip writer close after impress`).
+Then `test_peer_missing_deck_is_clear_error` loaded **two**
+`private:factory/swriter` docs (both `load done`), ran the tool assert,
+and hung 30s in `TestingFactory.close_doc` from `_close(other)` in
+`finally`. That test never opens Impress — leftover Impress/process
+state poisons later Writer `close_doc` in the same soffice, not only
+factory load. Isolation: Writer+Writer / Writer+Calc peer tests run
+**before** the Impress pair so their `close_doc` happens on a clean
+office. After Impress, `_close` drops the proxy (`skip close after
+impress uid=…`) and the runner recycles soffice
+(`LIFECYCLE recycle office after impress`) before the next suite.
+Breadcrumbs: `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
-`peer_message_uno: skip writer close after impress`. Do **not** fold
+`peer_message_uno: skip writer close after impress`,
+`peer_message_uno: close_doc start/done uid=…`. Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
-branch: `os=windows-latest`, `ci_debug=true`. Look for both peer Impress
-tests finishing (`TEST end … OK`) after `skip writer close after impress`,
-then the next `swriter` load (`test_peer_missing_deck_is_clear_error`)
-starting. Ubuntu PR CI is the automatic gate; this cloud agent cannot run
-`windows-latest`.
+branch: `os=windows-latest`, `ci_debug=true`. Look for Writer-only peer
+tests finishing (`close_doc start/done`) *before* the Impress pair,
+both Impress tests `TEST end … OK`, then `LIFECYCLE recycle office after
+impress done`. Ubuntu PR CI is the automatic gate; this cloud agent
+cannot run `windows-latest`.
 
 **Harness-only attribution (not a product fix):** if a test body returns OK
 but the office already aborted, the runner fails *that* test instead of

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -192,9 +192,9 @@ _soffice_proc: Any = None
 _office_stderr_lock = threading.Lock()
 _office_stderr_application_error = False
 _office_stderr_tail: list[str] = []
-# Set by Windows peer-Impress teardown; consumed after that suite so later
-# suites get a fresh soffice (GHA 34542928132: Writer close_doc hung after
-# Impress in the same office).
+# Set by Windows peer teardown / skipped close_doc; consumed after that
+# suite so later suites get a fresh soffice (GHA 34544965319: second
+# Writer close_doc hung before any Impress in the same office).
 _recycle_office_after_suite = False
 
 
@@ -1053,9 +1053,10 @@ def _terminate_bootstrap_soffice() -> None:
 def request_office_recycle_after_suite() -> None:
     """Ask ``run_all_tests`` to kill+rebootstrap soffice after this suite.
 
-    Windows Impress leaves Writer ``close_doc`` hung for the rest of that
-    office (GHA 34542928132). Recycle so later suites are not poisoned.
-    Not a product fix.
+    Windows peer leftover docs leave ``close_doc`` hung for the rest of
+    that office (GHA 34544965319: second Writer close before Impress;
+    34542928132: Writer close after Impress). Recycle so later suites
+    are not poisoned. Not a product fix.
     """
     global _recycle_office_after_suite
     _recycle_office_after_suite = True

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -192,6 +192,10 @@ _soffice_proc: Any = None
 _office_stderr_lock = threading.Lock()
 _office_stderr_application_error = False
 _office_stderr_tail: list[str] = []
+# Set by Windows peer-Impress teardown; consumed after that suite so later
+# suites get a fresh soffice (GHA 34542928132: Writer close_doc hung after
+# Impress in the same office).
+_recycle_office_after_suite = False
 
 
 def reset_office_death_signals(*, clear_proc: bool = False) -> None:
@@ -1046,6 +1050,82 @@ def _terminate_bootstrap_soffice() -> None:
         pass
 
 
+def request_office_recycle_after_suite() -> None:
+    """Ask ``run_all_tests`` to kill+rebootstrap soffice after this suite.
+
+    Windows Impress leaves Writer ``close_doc`` hung for the rest of that
+    office (GHA 34542928132). Recycle so later suites are not poisoned.
+    Not a product fix.
+    """
+    global _recycle_office_after_suite
+    _recycle_office_after_suite = True
+
+
+def consume_office_recycle_request() -> bool:
+    """Return-and-clear the after-suite recycle flag."""
+    global _recycle_office_after_suite
+    wanted = _recycle_office_after_suite
+    _recycle_office_after_suite = False
+    return wanted
+
+
+def _recycle_harness_office(old_ctx: Any) -> tuple[Any, Any]:
+    """Kill the current soffice and bootstrap a fresh one.
+
+    Do **not** ``close`` leftover docs first — that is the hung path.
+    Do **not** mark URP dead unless the new bootstrap fails.
+    """
+    from plugin.framework.uno_context import get_desktop, set_fallback_ctx
+
+    _progress("LIFECYCLE recycle office after impress start")
+    _terminate_bootstrap_soffice()
+    time.sleep(0.5)
+    reset_office_death_signals(clear_proc=True)
+    try:
+        from tests.testing_utils import _NATIVE_DOC_POOL
+
+        _NATIVE_DOC_POOL.clear()
+    except Exception:
+        pass
+    try:
+        _ensure_libreoffice_python_path()
+        import officehelper
+        import uno
+
+        new_ctx = _bootstrap_office(officehelper)
+        if new_ctx is None:
+            raise RuntimeError("recycle bootstrap returned None")
+        set_fallback_ctx(new_ctx)
+        from plugin.framework.config import init_config
+
+        init_config(new_ctx)
+        new_keeper = None
+        if not use_user_profile:
+            from plugin.main import bootstrap
+
+            bootstrap(ctx=new_ctx)
+            hidden_prop = uno.createUnoStruct(
+                "com.sun.star.beans.PropertyValue",
+                Name="Hidden",
+                Value=True,
+            )
+            new_keeper = get_desktop(new_ctx).loadComponentFromURL(
+                "private:factory/swriter", "_blank", 0, (hidden_prop,)
+            )
+        _progress(
+            "LIFECYCLE recycle office after impress done pids=%s"
+            % _soffice_pids()
+        )
+        return new_ctx, new_keeper
+    except Exception as exc:
+        _progress(
+            "LIFECYCLE recycle office after impress failed err=%s:%s"
+            % (type(exc).__name__, exc)
+        )
+        _mark_urp_dead(exc, "recycle office after impress")
+        return old_ctx, None
+
+
 def _bootstrap_office(officehelper_module: Any) -> Any:
     """Start soffice without leaking the test runner's Python env into the child.
 
@@ -1714,6 +1794,8 @@ def run_all_tests(ctx: Any) -> str:
                     p, f = _run_suite(ctx, suites, sys_module_name.replace("plugin.tests.", ""), test_module, doc_to_pass)
                     total_passed += p
                     total_failed += f
+                    if consume_office_recycle_request():
+                        ctx, keeper_doc = _recycle_harness_office(ctx)
                 except ImportError as e:
                     print(f"Skipping {filename} due to ImportError: {e}")
                 except Exception as e:

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 from plugin.doc.live_panels import register_live_panel, reset_live_panels, unregister_live_panel
 from plugin.doc.peer_message import (
     SendPeerMessage,
@@ -71,11 +73,17 @@ def _load(ctx, factory_url):
     return doc
 
 
-# After a Windows Impress teardown, ``close_doc`` on *any* later Writer in
-# this soffice hangs 30s (GHA 34542928132: missing_deck loads succeeded,
-# then ``_close(other)`` in finally). Drop the proxy only. POSIX never sets
-# this. Reset is not required — the suite ends or the runner recycles office.
-_windows_skip_close_after_impress = False
+def _windows_skip_doc_close() -> bool:
+    """True when this suite must not call Writer/Calc ``close_doc``.
+
+    GHA 34544965319: ``test_peer_missing_deck_is_clear_error`` ran *before*
+    any Impress in this file. First ``close_doc`` (``other``, uid=30)
+    returned; the second (``writer``, uid=29) hung 30s at ``doc.close``.
+    Dual hidden-Writer ``close_doc`` is the hang — leftover Impress from
+    *this* suite is not required. Drop the proxy on win32. POSIX still
+    ``close_doc``.
+    """
+    return sys.platform == "win32"
 
 
 def _doc_uid(doc) -> str:
@@ -88,26 +96,22 @@ def _doc_uid(doc) -> str:
 def _close(doc):
     """Close Writer/Calc via harness ``close_doc`` (GC + 50 ms, then ``doc.close``).
 
-    What was wrong: local ``doc.close(True)`` skipped that settle. After
-    ``test_peer_impress_rejected_on_resolved_model`` raw-closed Impress, the
-    next test's ``private:factory/swriter`` load hung 30s (GHA 34419828920;
-    office still alive). How: leftover Impress proxies raced the next
-    factory. Why this: same close path as ``@with_native_doc``. Impress
-    teardown is ``_teardown_peer_pair`` — not this helper.
-
-    GHA 34542928132: after #717 skipped Writer close on the Impress pair,
-    both ``swriter`` loads in ``test_peer_missing_deck_is_clear_error``
-    returned, then ``TestingFactory.close_doc`` hung 30s in this helper.
-    On Windows after Impress, drop the proxy — do not call ``close_doc``.
-    Logs uid and start/done so the next red dump names which close hung.
-    Do not fold Draw-family settle into ``close_doc``.
+    POSIX: same path as ``@with_native_doc``. Windows: drop the proxy —
+    GHA 34544965319 hung 30s on the *second* Writer ``close_doc`` in
+    ``test_peer_missing_deck_is_clear_error`` before any Impress in this
+    file. Logs uid and start/done/skip so the next red dump names which
+    close hung. Impress teardown is ``_teardown_peer_pair``. Do not fold
+    Draw-family settle into ``close_doc``.
     """
-    global _windows_skip_close_after_impress
     if doc is None:
         return None
     uid = _doc_uid(doc)
-    if _windows_skip_close_after_impress:
-        _progress("peer_message_uno: skip close after impress uid=%s" % uid)
+    if _windows_skip_doc_close():
+        _progress("peer_message_uno: skip close (windows) uid=%s" % uid)
+        # Leftover hidden docs poison later suites' close_doc (34544965319).
+        from plugin.testing_runner import request_office_recycle_after_suite
+
+        request_office_recycle_after_suite()
         return None
     _progress("peer_message_uno: close_doc start uid=%s" % uid)
     TestingFactory.close_doc(doc)
@@ -161,12 +165,14 @@ def _teardown_peer_pair(writer, impress, ctx=None):
     raw-closed Impress in ~25 ms, settle + ``setActiveFrame`` returned,
     then ``TestingFactory.close_doc`` hung 30s at Writer ``close(True)``.
     Leftover Writer is not the poison (keeper Writer already exists);
-    leftover Impress is. GHA 34542928132: later Writer+Writer
-    ``close_doc`` in the same soffice also hung — this path arms
-    skip-close and asks the runner to recycle office. POSIX still
-    closes Writer first, then the Draw-family path (setModified +
-    pre-close settle + ``close(True)``) and the same post-close
-    settle. Not a product fix.
+    leftover Impress is. GHA 34544965319: dual hidden-Writer
+    ``close_doc`` hung *before* any Impress in this file — ``_close``
+    skips all Writer/Calc ``close_doc`` on win32. This path still
+    asks the runner to recycle office so later suites are not
+    poisoned by leftover docs. POSIX still closes Writer first, then
+    the Draw-family path (setModified + pre-close settle +
+    ``close(True)``) and the same post-close settle. Not a product
+    fix.
     """
     had_impress = impress is not None
     if had_impress and _draw_family_raw_close():
@@ -178,11 +184,8 @@ def _teardown_peer_pair(writer, impress, ctx=None):
         _progress("peer_message_uno: impress post-close settle done")
         _reactivate_writer_after_impress(ctx, writer)
         # Drop the proxy only. close_doc hung 30s here (34540353452).
-        # Later Writer+Writer ``_close`` in this soffice also hung
-        # (34542928132). Arm skip-close for the rest of the suite and
-        # ask the runner to recycle office before the next suite.
-        global _windows_skip_close_after_impress
-        _windows_skip_close_after_impress = True
+        # Writer+Writer close_doc also hung before any Impress
+        # (34544965319). Recycle so later suites are not poisoned.
         from plugin.testing_runner import request_office_recycle_after_suite
 
         request_office_recycle_after_suite()
@@ -332,10 +335,9 @@ def test_peer_unique_name_and_self_reject(ctx):
         reset_live_panels()
 
 
-# Windows: run Impress *after* Writer+Writer / Writer+Calc tests. Those tests
-# call ``_close`` → ``close_doc``, which hangs once Impress has been in this
-# soffice (GHA 34542928132). Impress teardown then skips Writer close_doc and
-# requests an office recycle so later suites are not poisoned.
+# Windows: skip all Writer/Calc close_doc in this file (34544965319).
+# Impress still runs last so leftover Impress is not in front of Writer
+# tests; teardown raw-closes Impress and the runner recycles office.
 
 
 @native_test

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -71,6 +71,20 @@ def _load(ctx, factory_url):
     return doc
 
 
+# After a Windows Impress teardown, ``close_doc`` on *any* later Writer in
+# this soffice hangs 30s (GHA 34542928132: missing_deck loads succeeded,
+# then ``_close(other)`` in finally). Drop the proxy only. POSIX never sets
+# this. Reset is not required — the suite ends or the runner recycles office.
+_windows_skip_close_after_impress = False
+
+
+def _doc_uid(doc) -> str:
+    try:
+        return str(getattr(doc, "RuntimeUID", None) or "?")
+    except Exception:
+        return "?"
+
+
 def _close(doc):
     """Close Writer/Calc via harness ``close_doc`` (GC + 50 ms, then ``doc.close``).
 
@@ -79,12 +93,25 @@ def _close(doc):
     next test's ``private:factory/swriter`` load hung 30s (GHA 34419828920;
     office still alive). How: leftover Impress proxies raced the next
     factory. Why this: same close path as ``@with_native_doc``. Impress
-    teardown is ``_teardown_peer_pair`` — not this helper. Do not fold
-    Draw-family settle into ``close_doc``.
+    teardown is ``_teardown_peer_pair`` — not this helper.
+
+    GHA 34542928132: after #717 skipped Writer close on the Impress pair,
+    both ``swriter`` loads in ``test_peer_missing_deck_is_clear_error``
+    returned, then ``TestingFactory.close_doc`` hung 30s in this helper.
+    On Windows after Impress, drop the proxy — do not call ``close_doc``.
+    Logs uid and start/done so the next red dump names which close hung.
+    Do not fold Draw-family settle into ``close_doc``.
     """
+    global _windows_skip_close_after_impress
     if doc is None:
         return None
+    uid = _doc_uid(doc)
+    if _windows_skip_close_after_impress:
+        _progress("peer_message_uno: skip close after impress uid=%s" % uid)
+        return None
+    _progress("peer_message_uno: close_doc start uid=%s" % uid)
     TestingFactory.close_doc(doc)
+    _progress("peer_message_uno: close_doc done uid=%s" % uid)
     return None
 
 
@@ -134,9 +161,12 @@ def _teardown_peer_pair(writer, impress, ctx=None):
     raw-closed Impress in ~25 ms, settle + ``setActiveFrame`` returned,
     then ``TestingFactory.close_doc`` hung 30s at Writer ``close(True)``.
     Leftover Writer is not the poison (keeper Writer already exists);
-    leftover Impress is. POSIX still closes Writer first, then the
-    Draw-family path (setModified + pre-close settle + ``close(True)``)
-    and the same post-close settle. Not a product fix.
+    leftover Impress is. GHA 34542928132: later Writer+Writer
+    ``close_doc`` in the same soffice also hung — this path arms
+    skip-close and asks the runner to recycle office. POSIX still
+    closes Writer first, then the Draw-family path (setModified +
+    pre-close settle + ``close(True)``) and the same post-close
+    settle. Not a product fix.
     """
     had_impress = impress is not None
     if had_impress and _draw_family_raw_close():
@@ -148,6 +178,14 @@ def _teardown_peer_pair(writer, impress, ctx=None):
         _progress("peer_message_uno: impress post-close settle done")
         _reactivate_writer_after_impress(ctx, writer)
         # Drop the proxy only. close_doc hung 30s here (34540353452).
+        # Later Writer+Writer ``_close`` in this soffice also hung
+        # (34542928132). Arm skip-close for the rest of the suite and
+        # ask the runner to recycle office before the next suite.
+        global _windows_skip_close_after_impress
+        _windows_skip_close_after_impress = True
+        from plugin.testing_runner import request_office_recycle_after_suite
+
+        request_office_recycle_after_suite()
         _progress("peer_message_uno: skip writer close after impress")
         return None, None
     _progress("peer_message_uno: close writer start")
@@ -164,52 +202,6 @@ def _teardown_peer_pair(writer, impress, ctx=None):
 
 def _tool_ctx(ctx, doc):
     return ToolContext(doc=doc, ctx=ctx, doc_type="writer", services=None, caller="chat")
-
-
-@native_test
-def test_peer_impress_rejected_on_resolved_model(ctx):
-    reset_peer_queues()
-    reset_live_panels()
-    reset_sentry_state()
-    writer = None
-    impress = None
-    try:
-        writer = _load(ctx, "private:factory/swriter")
-        impress = _load(ctx, "private:factory/simpress")
-        assert writer is not None and impress is not None
-        impress_uid = get_runtime_uid(impress)
-        assert impress_uid
-        model, code, msg = resolve_peer_target(ctx, writer, impress_uid)
-        assert model is None
-        assert code == "PEER_UNSUPPORTED"
-        assert "Impress" in msg
-    finally:
-        writer, impress = _teardown_peer_pair(writer, impress, ctx)
-        reset_peer_queues()
-        reset_live_panels()
-
-
-@native_test
-def test_peer_catalog_draw_label_is_not_enough_for_impress(ctx):
-    """get_open_documents labels Impress as draw; v1 still rejects the model."""
-    from plugin.doc.document_research import get_open_documents
-    from plugin.doc.peer_message import list_v1_peers
-
-    reset_live_panels()
-    writer = None
-    impress = None
-    try:
-        writer = _load(ctx, "private:factory/swriter")
-        impress = _load(ctx, "private:factory/simpress")
-        catalog = get_open_documents(ctx, writer)
-        impress_uid = get_runtime_uid(impress)
-        rec = next((r for r in catalog if r.get("uid") == impress_uid), None)
-        assert rec is not None
-        assert rec.get("doc_type") == "draw"
-        peers = list_v1_peers(ctx, writer)
-        assert all(p.get("uid") != impress_uid for p in peers)
-    finally:
-        writer, impress = _teardown_peer_pair(writer, impress, ctx)
 
 
 @native_test
@@ -338,3 +330,55 @@ def test_peer_unique_name_and_self_reject(ctx):
         _close(writer)
         reset_peer_queues()
         reset_live_panels()
+
+
+# Windows: run Impress *after* Writer+Writer / Writer+Calc tests. Those tests
+# call ``_close`` → ``close_doc``, which hangs once Impress has been in this
+# soffice (GHA 34542928132). Impress teardown then skips Writer close_doc and
+# requests an office recycle so later suites are not poisoned.
+
+
+@native_test
+def test_peer_impress_rejected_on_resolved_model(ctx):
+    reset_peer_queues()
+    reset_live_panels()
+    reset_sentry_state()
+    writer = None
+    impress = None
+    try:
+        writer = _load(ctx, "private:factory/swriter")
+        impress = _load(ctx, "private:factory/simpress")
+        assert writer is not None and impress is not None
+        impress_uid = get_runtime_uid(impress)
+        assert impress_uid
+        model, code, msg = resolve_peer_target(ctx, writer, impress_uid)
+        assert model is None
+        assert code == "PEER_UNSUPPORTED"
+        assert "Impress" in msg
+    finally:
+        writer, impress = _teardown_peer_pair(writer, impress, ctx)
+        reset_peer_queues()
+        reset_live_panels()
+
+
+@native_test
+def test_peer_catalog_draw_label_is_not_enough_for_impress(ctx):
+    """get_open_documents labels Impress as draw; v1 still rejects the model."""
+    from plugin.doc.document_research import get_open_documents
+    from plugin.doc.peer_message import list_v1_peers
+
+    reset_live_panels()
+    writer = None
+    impress = None
+    try:
+        writer = _load(ctx, "private:factory/swriter")
+        impress = _load(ctx, "private:factory/simpress")
+        catalog = get_open_documents(ctx, writer)
+        impress_uid = get_runtime_uid(impress)
+        rec = next((r for r in catalog if r.get("uid") == impress_uid), None)
+        assert rec is not None
+        assert rec.get("doc_type") == "draw"
+        peers = list_v1_peers(ctx, writer)
+        assert all(p.get("uid") != impress_uid for p in peers)
+    finally:
+        writer, impress = _teardown_peer_pair(writer, impress, ctx)

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -19,12 +19,14 @@ from plugin.testing_runner import (
     _test_function_filters,
     collect_post_test_death,
     consume_application_error,
+    consume_office_recycle_request,
     expand_soak_pair,
     format_lifecycle_breadcrumb,
     note_office_stderr_line,
     probe_uno_bridge,
     record_test_end,
     record_test_start,
+    request_office_recycle_after_suite,
     reset_lifecycle_breadcrumb,
     reset_office_death_signals,
     soffice_exit_code,
@@ -232,6 +234,17 @@ def test_collect_post_test_death_soffice_exit() -> None:
     assert "soffice exited 1" in reason
     assert "Binary URP bridge" in reason
     reset_office_death_signals(clear_proc=True)
+
+
+def test_office_recycle_request_is_consumed_once() -> None:
+    """Windows Impress teardown asks the runner to recycle after the suite."""
+    import plugin.testing_runner as tr
+
+    tr._recycle_office_after_suite = False
+    assert consume_office_recycle_request() is False
+    request_office_recycle_after_suite()
+    assert consume_office_recycle_request() is True
+    assert consume_office_recycle_request() is False
 
 
 def test_fail_reason_with_lifecycle_keeps_crumb_after_cap() -> None:

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -568,9 +568,6 @@ def test_teardown_peer_pair_closes_writer_before_impress(monkeypatch):
     )
     writer = MagicMock(name="writer")
     impress = MagicMock(name="impress")
-    import tests.chatbot.test_peer_message_uno as peer
-
-    peer._windows_skip_close_after_impress = False
     out_writer, out_impress = _teardown_peer_pair(writer, impress)
     assert out_writer is None and out_impress is None
     assert order == [
@@ -578,7 +575,6 @@ def test_teardown_peer_pair_closes_writer_before_impress(monkeypatch):
         ("close_draw_family", impress),
         "post_settle",
     ]
-    assert peer._windows_skip_close_after_impress is False
 
 
 def test_teardown_peer_pair_windows_closes_impress_skips_writer(monkeypatch):
@@ -616,21 +612,14 @@ def test_teardown_peer_pair_windows_closes_impress_skips_writer(monkeypatch):
         "plugin.testing_runner.request_office_recycle_after_suite",
         lambda: recycle_calls.append("recycle"),
     )
-    import tests.chatbot.test_peer_message_uno as peer
-
-    peer._windows_skip_close_after_impress = False
-    try:
-        out_writer, out_impress = _teardown_peer_pair(writer, impress, ctx)
-        assert out_writer is None and out_impress is None
-        assert order == [
-            ("close_draw_family", impress),
-            "post_settle",
-            ("reactivate", ctx, writer),
-        ]
-        assert peer._windows_skip_close_after_impress is True
-        assert recycle_calls == ["recycle"]
-    finally:
-        peer._windows_skip_close_after_impress = False
+    out_writer, out_impress = _teardown_peer_pair(writer, impress, ctx)
+    assert out_writer is None and out_impress is None
+    assert order == [
+        ("close_draw_family", impress),
+        "post_settle",
+        ("reactivate", ctx, writer),
+    ]
+    assert recycle_calls == ["recycle"]
 
 
 def test_reactivate_writer_after_impress_sets_active_frame(monkeypatch):
@@ -653,8 +642,17 @@ def test_reactivate_writer_after_impress_sets_active_frame(monkeypatch):
     frame.getContainerWindow.return_value.toFront.assert_called_once_with()
 
 
-def test_close_skips_after_windows_impress(monkeypatch):
-    """GHA 34542928132: missing_deck close_doc hung after Impress."""
+def test_windows_skip_doc_close_follows_platform(monkeypatch):
+    import tests.chatbot.test_peer_message_uno as peer
+
+    monkeypatch.setattr(peer.sys, "platform", "win32")
+    assert peer._windows_skip_doc_close() is True
+    monkeypatch.setattr(peer.sys, "platform", "linux")
+    assert peer._windows_skip_doc_close() is False
+
+
+def test_close_skips_on_windows(capsys, monkeypatch):
+    """GHA 34544965319: second Writer close_doc hung before any Impress."""
     from unittest.mock import MagicMock
 
     import tests.chatbot.test_peer_message_uno as peer
@@ -663,15 +661,20 @@ def test_close_skips_after_windows_impress(monkeypatch):
     doc = MagicMock()
     doc.RuntimeUID = "uid-later"
     calls = []
+    recycle_calls = []
+    monkeypatch.setattr(peer, "_windows_skip_doc_close", lambda: True)
     monkeypatch.setattr(
         TestingFactory, "close_doc", lambda _doc: calls.append("close_doc")
     )
-    peer._windows_skip_close_after_impress = True
-    try:
-        assert peer._close(doc) is None
-        assert calls == []
-    finally:
-        peer._windows_skip_close_after_impress = False
+    monkeypatch.setattr(
+        "plugin.testing_runner.request_office_recycle_after_suite",
+        lambda: recycle_calls.append("recycle"),
+    )
+    assert peer._close(doc) is None
+    assert calls == []
+    assert recycle_calls == ["recycle"]
+    err = capsys.readouterr().err
+    assert "peer_message_uno: skip close (windows) uid=uid-later" in err
 
 
 def test_close_logs_uid_before_close_doc(capsys, monkeypatch):
@@ -682,8 +685,8 @@ def test_close_logs_uid_before_close_doc(capsys, monkeypatch):
 
     doc = MagicMock()
     doc.RuntimeUID = "uid-7"
+    monkeypatch.setattr(peer, "_windows_skip_doc_close", lambda: False)
     monkeypatch.setattr(TestingFactory, "close_doc", lambda _doc: None)
-    peer._windows_skip_close_after_impress = False
     peer._close(doc)
     err = capsys.readouterr().err
     assert "peer_message_uno: close_doc start uid=uid-7" in err

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -568,6 +568,9 @@ def test_teardown_peer_pair_closes_writer_before_impress(monkeypatch):
     )
     writer = MagicMock(name="writer")
     impress = MagicMock(name="impress")
+    import tests.chatbot.test_peer_message_uno as peer
+
+    peer._windows_skip_close_after_impress = False
     out_writer, out_impress = _teardown_peer_pair(writer, impress)
     assert out_writer is None and out_impress is None
     assert order == [
@@ -575,6 +578,7 @@ def test_teardown_peer_pair_closes_writer_before_impress(monkeypatch):
         ("close_draw_family", impress),
         "post_settle",
     ]
+    assert peer._windows_skip_close_after_impress is False
 
 
 def test_teardown_peer_pair_windows_closes_impress_skips_writer(monkeypatch):
@@ -607,13 +611,26 @@ def test_teardown_peer_pair_windows_closes_impress_skips_writer(monkeypatch):
     writer = MagicMock(name="writer")
     impress = MagicMock(name="impress")
     ctx = MagicMock(name="ctx")
-    out_writer, out_impress = _teardown_peer_pair(writer, impress, ctx)
-    assert out_writer is None and out_impress is None
-    assert order == [
-        ("close_draw_family", impress),
-        "post_settle",
-        ("reactivate", ctx, writer),
-    ]
+    recycle_calls = []
+    monkeypatch.setattr(
+        "plugin.testing_runner.request_office_recycle_after_suite",
+        lambda: recycle_calls.append("recycle"),
+    )
+    import tests.chatbot.test_peer_message_uno as peer
+
+    peer._windows_skip_close_after_impress = False
+    try:
+        out_writer, out_impress = _teardown_peer_pair(writer, impress, ctx)
+        assert out_writer is None and out_impress is None
+        assert order == [
+            ("close_draw_family", impress),
+            "post_settle",
+            ("reactivate", ctx, writer),
+        ]
+        assert peer._windows_skip_close_after_impress is True
+        assert recycle_calls == ["recycle"]
+    finally:
+        peer._windows_skip_close_after_impress = False
 
 
 def test_reactivate_writer_after_impress_sets_active_frame(monkeypatch):
@@ -634,6 +651,43 @@ def test_reactivate_writer_after_impress_sets_active_frame(monkeypatch):
     get_desktop.assert_called_once_with(ctx)
     desktop.setActiveFrame.assert_called_once_with(frame)
     frame.getContainerWindow.return_value.toFront.assert_called_once_with()
+
+
+def test_close_skips_after_windows_impress(monkeypatch):
+    """GHA 34542928132: missing_deck close_doc hung after Impress."""
+    from unittest.mock import MagicMock
+
+    import tests.chatbot.test_peer_message_uno as peer
+    from plugin.tests.testing_utils import TestingFactory
+
+    doc = MagicMock()
+    doc.RuntimeUID = "uid-later"
+    calls = []
+    monkeypatch.setattr(
+        TestingFactory, "close_doc", lambda _doc: calls.append("close_doc")
+    )
+    peer._windows_skip_close_after_impress = True
+    try:
+        assert peer._close(doc) is None
+        assert calls == []
+    finally:
+        peer._windows_skip_close_after_impress = False
+
+
+def test_close_logs_uid_before_close_doc(capsys, monkeypatch):
+    from unittest.mock import MagicMock
+
+    import tests.chatbot.test_peer_message_uno as peer
+    from plugin.tests.testing_utils import TestingFactory
+
+    doc = MagicMock()
+    doc.RuntimeUID = "uid-7"
+    monkeypatch.setattr(TestingFactory, "close_doc", lambda _doc: None)
+    peer._windows_skip_close_after_impress = False
+    peer._close(doc)
+    err = capsys.readouterr().err
+    assert "peer_message_uno: close_doc start uid=uid-7" in err
+    assert "peer_message_uno: close_doc done uid=uid-7" in err
 
 
 def test_teardown_peer_pair_windows_no_impress_just_closes_writer(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Harness-only follow-up after #717. No product behavior change. Does not reopen #716/#717.

## Hang trail

Master Windows dispatch [34542928132](https://github.com/KeithCu/writeragent/actions/runs/34542928132) on `fa60bd5e` (tip of #717):

1. Both Impress tests — OK (`raw close(True)` + `skip writer close after impress`)
2. `test_peer_missing_deck_is_clear_error` — both `private:factory/swriter` loads printed `load done`, tool assert ran, then hung 30s in `TestingFactory.close_doc` from `_close(other)` in `finally`

That test never opens Impress. Leftover Impress/process state after #717 still poisons **Writer `close_doc`** in the same soffice.

Isolate dispatch [34544965319](https://github.com/KeithCu/writeragent/actions/runs/34544965319) on `8494be63` (Impress **last**):

1. `test_peer_missing_deck_is_clear_error` ran **first**, before any Impress in this file
2. First `close_doc` (`other`, uid=30) returned
3. Second `close_doc` (`writer`, uid=29) hung 30s at `doc.close`

Dual hidden-Writer `close_doc` is the hang. Leftover Impress from *this* suite is not required. Isolation by reordering did not unblock `missing_deck`. Office stayed alive (`kill-libreoffice.ps1` then killed soffice).

## This PR

1. **Skip all Windows Writer/Calc `close_doc` in this suite:** `_close` drops the proxy (`peer_message_uno: skip close (windows) uid=…`) and requests an office recycle. POSIX still `close_doc`.
2. **Keep Impress last:** leftover Impress is still not in front of Writer tests; teardown uses the #717 path (raw `close(True)`, settle, reactivate, skip sibling Writer `close_doc`).
3. **Recycle office after the suite:** `request_office_recycle_after_suite` → kill+rebootstrap before the next UNO suite. Breadcrumb: `LIFECYCLE recycle office after impress`.

Do not fold Draw-family settle into `close_doc`.

## Windows re-dispatch

This agent cannot run `windows-latest`. After Ubuntu PR CI is green:

1. Actions → **PR CI** → **Run workflow**
2. Branch `cursor/windows-impress-isolate-peer-a0c4`
3. `os=windows-latest`, `ci_debug=true`

Look for `skip close (windows)`, all six peer tests `TEST end … OK`, then `LIFECYCLE recycle office after impress done`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca57e514-eea3-42e1-988b-3f8407cda0c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca57e514-eea3-42e1-988b-3f8407cda0c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

