### PR TITLE
Harness: close leftover HTML-paste Writers before Windows Writer factory

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -144,10 +144,16 @@ uid=27, `writers_open` 1→2. Calc teardown does not close them. Product
 must not close those Writers during a live paste (33771766524). After
 the first harness Writer `close_doc`, desktop current becomes a leftover
 paste Writer; the next factory then hangs (same family as leftover
-Impress, 34537826720). CharWeight itself is not the hung call. Before a
-Windows Writer factory the harness now closes non-keeper leftover
-Writers and `setActiveFrame`s the keeper
-(`html_paste_writer: close leftover start/done`,
+Impress, 34537826720). CharWeight itself is not the hung call.
+
+GHA 34556185752 (`#720` leftover-close attempt): first text_helpers
+factory called leftover `close(True)` on uid=27 (`frame=-`) and hung
+30s *inside that close* — same “do not close after paste” rule, still
+true minutes later. Do **not** close leftover paste Writers from the
+harness. Before a Windows Writer factory, log leftovers and
+`setActiveFrame` the keeper. After a Windows Writer `close_doc` (test
+docs still close — that returned on 34554275072), reactivate the
+keeper again (`html_paste_writer: leftovers open=…`,
 `html_paste_writer: keeper reactivated`).
 
 POSIX still `close_doc`. Breadcrumbs:
@@ -157,16 +163,16 @@ POSIX still `close_doc`. Breadcrumbs:
 `peer_message_uno: skip second impress close (windows)`,
 `peer_message_uno: skip close (windows) uid=…`,
 `peer_message_uno: close_doc start/done uid=…` (POSIX).
-`html_paste_writer: close leftover start/done uid=…`,
+`html_paste_writer: leftovers open=N uids=…`,
 `html_paste_writer: keeper reactivated`,
-`create_native_doc: windows writer factory leftover_closed=N`,
+`create_native_doc: windows writer factory leftover_open=N`,
 `close_doc: start/done uid=…` (Windows Writer). Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
-`html_paste_writer: close leftover` before the first text_helpers
-Writer load, `keeper reactivated`, both text_helpers tests
+`html_paste_writer: leftovers open` and `keeper reactivated` before
+the first text_helpers Writer load, both text_helpers tests
 `TEST end … OK`, later suites including the peer file last (six peer
 `TEST end … OK`), then
 `LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -129,22 +129,47 @@ rebootstrap is not a healthy office. Windows now runs
 office; after that suite, skip rebootstrap and terminate soffice
 (`recycle office skipped; no remaining suites`).
 
+GHA 34554275072 (master `633f8a39`, tip of `#719`) and 34553944171
+(pre-merge `#719` tip): peer suite never reached. `document_research_uno`
+(including `test_list_nearby_excludes_active`) passed — those tests are
+**Calc** (`@with_native_doc("calc")`), not a Writer factory cycle. Then
+`doc.test_text_helpers_uno.test_get_string_without_tracked_deletions_paragraph_bold_run_no_newline`
+OK (first Writer factory after leftovers + `close_doc` returned; same
+soffice pids `4480,2176`). The next test,
+`…_multi_para_joins_with_newline`, hung 30s in `create_native_doc`
+(`loadComponentFromURL(private:factory/swriter)`). Earlier
+`insert_cell_html_rich` left temp Writers open
+(`close skipped pasted=True`; `reused_existing=False`): uid=26 then
+uid=27, `writers_open` 1→2. Calc teardown does not close them. Product
+must not close those Writers during a live paste (33771766524). After
+the first harness Writer `close_doc`, desktop current becomes a leftover
+paste Writer; the next factory then hangs (same family as leftover
+Impress, 34537826720). CharWeight itself is not the hung call. Before a
+Windows Writer factory the harness now closes non-keeper leftover
+Writers and `setActiveFrame`s the keeper
+(`html_paste_writer: close leftover start/done`,
+`html_paste_writer: keeper reactivated`).
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
 `peer_message_uno: skip writer close after impress`,
 `peer_message_uno: skip second impress close (windows)`,
 `peer_message_uno: skip close (windows) uid=…`,
-`peer_message_uno: close_doc start/done uid=…` (POSIX). Do **not**
-fold Draw-family settle into `close_doc`. Not a product fix.
+`peer_message_uno: close_doc start/done uid=…` (POSIX).
+`html_paste_writer: close leftover start/done uid=…`,
+`html_paste_writer: keeper reactivated`,
+`create_native_doc: windows writer factory leftover_closed=N`,
+`close_doc: start/done uid=…` (Windows Writer). Do **not** fold
+Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
-branch: `os=windows-latest`, `ci_debug=true`. Look for other UNO
-suites finishing *before* the peer file, then `skip close (windows)`,
-first Impress `raw close(True)`, `skip second impress close (windows)`,
-all six peer tests `TEST end … OK`, then
-`LIFECYCLE recycle office skipped; no remaining suites` and
-`LIFECYCLE terminate office after peer leftovers done`. Ubuntu PR CI
+branch: `os=windows-latest`, `ci_debug=true`. Look for
+`html_paste_writer: close leftover` before the first text_helpers
+Writer load, `keeper reactivated`, both text_helpers tests
+`TEST end … OK`, later suites including the peer file last (six peer
+`TEST end … OK`), then
+`LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI
 is the automatic gate; this cloud agent cannot run `windows-latest`.
 
 **Harness-only attribution (not a product fix):** if a test body returns OK

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1167,6 +1167,14 @@ def _recycle_harness_office(old_ctx: Any) -> tuple[Any, Any]:
             new_keeper = get_desktop(new_ctx).loadComponentFromURL(
                 "private:factory/swriter", "_blank", 0, (hidden_prop,)
             )
+            try:
+                from tests.testing_utils import set_harness_keeper_uid
+
+                set_harness_keeper_uid(
+                    str(getattr(new_keeper, "RuntimeUID", None) or "")
+                )
+            except Exception:
+                pass
         _progress(
             "LIFECYCLE recycle office after impress done pids=%s"
             % _soffice_pids()
@@ -1676,6 +1684,12 @@ def run_all_tests(ctx: Any) -> str:
                 "KEEPER load done ok=%s uid=%s python_pid=%s soffice=%s"
                 % (keeper_doc is not None, keeper_uid, os.getpid(), _soffice_pids())
             )
+            try:
+                from tests.testing_utils import set_harness_keeper_uid
+
+                set_harness_keeper_uid(keeper_uid)
+            except Exception:
+                pass
     except Exception as e:
         log.warning("run_all_tests: could not create keeper document: %s", e)
         if _is_uno_bridge_disposed(e):

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1171,7 +1171,8 @@ def _recycle_harness_office(old_ctx: Any) -> tuple[Any, Any]:
                 from tests.testing_utils import set_harness_keeper_uid
 
                 set_harness_keeper_uid(
-                    str(getattr(new_keeper, "RuntimeUID", None) or "")
+                    str(getattr(new_keeper, "RuntimeUID", None) or ""),
+                    new_keeper,
                 )
             except Exception:
                 pass
@@ -1687,7 +1688,7 @@ def run_all_tests(ctx: Any) -> str:
             try:
                 from tests.testing_utils import set_harness_keeper_uid
 
-                set_harness_keeper_uid(keeper_uid)
+                set_harness_keeper_uid(keeper_uid, keeper_doc)
             except Exception:
                 pass
     except Exception as e:

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -272,8 +272,8 @@ def test_reraise_native_open_failure_passthrough_non_urp():
             _reraise_native_open_failure(exc, "private:factory/sdraw")
 
 
-def test_close_leftover_html_paste_writers_skips_keeper_and_closes_others(monkeypatch):
-    """GHA 34554275072: leftover _wa_calc_html Writers must not stay open."""
+def test_prepare_windows_writer_factory_logs_leftovers_and_does_not_close(monkeypatch):
+    """GHA 34556185752: leftover close(True) hung 30s. Log + reactivate only."""
     from unittest.mock import MagicMock
 
     from plugin.tests import testing_utils as tu
@@ -302,17 +302,17 @@ def test_close_leftover_html_paste_writers_skips_keeper_and_closes_others(monkey
         [keeper, leftover]
     )
     monkeypatch.setattr("plugin.framework.uno_context.get_desktop", lambda _ctx: desktop)
-    tu.set_harness_keeper_uid("1")
+    tu.set_harness_keeper_uid("1", keeper)
     try:
-        assert tu.close_leftover_html_paste_writers(object()) == 1
-        leftover.close.assert_called_once_with(True)
+        assert tu.prepare_windows_writer_factory(object()) == 1
+        leftover.close.assert_not_called()
         keeper.close.assert_not_called()
         desktop.setActiveFrame.assert_called_once_with(frame)
     finally:
         tu.set_harness_keeper_uid("")
 
 
-def test_close_leftover_html_paste_writers_keeper_only_skips_reactivate(monkeypatch):
+def test_prepare_windows_writer_factory_keeper_only_still_reactivates(monkeypatch):
     from unittest.mock import MagicMock
 
     from plugin.tests import testing_utils as tu
@@ -320,6 +320,8 @@ def test_close_leftover_html_paste_writers_keeper_only_skips_reactivate(monkeypa
     keeper = MagicMock(name="keeper")
     keeper.RuntimeUID = "1"
     keeper.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    frame = MagicMock(name="keeper_frame")
+    keeper.getCurrentController.return_value.getFrame.return_value = frame
 
     class _Enum:
         def __init__(self, items):
@@ -334,16 +336,16 @@ def test_close_leftover_html_paste_writers_keeper_only_skips_reactivate(monkeypa
     desktop = MagicMock()
     desktop.getComponents.return_value.createEnumeration.return_value = _Enum([keeper])
     monkeypatch.setattr("plugin.framework.uno_context.get_desktop", lambda _ctx: desktop)
-    tu.set_harness_keeper_uid("1")
+    tu.set_harness_keeper_uid("1", keeper)
     try:
-        assert tu.close_leftover_html_paste_writers(object()) == 0
+        assert tu.prepare_windows_writer_factory(object()) == 0
         keeper.close.assert_not_called()
-        desktop.setActiveFrame.assert_not_called()
+        desktop.setActiveFrame.assert_called_once_with(frame)
     finally:
         tu.set_harness_keeper_uid("")
 
 
-def test_create_native_doc_windows_closes_leftover_writers_before_load(monkeypatch):
+def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypatch):
     """Second text_helpers Writer factory hung after leftovers + one close_doc."""
     from unittest.mock import MagicMock, patch
 
@@ -355,7 +357,7 @@ def test_create_native_doc_windows_closes_leftover_writers_before_load(monkeypat
     calls = []
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(
-        tu, "close_leftover_html_paste_writers", lambda _ctx: calls.append("close_leftovers")
+        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 2
     )
     with (
         patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
@@ -363,11 +365,11 @@ def test_create_native_doc_windows_closes_leftover_writers_before_load(monkeypat
         patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
     ):
         TestingFactory.create_native_doc(object(), "writer")
-    assert calls == ["close_leftovers"]
+    assert calls == ["prepare"]
     desktop.loadComponentFromURL.assert_called_once()
 
 
-def test_create_native_doc_windows_calc_does_not_close_leftover_writers(monkeypatch):
+def test_create_native_doc_windows_calc_does_not_prepare_writer_factory(monkeypatch):
     from unittest.mock import MagicMock, patch
 
     from plugin.tests.testing_utils import TestingFactory
@@ -378,7 +380,7 @@ def test_create_native_doc_windows_calc_does_not_close_leftover_writers(monkeypa
     calls = []
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(
-        tu, "close_leftover_html_paste_writers", lambda _ctx: calls.append("close_leftovers")
+        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare")
     )
     with (
         patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
@@ -389,7 +391,7 @@ def test_create_native_doc_windows_calc_does_not_close_leftover_writers(monkeypa
     assert calls == []
 
 
-def test_create_native_doc_posix_does_not_close_leftover_writers(monkeypatch):
+def test_create_native_doc_posix_does_not_prepare_writer_factory(monkeypatch):
     from unittest.mock import MagicMock, patch
 
     from plugin.tests.testing_utils import TestingFactory
@@ -400,7 +402,7 @@ def test_create_native_doc_posix_does_not_close_leftover_writers(monkeypatch):
     calls = []
     monkeypatch.setattr(tu.sys, "platform", "linux")
     monkeypatch.setattr(
-        tu, "close_leftover_html_paste_writers", lambda _ctx: calls.append("close_leftovers")
+        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare")
     )
     with (
         patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
@@ -499,6 +501,33 @@ def test_close_doc_logs_urp_dispose(capsys, monkeypatch):
     err = capsys.readouterr().err
     assert "LIFECYCLE close_doc dispose" in err
     tr.reset_lifecycle_breadcrumb()
+
+
+def test_close_doc_windows_writer_reactivates_keeper(monkeypatch):
+    """GHA 34554275072: after test Writer close, keep leftover off current."""
+    from unittest.mock import MagicMock
+
+    from plugin.tests import testing_utils as tu
+    from plugin.tests.testing_utils import TestingFactory
+
+    keeper = MagicMock(name="keeper")
+    frame = MagicMock(name="keeper_frame")
+    desktop = MagicMock(name="desktop")
+    keeper.getCurrentController.return_value.getFrame.return_value = frame
+    frame.getCreator.return_value = desktop
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr("gc.collect", lambda: None)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    tu.set_harness_keeper_uid("1", keeper)
+    doc = MagicMock()
+    doc.RuntimeUID = "99"
+    doc.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    try:
+        TestingFactory.close_doc(doc)
+        doc.close.assert_called_once_with(True)
+        desktop.setActiveFrame.assert_called_once_with(frame)
+    finally:
+        tu.set_harness_keeper_uid("")
 
 
 def test_close_doc_settles_urp_before_close(monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -272,6 +272,145 @@ def test_reraise_native_open_failure_passthrough_non_urp():
             _reraise_native_open_failure(exc, "private:factory/sdraw")
 
 
+def test_close_leftover_html_paste_writers_skips_keeper_and_closes_others(monkeypatch):
+    """GHA 34554275072: leftover _wa_calc_html Writers must not stay open."""
+    from unittest.mock import MagicMock
+
+    from plugin.tests import testing_utils as tu
+
+    keeper = MagicMock(name="keeper")
+    keeper.RuntimeUID = "1"
+    leftover = MagicMock(name="leftover")
+    leftover.RuntimeUID = "26"
+    leftover.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    keeper.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    frame = MagicMock(name="keeper_frame")
+    keeper.getCurrentController.return_value.getFrame.return_value = frame
+
+    class _Enum:
+        def __init__(self, items):
+            self._items = list(items)
+
+        def hasMoreElements(self):
+            return bool(self._items)
+
+        def nextElement(self):
+            return self._items.pop(0)
+
+    desktop = MagicMock()
+    desktop.getComponents.return_value.createEnumeration.return_value = _Enum(
+        [keeper, leftover]
+    )
+    monkeypatch.setattr("plugin.framework.uno_context.get_desktop", lambda _ctx: desktop)
+    tu.set_harness_keeper_uid("1")
+    try:
+        assert tu.close_leftover_html_paste_writers(object()) == 1
+        leftover.close.assert_called_once_with(True)
+        keeper.close.assert_not_called()
+        desktop.setActiveFrame.assert_called_once_with(frame)
+    finally:
+        tu.set_harness_keeper_uid("")
+
+
+def test_close_leftover_html_paste_writers_keeper_only_skips_reactivate(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from plugin.tests import testing_utils as tu
+
+    keeper = MagicMock(name="keeper")
+    keeper.RuntimeUID = "1"
+    keeper.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+
+    class _Enum:
+        def __init__(self, items):
+            self._items = list(items)
+
+        def hasMoreElements(self):
+            return bool(self._items)
+
+        def nextElement(self):
+            return self._items.pop(0)
+
+    desktop = MagicMock()
+    desktop.getComponents.return_value.createEnumeration.return_value = _Enum([keeper])
+    monkeypatch.setattr("plugin.framework.uno_context.get_desktop", lambda _ctx: desktop)
+    tu.set_harness_keeper_uid("1")
+    try:
+        assert tu.close_leftover_html_paste_writers(object()) == 0
+        keeper.close.assert_not_called()
+        desktop.setActiveFrame.assert_not_called()
+    finally:
+        tu.set_harness_keeper_uid("")
+
+
+def test_create_native_doc_windows_closes_leftover_writers_before_load(monkeypatch):
+    """Second text_helpers Writer factory hung after leftovers + one close_doc."""
+    from unittest.mock import MagicMock, patch
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    desktop = MagicMock()
+    desktop.loadComponentFromURL.return_value = MagicMock()
+    calls = []
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(
+        tu, "close_leftover_html_paste_writers", lambda _ctx: calls.append("close_leftovers")
+    )
+    with (
+        patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+        patch("uno.createUnoStruct", return_value=MagicMock()),
+        patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
+    ):
+        TestingFactory.create_native_doc(object(), "writer")
+    assert calls == ["close_leftovers"]
+    desktop.loadComponentFromURL.assert_called_once()
+
+
+def test_create_native_doc_windows_calc_does_not_close_leftover_writers(monkeypatch):
+    from unittest.mock import MagicMock, patch
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    desktop = MagicMock()
+    desktop.loadComponentFromURL.return_value = MagicMock()
+    calls = []
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(
+        tu, "close_leftover_html_paste_writers", lambda _ctx: calls.append("close_leftovers")
+    )
+    with (
+        patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+        patch("uno.createUnoStruct", return_value=MagicMock()),
+        patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
+    ):
+        TestingFactory.create_native_doc(object(), "calc")
+    assert calls == []
+
+
+def test_create_native_doc_posix_does_not_close_leftover_writers(monkeypatch):
+    from unittest.mock import MagicMock, patch
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    desktop = MagicMock()
+    desktop.loadComponentFromURL.return_value = MagicMock()
+    calls = []
+    monkeypatch.setattr(tu.sys, "platform", "linux")
+    monkeypatch.setattr(
+        tu, "close_leftover_html_paste_writers", lambda _ctx: calls.append("close_leftovers")
+    )
+    with (
+        patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+        patch("uno.createUnoStruct", return_value=MagicMock()),
+        patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
+    ):
+        TestingFactory.create_native_doc(object(), "writer")
+    assert calls == []
+
+
 def test_create_native_doc_skips_load_when_bridge_already_dead(monkeypatch):
     from unittest.mock import MagicMock, patch
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -800,6 +800,129 @@ def _native_teardown_progress(msg: str) -> None:
     _progress(msg)
 
 
+# testing_runner keeper RuntimeUID. insert_cell_html_rich leaves extra
+# Writers open (close skipped after paste). Never close this uid.
+_HARNESS_KEEPER_UID = ""
+
+def set_harness_keeper_uid(uid: str) -> None:
+    """Record the hidden keeper Writer so leftover-paste cleanup skips it."""
+    global _HARNESS_KEEPER_UID
+    _HARNESS_KEEPER_UID = str(uid or "")
+
+
+def _writer_doc_uid(doc) -> str:
+    try:
+        return str(getattr(doc, "RuntimeUID", None) or "")
+    except Exception:
+        return ""
+
+
+def _writer_frame_name(doc) -> str:
+    try:
+        frame = doc.getCurrentController().getFrame()
+        name = frame.getName()
+        return str(name or "")
+    except Exception:
+        return ""
+
+
+def _iter_open_writer_docs(desktop):
+    """Yield (uid, doc) for open TextDocuments. Read-only enum; no close."""
+    try:
+        enum = desktop.getComponents().createEnumeration()
+    except Exception:
+        return
+    n = 0
+    while n < 64:
+        try:
+            if enum.hasMoreElements() is not True:
+                break
+            component = enum.nextElement()
+        except Exception:
+            break
+        n += 1
+        try:
+            if component.supportsService("com.sun.star.text.TextDocument"):
+                yield _writer_doc_uid(component), component
+        except Exception:
+            continue
+
+
+def close_leftover_html_paste_writers(ctx) -> int:
+    """Harness-only: close leftover ``_wa_calc_html`` Writers before a Writer factory.
+
+    What was wrong: GHA 34554275072 / 34553944171 hung 30s in
+    ``create_native_doc`` on the *second* text_helpers Writer load.
+    Leftovers were already open: ``insert_cell_html_rich`` left uid=26
+    then uid=27 (``close skipped pasted=True``, ``reused_existing=False``)
+    and Calc teardown does not close them. The *first* text_helpers
+    Writer factory + ``close_doc`` returned on that same office
+    (CharWeight close is not itself the hung call).
+    ``document_research_uno`` between leftovers and text_helpers is
+    Calc-only — it is not a successful Writer factory cycle.
+
+    How it happened: product must not close those Writers during a live
+    paste (GHA 33771766524 hung ``getComponents`` after ``close``). After
+    the first harness Writer ``close_doc``, desktop current becomes a
+    leftover paste Writer. The next ``private:factory/swriter`` then
+    hung 30s — same family as leftover Impress poisoning the next Writer
+    load (34537826720).
+
+    Why this: minutes later, before a harness Writer factory, close
+    every non-keeper Writer with a bare ``close(True)`` (frame name may
+    be empty because reuse failed) and ``setActiveFrame`` the keeper.
+    Do not re-enumerate after close. Do not fold this into ``close_doc``.
+    Returns how many closes were attempted. Windows-only caller. Not a
+    product fix.
+    """
+    if ctx is None:
+        return 0
+    from plugin.framework.uno_context import get_desktop
+    from plugin.testing_runner import _progress
+
+    desktop = get_desktop(ctx)
+    keeper = _HARNESS_KEEPER_UID
+    keeper_doc = None
+    to_close = []
+    for uid, doc in _iter_open_writer_docs(desktop):
+        if uid and uid == keeper:
+            keeper_doc = doc
+            continue
+        if not uid:
+            continue
+        # Reuse of _wa_calc_html failed (reused_existing=False), so leftovers
+        # may have an empty frame name. At harness Writer-factory time the
+        # only extra Writers are paste leftovers — close every non-keeper.
+        to_close.append((uid, doc))
+    closed = 0
+    for uid, doc in to_close:
+        _progress(
+            "html_paste_writer: close leftover start uid=%s frame=%s"
+            % (uid, _writer_frame_name(doc) or "-")
+        )
+        try:
+            if hasattr(doc, "close"):
+                doc.close(True)
+            closed += 1
+            _progress("html_paste_writer: close leftover done uid=%s" % uid)
+        except Exception as exc:
+            _progress(
+                "html_paste_writer: close leftover failed uid=%s err=%s"
+                % (uid, type(exc).__name__)
+            )
+    if closed and keeper_doc is not None:
+        try:
+            frame = keeper_doc.getCurrentController().getFrame()
+            desktop.setActiveFrame(frame)
+            _progress("html_paste_writer: keeper reactivated uid=%s" % keeper)
+        except Exception as exc:
+            _progress(
+                "html_paste_writer: keeper reactivate failed uid=%s err=%s"
+                % (keeper, type(exc).__name__)
+            )
+    return closed
+
+
 def _reraise_native_open_failure(
     exc: BaseException, factory_url: str, pre_open: str = "no_probe"
 ) -> None:
@@ -1412,6 +1535,16 @@ class TestingFactory:
 
         from plugin.testing_runner import probe_uno_bridge
 
+        leftover_closed = 0
+        if sys.platform == "win32" and factory_url == "private:factory/swriter":
+            leftover_closed = close_leftover_html_paste_writers(ctx)
+            from plugin.testing_runner import _progress
+
+            _progress(
+                "create_native_doc: windows writer factory leftover_closed=%s"
+                % leftover_closed
+            )
+
         # Distinguish "bridge already dead" (previous test) from "died during load".
         pre_open = probe_uno_bridge(ctx)
         if pre_open == "disposed":
@@ -1446,6 +1579,21 @@ class TestingFactory:
             import gc
             import time
 
+            uid = ""
+            is_writer = False
+            if sys.platform == "win32":
+                try:
+                    uid = str(getattr(doc, "RuntimeUID", None) or "")
+                    is_writer = bool(
+                        doc.supportsService("com.sun.star.text.TextDocument")
+                    )
+                except Exception:
+                    is_writer = False
+                if is_writer:
+                    from plugin.testing_runner import _progress
+
+                    _progress("close_doc: start uid=%s" % (uid or "-"))
+
             # Release PyUNO sequences before Calc tears down the document.
             # Large getDataArray results held across close can abort soffice (glibc double-free).
             gc.collect()
@@ -1460,6 +1608,10 @@ class TestingFactory:
                 doc.close(True)
             elif hasattr(doc, "dispose"):
                 doc.dispose()
+            if sys.platform == "win32" and is_writer:
+                from plugin.testing_runner import _progress
+
+                _progress("close_doc: done uid=%s" % (uid or "-"))
         except Exception as exc:
             # Harness-only: close used to swallow DisposedException, so the
             # *next* factory open became the named victim. Log the trail here.

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -800,14 +800,19 @@ def _native_teardown_progress(msg: str) -> None:
     _progress(msg)
 
 
-# testing_runner keeper RuntimeUID. insert_cell_html_rich leaves extra
-# Writers open (close skipped after paste). Never close this uid.
+# testing_runner keeper. insert_cell_html_rich leaves extra Writers open
+# (close skipped after paste). Never close those leftovers — GHA
+# 34556185752 hung 30s in leftover close(True). Reactivate this keeper
+# so a later Writer factory is not against a leftover current component.
 _HARNESS_KEEPER_UID = ""
+_HARNESS_KEEPER_DOC = None
 
-def set_harness_keeper_uid(uid: str) -> None:
-    """Record the hidden keeper Writer so leftover-paste cleanup skips it."""
-    global _HARNESS_KEEPER_UID
+
+def set_harness_keeper_uid(uid: str, doc=None) -> None:
+    """Record the hidden keeper Writer (uid + doc) for later setActiveFrame."""
+    global _HARNESS_KEEPER_UID, _HARNESS_KEEPER_DOC
     _HARNESS_KEEPER_UID = str(uid or "")
+    _HARNESS_KEEPER_DOC = doc if _HARNESS_KEEPER_UID else None
 
 
 def _writer_doc_uid(doc) -> str:
@@ -848,32 +853,48 @@ def _iter_open_writer_docs(desktop):
             continue
 
 
-def close_leftover_html_paste_writers(ctx) -> int:
-    """Harness-only: close leftover ``_wa_calc_html`` Writers before a Writer factory.
+def reactivate_harness_keeper(desktop=None) -> bool:
+    """``setActiveFrame`` the keeper. Does not close leftover paste Writers.
 
-    What was wrong: GHA 34554275072 / 34553944171 hung 30s in
-    ``create_native_doc`` on the *second* text_helpers Writer load.
-    Leftovers were already open: ``insert_cell_html_rich`` left uid=26
-    then uid=27 (``close skipped pasted=True``, ``reused_existing=False``)
-    and Calc teardown does not close them. The *first* text_helpers
-    Writer factory + ``close_doc`` returned on that same office
-    (CharWeight close is not itself the hung call).
-    ``document_research_uno`` between leftovers and text_helpers is
-    Calc-only — it is not a successful Writer factory cycle.
+    GHA 34556185752: leftover ``close(True)`` hung 30s (uid=27). GHA
+    34554275072: first text_helpers Writer factory + ``close_doc``
+    returned; the *next* factory hung. After a test Writer close,
+    desktop current becomes a leftover paste Writer. Reactivate the
+    keeper so the next ``swriter`` load is not against that leftover.
+    """
+    from plugin.testing_runner import _progress
 
-    How it happened: product must not close those Writers during a live
-    paste (GHA 33771766524 hung ``getComponents`` after ``close``). After
-    the first harness Writer ``close_doc``, desktop current becomes a
-    leftover paste Writer. The next ``private:factory/swriter`` then
-    hung 30s — same family as leftover Impress poisoning the next Writer
-    load (34537826720).
+    doc = _HARNESS_KEEPER_DOC
+    if doc is None:
+        return False
+    try:
+        frame = doc.getCurrentController().getFrame()
+        if desktop is None:
+            desktop = frame.getCreator()
+        desktop.setActiveFrame(frame)
+        _progress("html_paste_writer: keeper reactivated uid=%s" % _HARNESS_KEEPER_UID)
+        return True
+    except Exception as exc:
+        _progress(
+            "html_paste_writer: keeper reactivate failed uid=%s err=%s"
+            % (_HARNESS_KEEPER_UID or "-", type(exc).__name__)
+        )
+        return False
 
-    Why this: minutes later, before a harness Writer factory, close
-    every non-keeper Writer with a bare ``close(True)`` (frame name may
-    be empty because reuse failed) and ``setActiveFrame`` the keeper.
-    Do not re-enumerate after close. Do not fold this into ``close_doc``.
-    Returns how many closes were attempted. Windows-only caller. Not a
-    product fix.
+
+def prepare_windows_writer_factory(ctx) -> int:
+    """Harness-only: log leftover paste Writers and reactivate the keeper.
+
+    What was wrong: GHA 34554275072 / 34553944171 hung 30s on the
+    *second* text_helpers Writer factory. Leftovers uid=26/27 were
+    already open (``close skipped pasted=True``). The first factory +
+    ``close_doc`` returned. GHA 34556185752 then hung 30s *inside*
+    leftover ``close(True)`` — product and harness must not close those
+    Writers after paste (33771766524).
+
+    Why this: enum leftovers (read-only; safe before load) and
+    ``setActiveFrame`` the keeper. Do not close leftovers. Returns how
+    many non-keeper Writers are still open. Windows-only caller.
     """
     if ctx is None:
         return 0
@@ -882,45 +903,19 @@ def close_leftover_html_paste_writers(ctx) -> int:
 
     desktop = get_desktop(ctx)
     keeper = _HARNESS_KEEPER_UID
-    keeper_doc = None
-    to_close = []
+    leftover_uids = []
+    leftover_frames = []
     for uid, doc in _iter_open_writer_docs(desktop):
-        if uid and uid == keeper:
-            keeper_doc = doc
+        if not uid or uid == keeper:
             continue
-        if not uid:
-            continue
-        # Reuse of _wa_calc_html failed (reused_existing=False), so leftovers
-        # may have an empty frame name. At harness Writer-factory time the
-        # only extra Writers are paste leftovers — close every non-keeper.
-        to_close.append((uid, doc))
-    closed = 0
-    for uid, doc in to_close:
-        _progress(
-            "html_paste_writer: close leftover start uid=%s frame=%s"
-            % (uid, _writer_frame_name(doc) or "-")
-        )
-        try:
-            if hasattr(doc, "close"):
-                doc.close(True)
-            closed += 1
-            _progress("html_paste_writer: close leftover done uid=%s" % uid)
-        except Exception as exc:
-            _progress(
-                "html_paste_writer: close leftover failed uid=%s err=%s"
-                % (uid, type(exc).__name__)
-            )
-    if closed and keeper_doc is not None:
-        try:
-            frame = keeper_doc.getCurrentController().getFrame()
-            desktop.setActiveFrame(frame)
-            _progress("html_paste_writer: keeper reactivated uid=%s" % keeper)
-        except Exception as exc:
-            _progress(
-                "html_paste_writer: keeper reactivate failed uid=%s err=%s"
-                % (keeper, type(exc).__name__)
-            )
-    return closed
+        leftover_uids.append(uid)
+        leftover_frames.append(_writer_frame_name(doc) or "-")
+    _progress(
+        "html_paste_writer: leftovers open=%s uids=%s frames=%s keeper=%s"
+        % (len(leftover_uids), leftover_uids, leftover_frames, keeper or "-")
+    )
+    reactivate_harness_keeper(desktop)
+    return len(leftover_uids)
 
 
 def _reraise_native_open_failure(
@@ -1535,14 +1530,14 @@ class TestingFactory:
 
         from plugin.testing_runner import probe_uno_bridge
 
-        leftover_closed = 0
+        leftover_open = 0
         if sys.platform == "win32" and factory_url == "private:factory/swriter":
-            leftover_closed = close_leftover_html_paste_writers(ctx)
+            leftover_open = prepare_windows_writer_factory(ctx)
             from plugin.testing_runner import _progress
 
             _progress(
-                "create_native_doc: windows writer factory leftover_closed=%s"
-                % leftover_closed
+                "create_native_doc: windows writer factory leftover_open=%s"
+                % leftover_open
             )
 
         # Distinguish "bridge already dead" (previous test) from "died during load".
@@ -1611,6 +1606,10 @@ class TestingFactory:
             if sys.platform == "win32" and is_writer:
                 from plugin.testing_runner import _progress
 
+                # Test Writer close returned (34554275072). Leftover close
+                # hangs (34556185752). Reactivate keeper so the next factory
+                # is not against a leftover paste Writer as current.
+                reactivate_harness_keeper()
                 _progress("close_doc: done uid=%s" % (uid or "-"))
         except Exception as exc:
             # Harness-only: close used to swallow DisposedException, so the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Harness-only follow-up after #719. New PR from master `633f8a39`. No product behavior change. Do not reopen #716/#719.

## Hang trail

[34554275072](https://github.com/KeithCu/writeragent/actions/runs/34554275072) (master `633f8a39`, `#719` merge, job 103123477122): peer suite never reached. `document_research_uno` passed (Calc-only). First `doc.test_text_helpers_uno` Writer factory + `close_doc` OK on soffice `4480,2176`. Second test `…_multi_para_joins_with_newline` hung 30s in `create_native_doc` (`loadComponentFromURL(private:factory/swriter)`).

[34553944171](https://github.com/KeithCu/writeragent/actions/runs/34553944171): same fingerprint on the pre-merge `#719` tip.

Earlier `insert_cell_html_rich` left temp Writers open (`close skipped pasted=True`, `reused_existing=False`): uid=26 then uid=27, `writers_open` 1→2. Calc teardown does not close them. Product must not close those Writers during a live paste (33771766524). After the first harness Writer `close_doc`, desktop current becomes a leftover paste Writer; the next factory hangs (same family as leftover Impress, 34537826720). CharWeight itself is not the hung call.

[34556185752](https://github.com/KeithCu/writeragent/actions/runs/34556185752) (`59139afe` leftover-close attempt): first text_helpers factory called leftover `close(True)` on uid=27 (`frame=-`) and hung 30s *inside that close*. Closing leftover paste Writers later is not viable.

## This PR

Do **not** close leftover paste Writers. Before a Windows `private:factory/swriter` load, log leftover uids and `setActiveFrame` the keeper. After a Windows Writer `close_doc` (test docs still close — that returned on 34554275072), reactivate the keeper again so the next factory is not against a leftover current component. POSIX factory path and peer-last isolation are unchanged.

Breadcrumbs: `html_paste_writer: leftovers open=N uids=…`, `html_paste_writer: keeper reactivated`, `create_native_doc: windows writer factory leftover_open=N`, `close_doc: start/done uid=…` (Windows Writer).

## Windows re-dispatch

This agent cannot run `windows-latest`. After Ubuntu PR CI on tip `b4eb480a` is green:

1. Actions → **PR CI** → **Run workflow**
2. Use branch `cursor/windows-text-helpers-create-native-a0c4`
3. Set `os=windows-latest`, `ci_debug=true`

Hang is gone when the log shows `html_paste_writer: leftovers open` and `keeper reactivated` (no `close leftover start`), both text_helpers tests `TEST end … OK`, later suites including the peer file last (six peer `TEST end … OK`), then `LIFECYCLE recycle office skipped; no remaining suites`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca57e514-eea3-42e1-988b-3f8407cda0c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca57e514-eea3-42e1-988b-3f8407cda0c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

