### PR TITLE
Harness: skip second Windows Impress close; run peer suite last

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -120,6 +120,15 @@ Impress + skipped Writer docs; office still alive). Cause:
 `request_office_recycle_after_suite` / `consume_office_recycle_request`
 now touch both module objects.
 
+GHA 34551644954 (`0177648d`): recycle **did** run (`start` / `done`
+pids=`8188,6868`). `test_slash_popup` OK on the new office. Then
+`test_list_nearby_excludes_active` failed `Could not create system
+bitmap!` and the next Calc `create_native_doc` hung 30s. In-process
+rebootstrap is not a healthy office. Windows now runs
+`test_peer_message_uno` **last** so other suites keep the original
+office; after that suite, skip rebootstrap and terminate soffice
+(`recycle office skipped; no remaining suites`).
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
@@ -130,12 +139,13 @@ POSIX still `close_doc`. Breadcrumbs:
 fold Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
-branch: `os=windows-latest`, `ci_debug=true`. Look for
-`skip close (windows)`, first Impress `raw close(True)` +
-`skip second impress close (windows)`, all six peer tests
-`TEST end … OK`, then `LIFECYCLE recycle office after impress done`.
-Ubuntu PR CI is the automatic gate; this cloud agent cannot run
-`windows-latest`.
+branch: `os=windows-latest`, `ci_debug=true`. Look for other UNO
+suites finishing *before* the peer file, then `skip close (windows)`,
+first Impress `raw close(True)`, `skip second impress close (windows)`,
+all six peer tests `TEST end … OK`, then
+`LIFECYCLE recycle office skipped; no remaining suites` and
+`LIFECYCLE terminate office after peer leftovers done`. Ubuntu PR CI
+is the automatic gate; this cloud agent cannot run `windows-latest`.
 
 **Harness-only attribution (not a product fix):** if a test body returns OK
 but the office already aborted, the runner fails *that* test instead of

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -97,19 +97,35 @@ Windows `_close` therefore drops the proxy on every Writer/Calc
 (`LIFECYCLE recycle office after impress`) after this suite. Impress
 still runs last; teardown keeps the raw Impress `close(True)` +
 `setActiveFrame` path and does not `close_doc` the sibling Writer.
+
+GHA 34547869791 (master `0e570b15`, tip of `#718`): all four Writer/Calc
+peer tests `TEST end … OK` (`skip close (windows)`). First Impress
+raw close returned in ~21 ms (`writer reactivated`). Second Impress
+`raw close(True)` raised `DisposedException` after ~7 s and soffice
+**exited 0** — fail-closed
+`test_peer_catalog_draw_label_is_not_enough_for_impress` and skipped
+remaining suites. Two Windows Impress raw closes in one soffice (after
+leftover skipped Writer docs) is the killer. Skip the *second* Impress
+close (`skip second impress close (windows)`); leftover last Impress
+dies with recycle. Do not skip the first close — leftover Impress
+before a later Writer load hangs (34537826720).
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
 `peer_message_uno: skip writer close after impress`,
+`peer_message_uno: skip second impress close (windows)`,
 `peer_message_uno: skip close (windows) uid=…`,
 `peer_message_uno: close_doc start/done uid=…` (POSIX). Do **not**
 fold Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
-`skip close (windows)`, all six peer tests `TEST end … OK`, then
-`LIFECYCLE recycle office after impress done`. Ubuntu PR CI is the
-automatic gate; this cloud agent cannot run `windows-latest`.
+`skip close (windows)`, first Impress `raw close(True)` +
+`skip second impress close (windows)`, all six peer tests
+`TEST end … OK`, then `LIFECYCLE recycle office after impress done`.
+Ubuntu PR CI is the automatic gate; this cloud agent cannot run
+`windows-latest`.
 
 **Harness-only attribution (not a product fix):** if a test body returns OK
 but the office already aborted, the runner fails *that* test instead of

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -110,6 +110,16 @@ close (`skip second impress close (windows)`); leftover last Impress
 dies with recycle. Do not skip the first close — leftover Impress
 before a later Writer load hangs (34537826720).
 
+GHA 34549510317 (`#719`): all six peer tests `TEST end … OK` (skip
+second Impress close printed). Recycle **did not run** — next suite
+started on the same soffice (`6052,1752`). Later
+`doc.test_text_helpers_uno` hung 30s in `create_native_doc` (leftover
+Impress + skipped Writer docs; office still alive). Cause:
+`python -m plugin.testing_runner` is `__main__`; tests imported
+`plugin.testing_runner` and set the recycle flag on that copy.
+`request_office_recycle_after_suite` / `consume_office_recycle_request`
+now touch both module objects.
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1105,6 +1105,25 @@ def consume_office_recycle_request() -> bool:
     return wanted
 
 
+def _native_suite_sort_key(module_path: str) -> tuple[int, str]:
+    """Windows: run the peer suite last so leftover docs do not poison later loads.
+
+    GHA 34551644954: recycle *did* start a new soffice, then the next Calc
+    factory raised ``Could not create system bitmap`` and hung. Other
+    suites must keep the original office. Peer leftovers die with process
+    teardown, not in-process rebootstrap.
+    """
+    name = os.path.basename(module_path)
+    if sys.platform == "win32" and name == "test_peer_message_uno.py":
+        return (1, module_path)
+    return (0, module_path)
+
+
+def _should_rebootstrap_after_recycle(*, more_suites: bool) -> bool:
+    """False when this was the last suite — do not start a second soffice."""
+    return more_suites
+
+
 def _recycle_harness_office(old_ctx: Any) -> tuple[Any, Any]:
     """Kill the current soffice and bootstrap a fresh one.
 
@@ -1772,6 +1791,7 @@ def run_all_tests(ctx: Any) -> str:
                         test_candidates.append(full_path)
 
         soak_rounds = max(1, _soak_repeat)
+        skip_keeper_close = False
         if soak_rounds > 1:
             _progress(
                 "SOAK start rounds=%s suites=%s filter=%s"
@@ -1783,7 +1803,9 @@ def run_all_tests(ctx: Any) -> str:
             if _urp_bridge_dead:
                 _progress("SOAK stop: URP already disposed")
                 break
-            for module_path in sorted(test_candidates):
+            ordered_candidates = sorted(test_candidates, key=_native_suite_sort_key)
+            skip_keeper_close = False
+            for i, module_path in enumerate(ordered_candidates):
                 if _urp_bridge_dead:
                     _progress("SUITE skip remaining: URP already disposed")
                     break
@@ -1831,7 +1853,16 @@ def run_all_tests(ctx: Any) -> str:
                     total_passed += p
                     total_failed += f
                     if consume_office_recycle_request():
-                        ctx, keeper_doc = _recycle_harness_office(ctx)
+                        more = i + 1 < len(ordered_candidates)
+                        if _should_rebootstrap_after_recycle(more_suites=more):
+                            ctx, keeper_doc = _recycle_harness_office(ctx)
+                        else:
+                            # GHA 34551644954: rebootstrap then hung the next
+                            # scalc load. No remaining suites — just kill.
+                            _progress(
+                                "LIFECYCLE recycle office skipped; no remaining suites"
+                            )
+                            skip_keeper_close = True
                 except ImportError as e:
                     print(f"Skipping {filename} due to ImportError: {e}")
                 except Exception as e:
@@ -1845,6 +1876,12 @@ def run_all_tests(ctx: Any) -> str:
                             else:
                                 sys.modules[k] = v
 
+        if skip_keeper_close:
+            # Leftover peer docs / Impress: do not close(True). Kill soffice.
+            _progress("LIFECYCLE terminate office after peer leftovers start")
+            _terminate_bootstrap_soffice()
+            _progress("LIFECYCLE terminate office after peer leftovers done")
+            keeper_doc = None
         if keeper_doc is not None:
             try:
                 _progress("KEEPER close start")

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1050,6 +1050,39 @@ def _terminate_bootstrap_soffice() -> None:
         pass
 
 
+def _same_testing_runner_file(mod: Any) -> bool:
+    """True when ``mod`` is this file loaded under another ``sys.modules`` name."""
+    other = getattr(mod, "__file__", None)
+    if not other or not __file__:
+        return False
+    try:
+        return os.path.normcase(os.path.realpath(other)) == os.path.normcase(
+            os.path.realpath(__file__)
+        )
+    except Exception:
+        return False
+
+
+def _office_recycle_holders() -> list[Any]:
+    """Modules that share this file's recycle flag.
+
+    ``python -m plugin.testing_runner`` executes as ``__main__``. Peer
+    tests ``import plugin.testing_runner`` and get a second module
+    object. GHA 34549510317: all six peer tests OK, but recycle never
+    ran — the flag was set on the import copy and consumed on
+    ``__main__``. Touch both. Not a product fix.
+    """
+    seen: list[Any] = []
+    for name in ("__main__", "plugin.testing_runner", __name__):
+        mod = sys.modules.get(name)
+        if mod is None or mod in seen:
+            continue
+        if name != __name__ and not _same_testing_runner_file(mod):
+            continue
+        seen.append(mod)
+    return seen or [sys.modules[__name__]]
+
+
 def request_office_recycle_after_suite() -> None:
     """Ask ``run_all_tests`` to kill+rebootstrap soffice after this suite.
 
@@ -1058,15 +1091,17 @@ def request_office_recycle_after_suite() -> None:
     34542928132: Writer close after Impress). Recycle so later suites
     are not poisoned. Not a product fix.
     """
-    global _recycle_office_after_suite
-    _recycle_office_after_suite = True
+    for mod in _office_recycle_holders():
+        mod._recycle_office_after_suite = True
 
 
 def consume_office_recycle_request() -> bool:
     """Return-and-clear the after-suite recycle flag."""
-    global _recycle_office_after_suite
-    wanted = _recycle_office_after_suite
-    _recycle_office_after_suite = False
+    wanted = False
+    for mod in _office_recycle_holders():
+        if getattr(mod, "_recycle_office_after_suite", False):
+            wanted = True
+        mod._recycle_office_after_suite = False
     return wanted
 
 

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -366,8 +366,9 @@ def test_peer_unique_name_and_self_reject(ctx):
 
 
 # Windows: skip all Writer/Calc close_doc in this file (34544965319).
-# Impress still runs last so leftover Impress is not in front of Writer
-# tests; teardown raw-closes Impress and the runner recycles office.
+# Impress still runs last. Teardown raw-closes the first Impress; a
+# second close killed soffice (34547869791) so that one is skipped.
+# The runner recycles office after the suite.
 
 
 @native_test

--- a/tests/chatbot/test_peer_message_uno.py
+++ b/tests/chatbot/test_peer_message_uno.py
@@ -73,6 +73,26 @@ def _load(ctx, factory_url):
     return doc
 
 
+# After the first Windows Impress raw close in this file. A second
+# ``close(True)`` killed soffice (GHA 34547869791). Reset is not required
+# — the suite ends and the runner recycles office.
+_windows_impress_raw_closed = False
+
+
+def _windows_skip_impress_close() -> bool:
+    """True after this suite already raw-closed one Impress on Windows.
+
+    GHA 34547869791: skip-close unblocked Writer+Writer. First Impress
+    raw close returned (~21 ms). Second Impress raw close raised
+    ``DisposedException`` after ~7 s and soffice exited 0 — fail-closed
+    the catalog test and skipped remaining suites. Leftover Impress from
+    a skipped *last* close is OK: this is the last test in the file and
+    recycle kills soffice. Do not skip the first close — leftover
+    Impress before a later Writer load hangs (34537826720).
+    """
+    return _windows_impress_raw_closed
+
+
 def _windows_skip_doc_close() -> bool:
     """True when this suite must not call Writer/Calc ``close_doc``.
 
@@ -167,15 +187,25 @@ def _teardown_peer_pair(writer, impress, ctx=None):
     Leftover Writer is not the poison (keeper Writer already exists);
     leftover Impress is. GHA 34544965319: dual hidden-Writer
     ``close_doc`` hung *before* any Impress in this file — ``_close``
-    skips all Writer/Calc ``close_doc`` on win32. This path still
-    asks the runner to recycle office so later suites are not
-    poisoned by leftover docs. POSIX still closes Writer first, then
-    the Draw-family path (setModified + pre-close settle +
-    ``close(True)``) and the same post-close settle. Not a product
+    skips all Writer/Calc ``close_doc`` on win32. GHA 34547869791:
+    first Impress raw close returned; the second killed soffice
+    (exited 0). Skip that second close — leftover last Impress dies
+    with recycle. This path still asks the runner to recycle office
+    so later suites are not poisoned. POSIX still closes Writer
+    first, then the Draw-family path (setModified + pre-close settle
+    + ``close(True)``) and the same post-close settle. Not a product
     fix.
     """
     had_impress = impress is not None
     if had_impress and _draw_family_raw_close():
+        from plugin.testing_runner import request_office_recycle_after_suite
+
+        if _windows_skip_impress_close():
+            # Second raw close exited soffice 0 (34547869791). Last test
+            # in this file — leftover Impress dies with recycle.
+            _progress("peer_message_uno: skip second impress close (windows)")
+            request_office_recycle_after_suite()
+            return None, None
         _progress("peer_message_uno: close impress start")
         close_draw_family_doc(impress)
         impress = None
@@ -186,8 +216,8 @@ def _teardown_peer_pair(writer, impress, ctx=None):
         # Drop the proxy only. close_doc hung 30s here (34540353452).
         # Writer+Writer close_doc also hung before any Impress
         # (34544965319). Recycle so later suites are not poisoned.
-        from plugin.testing_runner import request_office_recycle_after_suite
-
+        global _windows_impress_raw_closed
+        _windows_impress_raw_closed = True
         request_office_recycle_after_suite()
         _progress("peer_message_uno: skip writer close after impress")
         return None, None

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -17,6 +17,8 @@ from plugin.testing_runner import (
     _function_name_matches,
     _is_case_id,
     _module_matches_filters,
+    _native_suite_sort_key,
+    _should_rebootstrap_after_recycle,
     _test_function_filters,
     collect_post_test_death,
     consume_application_error,
@@ -235,6 +237,27 @@ def test_collect_post_test_death_soffice_exit() -> None:
     assert "soffice exited 1" in reason
     assert "Binary URP bridge" in reason
     reset_office_death_signals(clear_proc=True)
+
+
+def test_native_suite_sort_key_windows_puts_peer_last(monkeypatch) -> None:
+    """GHA 34551644954: other suites must run before leftover peer docs."""
+    import plugin.testing_runner as tr
+
+    monkeypatch.setattr(tr.sys, "platform", "win32")
+    paths = [
+        "/tmp/tests/chatbot/test_peer_message_uno.py",
+        "/tmp/tests/doc/test_text_helpers_uno.py",
+        "/tmp/tests/chatbot/test_slash_popup_uno.py",
+    ]
+    ordered = sorted(paths, key=_native_suite_sort_key)
+    assert ordered[-1].endswith("test_peer_message_uno.py")
+    assert ordered[0].endswith("test_slash_popup_uno.py")
+
+
+def test_should_not_rebootstrap_when_no_remaining_suites() -> None:
+    """GHA 34551644954: recycled office hung the next scalc factory load."""
+    assert _should_rebootstrap_after_recycle(more_suites=True) is True
+    assert _should_rebootstrap_after_recycle(more_suites=False) is False
 
 
 def test_office_recycle_request_is_consumed_once() -> None:

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from plugin.testing_runner import (
@@ -245,6 +246,24 @@ def test_office_recycle_request_is_consumed_once() -> None:
     request_office_recycle_after_suite()
     assert consume_office_recycle_request() is True
     assert consume_office_recycle_request() is False
+
+
+def test_office_recycle_request_reaches_minus_m_main(monkeypatch) -> None:
+    """GHA 34549510317: ``-m`` is ``__main__``; tests import the package name."""
+    import types
+
+    import plugin.testing_runner as tr
+
+    fake_main = types.ModuleType("__main__")
+    fake_main.__file__ = tr.__file__
+    fake_main._recycle_office_after_suite = False
+    monkeypatch.setitem(sys.modules, "__main__", fake_main)
+    tr._recycle_office_after_suite = False
+    request_office_recycle_after_suite()
+    assert fake_main._recycle_office_after_suite is True
+    assert consume_office_recycle_request() is True
+    assert fake_main._recycle_office_after_suite is False
+    assert tr._recycle_office_after_suite is False
 
 
 def test_fail_reason_with_lifecycle_keeps_crumb_after_cap() -> None:

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -581,8 +581,10 @@ def test_teardown_peer_pair_windows_closes_impress_skips_writer(monkeypatch):
     """GHA 34540353452: Impress raw close returned; Writer close_doc hung."""
     from unittest.mock import MagicMock
 
+    import tests.chatbot.test_peer_message_uno as peer
     from tests.chatbot.test_peer_message_uno import _teardown_peer_pair
 
+    peer._windows_impress_raw_closed = False
     order = []
     monkeypatch.setattr(
         "tests.chatbot.test_peer_message_uno._draw_family_raw_close",
@@ -612,14 +614,72 @@ def test_teardown_peer_pair_windows_closes_impress_skips_writer(monkeypatch):
         "plugin.testing_runner.request_office_recycle_after_suite",
         lambda: recycle_calls.append("recycle"),
     )
-    out_writer, out_impress = _teardown_peer_pair(writer, impress, ctx)
-    assert out_writer is None and out_impress is None
-    assert order == [
-        ("close_draw_family", impress),
-        "post_settle",
-        ("reactivate", ctx, writer),
-    ]
-    assert recycle_calls == ["recycle"]
+    try:
+        out_writer, out_impress = _teardown_peer_pair(writer, impress, ctx)
+        assert out_writer is None and out_impress is None
+        assert order == [
+            ("close_draw_family", impress),
+            "post_settle",
+            ("reactivate", ctx, writer),
+        ]
+        assert recycle_calls == ["recycle"]
+        assert peer._windows_impress_raw_closed is True
+    finally:
+        peer._windows_impress_raw_closed = False
+
+
+def test_teardown_peer_pair_windows_skips_second_impress_close(capsys, monkeypatch):
+    """GHA 34547869791: second Impress raw close exited soffice 0."""
+    from unittest.mock import MagicMock
+
+    import tests.chatbot.test_peer_message_uno as peer
+    from tests.chatbot.test_peer_message_uno import _teardown_peer_pair
+
+    peer._windows_impress_raw_closed = False
+    order = []
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._draw_family_raw_close",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._close",
+        lambda doc: order.append(("close_doc", doc)) or None,
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno.close_draw_family_doc",
+        lambda doc: order.append(("close_draw_family", doc)),
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno.settle_after_draw_family_close",
+        lambda: order.append("post_settle"),
+    )
+    monkeypatch.setattr(
+        "tests.chatbot.test_peer_message_uno._reactivate_writer_after_impress",
+        lambda ctx, doc: order.append(("reactivate", ctx, doc)),
+    )
+    recycle_calls = []
+    monkeypatch.setattr(
+        "plugin.testing_runner.request_office_recycle_after_suite",
+        lambda: recycle_calls.append("recycle"),
+    )
+    writer1 = MagicMock(name="writer1")
+    impress1 = MagicMock(name="impress1")
+    writer2 = MagicMock(name="writer2")
+    impress2 = MagicMock(name="impress2")
+    ctx = MagicMock(name="ctx")
+    try:
+        _teardown_peer_pair(writer1, impress1, ctx)
+        _teardown_peer_pair(writer2, impress2, ctx)
+        assert order == [
+            ("close_draw_family", impress1),
+            "post_settle",
+            ("reactivate", ctx, writer1),
+        ]
+        assert recycle_calls == ["recycle", "recycle"]
+        err = capsys.readouterr().err
+        assert "peer_message_uno: skip second impress close (windows)" in err
+    finally:
+        peer._windows_impress_raw_closed = False
 
 
 def test_reactivate_writer_after_impress_sets_active_frame(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Harness-only follow-up after #718. No product behavior change.

## Hang trail

[34547869791](https://github.com/KeithCu/writeragent/actions/runs/34547869791) (#718 tip): second Impress `close(True)` exited soffice 0.

[34549510317](https://github.com/KeithCu/writeragent/actions/runs/34549510317): skip-second-close made all six peer tests OK, but recycle never ran (`python -m` vs `import plugin.testing_runner` flag split). Later `create_native_doc` hung.

[34551644954](https://github.com/KeithCu/writeragent/actions/runs/34551644954) (`0177648d`): recycle **did** run (`done pids=8188,6868`). `test_slash_popup` OK. Then `test_list_nearby_excludes_active` failed `Could not create system bitmap!` and the next Calc `create_native_doc` hung 30s. In-process rebootstrap is not a healthy office.

## This PR

1. Skip the **second** Windows Impress close. Do not skip the first.
2. Recycle flag is visible to both `__main__` and `plugin.testing_runner`.
3. On Windows, run `test_peer_message_uno` **last** so other suites keep the original office. After that suite, do **not** rebootstrap — terminate soffice (`recycle office skipped; no remaining suites`).

POSIX teardown and suite order are unchanged.

## Windows re-dispatch

This agent cannot run `windows-latest`. After Ubuntu PR CI is green:

1. Actions → **PR CI** → **Run workflow**
2. Branch `cursor/windows-impress-skip-second-close-a0c4`
3. `os=windows-latest`, `ci_debug=true`

Look for other UNO suites finishing *before* the peer file, then `skip close (windows)`, first Impress `raw close(True)`, `skip second impress close (windows)`, all six peer tests `TEST end … OK`, then `LIFECYCLE recycle office skipped; no remaining suites` and `LIFECYCLE terminate office after peer leftovers done`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca57e514-eea3-42e1-988b-3f8407cda0c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca57e514-eea3-42e1-988b-3f8407cda0c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

