### PR TITLE
Harness: leftover Writer reuse; Draw close breadcrumbs

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -173,6 +173,18 @@ the same traceback conversion). Harness: `prepare_windows_writer_factory`
 before every Windows `private:factory/` load. Breadcrumbs:
 `document_research_uno: create/store/close/list_nearby start/done`.
 
+GHA 34595675515 (`#722` first tip): breadcrumbs named the fail
+*after* `create budget calc start` + `leftovers open=3
+uids=['27','26','1'] keeper=-` and *before* `create budget calc done`.
+The traceback exception is `loadComponentFromURL(scalc)`, not
+`list_nearby_files`. `#720` stored the keeper on `tests.testing_utils`;
+suites import `plugin.tests.testing_utils` (same file, second object)
+so every prepare printed `keeper=-` and never `setActiveFrame`. Same
+dual-module family as #719 recycle. `set_harness_keeper_uid` now
+imports both names and writes both; `prepare` / `reactivate` adopt
+from the sibling if this copy is empty
+(`html_paste_writer: keeper adopted from sibling`).
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
@@ -189,7 +201,8 @@ Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
-`html_paste_writer: leftovers open` and `keeper reactivated` before
+`html_paste_writer: leftovers open` with a real `keeper=` uid (not
+`-`), optional `keeper adopted from sibling`, and `keeper reactivated` before
 Windows `private:factory/` loads (Writer **and** Calc),
 `document_research_uno` three tests `TEST end … OK`, both
 text_helpers tests `TEST end … OK`, later suites including the peer

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -208,6 +208,16 @@ With leftovers open, every Windows `private:factory/` load uses a unique
 `_wa_factory_N` target and CREATE|GLOBAL (`8|55`), not `_blank`. Do not
 close leftovers (34556185752).
 
+GHA 34601787293 (`fc34f0c6`) and 34602219973 (`ec40ed29`): unique
+targets loaded all three leftover Calc factories (`_wa_factory_1..3`,
+`document_research_uno` passed=3) and the first leftover swriter
+(`_wa_factory_4` uid=34, `close_doc` done). The *next* unique swriter
+(`_wa_factory_5`) hung 30s. Unique CREATE is not enough after a harness
+Writer `close_doc` while leftovers remain. Windows then reuses that
+first leftover Writer (wipe-and-reuse pool) and skips Writer `close_doc`
+while leftovers are open (`native_doc: leftover writer reuse`,
+`close_doc: skip writer close leftovers`).
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
@@ -220,7 +230,9 @@ POSIX still `close_doc`. Breadcrumbs:
 `create_native_doc: windows factory leftover_open=N url=… target=… flags=…`,
 `create_native_doc: load start/done` (leftover Windows factory),
 `document_research_uno: create/store/close/list_nearby start/done`,
-`close_doc: start/done uid=…` (Windows Writer). Do **not** fold
+`close_doc: start/done uid=…` (Windows Writer),
+`native_doc: leftover writer reuse`,
+`close_doc: skip writer close leftovers open=N uid=…`. Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
@@ -229,7 +241,9 @@ branch: `os=windows-latest`, `ci_debug=true`. Look for
 `-`), optional `keeper adopted from sibling`, and `keeper reactivated` before
 Windows `private:factory/` loads (Writer **and** Calc), leftover
 factory loads using `target=_wa_factory_N` (not `_blank`) plus
-`create_native_doc: load done`, `document_research_uno` three tests
+`create_native_doc: load done`, `native_doc: leftover writer reuse` and
+no second leftover swriter factory after the first text_helpers Writer,
+`document_research_uno` three tests
 `TEST end … OK`, both text_helpers tests `TEST end … OK` (no 30s
 Timeout in `create_native_doc`), later suites including the peer
 file last (six peer `TEST end … OK`), then

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -196,10 +196,17 @@ The *next* swriter (`…_multi_para_joins_with_newline`) hung 30s in
 `create_native_doc` after the same leftover log + keeper reactivate.
 `setActiveFrame` is not enough for a second consecutive Hidden `_blank`
 while leftover `_wa_calc_html` frames remain (same Windows frame-manager
-collision `rich_html.py` already avoids). With leftovers open, Windows
-swriter factories now use a unique `_wa_factory_N` target and CREATE|GLOBAL
-(`8|55`), not `_blank`. Do not close leftovers (34556185752). Calc stays
-`_blank`.
+collision `rich_html.py` already avoids).
+
+GHA 34599838644 (`afae5938`, swriter-only named target): Linux PR CI
+34599725706 green. Windows `workflow_dispatch` never reached
+text_helpers. Same leftovers + `keeper=1` + reactivate, then Calc
+`_blank` failed in ~1s (`Couldn't convert <traceback object> … getTypes`
+on `loadComponentFromURL(scalc)`) and the next Calc `_blank` hung 30s
+in `create_native_doc`. Calc `_blank` + leftovers is not reliable.
+With leftovers open, every Windows `private:factory/` load uses a unique
+`_wa_factory_N` target and CREATE|GLOBAL (`8|55`), not `_blank`. Do not
+close leftovers (34556185752).
 
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
@@ -221,7 +228,7 @@ branch: `os=windows-latest`, `ci_debug=true`. Look for
 `html_paste_writer: leftovers open` with a real `keeper=` uid (not
 `-`), optional `keeper adopted from sibling`, and `keeper reactivated` before
 Windows `private:factory/` loads (Writer **and** Calc), leftover
-swriter loads using `target=_wa_factory_N` (not `_blank`) plus
+factory loads using `target=_wa_factory_N` (not `_blank`) plus
 `create_native_doc: load done`, `document_research_uno` three tests
 `TEST end … OK`, both text_helpers tests `TEST end … OK` (no 30s
 Timeout in `create_native_doc`), later suites including the peer

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -185,6 +185,22 @@ imports both names and writes both; `prepare` / `reactivate` adopt
 from the sibling if this copy is empty
 (`html_paste_writer: keeper adopted from sibling`).
 
+GHA 34597506651 (`054a03e0`, second #722 tip): keeper sync worked.
+`document_research_uno` all three tests passed (`leftovers open=2
+uids=['27','26'] frames=['-','-'] keeper=1`, `keeper reactivated`,
+Calc factory loads finished, `list_nearby_files done status=ok`).
+Linux PR CI 34597434533 was green. Hang moved to
+`doc.test_text_helpers_uno`: first swriter (`…_paragraph_bold_run_no_newline`)
+printed leftovers + keeper reactivate, created uid=34, `close_doc` OK.
+The *next* swriter (`…_multi_para_joins_with_newline`) hung 30s in
+`create_native_doc` after the same leftover log + keeper reactivate.
+`setActiveFrame` is not enough for a second consecutive Hidden `_blank`
+while leftover `_wa_calc_html` frames remain (same Windows frame-manager
+collision `rich_html.py` already avoids). With leftovers open, Windows
+swriter factories now use a unique `_wa_factory_N` target and CREATE|GLOBAL
+(`8|55`), not `_blank`. Do not close leftovers (34556185752). Calc stays
+`_blank`.
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
@@ -194,7 +210,8 @@ POSIX still `close_doc`. Breadcrumbs:
 `peer_message_uno: close_doc start/done uid=…` (POSIX).
 `html_paste_writer: leftovers open=N uids=…`,
 `html_paste_writer: keeper reactivated`,
-`create_native_doc: windows factory leftover_open=N url=…`,
+`create_native_doc: windows factory leftover_open=N url=… target=… flags=…`,
+`create_native_doc: load start/done` (leftover Windows factory),
 `document_research_uno: create/store/close/list_nearby start/done`,
 `close_doc: start/done uid=…` (Windows Writer). Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
@@ -203,9 +220,11 @@ Draw-family settle into `close_doc`. Not a product fix.
 branch: `os=windows-latest`, `ci_debug=true`. Look for
 `html_paste_writer: leftovers open` with a real `keeper=` uid (not
 `-`), optional `keeper adopted from sibling`, and `keeper reactivated` before
-Windows `private:factory/` loads (Writer **and** Calc),
-`document_research_uno` three tests `TEST end … OK`, both
-text_helpers tests `TEST end … OK`, later suites including the peer
+Windows `private:factory/` loads (Writer **and** Calc), leftover
+swriter loads using `target=_wa_factory_N` (not `_blank`) plus
+`create_native_doc: load done`, `document_research_uno` three tests
+`TEST end … OK`, both text_helpers tests `TEST end … OK` (no 30s
+Timeout in `create_native_doc`), later suites including the peer
 file last (six peer `TEST end … OK`), then
 `LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI
 is the automatic gate; this cloud agent cannot run `windows-latest`.

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -156,6 +156,23 @@ docs still close — that returned on 34554275072), reactivate the
 keeper again (`html_paste_writer: leftovers open=…`,
 `html_paste_writer: keeper reactivated`).
 
+GHA 34593327841 (master `754620ba`, tip of `#720`): first Windows UNO
+run after that merge. `insert_cell_html_rich` again left uid=26/27
+(`close skipped pasted=True`). Calc + chatbot suites stayed green.
+`test_list_nearby_excludes_active` failed in ~1s with PyUNO
+`Couldn't convert <traceback object> … getTypes` (no Python traceback;
+office alive). The next test hung 30s in
+`create_native_doc(private:factory/scalc)` inside
+`_create_nearby_test_env`. `#720` only prepared *Writer* factory loads.
+Leftover paste Writers as desktop current also wedge a later **Calc**
+factory, and `list_nearby_files` walked those leftovers without a
+per-component try/except. Product: skip a broken desktop component in
+`_office_model_from_desktop_element` / `_collect_open_file_urls` (do
+not `log.exception` that walk — formatting a UNO exception can raise
+the same traceback conversion). Harness: `prepare_windows_writer_factory`
+before every Windows `private:factory/` load. Breadcrumbs:
+`document_research_uno: create/store/close/list_nearby start/done`.
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
@@ -165,16 +182,18 @@ POSIX still `close_doc`. Breadcrumbs:
 `peer_message_uno: close_doc start/done uid=…` (POSIX).
 `html_paste_writer: leftovers open=N uids=…`,
 `html_paste_writer: keeper reactivated`,
-`create_native_doc: windows writer factory leftover_open=N`,
+`create_native_doc: windows factory leftover_open=N url=…`,
+`document_research_uno: create/store/close/list_nearby start/done`,
 `close_doc: start/done uid=…` (Windows Writer). Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
 `html_paste_writer: leftovers open` and `keeper reactivated` before
-the first text_helpers Writer load, both text_helpers tests
-`TEST end … OK`, later suites including the peer file last (six peer
-`TEST end … OK`), then
+Windows `private:factory/` loads (Writer **and** Calc),
+`document_research_uno` three tests `TEST end … OK`, both
+text_helpers tests `TEST end … OK`, later suites including the peer
+file last (six peer `TEST end … OK`), then
 `LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI
 is the automatic gate; this cloud agent cannot run `windows-latest`.
 

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -204,18 +204,27 @@ text_helpers. Same leftovers + `keeper=1` + reactivate, then Calc
 `_blank` failed in ~1s (`Couldn't convert <traceback object> … getTypes`
 on `loadComponentFromURL(scalc)`) and the next Calc `_blank` hung 30s
 in `create_native_doc`. Calc `_blank` + leftovers is not reliable.
-With leftovers open, every Windows `private:factory/` load uses a unique
-`_wa_factory_N` target and CREATE|GLOBAL (`8|55`), not `_blank`. Do not
-close leftovers (34556185752).
+With leftovers open, leftover Hidden `swriter` reuses one CREATE|GLOBAL
+name `_wa_factory` (same pattern as `rich_html._wa_calc_html`). Leftover
+Calc/Draw/Impress still use a unique `_wa_factory_N` so a live pooled
+Calc is not replaced. Do not close leftovers (34556185752).
 
-GHA 34601787293 (`fc34f0c6`) and 34602219973 (`ec40ed29`): unique
-targets loaded all three leftover Calc factories (`_wa_factory_1..3`,
-`document_research_uno` passed=3) and the first leftover swriter
-(`_wa_factory_4` uid=34, `close_doc` done). The *next* unique swriter
-(`_wa_factory_5`) hung 30s. Unique CREATE is not enough after a harness
-Writer `close_doc` while leftovers remain. Windows then reuses that
-first leftover Writer (wipe-and-reuse pool) and skips Writer `close_doc`
-while leftovers are open (`native_doc: leftover writer reuse`,
+GHA 34601787293 (`fc34f0c6`) and 34602219973 (`ec40ed29`): Linux PR CI
+34602130908 green. Unique targets loaded leftover Calc
+(`document_research_uno` passed=3, `_wa_factory_1/2/3`) and the first
+leftover Hidden swriter
+(`doc.test_text_helpers_uno.test_get_string_without_tracked_deletions_paragraph_bold_run_no_newline`,
+`target=_wa_factory_4`, uid=34, `close_doc` OK, leftovers still
+uids=`['27','26']`). The *next* leftover Hidden swriter
+(`…_multi_para_joins_with_newline`, `target=_wa_factory_5`) hung 30s in
+`loadComponentFromURL` — no RuntimeException. Unique CREATE stacked
+empty named frames after harness Writer close; it did not fix the
+original consecutive leftover Hidden swriter hang (34597506651).
+Windows then (1) reuses one CREATE|GLOBAL name `_wa_factory` for
+leftover `swriter` so a direct `create_native_doc(writer)` replaces
+instead of stacking, and (2) pools that first leftover Writer and
+skips Writer `close_doc` while leftovers remain
+(`native_doc: leftover writer reuse`,
 `close_doc: skip writer close leftovers`).
 
 POSIX still `close_doc`. Breadcrumbs:
@@ -240,13 +249,15 @@ branch: `os=windows-latest`, `ci_debug=true`. Look for
 `html_paste_writer: leftovers open` with a real `keeper=` uid (not
 `-`), optional `keeper adopted from sibling`, and `keeper reactivated` before
 Windows `private:factory/` loads (Writer **and** Calc), leftover
-factory loads using `target=_wa_factory_N` (not `_blank`) plus
+swriter loads using `target=_wa_factory` (not `_blank` / not
+`_wa_factory_N`) plus leftover Calc using `target=_wa_factory_N`,
 `create_native_doc: load done`, `native_doc: leftover writer reuse` and
 no second leftover swriter factory after the first text_helpers Writer,
 `document_research_uno` three tests
 `TEST end … OK`, both text_helpers tests `TEST end … OK` (no 30s
-Timeout in `create_native_doc`), later suites including the peer
-file last (six peer `TEST end … OK`), then
+Timeout in `create_native_doc` on
+`…_multi_para_joins_with_newline` / `target=_wa_factory_5`), later
+suites including the peer file last (six peer `TEST end … OK`), then
 `LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI
 is the automatic gate; this cloud agent cannot run `windows-latest`.
 

--- a/docs/framework/uno-utilities.md
+++ b/docs/framework/uno-utilities.md
@@ -401,7 +401,7 @@ Classification: **intentional split** (keep) / **accidental copy** (unify later)
 | `uno_context.normalize_doc_url` vs `document_scripts._normalize_doc_url` | Trailing-slash strip | **Landed.** Script identity imports `normalize_doc_url`; the document_scripts copy is gone. |
 | `document_research._path_to_file_url` vs `embeddings_fs.path_to_file_url` vs `format._file_url` | `Path(abspath).as_uri()` | **Landed.** Shared `url_utils.path_to_file_url` (filesystem section). Old copies deleted; no aliases. |
 | `text_helpers.normalize_file_url` vs sandbox vs session_manager `file:/` repair | `file:/` → `file://` + rest | **Landed for UNO callers** (`get_document_path` + research). Sandbox / session_manager stay stdlib. |
-| Desktop component walks | `resolve_document_by_url`, `get_open_documents`, `_collect_open_file_urls` | All enumerate `desktop.getComponents()`. Research already has `_office_model_from_desktop_element`; resolve has a slightly different frame-vs-model walk. |
+| Desktop component walks | `resolve_document_by_url`, `get_open_documents`, `_collect_open_file_urls` | All enumerate `desktop.getComponents()`. Research already has `_office_model_from_desktop_element`; resolve has a slightly different frame-vs-model walk. GHA 34593327841: leftover HTML-paste Writers must be skipped per-component (`getController` / `getURL` can raise PyUNO traceback-conversion); do not abort the whole nearby listing. |
 
 ### 3.2 Intentional splits (do not collapse)
 

--- a/plugin/doc/document_research.py
+++ b/plugin/doc/document_research.py
@@ -282,8 +282,21 @@ def _office_model_from_desktop_element(elem: Any) -> Any | None:
     if elem is None:
         return None
     model = elem
-    if hasattr(elem, "getController") and elem.getController():
-        model = elem.getController().getModel()
+    try:
+        if hasattr(elem, "getController") and elem.getController():
+            model = elem.getController().getModel()
+    except Exception as exc:
+        # GHA 34593327841: leftover HTML-paste Writers (close skipped
+        # pasted=True) stay on the desktop. getController/getModel on those
+        # can raise, including PyUNO "Couldn't convert traceback … getTypes".
+        # An uncaught raise aborted list_nearby_files. Skip this component.
+        # Do not log exc_info: formatting a UNO exception can raise the same
+        # traceback-conversion RuntimeException.
+        log.debug(
+            "_office_model_from_desktop_element: skip component (%s)",
+            type(exc).__name__,
+        )
+        return None
     if model is None:
         return None
     from plugin.framework.thread_guard import guard_uno
@@ -308,25 +321,50 @@ def _collect_open_file_urls(
         if not comps:
             return out
         enum = comps.createEnumeration()
-        while enum and enum.hasMoreElements():
-            elem = enum.nextElement()
-            model = _office_model_from_desktop_element(elem)
-            if model is None or not hasattr(model, "getURL"):
+        # Same MagicMock / leftover-component guard as get_open_documents:
+        # a truthy mock or one broken paste Writer must not abort the walk.
+        while enum is not None:
+            try:
+                more = enum.hasMoreElements()
+            except Exception:
+                break
+            if more is not True and more != 1:
+                break
+            try:
+                elem = enum.nextElement()
+            except Exception:
+                break
+            try:
+                model = _office_model_from_desktop_element(elem)
+                if model is None or not hasattr(model, "getURL"):
+                    continue
+                url = model.getURL()
+                if not url or not str(url).startswith("file://"):
+                    continue
+                path = _system_path_from_url(str(url))
+                if not path:
+                    continue
+                if exclude_norm and _normalize_path(path) == exclude_norm:
+                    continue
+                ext = os.path.splitext(path)[1].lower()
+                if ext not in extensions:
+                    continue
+                out[_normalize_path(path)] = str(url)
+            except Exception as exc:
+                # GHA 34593327841: one leftover/broken component raised
+                # through getURL and aborted the whole nearby listing.
+                log.debug(
+                    "_collect_open_file_urls: skip component (%s)",
+                    type(exc).__name__,
+                )
                 continue
-            url = model.getURL()
-            if not url or not str(url).startswith("file://"):
-                continue
-            path = _system_path_from_url(str(url))
-            if not path:
-                continue
-            if exclude_norm and _normalize_path(path) == exclude_norm:
-                continue
-            ext = os.path.splitext(path)[1].lower()
-            if ext not in extensions:
-                continue
-            out[_normalize_path(path)] = str(url)
     except Exception:
-        log.exception("_collect_open_file_urls failed")
+        try:
+            log.exception("_collect_open_file_urls failed")
+        except Exception:
+            # PyUNO: logging a UNO exception can raise
+            # "Couldn't convert traceback … getTypes" (GHA 34593327841).
+            pass
     return out
 
 

--- a/tests/doc/test_document_research.py
+++ b/tests/doc/test_document_research.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from plugin.doc.document_research import (
     NEARBY_FILE_EXTENSIONS,
     NEARBY_IMAGE_EXTENSIONS,
+    _collect_open_file_urls,
     _system_path_from_url,
     close_document_research_document,
     guess_doc_type_from_path,
@@ -282,6 +283,99 @@ def test_list_nearby_files_file_kind_documents_explicit():
                     result = list_nearby_files(ctx, model, file_kind="documents")
         assert result["status"] == "ok"
         assert [f["name"] for f in result["files"]] == ["Budget.ods"]
+
+
+def test_collect_open_file_urls_skips_broken_desktop_component():
+    """GHA 34593327841: leftover paste Writer must not abort the nearby walk."""
+    with tempfile.TemporaryDirectory() as tmp:
+        budget = os.path.join(tmp, "Budget_2026.ods")
+        with open(budget, "wb"):
+            pass
+        budget_url = path_to_file_url(budget)
+        budget_norm = os.path.normpath(os.path.abspath(budget))
+
+        broken = MagicMock(name="leftover_paste_writer")
+        broken.getController.side_effect = RuntimeError(
+            "Couldn't convert <traceback object> to a UNO type"
+        )
+
+        good = MagicMock(name="saved_calc")
+        good.getController.return_value = None
+        good.getURL.return_value = budget_url
+
+        class _Enum:
+            def __init__(self, items):
+                self._items = list(items)
+
+            def hasMoreElements(self):
+                return bool(self._items)
+
+            def nextElement(self):
+                return self._items.pop(0)
+
+        desktop = MagicMock()
+        desktop.getComponents.return_value.createEnumeration.return_value = _Enum(
+            [broken, good]
+        )
+        with (
+            patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+            patch(
+                "plugin.doc.document_research._system_path_from_url",
+                side_effect=lambda url: budget_norm if url == budget_url else None,
+            ),
+            patch("plugin.framework.thread_guard.guard_uno", side_effect=lambda obj: obj),
+        ):
+            out = _collect_open_file_urls(
+                object(), exclude_path=None, extensions=NEARBY_FILE_EXTENSIONS
+            )
+        assert out == {budget_norm: budget_url}
+
+
+def test_collect_open_file_urls_skips_geturl_failure():
+    """Same leftover family: getURL raise must not abort later components."""
+    with tempfile.TemporaryDirectory() as tmp:
+        budget = os.path.join(tmp, "Budget_2026.ods")
+        with open(budget, "wb"):
+            pass
+        budget_url = path_to_file_url(budget)
+        budget_norm = os.path.normpath(os.path.abspath(budget))
+
+        broken = MagicMock(name="leftover_no_url")
+        broken.getController.return_value = None
+        broken.getURL.side_effect = RuntimeError(
+            "Couldn't convert <traceback object> to a UNO type"
+        )
+
+        good = MagicMock(name="saved_calc")
+        good.getController.return_value = None
+        good.getURL.return_value = budget_url
+
+        class _Enum:
+            def __init__(self, items):
+                self._items = list(items)
+
+            def hasMoreElements(self):
+                return bool(self._items)
+
+            def nextElement(self):
+                return self._items.pop(0)
+
+        desktop = MagicMock()
+        desktop.getComponents.return_value.createEnumeration.return_value = _Enum(
+            [broken, good]
+        )
+        with (
+            patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+            patch(
+                "plugin.doc.document_research._system_path_from_url",
+                side_effect=lambda url: budget_norm if url == budget_url else None,
+            ),
+            patch("plugin.framework.thread_guard.guard_uno", side_effect=lambda obj: obj),
+        ):
+            out = _collect_open_file_urls(
+                object(), exclude_path=None, extensions=NEARBY_FILE_EXTENSIONS
+            )
+        assert out == {budget_norm: budget_url}
 
 
 def test_close_document_research_document_skips_reused_open():

--- a/tests/doc/test_document_research_uno.py
+++ b/tests/doc/test_document_research_uno.py
@@ -16,21 +16,38 @@ from plugin.testing_runner import native_test
 from plugin.tests.testing_utils import TestingFactory, with_native_doc
 
 
+def _nearby_progress(msg: str) -> None:
+    """Name the last UNO call if Windows GHA fails without a Python traceback."""
+    from plugin.testing_runner import _progress
+
+    _progress("document_research_uno: %s" % msg)
+
+
 def _create_nearby_test_env(ctx, active_doc):
     temp_dir = tempfile.mkdtemp(prefix="wa_nearby_")
 
+    # GHA 34593327841: first fail had no Python traceback; the next scalc
+    # factory hung 30s. Breadcrumbs name store/close vs list_nearby.
+    _nearby_progress("create budget calc start")
     budget = TestingFactory.create_native_doc(ctx, "calc", hidden=True)
+    _nearby_progress("create budget calc done")
     sheet = budget.Sheets.getByIndex(0)
     sheet.getCellByPosition(0, 0).setFormula("100")
     sheet.getCellByPosition(0, 1).setFormula("Q4")
     sheet.getCellByPosition(1, 1).setFormula("42")
 
     budget_path = os.path.join(temp_dir, "Budget_2026.ods")
+    _nearby_progress("store budget start")
     budget.storeAsURL(uno.systemPathToFileUrl(budget_path), ())
+    _nearby_progress("store budget done")
+    _nearby_progress("close budget start")
     TestingFactory.close_doc(budget)
+    _nearby_progress("close budget done")
 
     active_path = os.path.join(temp_dir, "Report.ods")
+    _nearby_progress("store active start")
     active_doc.storeAsURL(uno.systemPathToFileUrl(active_path), ())
+    _nearby_progress("store active done")
 
     return temp_dir, budget_path
 
@@ -53,7 +70,9 @@ def _cleanup_nearby_test_env(temp_dir):
 def test_list_nearby_excludes_active(ctx, doc):
     temp_dir, _ = _create_nearby_test_env(ctx, doc)
     try:
+        _nearby_progress("list_nearby_files start")
         result = list_nearby_files(ctx, doc)
+        _nearby_progress("list_nearby_files done status=%s" % result.get("status"))
         assert result["status"] == "ok"
         names = {f["name"] for f in result["files"]}
         assert "Budget_2026.ods" in names

--- a/tests/framework/test_guard_uno_boundaries.py
+++ b/tests/framework/test_guard_uno_boundaries.py
@@ -217,6 +217,19 @@ class TestGuardUnoBoundaries(unittest.TestCase):
         self.assertIs(out, elem)
         mock_guard.assert_called_once_with(elem)
 
+    def test_office_model_from_desktop_element_skips_broken_controller(self) -> None:
+        """GHA 34593327841: leftover paste Writer getController must not abort listing."""
+        elem = MagicMock(name="leftover_paste_writer")
+        elem.getController.side_effect = RuntimeError(
+            "Couldn't convert <traceback object> to a UNO type"
+        )
+        with patch("plugin.framework.thread_guard.guard_uno") as mock_guard:
+            from plugin.doc.document_research import _office_model_from_desktop_element
+
+            out = _office_model_from_desktop_element(elem)
+        self.assertIsNone(out)
+        mock_guard.assert_not_called()
+
     def test_get_active_calc_cell_wraps_model(self) -> None:
         model = MagicMock()
         model.getSheets = MagicMock()

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -415,22 +415,29 @@ def test_prepare_windows_writer_factory_adopts_keeper_from_sibling(monkeypatch):
         tu.set_harness_keeper_uid("")
 
 
-def test_windows_factory_load_args_named_only_for_leftover_swriter():
-    """GHA 34597506651: second consecutive _blank swriter hung; unique CREATE target."""
+def test_windows_factory_load_args_named_for_any_leftover_factory():
+    """GHA 34597506651 / 34599838644: leftover _blank hangs Writer and Calc."""
     import plugin.tests.testing_utils as tu
 
     saved = tu._WINDOWS_FACTORY_SEQ
     tu._WINDOWS_FACTORY_SEQ = 0
     try:
         assert tu._windows_factory_load_args("private:factory/swriter", 0) == ("_blank", 0)
-        assert tu._windows_factory_load_args("private:factory/scalc", 2) == ("_blank", 0)
-        assert tu._windows_factory_load_args("private:factory/sdraw", 2) == ("_blank", 0)
-        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+        assert tu._windows_factory_load_args("private:factory/scalc", 0) == ("_blank", 0)
+        assert tu._windows_factory_load_args("private:factory/scalc", 2) == (
             "_wa_factory_1",
             8 | 55,
         )
-        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+        assert tu._windows_factory_load_args("private:factory/sdraw", 2) == (
             "_wa_factory_2",
+            8 | 55,
+        )
+        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+            "_wa_factory_3",
+            8 | 55,
+        )
+        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+            "_wa_factory_4",
             8 | 55,
         )
     finally:
@@ -490,22 +497,28 @@ def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
     desktop = MagicMock()
     desktop.loadComponentFromURL.return_value = MagicMock()
     calls = []
+    saved_seq = tu._WINDOWS_FACTORY_SEQ
+    tu._WINDOWS_FACTORY_SEQ = 0
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(
         tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 2
     )
-    with (
-        patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
-        patch("uno.createUnoStruct", return_value=MagicMock()),
-        patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
-    ):
-        TestingFactory.create_native_doc(object(), "calc")
-    assert calls == ["prepare"]
-    args = desktop.loadComponentFromURL.call_args.args
-    assert args[0] == "private:factory/scalc"
-    # Calc _blank already succeeds with leftovers; only swriter needs a named target.
-    assert args[1] == "_blank"
-    assert args[2] == 0
+    try:
+        with (
+            patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+            patch("uno.createUnoStruct", return_value=MagicMock()),
+            patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
+        ):
+            TestingFactory.create_native_doc(object(), "calc")
+        assert calls == ["prepare"]
+        args = desktop.loadComponentFromURL.call_args.args
+        assert args[0] == "private:factory/scalc"
+        # GHA 34599838644: leftover Calc _blank failed then hung. Same named
+        # CREATE target as leftover swriter.
+        assert args[1] == "_wa_factory_1"
+        assert args[2] == (8 | 55)
+    finally:
+        tu._WINDOWS_FACTORY_SEQ = saved_seq
 
 
 def test_create_native_doc_posix_does_not_prepare_writer_factory(monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -369,7 +369,8 @@ def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypat
     desktop.loadComponentFromURL.assert_called_once()
 
 
-def test_create_native_doc_windows_calc_does_not_prepare_writer_factory(monkeypatch):
+def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
+    """GHA 34593327841: leftover paste Writer as current hung the next scalc load."""
     from unittest.mock import MagicMock, patch
 
     from plugin.tests.testing_utils import TestingFactory
@@ -380,7 +381,7 @@ def test_create_native_doc_windows_calc_does_not_prepare_writer_factory(monkeypa
     calls = []
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(
-        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare")
+        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 2
     )
     with (
         patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
@@ -388,7 +389,8 @@ def test_create_native_doc_windows_calc_does_not_prepare_writer_factory(monkeypa
         patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
     ):
         TestingFactory.create_native_doc(object(), "calc")
-    assert calls == []
+    assert calls == ["prepare"]
+    desktop.loadComponentFromURL.assert_called_once()
 
 
 def test_create_native_doc_posix_does_not_prepare_writer_factory(monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -415,8 +415,36 @@ def test_prepare_windows_writer_factory_adopts_keeper_from_sibling(monkeypatch):
         tu.set_harness_keeper_uid("")
 
 
+def test_windows_factory_load_args_named_only_for_leftover_swriter():
+    """GHA 34597506651: second consecutive _blank swriter hung; unique CREATE target."""
+    import plugin.tests.testing_utils as tu
+
+    saved = tu._WINDOWS_FACTORY_SEQ
+    tu._WINDOWS_FACTORY_SEQ = 0
+    try:
+        assert tu._windows_factory_load_args("private:factory/swriter", 0) == ("_blank", 0)
+        assert tu._windows_factory_load_args("private:factory/scalc", 2) == ("_blank", 0)
+        assert tu._windows_factory_load_args("private:factory/sdraw", 2) == ("_blank", 0)
+        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+            "_wa_factory_1",
+            8 | 55,
+        )
+        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+            "_wa_factory_2",
+            8 | 55,
+        )
+    finally:
+        tu._WINDOWS_FACTORY_SEQ = saved
+
+
 def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypatch):
-    """Second text_helpers Writer factory hung after leftovers + one close_doc."""
+    """Second text_helpers Writer factory hung after leftovers + one close_doc.
+
+    GHA 34597506651: keeper reactivate printed, first swriter _blank returned,
+    the next _blank hung 30s. Named CREATE|GLOBAL target matches HTML paste
+    (rich_html._wa_calc_html) and must increment so two consecutive factories
+    do not share a frame name.
+    """
     from unittest.mock import MagicMock, patch
 
     from plugin.tests.testing_utils import TestingFactory
@@ -425,18 +453,31 @@ def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypat
     desktop = MagicMock()
     desktop.loadComponentFromURL.return_value = MagicMock()
     calls = []
+    saved_seq = tu._WINDOWS_FACTORY_SEQ
+    tu._WINDOWS_FACTORY_SEQ = 0
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(
         tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 2
     )
-    with (
-        patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
-        patch("uno.createUnoStruct", return_value=MagicMock()),
-        patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
-    ):
-        TestingFactory.create_native_doc(object(), "writer")
-    assert calls == ["prepare"]
-    desktop.loadComponentFromURL.assert_called_once()
+    try:
+        with (
+            patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+            patch("uno.createUnoStruct", return_value=MagicMock()),
+            patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
+        ):
+            TestingFactory.create_native_doc(object(), "writer")
+            assert calls == ["prepare"]
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/swriter"
+            assert args[1] == "_wa_factory_1"
+            assert args[2] == (8 | 55)
+            TestingFactory.create_native_doc(object(), "writer")
+            assert calls == ["prepare", "prepare"]
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[1] == "_wa_factory_2"
+            assert args[2] == (8 | 55)
+    finally:
+        tu._WINDOWS_FACTORY_SEQ = saved_seq
 
 
 def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
@@ -460,7 +501,11 @@ def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
     ):
         TestingFactory.create_native_doc(object(), "calc")
     assert calls == ["prepare"]
-    desktop.loadComponentFromURL.assert_called_once()
+    args = desktop.loadComponentFromURL.call_args.args
+    assert args[0] == "private:factory/scalc"
+    # Calc _blank already succeeds with leftovers; only swriter needs a named target.
+    assert args[1] == "_blank"
+    assert args[2] == 0
 
 
 def test_create_native_doc_posix_does_not_prepare_writer_factory(monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -527,6 +527,75 @@ def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
         tu._WINDOWS_FACTORY_SEQ = saved_seq
 
 
+def test_windows_should_reuse_writer_only_with_leftovers(monkeypatch):
+    """GHA 34602219973: second leftover swriter hung after close of uid=34."""
+    import plugin.tests.testing_utils as tu
+
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 2)
+    assert tu._windows_should_reuse_writer(object()) is True
+    monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 0)
+    assert tu._windows_should_reuse_writer(object()) is False
+    monkeypatch.setattr(tu.sys, "platform", "linux")
+    monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 2)
+    assert tu._windows_should_reuse_writer(object()) is False
+    assert tu._windows_should_reuse_writer(None) is False
+
+
+def test_close_doc_skips_windows_writer_when_leftovers_open(monkeypatch):
+    """GHA 34602219973: close_doc uid=34 returned; next unique swriter hung."""
+    from unittest.mock import MagicMock
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    doc = MagicMock()
+    doc.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    doc.RuntimeUID = "34"
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    tu._WINDOWS_LEFTOVER_OPEN = 2
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(tu, "reactivate_harness_keeper", lambda desktop=None: True)
+    try:
+        TestingFactory.close_doc(doc)
+        doc.close.assert_not_called()
+    finally:
+        tu._WINDOWS_LEFTOVER_OPEN = saved
+
+
+def test_native_doc_windows_reuses_writer_when_leftovers_open(monkeypatch):
+    """Second leftover swriter must not factory-load after the first close."""
+    from unittest.mock import MagicMock
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    writer = MagicMock(name="pooled_writer")
+    created = []
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 2)
+    monkeypatch.setattr(tu, "reset_native_doc", lambda *a, **k: None)
+    monkeypatch.setattr(tu, "_writer_pool_is_clean", lambda _doc: True)
+    monkeypatch.setattr(
+        TestingFactory,
+        "create_native_doc",
+        lambda *a, **k: created.append("create") or writer,
+    )
+    monkeypatch.setattr(
+        TestingFactory, "close_doc", lambda *a, **k: created.append("close")
+    )
+    tu._NATIVE_DOC_POOL.clear()
+    ctx = object()
+    try:
+        with TestingFactory.native_doc(ctx, "writer") as first:
+            assert first is writer
+        with TestingFactory.native_doc(ctx, "writer") as second:
+            assert second is writer
+        assert created == ["create"]
+    finally:
+        tu._NATIVE_DOC_POOL.clear()
+
+
 def test_create_native_doc_posix_does_not_prepare_writer_factory(monkeypatch):
     from unittest.mock import MagicMock, patch
 
@@ -655,6 +724,8 @@ def test_close_doc_windows_writer_reactivates_keeper(monkeypatch):
     monkeypatch.setattr("gc.collect", lambda: None)
     monkeypatch.setattr("time.sleep", lambda _seconds: None)
     tu.set_harness_keeper_uid("1", keeper)
+    saved_leftover = tu._WINDOWS_LEFTOVER_OPEN
+    tu._WINDOWS_LEFTOVER_OPEN = 0
     doc = MagicMock()
     doc.RuntimeUID = "99"
     doc.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
@@ -663,6 +734,7 @@ def test_close_doc_windows_writer_reactivates_keeper(monkeypatch):
         doc.close.assert_called_once_with(True)
         desktop.setActiveFrame.assert_called_once_with(frame)
     finally:
+        tu._WINDOWS_LEFTOVER_OPEN = saved_leftover
         tu.set_harness_keeper_uid("")
 
 

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -345,6 +345,76 @@ def test_prepare_windows_writer_factory_keeper_only_still_reactivates(monkeypatc
         tu.set_harness_keeper_uid("")
 
 
+def test_set_harness_keeper_uid_writes_sibling_testing_utils_module(monkeypatch):
+    """GHA 34595675515: runner set tests.testing_utils; factory read plugin.tests copy."""
+    import sys
+    import types
+
+    from plugin.tests import testing_utils as tu
+
+    sibling = types.ModuleType("tests.testing_utils")
+    sibling.__file__ = tu.__file__
+    sibling._HARNESS_KEEPER_UID = ""
+    sibling._HARNESS_KEEPER_DOC = None
+    monkeypatch.setitem(sys.modules, "tests.testing_utils", sibling)
+    keeper_doc = object()
+    try:
+        tu.set_harness_keeper_uid("1", keeper_doc)
+        assert tu._HARNESS_KEEPER_UID == "1"
+        assert sibling._HARNESS_KEEPER_UID == "1"
+        assert sibling._HARNESS_KEEPER_DOC is keeper_doc
+    finally:
+        tu.set_harness_keeper_uid("")
+
+
+def test_prepare_windows_writer_factory_adopts_keeper_from_sibling(monkeypatch):
+    """Same dual-module miss: prepare saw keeper=- and counted uid=1 as leftover."""
+    import sys
+    import types
+    from unittest.mock import MagicMock
+
+    from plugin.tests import testing_utils as tu
+
+    sibling = types.ModuleType("tests.testing_utils")
+    sibling.__file__ = tu.__file__
+    keeper = MagicMock(name="keeper")
+    keeper.RuntimeUID = "1"
+    keeper.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    frame = MagicMock(name="keeper_frame")
+    keeper.getCurrentController.return_value.getFrame.return_value = frame
+    leftover = MagicMock(name="leftover")
+    leftover.RuntimeUID = "26"
+    leftover.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    sibling._HARNESS_KEEPER_UID = "1"
+    sibling._HARNESS_KEEPER_DOC = keeper
+
+    class _Enum:
+        def __init__(self, items):
+            self._items = list(items)
+
+        def hasMoreElements(self):
+            return bool(self._items)
+
+        def nextElement(self):
+            return self._items.pop(0)
+
+    desktop = MagicMock()
+    desktop.getComponents.return_value.createEnumeration.return_value = _Enum(
+        [keeper, leftover]
+    )
+    monkeypatch.setitem(sys.modules, "tests.testing_utils", sibling)
+    monkeypatch.setattr("plugin.framework.uno_context.get_desktop", lambda _ctx: desktop)
+    tu._HARNESS_KEEPER_UID = ""
+    tu._HARNESS_KEEPER_DOC = None
+    try:
+        assert tu.prepare_windows_writer_factory(object()) == 1
+        leftover.close.assert_not_called()
+        desktop.setActiveFrame.assert_called_once_with(frame)
+        assert tu._HARNESS_KEEPER_UID == "1"
+    finally:
+        tu.set_harness_keeper_uid("")
+
+
 def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypatch):
     """Second text_helpers Writer factory hung after leftovers + one close_doc."""
     from unittest.mock import MagicMock, patch

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -488,7 +488,7 @@ def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypat
 
 
 def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
-    """GHA 34593327841: leftover paste Writer as current hung the next scalc load."""
+    """GHA 34599838644: leftover scalc _blank failed then hung; named CREATE target."""
     from unittest.mock import MagicMock, patch
 
     from plugin.tests.testing_utils import TestingFactory
@@ -510,13 +510,19 @@ def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
             patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
         ):
             TestingFactory.create_native_doc(object(), "calc")
-        assert calls == ["prepare"]
-        args = desktop.loadComponentFromURL.call_args.args
-        assert args[0] == "private:factory/scalc"
-        # GHA 34599838644: leftover Calc _blank failed then hung. Same named
-        # CREATE target as leftover swriter.
-        assert args[1] == "_wa_factory_1"
-        assert args[2] == (8 | 55)
+            assert calls == ["prepare"]
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/scalc"
+            assert args[1] == "_wa_factory_1"
+            assert args[2] == (8 | 55)
+            # Same hang family as leftover consecutive Hidden _blank swriter:
+            # the next leftover scalc must not reuse the frame name.
+            TestingFactory.create_native_doc(object(), "calc")
+            assert calls == ["prepare", "prepare"]
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/scalc"
+            assert args[1] == "_wa_factory_2"
+            assert args[2] == (8 | 55)
     finally:
         tu._WINDOWS_FACTORY_SEQ = saved_seq
 

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -416,7 +416,7 @@ def test_prepare_windows_writer_factory_adopts_keeper_from_sibling(monkeypatch):
 
 
 def test_windows_factory_load_args_named_for_any_leftover_factory():
-    """GHA 34597506651 / 34599838644: leftover _blank hangs Writer and Calc."""
+    """GHA 34602219973: leftover swriter reuses _wa_factory; Calc stays unique."""
     import plugin.tests.testing_utils as tu
 
     saved = tu._WINDOWS_FACTORY_SEQ
@@ -424,6 +424,16 @@ def test_windows_factory_load_args_named_for_any_leftover_factory():
     try:
         assert tu._windows_factory_load_args("private:factory/swriter", 0) == ("_blank", 0)
         assert tu._windows_factory_load_args("private:factory/scalc", 0) == ("_blank", 0)
+        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+            "_wa_factory",
+            8 | 55,
+        )
+        # Consecutive leftover Hidden swriter must reuse the same CREATE
+        # name (rich_html._wa_calc_html). Unique _wa_factory_5 hung.
+        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+            "_wa_factory",
+            8 | 55,
+        )
         assert tu._windows_factory_load_args("private:factory/scalc", 2) == (
             "_wa_factory_1",
             8 | 55,
@@ -432,12 +442,13 @@ def test_windows_factory_load_args_named_for_any_leftover_factory():
             "_wa_factory_2",
             8 | 55,
         )
-        assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
+        assert tu._windows_factory_load_args("private:factory/scalc", 2) == (
             "_wa_factory_3",
             8 | 55,
         )
+        # Writer reuse must not consume the Calc/Draw seq.
         assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
-            "_wa_factory_4",
+            "_wa_factory",
             8 | 55,
         )
     finally:
@@ -445,12 +456,12 @@ def test_windows_factory_load_args_named_for_any_leftover_factory():
 
 
 def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypatch):
-    """Second text_helpers Writer factory hung after leftovers + one close_doc.
+    """GHA 34602219973: second leftover Hidden swriter hung at target=_wa_factory_5.
 
-    GHA 34597506651: keeper reactivate printed, first swriter _blank returned,
-    the next _blank hung 30s. Named CREATE|GLOBAL target matches HTML paste
-    (rich_html._wa_calc_html) and must increment so two consecutive factories
-    do not share a frame name.
+    First leftover swriter (_wa_factory_4) + close_doc returned. Unique
+    CREATE stacked an empty named frame; the next unique name hung 30s
+    in loadComponentFromURL. Consecutive leftover Hidden
+    create_native_doc(writer) must reuse one CREATE|GLOBAL name.
     """
     from unittest.mock import MagicMock, patch
 
@@ -476,19 +487,31 @@ def test_create_native_doc_windows_prepares_writer_factory_before_load(monkeypat
             assert calls == ["prepare"]
             args = desktop.loadComponentFromURL.call_args.args
             assert args[0] == "private:factory/swriter"
-            assert args[1] == "_wa_factory_1"
+            assert args[1] == "_wa_factory"
             assert args[2] == (8 | 55)
             TestingFactory.create_native_doc(object(), "writer")
             assert calls == ["prepare", "prepare"]
             args = desktop.loadComponentFromURL.call_args.args
-            assert args[1] == "_wa_factory_2"
+            assert args[0] == "private:factory/swriter"
+            assert args[1] == "_wa_factory"
+            assert args[2] == (8 | 55)
+            # Leftover Calc still increments so a live pooled Calc is not replaced.
+            TestingFactory.create_native_doc(object(), "calc")
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/scalc"
+            assert args[1] == "_wa_factory_1"
             assert args[2] == (8 | 55)
     finally:
         tu._WINDOWS_FACTORY_SEQ = saved_seq
 
 
 def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
-    """GHA 34599838644: leftover scalc _blank failed then hung; named CREATE target."""
+    """GHA 34599838644 / 34602219973: leftover scalc stays unique under leftover_open>0.
+
+    document_research_uno holds a pooled Calc and a budget Calc at once.
+    Consecutive leftover Hidden create_native_doc(calc) must not share a
+    frame name. Writer reuse uses _wa_factory and must not steal the seq.
+    """
     from unittest.mock import MagicMock, patch
 
     from plugin.tests.testing_utils import TestingFactory
@@ -515,13 +538,21 @@ def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
             assert args[0] == "private:factory/scalc"
             assert args[1] == "_wa_factory_1"
             assert args[2] == (8 | 55)
-            # Same hang family as leftover consecutive Hidden _blank swriter:
-            # the next leftover scalc must not reuse the frame name.
             TestingFactory.create_native_doc(object(), "calc")
             assert calls == ["prepare", "prepare"]
             args = desktop.loadComponentFromURL.call_args.args
             assert args[0] == "private:factory/scalc"
             assert args[1] == "_wa_factory_2"
+            assert args[2] == (8 | 55)
+            TestingFactory.create_native_doc(object(), "writer")
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/swriter"
+            assert args[1] == "_wa_factory"
+            assert args[2] == (8 | 55)
+            TestingFactory.create_native_doc(object(), "calc")
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/scalc"
+            assert args[1] == "_wa_factory_3"
             assert args[2] == (8 | 55)
     finally:
         tu._WINDOWS_FACTORY_SEQ = saved_seq

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1012,15 +1012,20 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
     GHA 34597506651: keeper sync worked (``keeper=1``, reactivated).
     First text_helpers ``_blank`` swriter + leftovers returned (uid=34,
     close_doc OK). The *next* ``_blank`` swriter hung 30s after the same
-    leftover log + keeper reactivate. ``setActiveFrame`` is not enough
-    for a second consecutive Hidden ``_blank`` while leftover
-    ``_wa_calc_html`` frames exist (rich_html.py: not ``_blank`` /
-    ``_default``). Unique CREATE target avoids that collision. Do not
-    close leftovers (34556185752). Calc ``_blank`` already succeeds
-    with leftovers — only swriter needs the named target.
+    leftover log + keeper reactivate.
+
+    GHA 34599838644: same leftovers + ``keeper=1``, but Calc ``_blank``
+    failed in ~1s (PyUNO traceback conversion on
+    ``loadComponentFromURL(scalc)``) and the next Calc ``_blank`` hung
+    30s — ``document_research_uno`` never finished, so the swriter-only
+    named target was never reached. ``setActiveFrame`` is not enough
+    for Hidden ``_blank`` while leftover ``_wa_calc_html`` frames exist
+    (rich_html.py: not ``_blank`` / ``_default``). Unique CREATE target
+    for every leftover Windows factory. Do not close leftovers
+    (34556185752).
     """
     global _WINDOWS_FACTORY_SEQ
-    if leftover_open <= 0 or factory_url != "private:factory/swriter":
+    if leftover_open <= 0 or not factory_url.startswith("private:factory/"):
         return "_blank", 0
     _WINDOWS_FACTORY_SEQ += 1
     return "_wa_factory_%s" % _WINDOWS_FACTORY_SEQ, _WINDOWS_FACTORY_SEARCH_FLAGS

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -999,6 +999,33 @@ def prepare_windows_writer_factory(ctx) -> int:
     return len(leftover_uids)
 
 
+# Same CREATE|GLOBAL as insert_cell_html_rich (8|55=63). Named target with
+# flags 0 can search instead of creating. Do not reuse "_blank" / "_default"
+# while leftover paste Writers are open — see _windows_factory_load_args.
+_WINDOWS_FACTORY_SEARCH_FLAGS = 8 | 55
+_WINDOWS_FACTORY_SEQ = 0
+
+
+def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[str, int]:
+    """Target + FrameSearchFlag for a Windows factory load.
+
+    GHA 34597506651: keeper sync worked (``keeper=1``, reactivated).
+    First text_helpers ``_blank`` swriter + leftovers returned (uid=34,
+    close_doc OK). The *next* ``_blank`` swriter hung 30s after the same
+    leftover log + keeper reactivate. ``setActiveFrame`` is not enough
+    for a second consecutive Hidden ``_blank`` while leftover
+    ``_wa_calc_html`` frames exist (rich_html.py: not ``_blank`` /
+    ``_default``). Unique CREATE target avoids that collision. Do not
+    close leftovers (34556185752). Calc ``_blank`` already succeeds
+    with leftovers — only swriter needs the named target.
+    """
+    global _WINDOWS_FACTORY_SEQ
+    if leftover_open <= 0 or factory_url != "private:factory/swriter":
+        return "_blank", 0
+    _WINDOWS_FACTORY_SEQ += 1
+    return "_wa_factory_%s" % _WINDOWS_FACTORY_SEQ, _WINDOWS_FACTORY_SEARCH_FLAGS
+
+
 def _reraise_native_open_failure(
     exc: BaseException, factory_url: str, pre_open: str = "no_probe"
 ) -> None:
@@ -1612,16 +1639,18 @@ class TestingFactory:
         from plugin.testing_runner import probe_uno_bridge
 
         leftover_open = 0
+        target, flags = "_blank", 0
         # GHA 34593327841: leftover paste Writers as desktop current hung
         # the next scalc factory (30s) after list_nearby failed. #720 only
         # prepared swriter. Reactivate the keeper before any factory load.
         if sys.platform == "win32" and factory_url.startswith("private:factory/"):
             leftover_open = prepare_windows_writer_factory(ctx)
+            target, flags = _windows_factory_load_args(factory_url, leftover_open)
             from plugin.testing_runner import _progress
 
             _progress(
-                "create_native_doc: windows factory leftover_open=%s url=%s"
-                % (leftover_open, factory_url)
+                "create_native_doc: windows factory leftover_open=%s url=%s target=%s flags=%s"
+                % (leftover_open, factory_url, target, flags)
             )
 
         # Distinguish "bridge already dead" (previous test) from "died during load".
@@ -1634,7 +1663,26 @@ class TestingFactory:
             )
             raise
         try:
-            doc = desktop.loadComponentFromURL(factory_url, "_blank", 0, tuple(props))
+            if sys.platform == "win32" and leftover_open:
+                from plugin.testing_runner import _progress
+
+                _progress(
+                    "create_native_doc: load start url=%s target=%s flags=%s"
+                    % (factory_url, target, flags)
+                )
+            doc = desktop.loadComponentFromURL(factory_url, target, flags, tuple(props))
+            if sys.platform == "win32" and leftover_open:
+                from plugin.testing_runner import _progress
+
+                uid = ""
+                try:
+                    uid = str(getattr(doc, "RuntimeUID", None) or "")
+                except Exception:
+                    uid = ""
+                _progress(
+                    "create_native_doc: load done url=%s target=%s uid=%s"
+                    % (factory_url, target, uid or "-")
+                )
         except Exception as exc:
             _reraise_native_open_failure(exc, factory_url, pre_open=pre_open)
             raise

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -895,6 +895,10 @@ def prepare_windows_writer_factory(ctx) -> int:
     Why this: enum leftovers (read-only; safe before load) and
     ``setActiveFrame`` the keeper. Do not close leftovers. Returns how
     many non-keeper Writers are still open. Windows-only caller.
+
+    GHA 34593327841: the next hang was ``private:factory/scalc`` in
+    ``document_research_uno`` ``_create_nearby_test_env``, not swriter.
+    Call this before every Windows ``private:factory/`` load.
     """
     if ctx is None:
         return 0
@@ -1531,13 +1535,16 @@ class TestingFactory:
         from plugin.testing_runner import probe_uno_bridge
 
         leftover_open = 0
-        if sys.platform == "win32" and factory_url == "private:factory/swriter":
+        # GHA 34593327841: leftover paste Writers as desktop current hung
+        # the next scalc factory (30s) after list_nearby failed. #720 only
+        # prepared swriter. Reactivate the keeper before any factory load.
+        if sys.platform == "win32" and factory_url.startswith("private:factory/"):
             leftover_open = prepare_windows_writer_factory(ctx)
             from plugin.testing_runner import _progress
 
             _progress(
-                "create_native_doc: windows writer factory leftover_open=%s"
-                % leftover_open
+                "create_native_doc: windows factory leftover_open=%s url=%s"
+                % (leftover_open, factory_url)
             )
 
         # Distinguish "bridge already dead" (previous test) from "died during load".

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -808,11 +808,78 @@ _HARNESS_KEEPER_UID = ""
 _HARNESS_KEEPER_DOC = None
 
 
+def _testing_utils_holders():
+    """Modules that share this file's keeper globals.
+
+    ``python -m plugin.testing_runner`` imports ``tests.testing_utils`` to
+    record the keeper. Suites import ``plugin.tests.testing_utils``
+    (``plugin/tests/__init__.py`` points ``__path__`` at ``tests/``). Same
+    file, second object. GHA 34595675515: every factory prepare printed
+    ``keeper=-`` and treated uid=1 as a leftover — #720 never reactivated.
+    Same dual-module family as #719 recycle. Touch both.
+    """
+    import os
+
+    seen = []
+    try:
+        here_file = os.path.normcase(os.path.realpath(__file__))
+    except Exception:
+        here_file = ""
+    for name in ("tests.testing_utils", "plugin.tests.testing_utils", __name__):
+        mod = sys.modules.get(name)
+        if mod is None or mod in seen:
+            continue
+        other = getattr(mod, "__file__", None)
+        if other and here_file:
+            try:
+                if os.path.normcase(os.path.realpath(other)) != here_file:
+                    continue
+            except Exception:
+                continue
+        seen.append(mod)
+    return seen or [sys.modules[__name__]]
+
+
+def _ensure_testing_utils_aliases() -> None:
+    """Import both sys.modules names so set/adopt can write both copies."""
+    try:
+        import tests.testing_utils as _tests_tu  # noqa: F401
+    except Exception:
+        pass
+    try:
+        import plugin.tests.testing_utils as _plugin_tu  # noqa: F401
+    except Exception:
+        pass
+
+
 def set_harness_keeper_uid(uid: str, doc=None) -> None:
     """Record the hidden keeper Writer (uid + doc) for later setActiveFrame."""
+    _ensure_testing_utils_aliases()
+    uid_s = str(uid or "")
+    if uid_s == "-":
+        uid_s = ""
+    doc_s = doc if uid_s else None
+    for mod in _testing_utils_holders():
+        mod._HARNESS_KEEPER_UID = uid_s
+        mod._HARNESS_KEEPER_DOC = doc_s
+
+
+def _adopt_keeper_from_sibling() -> bool:
+    """Copy keeper uid/doc from the other testing_utils module if we have none."""
     global _HARNESS_KEEPER_UID, _HARNESS_KEEPER_DOC
-    _HARNESS_KEEPER_UID = str(uid or "")
-    _HARNESS_KEEPER_DOC = doc if _HARNESS_KEEPER_UID else None
+    if _HARNESS_KEEPER_UID:
+        return False
+    here = sys.modules.get(__name__)
+    for mod in _testing_utils_holders():
+        if mod is here:
+            continue
+        uid = str(getattr(mod, "_HARNESS_KEEPER_UID", "") or "")
+        if not uid or uid == "-":
+            continue
+        _HARNESS_KEEPER_UID = uid
+        _HARNESS_KEEPER_DOC = getattr(mod, "_HARNESS_KEEPER_DOC", None)
+        return True
+    return False
 
 
 def _writer_doc_uid(doc) -> str:
@@ -864,6 +931,11 @@ def reactivate_harness_keeper(desktop=None) -> bool:
     """
     from plugin.testing_runner import _progress
 
+    if _adopt_keeper_from_sibling():
+        _progress(
+            "html_paste_writer: keeper adopted from sibling uid=%s"
+            % (_HARNESS_KEEPER_UID or "-")
+        )
     doc = _HARNESS_KEEPER_DOC
     if doc is None:
         return False
@@ -905,6 +977,11 @@ def prepare_windows_writer_factory(ctx) -> int:
     from plugin.framework.uno_context import get_desktop
     from plugin.testing_runner import _progress
 
+    if _adopt_keeper_from_sibling():
+        _progress(
+            "html_paste_writer: keeper adopted from sibling uid=%s"
+            % (_HARNESS_KEEPER_UID or "-")
+        )
     desktop = get_desktop(ctx)
     keeper = _HARNESS_KEEPER_UID
     leftover_uids = []

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -991,12 +991,53 @@ def prepare_windows_writer_factory(ctx) -> int:
             continue
         leftover_uids.append(uid)
         leftover_frames.append(_writer_frame_name(doc) or "-")
+    leftover_open = len(leftover_uids)
+    _set_windows_leftover_open(leftover_open)
     _progress(
         "html_paste_writer: leftovers open=%s uids=%s frames=%s keeper=%s"
-        % (len(leftover_uids), leftover_uids, leftover_frames, keeper or "-")
+        % (leftover_open, leftover_uids, leftover_frames, keeper or "-")
     )
     reactivate_harness_keeper(desktop)
-    return len(leftover_uids)
+    return leftover_open
+
+
+# Last leftover count from prepare. close_doc / native_doc reuse read this
+# instead of enumerating again (getComponents after paste close can hang).
+_WINDOWS_LEFTOVER_OPEN = 0
+
+
+def _set_windows_leftover_open(n: int) -> None:
+    """Write leftover count on both testing_utils module copies."""
+    n_i = int(n or 0)
+    for mod in _testing_utils_holders():
+        mod._WINDOWS_LEFTOVER_OPEN = n_i
+
+
+def _windows_leftover_open() -> int:
+    n = int(_WINDOWS_LEFTOVER_OPEN or 0)
+    if n > 0:
+        return n
+    here = sys.modules.get(__name__)
+    for mod in _testing_utils_holders():
+        if mod is here:
+            continue
+        other = int(getattr(mod, "_WINDOWS_LEFTOVER_OPEN", 0) or 0)
+        if other > 0:
+            return other
+    return 0
+
+
+def _windows_should_reuse_writer(ctx) -> bool:
+    """True when a later Windows Writer factory would hang after leftovers.
+
+    GHA 34601787293 / 34602219973: unique ``_wa_factory_N`` loaded three
+    leftover Calc factories and the first leftover swriter (uid=34).
+    ``close_doc`` of that Writer returned; the next unique swriter hung
+    30s. Reuse the first leftover Writer instead of close + factory.
+    """
+    if ctx is None or sys.platform != "win32":
+        return False
+    return prepare_windows_writer_factory(ctx) > 0
 
 
 # Same CREATE|GLOBAL as insert_cell_html_rich (8|55=63). Named target with
@@ -1699,6 +1740,34 @@ class TestingFactory:
         """Safely closes a document instance if available."""
         if not doc:
             return
+        # Skip leftover-window Writer close *before* dropping the pool entry
+        # so reuse can still find the doc (34602219973).
+        uid = ""
+        is_writer = False
+        if sys.platform == "win32":
+            try:
+                uid = str(getattr(doc, "RuntimeUID", None) or "")
+                is_writer = bool(doc.supportsService("com.sun.star.text.TextDocument"))
+            except Exception:
+                is_writer = False
+            if is_writer:
+                from plugin.testing_runner import _progress
+
+                leftover_open = _windows_leftover_open()
+                _progress(
+                    "close_doc: start uid=%s leftovers=%s" % (uid or "-", leftover_open)
+                )
+                if leftover_open > 0:
+                    # GHA 34602219973: close uid=34 returned; next unique
+                    # _wa_factory_5 swriter hung 30s. Do not close a
+                    # harness Writer while paste leftovers remain (same
+                    # ban as leftover paste close, 34556185752).
+                    reactivate_harness_keeper()
+                    _progress(
+                        "close_doc: skip writer close leftovers open=%s uid=%s"
+                        % (leftover_open, uid or "-")
+                    )
+                    return
         for key, pooled in list(_NATIVE_DOC_POOL.items()):
             if pooled is doc:
                 del _NATIVE_DOC_POOL[key]
@@ -1711,21 +1780,6 @@ class TestingFactory:
         try:
             import gc
             import time
-
-            uid = ""
-            is_writer = False
-            if sys.platform == "win32":
-                try:
-                    uid = str(getattr(doc, "RuntimeUID", None) or "")
-                    is_writer = bool(
-                        doc.supportsService("com.sun.star.text.TextDocument")
-                    )
-                except Exception:
-                    is_writer = False
-                if is_writer:
-                    from plugin.testing_runner import _progress
-
-                    _progress("close_doc: start uid=%s" % (uid or "-"))
 
             # Release PyUNO sequences before Calc tears down the document.
             # Large getDataArray results held across close can abort soffice (glibc double-free).
@@ -1761,6 +1815,11 @@ class TestingFactory:
         """Yield a native LO document. Calc defaults to experimental wipe-and-reuse; Writer does not."""
         if reuse is None:
             reuse = _default_native_doc_reuse(doc_type)
+            if doc_type == "writer" and _windows_should_reuse_writer(ctx):
+                from plugin.testing_runner import _progress
+
+                reuse = True
+                _progress("native_doc: leftover writer reuse")
         use_pool = bool(reuse) and doc_type in ("writer", "calc")
         doc = None
         pooled = False
@@ -1771,14 +1830,31 @@ class TestingFactory:
                 try:
                     reset_native_doc(candidate, doc_type, ctx)
                     if doc_type == "writer" and not _writer_pool_is_clean(candidate):
-                        TestingFactory.close_doc(candidate)
-                        doc = None
+                        if sys.platform == "win32" and _windows_leftover_open() > 0:
+                            from plugin.testing_runner import _progress
+
+                            # close + factory hangs (34602219973). Wipe again
+                            # and keep the leftover-window Writer.
+                            _progress("native_doc: leftover writer pool dirty; keep")
+                            reset_native_doc(candidate, doc_type, ctx)
+                            doc = candidate
+                            pooled = True
+                        else:
+                            TestingFactory.close_doc(candidate)
+                            doc = None
                     else:
                         doc = candidate
                         pooled = True
                 except Exception:
-                    TestingFactory.close_doc(candidate)
-                    doc = None
+                    if sys.platform == "win32" and _windows_leftover_open() > 0:
+                        from plugin.testing_runner import _progress
+
+                        _progress("native_doc: leftover writer reset failed; keep")
+                        doc = candidate
+                        pooled = True
+                    else:
+                        TestingFactory.close_doc(candidate)
+                        doc = None
             if doc is None:
                 doc = TestingFactory.create_native_doc(ctx, doc_type=doc_type, hidden=hidden)
                 _NATIVE_DOC_POOL[key] = doc

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1044,6 +1044,13 @@ def _windows_should_reuse_writer(ctx) -> bool:
 # flags 0 can search instead of creating. Do not reuse "_blank" / "_default"
 # while leftover paste Writers are open — see _windows_factory_load_args.
 _WINDOWS_FACTORY_SEARCH_FLAGS = 8 | 55
+# Leftover Hidden swriter only. rich_html reuses one CREATE|GLOBAL name
+# (_wa_calc_html). Unique _wa_factory_N stacked empty frames after close
+# and the second leftover swriter hung (GHA 34602219973, _wa_factory_5).
+_WINDOWS_FACTORY_TARGET = "_wa_factory"
+# Leftover Calc/Draw/Impress still increment. document_research_uno holds
+# a pooled @with_native_doc Calc and a second create_native_doc budget
+# Calc at once — a shared name would replace the live pooled workbook.
 _WINDOWS_FACTORY_SEQ = 0
 
 
@@ -1061,13 +1068,30 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
     30s — ``document_research_uno`` never finished, so the swriter-only
     named target was never reached. ``setActiveFrame`` is not enough
     for Hidden ``_blank`` while leftover ``_wa_calc_html`` frames exist
-    (rich_html.py: not ``_blank`` / ``_default``). Unique CREATE target
-    for every leftover Windows factory. Do not close leftovers
-    (34556185752).
+    (rich_html.py: not ``_blank`` / ``_default``).
+
+    GHA 34602219973 (``ec40ed29``): unique ``_wa_factory_N`` loaded
+    leftover Calc (``document_research_uno`` passed=3, targets
+    ``_wa_factory_1/2/3``) and the first leftover Hidden swriter
+    (``doc.test_text_helpers_uno.test_get_string_without_tracked_deletions_paragraph_bold_run_no_newline``,
+    ``target=_wa_factory_4``, uid=34, ``close_doc`` OK). The *next*
+    leftover Hidden swriter
+    (``…_multi_para_joins_with_newline``, ``target=_wa_factory_5``)
+    hung 30s in ``loadComponentFromURL`` — no RuntimeException. Unique
+    CREATE stacks empty named frames after harness Writer close; it
+    does not fix consecutive leftover Hidden swriter (same hang family
+    as 34597506651). Reuse one CREATE|GLOBAL name for leftover
+    ``swriter`` so CREATE replaces/reuses instead of stacking. Keep
+    unique names for leftover Calc — concurrent pooled + budget Calc.
+    Do not close leftover paste Writers (34556185752).
     """
     global _WINDOWS_FACTORY_SEQ
     if leftover_open <= 0 or not factory_url.startswith("private:factory/"):
         return "_blank", 0
+    # One stable name, like rich_html._wa_calc_html. CREATE|GLOBAL finds
+    # the empty frame left by the previous leftover-mode Writer close.
+    if factory_url == "private:factory/swriter":
+        return _WINDOWS_FACTORY_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
     _WINDOWS_FACTORY_SEQ += 1
     return "_wa_factory_%s" % _WINDOWS_FACTORY_SEQ, _WINDOWS_FACTORY_SEARCH_FLAGS
 
@@ -1686,10 +1710,12 @@ class TestingFactory:
 
         leftover_open = 0
         target, flags = "_blank", 0
-        # GHA 34593327841 / 34599838644: leftover paste Writers as desktop
-        # current hung the next scalc factory (30s). #720 only prepared
-        # swriter. Reactivate the keeper, then use a unique CREATE target
-        # for any leftover private:factory/ load (not only swriter).
+        # GHA 34593327841 / 34599838644 / 34602219973: leftover paste
+        # Writers as desktop current hung the next factory (30s). #720
+        # only prepared swriter. Reactivate the keeper. Leftover swriter
+        # reuses one CREATE|GLOBAL name (_wa_factory). Leftover Calc and
+        # other factories keep a unique _wa_factory_N so a live pooled
+        # Calc is not replaced.
         if sys.platform == "win32" and factory_url.startswith("private:factory/"):
             leftover_open = prepare_windows_writer_factory(ctx)
             target, flags = _windows_factory_load_args(factory_url, leftover_open)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1645,9 +1645,10 @@ class TestingFactory:
 
         leftover_open = 0
         target, flags = "_blank", 0
-        # GHA 34593327841: leftover paste Writers as desktop current hung
-        # the next scalc factory (30s) after list_nearby failed. #720 only
-        # prepared swriter. Reactivate the keeper before any factory load.
+        # GHA 34593327841 / 34599838644: leftover paste Writers as desktop
+        # current hung the next scalc factory (30s). #720 only prepared
+        # swriter. Reactivate the keeper, then use a unique CREATE target
+        # for any leftover private:factory/ load (not only swriter).
         if sys.platform == "win32" and factory_url.startswith("private:factory/"):
             leftover_open = prepare_windows_writer_factory(ctx)
             target, flags = _windows_factory_load_args(factory_url, leftover_open)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Windows UNO harness hang on leftover Hidden `swriter` after paste leftovers stay open. Product and harness must not `close(True)` those leftovers (GHA 34556185752 hung 30s on leftover close).

## Proof trail

- [34595675515](https://github.com/KeithCu/writeragent/actions/runs/34595675515) (`1eaf4e52`): keeper was `-` (dual-module miss). Calc factory failed then hung.
- [34597506651](https://github.com/KeithCu/writeragent/actions/runs/34597506651) (`054a03e0`): keeper sync worked. `document_research_uno` 3/3 OK. Hang moved to the **second** text_helpers `_blank` swriter.
- [34599838644](https://github.com/KeithCu/writeragent/actions/runs/34599838644) (`afae5938`, swriter-only named target): Calc `_blank` failed then hung again. `document_research` never finished.
- [34602219973](https://github.com/KeithCu/writeragent/actions/runs/34602219973) (`ec40ed29`): unique `_wa_factory_N` loaded leftover Calc and the first leftover Hidden swriter (`target=_wa_factory_4`). The **next** leftover Hidden swriter hung 30s (`…_multi_para_joins_with_newline`, `target=_wa_factory_5`).
- [34606276107](https://github.com/KeithCu/writeragent/actions/runs/34606276107) (`248da30d`): leftover Hidden swriter hang is gone. `document_research_uno` 3/3 OK, both `text_helpers_uno` tests OK, 139 passed. New fail: `draw.test_draw_uno.test_insert_math_draw` — load done `target=_wa_factory_17 uid=48`, ~8s later `LIFECYCLE close_doc dispose` then `office dead after close doc_type=draw`, soffice exited 0. `close_doc` dispose printed `previous=- current=-` (`-m` vs `plugin.testing_runner` dual-module). Nine Draw closes with `leftovers open=3 uids=['34','27','26'] keeper=1` survived, so leftover-Writer reuse is not a proven Draw-close killer. This may be the known `get_draw_tree` → `insert_math_draw` flake now reachable.

Linux PR CI stayed green on `248da30d`.

## Change

- Skip broken leftover desktop components in the nearby walk (no `exc_info` on the skip path).
- Keeper uid is written to both `tests.testing_utils` and `plugin.tests.testing_utils`.
- `prepare_windows_writer_factory` before every Windows `private:factory/` load.
- With leftovers open, leftover Hidden `swriter` reuses one CREATE|GLOBAL name `_wa_factory`. Leftover Calc/Draw/Impress still use unique `_wa_factory_N`.
- With leftovers open, pool the first leftover-window Writer and skip Writer `close_doc`. Do not close leftover paste Writers.
- Lifecycle trail is written to both `__main__` and `plugin.testing_runner`; `format_lifecycle_breadcrumb` adopts from the sibling if this copy is empty.
- Windows Draw/Impress `close_doc` logs `start uid= svc= leftovers= keeper= pids=` and `close(True) start/done`. `insert_math_draw` / `get_draw_tree` name the tool call vs teardown. No product change.

## Tests

- Unit: leftover factory targets; leftover-window Writer reuse; lifecycle adopt from `__main__`; Draw `close_doc` breadcrumbs.
- `make typecheck` clean.

Windows proof needs another `workflow_dispatch` of PR CI on this branch: `os=windows-latest`, `ci_debug=true` (this environment cannot dispatch). Look for `close_doc: close(True) start uid= svc=draw leftovers= keeper=`, `insert_math_draw: insert_math start/done` vs `body done`, and `LIFECYCLE close_doc dispose` with `current=draw.test_draw_uno.test_insert_math_draw` (not `previous=-`).

Do not merge from this PR; Keith merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35991b52-4e5f-4ccf-a1b7-d6f444fbc202?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35991b52-4e5f-4ccf-a1b7-d6f444fbc202&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

