### PR TITLE
Harness: log Windows factory/close around document_research hang

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -178,6 +178,24 @@ the first text_helpers Writer load, both text_helpers tests
 `LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI
 is the automatic gate; this cloud agent cannot run `windows-latest`.
 
+GHA 34593327841 (master `754620ba`, `#720` merge, windows-latest):
+keeper reactivate **never ran** — no Writer factory yet. Leftovers
+uid=26/27 still open after `insert_cell_html_rich`. Then
+`doc.test_document_research_uno.test_list_nearby_excludes_active`
+FAIL (`Couldn't convert <traceback object> to a UNO type` /
+`getTypes`) in ~1s. Next test
+`test_open_document_for_read_hidden_readonly` hung 30s in
+`create_native_doc` `loadComponentFromURL(private:factory/scalc)`
+inside `_create_nearby_test_env` (line 22). Office stayed alive
+(`1568,4728`). On earlier `#719` tips this Calc pair passed and the
+hang was the *second* text_helpers Writer factory. Cause of the
+list_nearby FAIL vs Calc-factory hang is not proven — do not guess a
+product fix. Windows factory/close now log
+`create_native_doc: load start/done url=… leftover_open=N` and
+`close_doc: start/done kind=writer|calc`; the nearby helper logs
+`nearby_env: …` around budget create/store/close and
+`list_nearby_files`.
+
 **Harness-only attribution (not a product fix):** if a test body returns OK
 but the office already aborted, the runner fails *that* test instead of
 letting the next factory open be the named victim:

--- a/tests/doc/test_document_research_uno.py
+++ b/tests/doc/test_document_research_uno.py
@@ -17,20 +17,29 @@ from plugin.tests.testing_utils import TestingFactory, with_native_doc
 
 
 def _create_nearby_test_env(ctx, active_doc):
-    temp_dir = tempfile.mkdtemp(prefix="wa_nearby_")
+    from plugin.testing_runner import _progress
 
+    temp_dir = tempfile.mkdtemp(prefix="wa_nearby_")
+    _progress("nearby_env: create budget calc start")
     budget = TestingFactory.create_native_doc(ctx, "calc", hidden=True)
+    _progress("nearby_env: create budget calc done")
     sheet = budget.Sheets.getByIndex(0)
     sheet.getCellByPosition(0, 0).setFormula("100")
     sheet.getCellByPosition(0, 1).setFormula("Q4")
     sheet.getCellByPosition(1, 1).setFormula("42")
 
     budget_path = os.path.join(temp_dir, "Budget_2026.ods")
+    _progress("nearby_env: storeAsURL budget start")
     budget.storeAsURL(uno.systemPathToFileUrl(budget_path), ())
+    _progress("nearby_env: storeAsURL budget done")
+    _progress("nearby_env: close_doc budget start")
     TestingFactory.close_doc(budget)
+    _progress("nearby_env: close_doc budget done")
 
     active_path = os.path.join(temp_dir, "Report.ods")
+    _progress("nearby_env: storeAsURL active start")
     active_doc.storeAsURL(uno.systemPathToFileUrl(active_path), ())
+    _progress("nearby_env: storeAsURL active done")
 
     return temp_dir, budget_path
 
@@ -53,7 +62,11 @@ def _cleanup_nearby_test_env(temp_dir):
 def test_list_nearby_excludes_active(ctx, doc):
     temp_dir, _ = _create_nearby_test_env(ctx, doc)
     try:
+        from plugin.testing_runner import _progress
+
+        _progress("nearby_env: list_nearby_files start")
         result = list_nearby_files(ctx, doc)
+        _progress("nearby_env: list_nearby_files done status=%s" % result.get("status"))
         assert result["status"] == "ok"
         names = {f["name"] for f in result["files"]}
         assert "Budget_2026.ods" in names

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -272,6 +272,43 @@ def test_reraise_native_open_failure_passthrough_non_urp():
             _reraise_native_open_failure(exc, "private:factory/sdraw")
 
 
+def test_log_open_writer_leftovers_does_not_close_or_reactivate(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from plugin.tests import testing_utils as tu
+
+    keeper = MagicMock(name="keeper")
+    keeper.RuntimeUID = "1"
+    leftover = MagicMock(name="leftover")
+    leftover.RuntimeUID = "26"
+    leftover.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    keeper.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+
+    class _Enum:
+        def __init__(self, items):
+            self._items = list(items)
+
+        def hasMoreElements(self):
+            return bool(self._items)
+
+        def nextElement(self):
+            return self._items.pop(0)
+
+    desktop = MagicMock()
+    desktop.getComponents.return_value.createEnumeration.return_value = _Enum(
+        [keeper, leftover]
+    )
+    monkeypatch.setattr("plugin.framework.uno_context.get_desktop", lambda _ctx: desktop)
+    tu.set_harness_keeper_uid("1", keeper)
+    try:
+        assert tu.log_open_writer_leftovers(object()) == 1
+        leftover.close.assert_not_called()
+        keeper.close.assert_not_called()
+        desktop.setActiveFrame.assert_not_called()
+    finally:
+        tu.set_harness_keeper_uid("")
+
+
 def test_prepare_windows_writer_factory_logs_leftovers_and_does_not_close(monkeypatch):
     """GHA 34556185752: leftover close(True) hung 30s. Log + reactivate only."""
     from unittest.mock import MagicMock
@@ -369,7 +406,7 @@ def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypat
     desktop.loadComponentFromURL.assert_called_once()
 
 
-def test_create_native_doc_windows_calc_does_not_prepare_writer_factory(monkeypatch):
+def test_create_native_doc_windows_calc_logs_leftovers_without_prepare(monkeypatch):
     from unittest.mock import MagicMock, patch
 
     from plugin.tests.testing_utils import TestingFactory
@@ -382,13 +419,16 @@ def test_create_native_doc_windows_calc_does_not_prepare_writer_factory(monkeypa
     monkeypatch.setattr(
         tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare")
     )
+    monkeypatch.setattr(
+        tu, "log_open_writer_leftovers", lambda _ctx: calls.append("log") or 2
+    )
     with (
         patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
         patch("uno.createUnoStruct", return_value=MagicMock()),
         patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
     ):
         TestingFactory.create_native_doc(object(), "calc")
-    assert calls == []
+    assert calls == ["log"]
 
 
 def test_create_native_doc_posix_does_not_prepare_writer_factory(monkeypatch):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -882,20 +882,8 @@ def reactivate_harness_keeper(desktop=None) -> bool:
         return False
 
 
-def prepare_windows_writer_factory(ctx) -> int:
-    """Harness-only: log leftover paste Writers and reactivate the keeper.
-
-    What was wrong: GHA 34554275072 / 34553944171 hung 30s on the
-    *second* text_helpers Writer factory. Leftovers uid=26/27 were
-    already open (``close skipped pasted=True``). The first factory +
-    ``close_doc`` returned. GHA 34556185752 then hung 30s *inside*
-    leftover ``close(True)`` — product and harness must not close those
-    Writers after paste (33771766524).
-
-    Why this: enum leftovers (read-only; safe before load) and
-    ``setActiveFrame`` the keeper. Do not close leftovers. Returns how
-    many non-keeper Writers are still open. Windows-only caller.
-    """
+def log_open_writer_leftovers(ctx) -> int:
+    """Read-only leftover Writer count. Does not close or setActiveFrame."""
     if ctx is None:
         return 0
     from plugin.framework.uno_context import get_desktop
@@ -914,8 +902,30 @@ def prepare_windows_writer_factory(ctx) -> int:
         "html_paste_writer: leftovers open=%s uids=%s frames=%s keeper=%s"
         % (len(leftover_uids), leftover_uids, leftover_frames, keeper or "-")
     )
-    reactivate_harness_keeper(desktop)
     return len(leftover_uids)
+
+
+def prepare_windows_writer_factory(ctx) -> int:
+    """Harness-only: log leftover paste Writers and reactivate the keeper.
+
+    What was wrong: GHA 34554275072 / 34553944171 hung 30s on the
+    *second* text_helpers Writer factory. Leftovers uid=26/27 were
+    already open (``close skipped pasted=True``). The first factory +
+    ``close_doc`` returned. GHA 34556185752 then hung 30s *inside*
+    leftover ``close(True)`` — product and harness must not close those
+    Writers after paste (33771766524).
+
+    Why this: enum leftovers (read-only; safe before load) and
+    ``setActiveFrame`` the keeper. Do not close leftovers. Returns how
+    many non-keeper Writers are still open. Windows-only caller.
+    """
+    if ctx is None:
+        return 0
+    from plugin.framework.uno_context import get_desktop
+
+    leftover_open = log_open_writer_leftovers(ctx)
+    reactivate_harness_keeper(get_desktop(ctx))
+    return leftover_open
 
 
 def _reraise_native_open_failure(
@@ -1531,13 +1541,16 @@ class TestingFactory:
         from plugin.testing_runner import probe_uno_bridge
 
         leftover_open = 0
-        if sys.platform == "win32" and factory_url == "private:factory/swriter":
-            leftover_open = prepare_windows_writer_factory(ctx)
+        if sys.platform == "win32":
             from plugin.testing_runner import _progress
 
+            if factory_url == "private:factory/swriter":
+                leftover_open = prepare_windows_writer_factory(ctx)
+            else:
+                leftover_open = log_open_writer_leftovers(ctx)
             _progress(
-                "create_native_doc: windows writer factory leftover_open=%s"
-                % leftover_open
+                "create_native_doc: load start url=%s leftover_open=%s"
+                % (factory_url, leftover_open)
             )
 
         # Distinguish "bridge already dead" (previous test) from "died during load".
@@ -1554,6 +1567,18 @@ class TestingFactory:
         except Exception as exc:
             _reraise_native_open_failure(exc, factory_url, pre_open=pre_open)
             raise
+        if sys.platform == "win32":
+            from plugin.testing_runner import _progress
+
+            uid = ""
+            try:
+                uid = str(getattr(doc, "RuntimeUID", None) or "")
+            except Exception:
+                uid = ""
+            _progress(
+                "create_native_doc: load done url=%s ok=%s uid=%s"
+                % (factory_url, doc is not None, uid or "-")
+            )
         return doc
 
     @staticmethod
@@ -1576,18 +1601,24 @@ class TestingFactory:
 
             uid = ""
             is_writer = False
+            is_calc = False
             if sys.platform == "win32":
                 try:
                     uid = str(getattr(doc, "RuntimeUID", None) or "")
                     is_writer = bool(
                         doc.supportsService("com.sun.star.text.TextDocument")
                     )
+                    is_calc = bool(
+                        doc.supportsService("com.sun.star.sheet.SpreadsheetDocument")
+                    )
                 except Exception:
                     is_writer = False
-                if is_writer:
+                    is_calc = False
+                if is_writer or is_calc:
                     from plugin.testing_runner import _progress
 
-                    _progress("close_doc: start uid=%s" % (uid or "-"))
+                    kind = "writer" if is_writer else "calc"
+                    _progress("close_doc: start kind=%s uid=%s" % (kind, uid or "-"))
 
             # Release PyUNO sequences before Calc tears down the document.
             # Large getDataArray results held across close can abort soffice (glibc double-free).
@@ -1603,14 +1634,18 @@ class TestingFactory:
                 doc.close(True)
             elif hasattr(doc, "dispose"):
                 doc.dispose()
-            if sys.platform == "win32" and is_writer:
+            if sys.platform == "win32" and (is_writer or is_calc):
                 from plugin.testing_runner import _progress
 
                 # Test Writer close returned (34554275072). Leftover close
                 # hangs (34556185752). Reactivate keeper so the next factory
                 # is not against a leftover paste Writer as current.
-                reactivate_harness_keeper()
-                _progress("close_doc: done uid=%s" % (uid or "-"))
+                # GHA 34593327841: after list_nearby FAIL, the *next* Calc
+                # factory hung — log Calc close too.
+                if is_writer:
+                    reactivate_harness_keeper()
+                kind = "writer" if is_writer else "calc"
+                _progress("close_doc: done kind=%s uid=%s" % (kind, uid or "-"))
         except Exception as exc:
             # Harness-only: close used to swallow DisposedException, so the
             # *next* factory open became the named victim. Log the trail here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Logging-only follow-up after #720 merged. No product behavior change. Do not guess a fix.

## Hang trail

[34554275072](https://github.com/KeithCu/writeragent/actions/runs/34554275072) / [34553944171](https://github.com/KeithCu/writeragent/actions/runs/34553944171): second `doc.test_text_helpers_uno` Writer factory hung 30s. Leftover paste Writers uid=26/27 (`close skipped pasted=True`).

[34556185752](https://github.com/KeithCu/writeragent/actions/runs/34556185752): leftover `close(True)` hung 30s on uid=27.

[34593327841](https://github.com/KeithCu/writeragent/actions/runs/34593327841) (master `754620ba`, `#720` merge, windows-latest): keeper reactivate **never ran** (no Writer factory yet). `test_list_nearby_excludes_active` FAIL (`Couldn't convert <traceback object> to a UNO type` / `getTypes`) in ~1s. Next test `test_open_document_for_read_hidden_readonly` hung 30s in `create_native_doc` `loadComponentFromURL(private:factory/scalc)` inside `_create_nearby_test_env`. Office stayed alive (`1568,4728`). On `#719` tips this Calc pair passed.

Cause of the list_nearby FAIL vs the Calc-factory hang is not proven.

## This PR

Windows `create_native_doc` logs `load start/done url=… leftover_open=N` for every factory. Calc `close_doc` logs `start/done kind=calc`. Nearby helper logs `nearby_env: …` around budget create/store/close and `list_nearby_files`. Still does not close leftover paste Writers.

## Windows re-dispatch

This agent cannot run `windows-latest`. After Ubuntu PR CI is green:

1. Actions → **PR CI** → **Run workflow**
2. Branch `cursor/windows-doc-research-create-native-a0c4`
3. `os=windows-latest`, `ci_debug=true`

Look for `nearby_env:` / `create_native_doc: load start` immediately before the FAIL or 30s Timeout so the next change can name the hung call.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca57e514-eea3-42e1-988b-3f8407cda0c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca57e514-eea3-42e1-988b-3f8407cda0c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

