### PR TITLE
Harness: Draw close breadcrumbs and lifecycle dual-module adopt

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -248,12 +248,11 @@ POSIX still `close_doc`. Breadcrumbs:
 `insert_math_draw: insert_math start/done` and `body done`. Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
 
-GHA 34606276107 (`248da30d`, leftover hang fixed): leftover paste +
-leftover-window Writer stayed open (`leftovers open=3 uids=['34','27','26']
-keeper=1`). `document_research_uno` 3/3 and both `text_helpers_uno`
-tests OK. Draw factories `_wa_factory_4`…`_wa_factory_16` loaded and
-closed; `test_get_draw_tree` OK (`uid=47`). `test_insert_math_draw`
-loaded `target=_wa_factory_17 uid=48`, then ~8s later
+GHA 34606276107 (`248da30d`, leftover hang fixed) and master
+34607010446 (`3720c175`, #722 merge): leftover paste + leftover-window
+Writer stayed open (`leftovers open=3`). `document_research_uno` 3/3
+and both `text_helpers_uno` tests OK. Draw factories loaded and
+closed; `test_get_draw_tree` OK. `test_insert_math_draw` then
 `LIFECYCLE close_doc dispose` (pids still live) and
 `office dead after close doc_type=draw pids=-`. TEST returned; soffice
 exited 0. `close_doc` dispose printed `previous=- current=-` — `-m`

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -239,10 +239,30 @@ POSIX still `close_doc`. Breadcrumbs:
 `create_native_doc: windows factory leftover_open=N url=… target=… flags=…`,
 `create_native_doc: load start/done` (leftover Windows factory),
 `document_research_uno: create/store/close/list_nearby start/done`,
-`close_doc: start/done uid=…` (Windows Writer),
+`close_doc: start uid= svc= leftovers= keeper= pids=` (Windows Writer/Draw/Impress),
+`close_doc: close(True) start/done` (Windows Draw/Impress),
+`close_doc: done uid=…` (Windows Writer),
 `native_doc: leftover writer reuse`,
-`close_doc: skip writer close leftovers open=N uid=…`. Do **not** fold
+`close_doc: skip writer close leftovers open=N uid=…`,
+`get_draw_tree: body start/execute done/body done`,
+`insert_math_draw: insert_math start/done` and `body done`. Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
+
+GHA 34606276107 (`248da30d`, leftover hang fixed): leftover paste +
+leftover-window Writer stayed open (`leftovers open=3 uids=['34','27','26']
+keeper=1`). `document_research_uno` 3/3 and both `text_helpers_uno`
+tests OK. Draw factories `_wa_factory_4`…`_wa_factory_16` loaded and
+closed; `test_get_draw_tree` OK (`uid=47`). `test_insert_math_draw`
+loaded `target=_wa_factory_17 uid=48`, then ~8s later
+`LIFECYCLE close_doc dispose` (pids still live) and
+`office dead after close doc_type=draw pids=-`. TEST returned; soffice
+exited 0. `close_doc` dispose printed `previous=- current=-` — `-m`
+lifecycle lives on `__main__`, close_doc imported
+`plugin.testing_runner`. Nine Draw closes with the same leftovers
+survived, so leftover-Writer reuse is not a proven Draw-close killer;
+this may be the known `get_draw_tree` → `insert_math_draw` flake now
+reachable. No product change. Breadcrumbs now name Draw `close(True)`
+and adopt the lifecycle trail across both runner module copies.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -166,6 +166,20 @@ _lifecycle_current_qual: str = ""
 _lifecycle_current_start_pids: str = ""
 _lifecycle_current_start_mono: float = 0.0
 _lifecycle_current_bridge: str = ""
+# ``python -m plugin.testing_runner`` records on ``__main__``. close_doc
+# imports ``plugin.testing_runner`` (second object). GHA 34606276107
+# printed previous=- current=- on close_doc dispose. Touch both.
+_LIFECYCLE_ATTRS = (
+    "_lifecycle_last_qual",
+    "_lifecycle_last_result",
+    "_lifecycle_last_end_pids",
+    "_lifecycle_last_ok_qual",
+    "_lifecycle_last_end_mono",
+    "_lifecycle_current_qual",
+    "_lifecycle_current_start_pids",
+    "_lifecycle_current_start_mono",
+    "_lifecycle_current_bridge",
+)
 
 # ``--repeat N`` / ``WRITERAGENT_UNO_SOAK``: re-run selected suites in one office.
 _soak_repeat: int = 1
@@ -223,6 +237,7 @@ def reset_lifecycle_breadcrumb() -> None:
     _lifecycle_current_start_pids = ""
     _lifecycle_current_start_mono = 0.0
     _lifecycle_current_bridge = ""
+    _sync_lifecycle_to_holders()
     reset_office_death_signals()
 
 
@@ -387,6 +402,44 @@ def probe_uno_bridge(ctx: Any = None) -> str:
     return "alive"
 
 
+def _sync_lifecycle_to_holders() -> None:
+    """Write lifecycle trail on ``__main__`` and ``plugin.testing_runner``."""
+    here = sys.modules.get(__name__)
+    for mod in _office_recycle_holders():
+        if mod is here:
+            continue
+        for attr in _LIFECYCLE_ATTRS:
+            setattr(mod, attr, getattr(here, attr))
+
+
+def _adopt_lifecycle_from_sibling() -> bool:
+    """Copy lifecycle trail from the other runner module if this copy is empty.
+
+    GHA 34606276107: ``close_doc`` dispose printed ``previous=- current=-``
+    because ``-m`` recorded on ``__main__`` and testing_utils imported
+    ``plugin.testing_runner``. Same dual-module family as recycle (#719).
+    """
+    global _lifecycle_last_qual, _lifecycle_last_result, _lifecycle_last_end_pids
+    global _lifecycle_last_ok_qual, _lifecycle_last_end_mono
+    global _lifecycle_current_qual, _lifecycle_current_start_pids
+    global _lifecycle_current_start_mono, _lifecycle_current_bridge
+    if _lifecycle_current_qual or _lifecycle_last_qual:
+        return False
+    here = sys.modules.get(__name__)
+    for mod in _office_recycle_holders():
+        if mod is here:
+            continue
+        if not (
+            getattr(mod, "_lifecycle_current_qual", "")
+            or getattr(mod, "_lifecycle_last_qual", "")
+        ):
+            continue
+        for attr in _LIFECYCLE_ATTRS:
+            globals()[attr] = getattr(mod, attr)
+        return True
+    return False
+
+
 def record_test_start(qual: str, ctx: Any = None) -> None:
     """Remember the test about to run, soffice PIDs, and a cheap bridge probe."""
     global _lifecycle_current_qual, _lifecycle_current_start_pids
@@ -395,6 +448,7 @@ def record_test_start(qual: str, ctx: Any = None) -> None:
     _lifecycle_current_start_pids = _soffice_pids()
     _lifecycle_current_start_mono = time.monotonic()
     _lifecycle_current_bridge = probe_uno_bridge(ctx)
+    _sync_lifecycle_to_holders()
 
 
 def record_test_end(qual: str, result: str) -> None:
@@ -413,6 +467,7 @@ def record_test_end(qual: str, result: str) -> None:
     _lifecycle_current_start_pids = ""
     _lifecycle_current_start_mono = 0.0
     _lifecycle_current_bridge = ""
+    _sync_lifecycle_to_holders()
 
 
 def format_lifecycle_breadcrumb() -> str:
@@ -424,6 +479,7 @@ def format_lifecycle_breadcrumb() -> str:
     elapsed ms since that end, whether soffice PIDs changed, and a cheap
     getServiceManager probe.
     """
+    _adopt_lifecycle_from_sibling()
     prev = _lifecycle_last_qual or "-"
     prev_result = _lifecycle_last_result or "-"
     prev_pids = _lifecycle_last_end_pids or "-"

--- a/tests/draw/test_draw_uno.py
+++ b/tests/draw/test_draw_uno.py
@@ -291,6 +291,11 @@ def test_master_slides(ctx, doc):
 @native_test
 @with_native_doc("draw")
 def test_get_draw_tree(ctx, doc):
+    from plugin.testing_runner import _progress
+
+    # GHA 34606276107: this TEST end OK; the next insert_math_draw close
+    # killed soffice. Name the tree call vs teardown.
+    _progress("get_draw_tree: body start")
     # Ensure there is at least one shape to build a tree with
     _exec_tool(doc, ctx, "shape_upsert", {
         "action": "create",
@@ -302,6 +307,7 @@ def test_get_draw_tree(ctx, doc):
 
     result = _exec_tool(doc, ctx, "get_draw_tree", {"page": _active_draw_page_index(doc)})
     data = json.loads(result)
+    _progress("get_draw_tree: execute done status=%s" % data.get("status"))
     assert data.get("status") == "ok", f"get_draw_tree failed: {result}"
     tree = data.get("tree", [])
     assert len(tree) > 0, "Draw tree is empty"
@@ -313,11 +319,17 @@ def test_get_draw_tree(ctx, doc):
             found = True
             break
     assert found, "Created shape not found in draw tree"
+    _progress("get_draw_tree: body done")
 
 
 @native_test
 @with_native_doc("draw")
 def test_insert_math_draw(ctx, doc):
+    from plugin.testing_runner import _progress
+
+    # GHA 34606276107: load done uid=48 then ~8s later close_doc dispose
+    # and soffice exited 0. Name insert_math vs close_doc teardown.
+    _progress("insert_math_draw: insert_math start")
     # Insert math (formula_type + formula + page + x + y; size from UNO/heuristic)
     result = _exec_tool(doc, ctx, "insert_math", {
         "formula_type": "latex",
@@ -328,6 +340,7 @@ def test_insert_math_draw(ctx, doc):
     })
 
     data = json.loads(result)
+    _progress("insert_math_draw: insert_math done status=%s" % data.get("status"))
     assert data.get("status") == "ok", f"insert_math failed: {result}"
 
     # insert_math used page_index 0 — read shape from that page (current slide may differ after prior tests).
@@ -337,6 +350,7 @@ def test_insert_math_draw(ctx, doc):
     assert shape.CLSID == "078B7ABA-54FC-457F-8551-6147e776a997"
     sz = shape.getSize()
     assert sz.Width >= 400 and sz.Height >= 300, f"expected plausible size, got {sz.Width}x{sz.Height}"
+    _progress("insert_math_draw: body done")
 
 
 @native_test

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -271,6 +271,31 @@ def test_office_recycle_request_is_consumed_once() -> None:
     assert consume_office_recycle_request() is False
 
 
+def test_lifecycle_breadcrumb_adopts_from_minus_m_main(monkeypatch) -> None:
+    """GHA 34606276107: close_doc dispose printed previous=- current=-."""
+    import types
+
+    import plugin.testing_runner as tr
+
+    reset_lifecycle_breadcrumb()
+    fake_main = types.ModuleType("__main__")
+    fake_main.__file__ = tr.__file__
+    fake_main._lifecycle_last_qual = "draw.test_draw_uno.test_get_draw_tree"
+    fake_main._lifecycle_last_result = "OK"
+    fake_main._lifecycle_last_end_pids = "7196,5792"
+    fake_main._lifecycle_last_ok_qual = "draw.test_draw_uno.test_get_draw_tree"
+    fake_main._lifecycle_last_end_mono = 1.0
+    fake_main._lifecycle_current_qual = "draw.test_draw_uno.test_insert_math_draw"
+    fake_main._lifecycle_current_start_pids = "7196,5792"
+    fake_main._lifecycle_current_start_mono = 2.0
+    fake_main._lifecycle_current_bridge = "alive"
+    monkeypatch.setitem(sys.modules, "__main__", fake_main)
+    crumb = format_lifecycle_breadcrumb()
+    assert "previous=draw.test_draw_uno.test_get_draw_tree" in crumb
+    assert "current=draw.test_draw_uno.test_insert_math_draw" in crumb
+    reset_lifecycle_breadcrumb()
+
+
 def test_office_recycle_request_reaches_minus_m_main(monkeypatch) -> None:
     """GHA 34549510317: ``-m`` is ``__main__``; tests import the package name."""
     import types

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -309,6 +309,7 @@ def test_prepare_windows_writer_factory_logs_leftovers_and_does_not_close(monkey
         keeper.close.assert_not_called()
         desktop.setActiveFrame.assert_called_once_with(frame)
     finally:
+        tu._set_windows_leftover_open(0)
         tu.set_harness_keeper_uid("")
 
 
@@ -342,6 +343,7 @@ def test_prepare_windows_writer_factory_keeper_only_still_reactivates(monkeypatc
         keeper.close.assert_not_called()
         desktop.setActiveFrame.assert_called_once_with(frame)
     finally:
+        tu._set_windows_leftover_open(0)
         tu.set_harness_keeper_uid("")
 
 
@@ -412,6 +414,7 @@ def test_prepare_windows_writer_factory_adopts_keeper_from_sibling(monkeypatch):
         desktop.setActiveFrame.assert_called_once_with(frame)
         assert tu._HARNESS_KEEPER_UID == "1"
     finally:
+        tu._set_windows_leftover_open(0)
         tu.set_harness_keeper_uid("")
 
 
@@ -726,17 +729,59 @@ def test_close_doc_logs_urp_dispose(capsys, monkeypatch):
     from unittest.mock import MagicMock
 
     import plugin.testing_runner as tr
+    from plugin.tests import testing_utils as tu
     from plugin.tests.testing_utils import TestingFactory
 
+    # GHA 34609539461: prepare left leftover=1; MagicMock looked like Writer
+    # and Windows skip-close hid the dispose breadcrumb.
     monkeypatch.setattr(tr, "_soffice_pids", lambda: "8")
     tr.reset_lifecycle_breadcrumb()
     tr.record_test_start("draw.test_draw_uno.test_get_draw_tree")
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    tu._set_windows_leftover_open(0)
     doc = MagicMock()
     doc.close.side_effect = RuntimeError("Binary URP bridge disposed during call")
-    TestingFactory.close_doc(doc)
-    err = capsys.readouterr().err
-    assert "LIFECYCLE close_doc dispose" in err
-    tr.reset_lifecycle_breadcrumb()
+    try:
+        TestingFactory.close_doc(doc)
+        err = capsys.readouterr().err
+        assert "LIFECYCLE close_doc dispose" in err
+    finally:
+        tu._set_windows_leftover_open(saved)
+        tr.reset_lifecycle_breadcrumb()
+
+
+def test_close_doc_windows_untyped_mock_still_logs_dispose(capsys, monkeypatch):
+    """GHA 34609539461: leftover=1 + MagicMock Writer skip hid the dispose log."""
+    from unittest.mock import MagicMock
+
+    import plugin.testing_runner as tr
+    from plugin.tests import testing_utils as tu
+    from plugin.tests.testing_utils import TestingFactory
+
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(tr, "_soffice_pids", lambda: "8")
+    monkeypatch.setattr("gc.collect", lambda: None)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    tu._set_windows_leftover_open(1)
+    doc = MagicMock()
+    doc.close.side_effect = RuntimeError("Binary URP bridge disposed during call")
+    try:
+        TestingFactory.close_doc(doc)
+        err = capsys.readouterr().err
+        assert "LIFECYCLE close_doc dispose" in err
+        assert "skip writer close" not in err
+    finally:
+        tu._set_windows_leftover_open(saved)
+
+
+def test_native_doc_svc_magicmock_is_not_writer():
+    """GHA 34609539461: truthy MagicMock.supportsService classified mocks as Writer."""
+    from unittest.mock import MagicMock
+
+    from plugin.tests.testing_utils import _native_doc_svc
+
+    assert _native_doc_svc(MagicMock()) == ""
 
 
 def test_close_doc_windows_draw_logs_close_steps(capsys, monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -739,6 +739,35 @@ def test_close_doc_logs_urp_dispose(capsys, monkeypatch):
     tr.reset_lifecycle_breadcrumb()
 
 
+def test_close_doc_windows_draw_logs_close_steps(capsys, monkeypatch):
+    """GHA 34606276107: Draw close_doc dispose had no start/close(True) trail."""
+    from unittest.mock import MagicMock
+
+    from plugin.tests import testing_utils as tu
+    from plugin.tests.testing_utils import TestingFactory
+
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr("gc.collect", lambda: None)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("plugin.testing_runner._soffice_pids", lambda: "7196,5792")
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    tu._WINDOWS_LEFTOVER_OPEN = 3
+    tu.set_harness_keeper_uid("1")
+    doc = MagicMock()
+    doc.RuntimeUID = "48"
+    doc.supportsService.side_effect = lambda svc: svc.endswith("DrawingDocument")
+    try:
+        TestingFactory.close_doc(doc)
+        doc.close.assert_called_once_with(True)
+        err = capsys.readouterr().err
+        assert "close_doc: start uid=48 svc=draw leftovers=3 keeper=1 pids=7196,5792" in err
+        assert "close_doc: close(True) start uid=48 svc=draw leftovers=3 pids=7196,5792" in err
+        assert "close_doc: close(True) done uid=48 svc=draw pids=7196,5792" in err
+    finally:
+        tu._WINDOWS_LEFTOVER_OPEN = saved
+        tu.set_harness_keeper_uid("")
+
+
 def test_close_doc_windows_writer_reactivates_keeper(monkeypatch):
     """GHA 34554275072: after test Writer close, keep leftover off current."""
     from unittest.mock import MagicMock

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -898,6 +898,22 @@ def _writer_frame_name(doc) -> str:
         return ""
 
 
+def _native_doc_svc(doc) -> str:
+    """Harness breadcrumb: writer / calc / impress / draw. Impress first."""
+    try:
+        if doc.supportsService("com.sun.star.text.TextDocument"):
+            return "writer"
+        if doc.supportsService("com.sun.star.sheet.SpreadsheetDocument"):
+            return "calc"
+        if doc.supportsService("com.sun.star.presentation.PresentationDocument"):
+            return "impress"
+        if doc.supportsService("com.sun.star.drawing.DrawingDocument"):
+            return "draw"
+    except Exception:
+        return ""
+    return ""
+
+
 def _iter_open_writer_docs(desktop):
     """Yield (uid, doc) for open TextDocuments. Read-only enum; no close."""
     try:
@@ -1770,20 +1786,33 @@ class TestingFactory:
         # so reuse can still find the doc (34602219973).
         uid = ""
         is_writer = False
+        doc_svc = ""
+        leftover_open = 0
         if sys.platform == "win32":
             try:
                 uid = str(getattr(doc, "RuntimeUID", None) or "")
-                is_writer = bool(doc.supportsService("com.sun.star.text.TextDocument"))
+                doc_svc = _native_doc_svc(doc)
+                is_writer = doc_svc == "writer"
             except Exception:
                 is_writer = False
-            if is_writer:
-                from plugin.testing_runner import _progress
+            leftover_open = _windows_leftover_open()
+            if is_writer or doc_svc in ("draw", "impress"):
+                from plugin.testing_runner import _progress, _soffice_pids
 
-                leftover_open = _windows_leftover_open()
+                # GHA 34606276107: insert_math_draw close_doc dispose then
+                # soffice exited 0. Writer-only start hid Draw teardown.
+                # leftovers/keeper name leftover-window reuse vs Draw close.
                 _progress(
-                    "close_doc: start uid=%s leftovers=%s" % (uid or "-", leftover_open)
+                    "close_doc: start uid=%s svc=%s leftovers=%s keeper=%s pids=%s"
+                    % (
+                        uid or "-",
+                        doc_svc or "-",
+                        leftover_open,
+                        _HARNESS_KEEPER_UID or "-",
+                        _soffice_pids(),
+                    )
                 )
-                if leftover_open > 0:
+                if is_writer and leftover_open > 0:
                     # GHA 34602219973: close uid=34 returned; next unique
                     # _wa_factory_5 swriter hung 30s. Do not close a
                     # harness Writer while paste leftovers remain (same
@@ -1817,10 +1846,24 @@ class TestingFactory:
             # settle lets ~SvxShape finish before close. Unscoped: Writer
             # ControlShape / charts use the same pool. Post-close wait did not help.
             time.sleep(_CLOSE_DOC_URP_SETTLE_S)
+            if sys.platform == "win32" and doc_svc in ("draw", "impress"):
+                from plugin.testing_runner import _progress, _soffice_pids
+
+                _progress(
+                    "close_doc: close(True) start uid=%s svc=%s leftovers=%s pids=%s"
+                    % (uid or "-", doc_svc, leftover_open, _soffice_pids())
+                )
             if hasattr(doc, "close"):
                 doc.close(True)
             elif hasattr(doc, "dispose"):
                 doc.dispose()
+            if sys.platform == "win32" and doc_svc in ("draw", "impress"):
+                from plugin.testing_runner import _progress, _soffice_pids
+
+                _progress(
+                    "close_doc: close(True) done uid=%s svc=%s pids=%s"
+                    % (uid or "-", doc_svc, _soffice_pids())
+                )
             if sys.platform == "win32" and is_writer:
                 from plugin.testing_runner import _progress
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -899,15 +899,21 @@ def _writer_frame_name(doc) -> str:
 
 
 def _native_doc_svc(doc) -> str:
-    """Harness breadcrumb: writer / calc / impress / draw. Impress first."""
+    """Harness breadcrumb: writer / calc / impress / draw. Impress first.
+
+    ``is True``: MagicMock.supportsService() is truthy and would classify
+    every mock as Writer. GHA 34609539461: leftover=1 from a prior prepare
+    test then skipped close on an untyped mock, so
+    ``test_close_doc_logs_urp_dispose`` never saw the dispose breadcrumb.
+    """
     try:
-        if doc.supportsService("com.sun.star.text.TextDocument"):
+        if doc.supportsService("com.sun.star.text.TextDocument") is True:
             return "writer"
-        if doc.supportsService("com.sun.star.sheet.SpreadsheetDocument"):
+        if doc.supportsService("com.sun.star.sheet.SpreadsheetDocument") is True:
             return "calc"
-        if doc.supportsService("com.sun.star.presentation.PresentationDocument"):
+        if doc.supportsService("com.sun.star.presentation.PresentationDocument") is True:
             return "impress"
-        if doc.supportsService("com.sun.star.drawing.DrawingDocument"):
+        if doc.supportsService("com.sun.star.drawing.DrawingDocument") is True:
             return "draw"
     except Exception:
         return ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#722 leftover Writer reuse is on master (`3720c175`). Windows UNO now dies later in Draw teardown. Cause is still unclear — logging only, no product fix.

## Proof trail

- [34606276107](https://github.com/KeithCu/writeragent/actions/runs/34606276107) (branch `248da30d`): leftover Hidden swriter hang gone. `test_insert_math_draw` then `LIFECYCLE close_doc dispose` and soffice exited 0. `close_doc` dispose printed `previous=- current=-`.
- [34607010446](https://github.com/KeithCu/writeragent/actions/runs/34607010446) (master `3720c175`): same symptom after #722 merge.
- [34609539461](https://github.com/KeithCu/writeragent/actions/runs/34609539461) (this PR `750a3f0d`, Windows `workflow_dispatch`): Linux PR CI was green. Windows **pytest** failed `test_close_doc_logs_urp_dispose` — prepare left `leftover=1` and MagicMock `supportsService()` is truthy, so `close_doc` skipped the mock as a leftover Writer. Not the Draw flake.

## Change

Logging / dual-module only:

- Lifecycle trail is written to both `__main__` and `plugin.testing_runner`; `format_lifecycle_breadcrumb` adopts from the sibling if this copy is empty.
- Windows Draw/Impress `close_doc` logs `start uid= svc= leftovers= keeper= pids=` and `close(True) start/done`.
- `get_draw_tree` / `insert_math_draw` name the tool call vs body done vs teardown.
- `_native_doc_svc` uses `is True` so MagicMock is not classified as Writer; prepare tests reset leftover count.
- Docs + unit tests.

No product change. Do not close leftover paste Writers.

## Tests

- Unit: lifecycle adopt; Draw `close_doc` breadcrumbs; MagicMock is not Writer; leftover=1 + untyped mock still logs dispose.
- `make typecheck` green.

Parent will `workflow_dispatch` Windows PR CI on this branch (`os=windows-latest`, `ci_debug=true`). Look for Windows pytest green, then UNO `close_doc: close(True) start uid= svc=draw leftovers= keeper=`, `insert_math_draw: insert_math start/done` vs `body done`, and `LIFECYCLE close_doc dispose` with `current=draw.test_draw_uno.test_insert_math_draw` (not `previous=-`).

Keith merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a6845b6-05d7-4814-bb20-8892904bfe16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a6845b6-05d7-4814-bb20-8892904bfe16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

