### PR TITLE
Harness: skip Windows Draw close after insert_math OLE

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -14,7 +14,7 @@ Related: [archive/test_architecture_analysis.md](../archive/test_architecture_an
 |------|--------|------|-------|
 | Calc `@with_native_doc` | Yes (wipe-and-reuse pool) | Factory only on first use / dead pool | Close only if reset fails |
 | Writer `@with_native_doc` | No (unless `reuse=True`) | Factory each test | `close_doc` (`gc.collect` + 50 ms + `close`) |
-| Draw / Impress | **Never** | Factory each test (`private:factory/sdraw`) | Always `close_doc` |
+| Draw / Impress | **Never** | Factory each test (`private:factory/sdraw`) | `close_doc` (Windows **skips** close when the Draw still holds Math OLE) |
 
 `create_native_doc` is a thin `loadComponentFromURL`. Draw tests do **not**
 share a pooled document. A keeper hidden Writer is opened once in
@@ -227,6 +227,28 @@ skips Writer `close_doc` while leftovers remain
 (`native_doc: leftover writer reuse`,
 `close_doc: skip writer close leftovers`).
 
+GHA 34607010446 (master `3720c175`, `#722` merge, leftover Writer
+reuse already past): `document_research_uno` and both text_helpers
+tests OK. Draw suite: nine tests `TEST end … OK` including
+`test_get_draw_tree` (same soffice `6200,2084`, leftovers
+uids=`['34','27','26']` keeper=1). `test_insert_math_draw` printed
+`TEST call`, factory `load done uid=48`, then
+`LIFECYCLE close_doc dispose` (pids still `6200,2084`) and
+`office dead after close doc_type=draw` (pids `-`). soffice exited 0.
+`TEST returned` then fail-closed; remaining suites aborted. The
+`close_doc dispose` line printed `previous=- current=-` because
+`python -m` records the trail on `__main__` and `close_doc` imported
+`plugin.testing_runner` (same dual-module family as #719 recycle).
+Nine ordinary Draw `close_doc` calls survived, so leftover-Writer
+reuse is not the Draw-close killer. `close_doc` of a Draw that still
+holds Math OLE is. Windows therefore **skips** that close
+(`close_doc: skip math ole close (windows)`), reactivates the keeper,
+and does **not** recycle mid-run (34551644954). POSIX still closes.
+`test_insert_math_draw` runs last in `test_draw_uno.py` so a leftover
+is not current for later tests in that file. Trail start/end now
+writes both runner modules; `format_lifecycle_breadcrumb` adopts from
+the sibling if this copy is empty.
+
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
 `peer_message_uno: writer reactivated`,
@@ -245,6 +267,7 @@ POSIX still `close_doc`. Breadcrumbs:
 `native_doc: leftover writer reuse`,
 `close_doc: skip writer close leftovers open=N uid=…`,
 `get_draw_tree: body start/execute done/body done`,
+`close_doc: skip math ole close (windows) uid= svc= leftovers= keeper= pids=`,
 `insert_math_draw: insert_math start/done` and `body done`. Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
 
@@ -258,10 +281,10 @@ closed; `test_get_draw_tree` OK. `test_insert_math_draw` then
 exited 0. `close_doc` dispose printed `previous=- current=-` — `-m`
 lifecycle lives on `__main__`, close_doc imported
 `plugin.testing_runner`. Nine Draw closes with the same leftovers
-survived, so leftover-Writer reuse is not a proven Draw-close killer;
-this may be the known `get_draw_tree` → `insert_math_draw` flake now
-reachable. No product change. Breadcrumbs now name Draw `close(True)`
-and adopt the lifecycle trail across both runner module copies.
+survived, so leftover-Writer reuse is not a proven Draw-close killer.
+`#723` named Draw `close(True)` and adopted the lifecycle trail across
+both runner copies. Windows now **skips** that Math OLE `close_doc`
+(see the 34607010446 paragraph above). No product change.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
@@ -275,7 +298,11 @@ no second leftover swriter factory after the first text_helpers Writer,
 `document_research_uno` three tests
 `TEST end … OK`, both text_helpers tests `TEST end … OK` (no 30s
 Timeout in `create_native_doc` on
-`…_multi_para_joins_with_newline` / `target=_wa_factory_5`), later
+`…_multi_para_joins_with_newline` / `target=_wa_factory_5`),
+`insert_math_draw: insert_math start/done` then
+`close_doc: skip math ole close (windows)` (not
+`LIFECYCLE close_doc dispose` / `office dead after close doc_type=draw`),
+`TEST end draw.test_draw_uno.test_insert_math_draw OK`, later
 suites including the peer file last (six peer `TEST end … OK`), then
 `LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI
 is the automatic gate; this cloud agent cannot run `windows-latest`.

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -257,16 +257,23 @@ only. Do not walk for Math CLSID at teardown.
 `test_insert_math_draw` runs last in `test_draw_uno.py` so a leftover
 is not current for later tests in that file. On Windows the runner
 also sorts `test_draw_uno.py` just before the peer suite
-(`_native_suite_sort_key` band 1, peer band 2). GHA 34616287301:
-skip printed `close_doc: skip math ole close (windows) uid=50
-leftovers=3 keeper=1`, `test_insert_math_draw` OK, later Impress
-suites OK, then `notebook.test_import_filter_uno_detect_without_filtername`
-hung 30s on `loadComponentFromURL` (soffice still `9124,6920`).
-Deferring the leftover Math Draw until leftover-Impress + process
-teardown keeps notebook import-filter on the original office
-without `close(True)` and without mid-run recycle. Trail start/end
-now writes both runner modules; `format_lifecycle_breadcrumb`
-adopts from the sibling if this copy is empty.
+(`_native_suite_sort_key` band 1, peer band 2) so that leftover Draw
+is not `close(True)`'d (34607010446) and is not recycled mid-run
+(34551644954). GHA 34616287301: skip printed
+`close_doc: skip math ole close (windows) uid=50 leftovers=3 keeper=1`,
+`test_insert_math_draw` OK, later Impress suites OK, then
+`notebook.test_import_filter_uno_detect_without_filtername` hung 30s.
+GHA 34619751330 deferred `test_draw_uno` and the same notebook detect
+hang happened *before* `insert_math` (soffice still `2444,5124`,
+leftovers `['34','27','26']`). Leftover Math Draw is not that hang.
+`test_import_filter_uno_load_component` Hidden `_blank` + FilterName
+returned, then raw `close(True)`; the next Hidden `_blank` detect
+hung — consecutive leftover Hidden `_blank` (34597506651). Windows
+notebook loads now use `windows_notebook_load_args` (`_wa_notebook`,
+CREATE|GLOBAL) and `TestingFactory.close_doc` (skip Writer close
+while leftovers remain). Trail start/end now writes both runner
+modules; `format_lifecycle_breadcrumb` adopts from the sibling if
+this copy is empty.
 
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
@@ -285,8 +292,10 @@ POSIX still `close_doc`. Breadcrumbs:
 `close_doc: skip writer close leftovers open=N uid=…`,
 `get_draw_tree: body start/execute done/body done`,
 `close_doc: skip math ole close (windows) uid= leftovers= keeper= pids=`,
-`insert_math_draw: insert_math start/done` and `body done`. Do **not** fold
-Draw-family settle into `close_doc`. Not a product fix.
+`insert_math_draw: insert_math start/done` and `body done`,
+`import_filter_uno: load start/done` (`target=_wa_notebook` on
+Windows). Do **not** fold Draw-family settle into `close_doc`. Not a
+product fix.
 
 GHA 34606276107 (`248da30d`, leftover hang fixed) and master
 34607010446 (`3720c175`, #722 merge): leftover paste + leftover-window
@@ -321,9 +330,14 @@ Timeout in `create_native_doc` on
 that close), `insert_math_draw: insert_math start/done` then
 `close_doc: skip math ole close (windows)` (not
 `LIFECYCLE close_doc dispose` / `office dead after close doc_type=draw`),
-`TEST end draw.test_draw_uno.test_insert_math_draw OK` **after**
-`notebook.test_import_filter_uno` both tests `TEST end … OK` (no 30s
-Timeout on `detect_without_filtername`), later leftover-Impress
+`import_filter_uno: load start target=_wa_notebook` (not `_blank`)
+for both notebook import-filter tests, `close_doc: skip writer close`
+or `close_doc: start` (not raw `doc.close(True)`), both
+`notebook.test_import_filter_uno` tests `TEST end … OK` (no 30s
+Timeout on `detect_without_filtername`), **then**
+`TEST end draw.test_draw_uno.test_insert_math_draw OK` after
+`insert_math_draw: insert_math start/done` and
+`close_doc: skip math ole close (windows)`, leftover-Impress
 suites, then the peer file last (six peer `TEST end … OK`), then
 `LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI
 is the automatic gate; this cloud agent cannot run `windows-latest`.

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -255,9 +255,18 @@ walked pages/shapes and `_native_doc_svc` before `close(True)`.
 Unmarked Draw close is again RuntimeUID + GC + 50 ms + `close(True)`
 only. Do not walk for Math CLSID at teardown.
 `test_insert_math_draw` runs last in `test_draw_uno.py` so a leftover
-is not current for later tests in that file. Trail start/end now
-writes both runner modules; `format_lifecycle_breadcrumb` adopts from
-the sibling if this copy is empty.
+is not current for later tests in that file. On Windows the runner
+also sorts `test_draw_uno.py` just before the peer suite
+(`_native_suite_sort_key` band 1, peer band 2). GHA 34616287301:
+skip printed `close_doc: skip math ole close (windows) uid=50
+leftovers=3 keeper=1`, `test_insert_math_draw` OK, later Impress
+suites OK, then `notebook.test_import_filter_uno_detect_without_filtername`
+hung 30s on `loadComponentFromURL` (soffice still `9124,6920`).
+Deferring the leftover Math Draw until leftover-Impress + process
+teardown keeps notebook import-filter on the original office
+without `close(True)` and without mid-run recycle. Trail start/end
+now writes both runner modules; `format_lifecycle_breadcrumb`
+adopts from the sibling if this copy is empty.
 
 POSIX still `close_doc`. Breadcrumbs:
 `close_draw_family: raw close(True) start/done`,
@@ -312,8 +321,10 @@ Timeout in `create_native_doc` on
 that close), `insert_math_draw: insert_math start/done` then
 `close_doc: skip math ole close (windows)` (not
 `LIFECYCLE close_doc dispose` / `office dead after close doc_type=draw`),
-`TEST end draw.test_draw_uno.test_insert_math_draw OK`, later
-suites including the peer file last (six peer `TEST end … OK`), then
+`TEST end draw.test_draw_uno.test_insert_math_draw OK` **after**
+`notebook.test_import_filter_uno` both tests `TEST end … OK` (no 30s
+Timeout on `detect_without_filtername`), later leftover-Impress
+suites, then the peer file last (six peer `TEST end … OK`), then
 `LIFECYCLE recycle office skipped; no remaining suites`. Ubuntu PR CI
 is the automatic gate; this cloud agent cannot run `windows-latest`.
 

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -241,9 +241,19 @@ uids=`['34','27','26']` keeper=1). `test_insert_math_draw` printed
 `plugin.testing_runner` (same dual-module family as #719 recycle).
 Nine ordinary Draw `close_doc` calls survived, so leftover-Writer
 reuse is not the Draw-close killer. `close_doc` of a Draw that still
-holds Math OLE is. Windows therefore **skips** that close
+holds Math OLE is. Windows therefore **skips** that close when
+`mark_windows_math_ole_doc` recorded the uid
 (`close_doc: skip math ole close (windows)`), reactivates the keeper,
 and does **not** recycle mid-run (34551644954). POSIX still closes.
+
+GHA 34609996253 / 34612145495 (this skip on the PR tip): leftover
+Writer reuse and text_helpers still OK, then the *first* Draw close
+(`draw.test_draw_forms_uno.test_draw_form_lifecycle`, uid=35) printed
+`close_doc: start` / `close(True) start` and soffice exited 0.
+Master 34607010446 closed that same forms Draw. The skip path had
+walked pages/shapes and `_native_doc_svc` before `close(True)`.
+Unmarked Draw close is again RuntimeUID + GC + 50 ms + `close(True)`
+only. Do not walk for Math CLSID at teardown.
 `test_insert_math_draw` runs last in `test_draw_uno.py` so a leftover
 is not current for later tests in that file. Trail start/end now
 writes both runner modules; `format_lifecycle_breadcrumb` adopts from
@@ -261,13 +271,11 @@ POSIX still `close_doc`. Breadcrumbs:
 `create_native_doc: windows factory leftover_open=N url=… target=… flags=…`,
 `create_native_doc: load start/done` (leftover Windows factory),
 `document_research_uno: create/store/close/list_nearby start/done`,
-`close_doc: start uid= svc= leftovers= keeper= pids=` (Windows Writer/Draw/Impress),
-`close_doc: close(True) start/done` (Windows Draw/Impress),
-`close_doc: done uid=…` (Windows Writer),
+`close_doc: start/done uid= leftovers=` (Windows Writer),
 `native_doc: leftover writer reuse`,
 `close_doc: skip writer close leftovers open=N uid=…`,
 `get_draw_tree: body start/execute done/body done`,
-`close_doc: skip math ole close (windows) uid= svc= leftovers= keeper= pids=`,
+`close_doc: skip math ole close (windows) uid= leftovers= keeper= pids=`,
 `insert_math_draw: insert_math start/done` and `body done`. Do **not** fold
 Draw-family settle into `close_doc`. Not a product fix.
 
@@ -299,7 +307,9 @@ no second leftover swriter factory after the first text_helpers Writer,
 `TEST end … OK`, both text_helpers tests `TEST end … OK` (no 30s
 Timeout in `create_native_doc` on
 `…_multi_para_joins_with_newline` / `target=_wa_factory_5`),
-`insert_math_draw: insert_math start/done` then
+`draw.test_draw_forms_uno` four tests `TEST end … OK` (first Draw
+`close(True)` must return; no `close_doc: start uid= svc=draw` before
+that close), `insert_math_draw: insert_math start/done` then
 `close_doc: skip math ole close (windows)` (not
 `LIFECYCLE close_doc dispose` / `office dead after close doc_type=draw`),
 `TEST end draw.test_draw_uno.test_insert_math_draw OK`, later

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1170,13 +1170,12 @@ def _native_suite_sort_key(module_path: str) -> tuple[int, str]:
     teardown, not in-process rebootstrap.
 
     GHA 34616287301: skipping Math OLE ``close_doc`` kept Draw uid=50
-    open (``leftovers=3 keeper=1``). Impress suites after that skip still
-    ``TEST end … OK``. ``notebook.test_import_filter_uno_detect_without_filtername``
-    then hung 30s on ``loadComponentFromURL`` (soffice still
-    ``9124,6920``). Run ``test_draw_uno`` just before the peer suite so
-    the leftover Math Draw exists only for leftover-Impress tests and
-    process teardown. Do **not** ``close(True)`` that Draw (34607010446
-    exit 0) and do **not** recycle mid-run (34551644954).
+    open. GHA 34619751330 deferred this file and the notebook detect
+    hang still happened *before* ``insert_math`` — leftover Math Draw
+    is not that hang. Still run ``test_draw_uno`` just before the peer
+    suite so the leftover Math Draw is not closed (34607010446 exit 0)
+    and does not recycle mid-run (34551644954). Notebook Hidden
+    ``_blank`` isolation is ``windows_notebook_load_args``.
     """
     name = os.path.basename(module_path)
     if sys.platform != "win32":

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1162,15 +1162,28 @@ def consume_office_recycle_request() -> bool:
 
 
 def _native_suite_sort_key(module_path: str) -> tuple[int, str]:
-    """Windows: run the peer suite last so leftover docs do not poison later loads.
+    """Windows: leftover-leaving suites run last so they do not poison later loads.
 
     GHA 34551644954: recycle *did* start a new soffice, then the next Calc
     factory raised ``Could not create system bitmap`` and hung. Other
     suites must keep the original office. Peer leftovers die with process
     teardown, not in-process rebootstrap.
+
+    GHA 34616287301: skipping Math OLE ``close_doc`` kept Draw uid=50
+    open (``leftovers=3 keeper=1``). Impress suites after that skip still
+    ``TEST end … OK``. ``notebook.test_import_filter_uno_detect_without_filtername``
+    then hung 30s on ``loadComponentFromURL`` (soffice still
+    ``9124,6920``). Run ``test_draw_uno`` just before the peer suite so
+    the leftover Math Draw exists only for leftover-Impress tests and
+    process teardown. Do **not** ``close(True)`` that Draw (34607010446
+    exit 0) and do **not** recycle mid-run (34551644954).
     """
     name = os.path.basename(module_path)
-    if sys.platform == "win32" and name == "test_peer_message_uno.py":
+    if sys.platform != "win32":
+        return (0, module_path)
+    if name == "test_peer_message_uno.py":
+        return (2, module_path)
+    if name == "test_draw_uno.py":
         return (1, module_path)
     return (0, module_path)
 

--- a/tests/draw/test_draw_uno.py
+++ b/tests/draw/test_draw_uno.py
@@ -462,7 +462,8 @@ def test_insert_math_draw(ctx, doc):
     # killed soffice (GHA 34607010446, exit 0). Run after the other tests
     # so a skipped leftover is not desktop current for later cases here.
     # The runner also defers this file until just before the peer suite
-    # (GHA 34616287301: leftover uid=50 hung notebook import-filter load).
+    # so this leftover is not closed (34607010446). Notebook detect hang
+    # on 34619751330 was leftover Hidden _blank, not this Draw.
     from plugin.testing_runner import _progress
     from plugin.tests.testing_utils import mark_windows_math_ole_doc
 

--- a/tests/draw/test_draw_uno.py
+++ b/tests/draw/test_draw_uno.py
@@ -461,6 +461,8 @@ def test_insert_math_draw(ctx, doc):
     # Last Draw close in this file on Windows: close_doc of a Math OLE Draw
     # killed soffice (GHA 34607010446, exit 0). Run after the other tests
     # so a skipped leftover is not desktop current for later cases here.
+    # The runner also defers this file until just before the peer suite
+    # (GHA 34616287301: leftover uid=50 hung notebook import-filter load).
     from plugin.testing_runner import _progress
     from plugin.tests.testing_utils import mark_windows_math_ole_doc
 

--- a/tests/draw/test_draw_uno.py
+++ b/tests/draw/test_draw_uno.py
@@ -324,37 +324,6 @@ def test_get_draw_tree(ctx, doc):
 
 @native_test
 @with_native_doc("draw")
-def test_insert_math_draw(ctx, doc):
-    from plugin.testing_runner import _progress
-
-    # GHA 34606276107: load done uid=48 then ~8s later close_doc dispose
-    # and soffice exited 0. Name insert_math vs close_doc teardown.
-    _progress("insert_math_draw: insert_math start")
-    # Insert math (formula_type + formula + page + x + y; size from UNO/heuristic)
-    result = _exec_tool(doc, ctx, "insert_math", {
-        "formula_type": "latex",
-        "formula": "E = mc^2",
-        "page": 0,
-        "x": 2000,
-        "y": 2000,
-    })
-
-    data = json.loads(result)
-    _progress("insert_math_draw: insert_math done status=%s" % data.get("status"))
-    assert data.get("status") == "ok", f"insert_math failed: {result}"
-
-    # insert_math used page_index 0 — read shape from that page (current slide may differ after prior tests).
-    target_page = doc.getDrawPages().getByIndex(0)
-    shape = target_page.getByIndex(data.get("index"))
-
-    assert shape.CLSID == "078B7ABA-54FC-457F-8551-6147e776a997"
-    sz = shape.getSize()
-    assert sz.Width >= 400 and sz.Height >= 300, f"expected plausible size, got {sz.Width}x{sz.Height}"
-    _progress("insert_math_draw: body done")
-
-
-@native_test
-@with_native_doc("draw")
 def test_get_draw_tree_marks_blank_and_label_hint(ctx, doc):
     page_idx = _active_draw_page_index(doc)
     _exec_tool(doc, ctx, "shape_upsert", {
@@ -484,4 +453,44 @@ def test_writer_star24_with_text_keeps_explicit_size(ctx, doc):
     assert abs(size.Width - 4000) <= 2, f"Width collapsed: {size.Width}x{size.Height}"
     assert abs(size.Height - 4000) <= 2, f"Height collapsed: {size.Width}x{size.Height}"
     assert shape.String == "24-sided Star" or shape.getString() == "24-sided Star"
+
+
+@native_test
+@with_native_doc("draw")
+def test_insert_math_draw(ctx, doc):
+    # Last Draw close in this file on Windows: close_doc of a Math OLE Draw
+    # killed soffice (GHA 34607010446, exit 0). Run after the other tests
+    # so a skipped leftover is not desktop current for later cases here.
+    from plugin.testing_runner import _progress
+    from plugin.tests.testing_utils import mark_windows_math_ole_doc
+
+    # GHA 34606276107: load done uid=48 then ~8s later close_doc dispose
+    # and soffice exited 0. Name insert_math vs close_doc teardown.
+    _progress("insert_math_draw: insert_math start")
+    result = _exec_tool(doc, ctx, "insert_math", {
+        "formula_type": "latex",
+        "formula": "E = mc^2",
+        "page": 0,
+        "x": 2000,
+        "y": 2000,
+    })
+
+    data = json.loads(result)
+    _progress("insert_math_draw: insert_math done status=%s" % data.get("status"))
+    assert data.get("status") == "ok", f"insert_math failed: {result}"
+
+    # insert_math used page_index 0 — read shape from that page (current slide may differ after prior tests).
+    target_page = doc.getDrawPages().getByIndex(0)
+    shape = target_page.getByIndex(data.get("index"))
+
+    assert shape.CLSID == "078B7ABA-54FC-457F-8551-6147e776a997"
+    sz = shape.getSize()
+    assert sz.Width >= 400 and sz.Height >= 300, f"expected plausible size, got {sz.Width}x{sz.Height}"
+
+    # Drop Math OLE proxies before teardown. close_doc still GCs; Windows
+    # skips the close after mark (34607010446 dispose killed soffice).
+    mark_windows_math_ole_doc(doc)
+    shape = None
+    target_page = None
+    _progress("insert_math_draw: body done")
 

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -254,6 +254,41 @@ def test_native_suite_sort_key_windows_puts_peer_last(monkeypatch) -> None:
     assert ordered[0].endswith("test_slash_popup_uno.py")
 
 
+def test_native_suite_sort_key_windows_puts_draw_uno_before_peer(
+    monkeypatch,
+) -> None:
+    """GHA 34616287301: leftover Math Draw hung notebook import-filter load."""
+    import plugin.testing_runner as tr
+
+    monkeypatch.setattr(tr.sys, "platform", "win32")
+    paths = [
+        "/tmp/tests/chatbot/test_peer_message_uno.py",
+        "/tmp/tests/draw/test_draw_uno.py",
+        "/tmp/tests/notebook/test_import_filter_uno.py",
+        "/tmp/tests/draw/test_draw_forms_uno.py",
+        "/tmp/tests/impress/test_impress_uno.py",
+    ]
+    ordered = sorted(paths, key=_native_suite_sort_key)
+    names = [p.rsplit("/", 1)[-1] for p in ordered]
+    assert names[-1] == "test_peer_message_uno.py"
+    assert names[-2] == "test_draw_uno.py"
+    assert names.index("test_import_filter_uno.py") < names.index("test_draw_uno.py")
+    assert names.index("test_draw_forms_uno.py") < names.index("test_draw_uno.py")
+
+
+def test_native_suite_sort_key_posix_keeps_path_order(monkeypatch) -> None:
+    """Linux PR CI must not defer draw_uno; POSIX still closes Math OLE."""
+    import plugin.testing_runner as tr
+
+    monkeypatch.setattr(tr.sys, "platform", "linux")
+    paths = [
+        "/tmp/tests/chatbot/test_peer_message_uno.py",
+        "/tmp/tests/draw/test_draw_uno.py",
+        "/tmp/tests/notebook/test_import_filter_uno.py",
+    ]
+    assert sorted(paths, key=_native_suite_sort_key) == sorted(paths)
+
+
 def test_should_not_rebootstrap_when_no_remaining_suites() -> None:
     """GHA 34551644954: recycled office hung the next scalc factory load."""
     assert _should_rebootstrap_after_recycle(more_suites=True) is True

--- a/tests/notebook/test_import_filter_uno.py
+++ b/tests/notebook/test_import_filter_uno.py
@@ -13,52 +13,75 @@ import uno
 from plugin.doc.doc_type import is_writer
 from plugin.framework.uno_context import get_desktop
 from plugin.notebook.cell_registry import load_registry
-from plugin.testing_runner import native_test
+from plugin.testing_runner import _progress, native_test
+from plugin.tests.testing_utils import TestingFactory, windows_notebook_load_args
 
 
-@native_test
-def test_import_filter_uno_load_component(ctx):
-    """Load an .ipynb via desktop.loadComponentFromURL using the native filter."""
-    desktop = get_desktop(ctx)
-    assert desktop is not None
-
+def _ipynb_fixture_url() -> str:
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
     fixture_path = os.path.join(
         repo_root, "tests", "fixtures", "introduction-to-numpy-small.ipynb"
     )
     assert os.path.exists(fixture_path), f"Fixture not found: {fixture_path}"
+    return uno.systemPathToFileUrl(fixture_path)
 
-    file_url = uno.systemPathToFileUrl(fixture_path)
 
-    from com.sun.star.beans import PropertyValue
-
-    prop = PropertyValue()
-    prop.Name = "FilterName"
-    prop.Value = "writer_WriterAgent_Jupyter_Notebook"
-
-    prop_hidden = PropertyValue()
-    prop_hidden.Name = "Hidden"
-    prop_hidden.Value = True
-
-    # Query LibreOffice FilterFactory for the Jupyter Notebook native filter
+def _has_notebook_filter(ctx) -> bool:
     try:
         filter_factory = ctx.getServiceManager().createInstanceWithContext(
             "com.sun.star.document.FilterFactory", ctx
         )
-        has_filter = filter_factory is not None and filter_factory.hasByName(
+        return filter_factory is not None and filter_factory.hasByName(
             "writer_WriterAgent_Jupyter_Notebook"
         )
     except Exception:
-        has_filter = False
+        return False
 
-    if not has_filter:
+
+def _load_ipynb(ctx, *, filter_name: str | None = None):
+    """Hidden .ipynb load. Windows avoids leftover Hidden ``_blank`` (34619751330)."""
+    desktop = get_desktop(ctx)
+    assert desktop is not None
+    from com.sun.star.beans import PropertyValue
+
+    props = []
+    if filter_name:
+        prop = PropertyValue()
+        prop.Name = "FilterName"
+        prop.Value = filter_name
+        props.append(prop)
+    prop_hidden = PropertyValue()
+    prop_hidden.Name = "Hidden"
+    prop_hidden.Value = True
+    props.append(prop_hidden)
+    target, flags = windows_notebook_load_args()
+    _progress(
+        "import_filter_uno: load start target=%s flags=%s filter=%s"
+        % (target, flags, filter_name or "-")
+    )
+    doc = desktop.loadComponentFromURL(
+        _ipynb_fixture_url(), target, flags, tuple(props)
+    )
+    uid = ""
+    try:
+        uid = str(getattr(doc, "RuntimeUID", None) or "")
+    except Exception:
+        uid = ""
+    _progress("import_filter_uno: load done uid=%s" % (uid or "-"))
+    return doc
+
+
+@native_test
+def test_import_filter_uno_load_component(ctx):
+    """Load an .ipynb via desktop.loadComponentFromURL using the native filter."""
+    if not _has_notebook_filter(ctx):
         # FIXME: testing_runner bootstraps with a throwaway profile (-env:UserInstallation in /tmp)
         # which does not inherit user-level extensions installed via `unopkg add` into ~/.config/libreoffice.
         # Once testing_runner uses a shared extension install or mounts the profile, require has_filter to be True.
         print("Note: writer_WriterAgent_Jupyter_Notebook filter not registered in throwaway profile; skipping loadComponent test")
         return
 
-    doc = desktop.loadComponentFromURL(file_url, "_blank", 0, (prop, prop_hidden))
+    doc = _load_ipynb(ctx, filter_name="writer_WriterAgent_Jupyter_Notebook")
     try:
         assert doc is not None
         assert is_writer(doc)
@@ -67,48 +90,20 @@ def test_import_filter_uno_load_component(ctx):
         assert len(state.code_cells) > 0
         assert "In [" in doc.getText().getString()
     finally:
-        if doc is not None:
-            doc.close(True)
+        # Raw close(True) + next Hidden _blank hung detect (34619751330).
+        TestingFactory.close_doc(doc)
 
 
 @native_test
 def test_import_filter_uno_detect_without_filtername(ctx):
     """Load an .ipynb via desktop.loadComponentFromURL without explicit FilterName to test detect()."""
-    desktop = get_desktop(ctx)
-    assert desktop is not None
-
-    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    fixture_path = os.path.join(
-        repo_root, "tests", "fixtures", "introduction-to-numpy-small.ipynb"
-    )
-    assert os.path.exists(fixture_path), f"Fixture not found: {fixture_path}"
-
-    file_url = uno.systemPathToFileUrl(fixture_path)
-
-    from com.sun.star.beans import PropertyValue
-
-    prop_hidden = PropertyValue()
-    prop_hidden.Name = "Hidden"
-    prop_hidden.Value = True
-
-    # Query LibreOffice FilterFactory for the Jupyter Notebook native filter
-    try:
-        filter_factory = ctx.getServiceManager().createInstanceWithContext(
-            "com.sun.star.document.FilterFactory", ctx
-        )
-        has_filter = filter_factory is not None and filter_factory.hasByName(
-            "writer_WriterAgent_Jupyter_Notebook"
-        )
-    except Exception:
-        has_filter = False
-
-    if not has_filter:
+    if not _has_notebook_filter(ctx):
         # FIXME: testing_runner bootstraps with a throwaway profile (-env:UserInstallation in /tmp)
         # which does not inherit user-level extensions installed via `unopkg add` into ~/.config/libreoffice.
         print("Note: writer_WriterAgent_Jupyter_Notebook filter not registered in throwaway profile; skipping detect test")
         return
 
-    doc = desktop.loadComponentFromURL(file_url, "_blank", 0, (prop_hidden,))
+    doc = _load_ipynb(ctx)
     try:
         assert doc is not None
         assert is_writer(doc)
@@ -122,5 +117,4 @@ def test_import_filter_uno_detect_without_filtername(ctx):
 
         assert doc.ApplyFormDesignMode is False
     finally:
-        if doc is not None:
-            doc.close(True)
+        TestingFactory.close_doc(doc)

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -576,6 +576,106 @@ def test_windows_should_reuse_writer_only_with_leftovers(monkeypatch):
     assert tu._windows_should_reuse_writer(None) is False
 
 
+def test_draw_doc_has_math_ole_reads_clsid():
+    from unittest.mock import MagicMock
+
+    from plugin.tests.testing_utils import _MATH_OLE_CLSID, _draw_doc_has_math_ole
+
+    shape = MagicMock()
+    shape.CLSID = _MATH_OLE_CLSID
+    page = MagicMock()
+    page.getCount.return_value = 1
+    page.getByIndex.return_value = shape
+    pages = MagicMock()
+    pages.getCount.return_value = 1
+    pages.getByIndex.return_value = page
+    doc = MagicMock()
+    doc.getDrawPages.return_value = pages
+    assert _draw_doc_has_math_ole(doc) is True
+    shape.CLSID = "not-math"
+    assert _draw_doc_has_math_ole(doc) is False
+    assert _draw_doc_has_math_ole(None) is False
+
+
+def test_close_doc_windows_skips_math_ole_draw(monkeypatch, capsys):
+    """GHA 34607010446: close_doc dispose of Math OLE Draw killed soffice."""
+    from unittest.mock import MagicMock
+
+    from plugin.tests.testing_utils import TestingFactory, mark_windows_math_ole_doc
+    import plugin.tests.testing_utils as tu
+
+    doc = MagicMock()
+    doc.RuntimeUID = "48"
+    doc.supportsService.side_effect = lambda svc: svc.endswith("DrawingDocument")
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(tu, "reactivate_harness_keeper", lambda desktop=None: True)
+    saved = set(tu._WINDOWS_MATH_OLE_UIDS)
+    tu._WINDOWS_MATH_OLE_UIDS.clear()
+    try:
+        mark_windows_math_ole_doc(doc)
+        TestingFactory.close_doc(doc)
+        doc.close.assert_not_called()
+        err = capsys.readouterr().err
+        assert "close_doc: skip math ole close (windows) uid=48 svc=draw" in err
+    finally:
+        tu._WINDOWS_MATH_OLE_UIDS.clear()
+        tu._WINDOWS_MATH_OLE_UIDS.update(saved)
+
+
+def test_close_doc_windows_draw_without_math_still_closes(monkeypatch, capsys):
+    from unittest.mock import MagicMock
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    shape = MagicMock()
+    shape.CLSID = "not-math"
+    page = MagicMock()
+    page.getCount.return_value = 1
+    page.getByIndex.return_value = shape
+    pages = MagicMock()
+    pages.getCount.return_value = 1
+    pages.getByIndex.return_value = page
+    doc = MagicMock()
+    doc.RuntimeUID = "47"
+    doc.supportsService.side_effect = lambda svc: svc.endswith("DrawingDocument")
+    doc.getDrawPages.return_value = pages
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr("gc.collect", lambda: None)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    monkeypatch.setattr(tu, "_windows_leftover_open", lambda: 3)
+    tu._HARNESS_KEEPER_UID = "1"
+    tu._WINDOWS_MATH_OLE_UIDS.clear()
+    try:
+        TestingFactory.close_doc(doc)
+        doc.close.assert_called_once_with(True)
+        err = capsys.readouterr().err
+        assert "close_doc: start uid=47 svc=draw leftovers=3 keeper=1" in err
+        assert "close_doc: close(True) start uid=47 svc=draw" in err
+        assert "close_doc: close(True) done uid=47 svc=draw" in err
+        assert "skip math ole close" not in err
+    finally:
+        tu._HARNESS_KEEPER_UID = ""
+        tu._WINDOWS_MATH_OLE_UIDS.clear()
+
+
+def test_close_doc_posix_closes_math_ole_draw(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from plugin.tests.testing_utils import TestingFactory, mark_windows_math_ole_doc
+    import plugin.tests.testing_utils as tu
+
+    doc = MagicMock()
+    doc.RuntimeUID = "48"
+    doc.supportsService.side_effect = lambda svc: svc.endswith("DrawingDocument")
+    monkeypatch.setattr(tu.sys, "platform", "linux")
+    monkeypatch.setattr("gc.collect", lambda: None)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    mark_windows_math_ole_doc(doc)
+    TestingFactory.close_doc(doc)
+    doc.close.assert_called_once_with(True)
+
+
 def test_close_doc_skips_windows_writer_when_leftovers_open(monkeypatch):
     """GHA 34602219973: close_doc uid=34 returned; next unique swriter hung."""
     from unittest.mock import MagicMock
@@ -798,6 +898,8 @@ def test_close_doc_windows_draw_logs_close_steps(capsys, monkeypatch):
     saved = tu._WINDOWS_LEFTOVER_OPEN
     tu._WINDOWS_LEFTOVER_OPEN = 3
     tu.set_harness_keeper_uid("1")
+    saved_math = set(tu._WINDOWS_MATH_OLE_UIDS)
+    tu._WINDOWS_MATH_OLE_UIDS.clear()
     doc = MagicMock()
     doc.RuntimeUID = "48"
     doc.supportsService.side_effect = lambda svc: svc.endswith("DrawingDocument")
@@ -808,9 +910,12 @@ def test_close_doc_windows_draw_logs_close_steps(capsys, monkeypatch):
         assert "close_doc: start uid=48 svc=draw leftovers=3 keeper=1 pids=7196,5792" in err
         assert "close_doc: close(True) start uid=48 svc=draw leftovers=3 pids=7196,5792" in err
         assert "close_doc: close(True) done uid=48 svc=draw pids=7196,5792" in err
+        assert "skip math ole close" not in err
     finally:
         tu._WINDOWS_LEFTOVER_OPEN = saved
         tu.set_harness_keeper_uid("")
+        tu._WINDOWS_MATH_OLE_UIDS.clear()
+        tu._WINDOWS_MATH_OLE_UIDS.update(saved_math)
 
 
 def test_close_doc_windows_writer_reactivates_keeper(monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -614,8 +614,10 @@ def test_close_doc_windows_skips_math_ole_draw(monkeypatch, capsys):
         mark_windows_math_ole_doc(doc)
         TestingFactory.close_doc(doc)
         doc.close.assert_not_called()
+        doc.supportsService.assert_not_called()
         err = capsys.readouterr().err
-        assert "close_doc: skip math ole close (windows) uid=48 svc=draw" in err
+        assert "close_doc: skip math ole close (windows) uid=48" in err
+        assert "svc=draw" not in err
     finally:
         tu._clear_windows_math_ole_uids()
 
@@ -647,11 +649,10 @@ def test_close_doc_windows_draw_without_math_still_closes(monkeypatch, capsys):
     try:
         TestingFactory.close_doc(doc)
         doc.close.assert_called_once_with(True)
+        doc.getDrawPages.assert_not_called()
         err = capsys.readouterr().err
-        assert "close_doc: start uid=47 svc=draw leftovers=3 keeper=1" in err
-        assert "close_doc: close(True) start uid=47 svc=draw" in err
-        assert "close_doc: close(True) done uid=47 svc=draw" in err
         assert "skip math ole close" not in err
+        assert "svc=draw" not in err
     finally:
         tu._HARNESS_KEEPER_UID = ""
         tu._clear_windows_math_ole_uids()
@@ -904,10 +905,11 @@ def test_close_doc_windows_draw_logs_close_steps(capsys, monkeypatch):
         TestingFactory.close_doc(doc)
         doc.close.assert_called_once_with(True)
         err = capsys.readouterr().err
-        assert "close_doc: start uid=48 svc=draw leftovers=3 keeper=1 pids=7196,5792" in err
-        assert "close_doc: close(True) start uid=48 svc=draw leftovers=3 pids=7196,5792" in err
-        assert "close_doc: close(True) done uid=48 svc=draw pids=7196,5792" in err
+        # GHA 34612145495: Draw svc probe + page walk before close(True)
+        # killed the first forms Draw. Unmarked Draw must close like master.
         assert "skip math ole close" not in err
+        assert "close_doc: start uid=48 svc=draw" not in err
+        assert "close_doc: close(True) start uid=48" not in err
     finally:
         tu._WINDOWS_LEFTOVER_OPEN = saved
         tu.set_harness_keeper_uid("")

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -609,8 +609,7 @@ def test_close_doc_windows_skips_math_ole_draw(monkeypatch, capsys):
     doc.supportsService.side_effect = lambda svc: svc.endswith("DrawingDocument")
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(tu, "reactivate_harness_keeper", lambda desktop=None: True)
-    saved = set(tu._WINDOWS_MATH_OLE_UIDS)
-    tu._WINDOWS_MATH_OLE_UIDS.clear()
+    tu._clear_windows_math_ole_uids()
     try:
         mark_windows_math_ole_doc(doc)
         TestingFactory.close_doc(doc)
@@ -618,8 +617,7 @@ def test_close_doc_windows_skips_math_ole_draw(monkeypatch, capsys):
         err = capsys.readouterr().err
         assert "close_doc: skip math ole close (windows) uid=48 svc=draw" in err
     finally:
-        tu._WINDOWS_MATH_OLE_UIDS.clear()
-        tu._WINDOWS_MATH_OLE_UIDS.update(saved)
+        tu._clear_windows_math_ole_uids()
 
 
 def test_close_doc_windows_draw_without_math_still_closes(monkeypatch, capsys):
@@ -645,7 +643,7 @@ def test_close_doc_windows_draw_without_math_still_closes(monkeypatch, capsys):
     monkeypatch.setattr("time.sleep", lambda _seconds: None)
     monkeypatch.setattr(tu, "_windows_leftover_open", lambda: 3)
     tu._HARNESS_KEEPER_UID = "1"
-    tu._WINDOWS_MATH_OLE_UIDS.clear()
+    tu._clear_windows_math_ole_uids()
     try:
         TestingFactory.close_doc(doc)
         doc.close.assert_called_once_with(True)
@@ -656,7 +654,7 @@ def test_close_doc_windows_draw_without_math_still_closes(monkeypatch, capsys):
         assert "skip math ole close" not in err
     finally:
         tu._HARNESS_KEEPER_UID = ""
-        tu._WINDOWS_MATH_OLE_UIDS.clear()
+        tu._clear_windows_math_ole_uids()
 
 
 def test_close_doc_posix_closes_math_ole_draw(monkeypatch):
@@ -898,8 +896,7 @@ def test_close_doc_windows_draw_logs_close_steps(capsys, monkeypatch):
     saved = tu._WINDOWS_LEFTOVER_OPEN
     tu._WINDOWS_LEFTOVER_OPEN = 3
     tu.set_harness_keeper_uid("1")
-    saved_math = set(tu._WINDOWS_MATH_OLE_UIDS)
-    tu._WINDOWS_MATH_OLE_UIDS.clear()
+    tu._clear_windows_math_ole_uids()
     doc = MagicMock()
     doc.RuntimeUID = "48"
     doc.supportsService.side_effect = lambda svc: svc.endswith("DrawingDocument")
@@ -914,8 +911,7 @@ def test_close_doc_windows_draw_logs_close_steps(capsys, monkeypatch):
     finally:
         tu._WINDOWS_LEFTOVER_OPEN = saved
         tu.set_harness_keeper_uid("")
-        tu._WINDOWS_MATH_OLE_UIDS.clear()
-        tu._WINDOWS_MATH_OLE_UIDS.update(saved_math)
+        tu._clear_windows_math_ole_uids()
 
 
 def test_close_doc_windows_writer_reactivates_keeper(monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -561,6 +561,18 @@ def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
         tu._WINDOWS_FACTORY_SEQ = saved_seq
 
 
+def test_windows_notebook_load_args_avoids_blank(monkeypatch):
+    """GHA 34619751330: second Hidden _blank .ipynb hung after raw close."""
+    import plugin.tests.testing_utils as tu
+
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    target, flags = tu.windows_notebook_load_args()
+    assert target == "_wa_notebook"
+    assert flags == (8 | 55)
+    monkeypatch.setattr(tu.sys, "platform", "linux")
+    assert tu.windows_notebook_load_args() == ("_blank", 0)
+
+
 def test_windows_should_reuse_writer_only_with_leftovers(monkeypatch):
     """GHA 34602219973: second leftover swriter hung after close of uid=34."""
     import plugin.tests.testing_utils as tu

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1243,16 +1243,113 @@ def _draw_family_raw_close() -> bool:
 def _draw_family_doc_label(doc) -> str:
     """Harness-only: impress / draw / unknown for close breadcrumbs."""
     try:
-        if doc.supportsService("com.sun.star.presentation.PresentationDocument"):
+        # ``is True``: MagicMock.supportsService() is truthy and must not
+        # look like Draw-family during unit tests (Windows pytest).
+        if doc.supportsService("com.sun.star.presentation.PresentationDocument") is True:
             return "impress"
     except Exception:
         pass
     try:
-        if doc.supportsService("com.sun.star.drawing.DrawingDocument"):
+        if doc.supportsService("com.sun.star.drawing.DrawingDocument") is True:
             return "draw"
     except Exception:
         pass
     return "unknown"
+
+
+# plugin/draw/math_insert.py MATH_CLSID. close_doc of a Draw that still
+# holds this OLE killed soffice (GHA 34607010446, exit 0).
+_MATH_OLE_CLSID = "078B7ABA-54FC-457F-8551-6147e776a997"
+_WINDOWS_MATH_OLE_UIDS: set[str] = set()
+
+
+def mark_windows_math_ole_doc(doc) -> None:
+    """Harness-only: this Draw/Impress still holds a Math OLE.
+
+    GHA 34607010446: ``test_insert_math_draw`` body returned, then
+    ``close_doc`` ``dispose`` of that Draw killed soffice (exit 0).
+    Nine earlier Draw ``close_doc`` calls in the same suite survived.
+    Remember the uid on both testing_utils copies so teardown can skip
+    the close. Not a product fix.
+    """
+    if sys.platform != "win32" or not doc:
+        return
+    try:
+        uid = str(getattr(doc, "RuntimeUID", None) or "")
+    except Exception:
+        uid = ""
+    if not uid:
+        return
+    for mod in _testing_utils_holders():
+        uids = getattr(mod, "_WINDOWS_MATH_OLE_UIDS", None)
+        if uids is None:
+            mod._WINDOWS_MATH_OLE_UIDS = set()
+            uids = mod._WINDOWS_MATH_OLE_UIDS
+        uids.add(uid)
+
+
+def _windows_math_ole_uids() -> set[str]:
+    uids = set(_WINDOWS_MATH_OLE_UIDS)
+    here = sys.modules.get(__name__)
+    for mod in _testing_utils_holders():
+        if mod is here:
+            continue
+        other = getattr(mod, "_WINDOWS_MATH_OLE_UIDS", None)
+        if other:
+            uids.update(other)
+    return uids
+
+
+def _draw_doc_has_math_ole(doc) -> bool:
+    """True when a Draw/Impress page still has a Math OLE2Shape."""
+    if not doc:
+        return False
+    try:
+        pages = doc.getDrawPages()
+        n_pages = pages.getCount()
+    except Exception:
+        return False
+    try:
+        page_count = int(n_pages)
+    except (TypeError, ValueError):
+        return False
+    for i in range(page_count):
+        try:
+            page = pages.getByIndex(i)
+            n_shapes = int(page.getCount())
+        except Exception:
+            continue
+        for j in range(n_shapes):
+            try:
+                shape = page.getByIndex(j)
+                clsid = str(getattr(shape, "CLSID", "") or "")
+            except Exception:
+                continue
+            if clsid == _MATH_OLE_CLSID:
+                return True
+    return False
+
+
+def _windows_should_skip_math_ole_close(doc, uid: str = "") -> bool:
+    """True when Windows must not ``close_doc`` this Draw/Impress.
+
+    What was wrong: GHA 34607010446 (master ``3720c175``) printed
+    ``TEST call`` / factory ``load done uid=48``, then
+    ``LIFECYCLE close_doc dispose`` (pids still live) and
+    ``office dead after close doc_type=draw`` (pids gone). soffice
+    exited 0. ``get_draw_tree`` and eight earlier Draw closes on the
+    same office returned.
+
+    How: do not ``gc`` + ``close(True)`` a Windows Draw that still
+    holds Math OLE. Leftover stays; reactivate the keeper so it is
+    not desktop current. Do **not** recycle mid-run (34551644954).
+    POSIX still closes. Not a product fix.
+    """
+    if sys.platform != "win32" or not doc:
+        return False
+    if uid and uid in _windows_math_ole_uids():
+        return True
+    return _draw_doc_has_math_ole(doc)
 
 
 def close_draw_family_doc(doc):
@@ -1827,6 +1924,25 @@ class TestingFactory:
                     _progress(
                         "close_doc: skip writer close leftovers open=%s uid=%s"
                         % (leftover_open, uid or "-")
+                    )
+                    return
+                if doc_svc in ("draw", "impress") and _windows_should_skip_math_ole_close(
+                    doc, uid
+                ):
+                    # GHA 34607010446: close_doc dispose of Math OLE Draw
+                    # killed soffice (exit 0). Do not close; leftover is
+                    # not current after keeper reactivate.
+                    reactivate_harness_keeper()
+                    _progress(
+                        "close_doc: skip math ole close (windows) uid=%s svc=%s "
+                        "leftovers=%s keeper=%s pids=%s"
+                        % (
+                            uid or "-",
+                            doc_svc,
+                            leftover_open,
+                            _HARNESS_KEEPER_UID or "-",
+                            _soffice_pids(),
+                        )
                     )
                     return
         for key, pooled in list(_NATIVE_DOC_POOL.items()):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1300,6 +1300,18 @@ def _windows_math_ole_uids() -> set[str]:
     return uids
 
 
+def _clear_windows_math_ole_uids() -> None:
+    """Unit-test reset. ``mark_windows_math_ole_doc`` writes both copies."""
+    _WINDOWS_MATH_OLE_UIDS.clear()
+    here = sys.modules.get(__name__)
+    for mod in _testing_utils_holders():
+        if mod is here:
+            continue
+        other = getattr(mod, "_WINDOWS_MATH_OLE_UIDS", None)
+        if other is not None:
+            other.clear()
+
+
 def _draw_doc_has_math_ole(doc) -> bool:
     """True when a Draw/Impress page still has a Math OLE2Shape."""
     if not doc:

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1270,7 +1270,10 @@ def mark_windows_math_ole_doc(doc) -> None:
     ``close_doc`` ``dispose`` of that Draw killed soffice (exit 0).
     Nine earlier Draw ``close_doc`` calls in the same suite survived.
     Remember the uid on both testing_utils copies so teardown can skip
-    the close. Not a product fix.
+    the close. The runner then defers ``test_draw_uno`` until just
+    before the peer suite so the leftover Draw does not hang later
+    factory loads (GHA 34616287301 notebook import-filter). Not a
+    product fix.
     """
     if sys.platform != "win32" or not doc:
         return

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1342,26 +1342,22 @@ def _draw_doc_has_math_ole(doc) -> bool:
     return False
 
 
-def _windows_should_skip_math_ole_close(doc, uid: str = "") -> bool:
-    """True when Windows must not ``close_doc`` this Draw/Impress.
+def _windows_should_skip_math_ole_close(uid: str = "") -> bool:
+    """True when Windows must not ``close_doc`` this marked Math OLE uid.
 
-    What was wrong: GHA 34607010446 (master ``3720c175``) printed
-    ``TEST call`` / factory ``load done uid=48``, then
-    ``LIFECYCLE close_doc dispose`` (pids still live) and
-    ``office dead after close doc_type=draw`` (pids gone). soffice
-    exited 0. ``get_draw_tree`` and eight earlier Draw closes on the
-    same office returned.
+    What was wrong: GHA 34607010446 (master ``3720c175``) closed a Draw
+    after ``insert_math`` and soffice exited 0. GHA 34612145495 then
+    died on the *first* Draw forms ``close(True)`` after this helper
+    walked pages/shapes and ``_native_doc_svc`` probed the model.
+    Master closed ordinary Draw docs without that extra UNO.
 
-    How: do not ``gc`` + ``close(True)`` a Windows Draw that still
-    holds Math OLE. Leftover stays; reactivate the keeper so it is
-    not desktop current. Do **not** recycle mid-run (34551644954).
-    POSIX still closes. Not a product fix.
+    How: skip only when ``mark_windows_math_ole_doc`` recorded the uid.
+    Do not walk the document. Unmarked Draw close stays GC + 50 ms +
+    ``close(True)``. Not a product fix.
     """
-    if sys.platform != "win32" or not doc:
+    if sys.platform != "win32" or not uid:
         return False
-    if uid and uid in _windows_math_ole_uids():
-        return True
-    return _draw_doc_has_math_ole(doc)
+    return uid in _windows_math_ole_uids()
 
 
 def close_draw_family_doc(doc):
@@ -1901,33 +1897,46 @@ class TestingFactory:
         # so reuse can still find the doc (34602219973).
         uid = ""
         is_writer = False
-        doc_svc = ""
         leftover_open = 0
         if sys.platform == "win32":
             try:
                 uid = str(getattr(doc, "RuntimeUID", None) or "")
-                doc_svc = _native_doc_svc(doc)
-                is_writer = doc_svc == "writer"
             except Exception:
-                is_writer = False
-            leftover_open = _windows_leftover_open()
-            if is_writer or doc_svc in ("draw", "impress"):
+                uid = ""
+            # GHA 34612145495: _native_doc_svc + page walk before the first
+            # Draw forms close(True) killed soffice (exit 0). Master
+            # 34607010446 closed that same forms Draw. Check the Math
+            # mark from RuntimeUID only — no supportsService / getDrawPages.
+            if _windows_should_skip_math_ole_close(uid):
                 from plugin.testing_runner import _progress, _soffice_pids
 
-                # GHA 34606276107: insert_math_draw close_doc dispose then
-                # soffice exited 0. Writer-only start hid Draw teardown.
-                # leftovers/keeper name leftover-window reuse vs Draw close.
+                leftover_open = _windows_leftover_open()
+                reactivate_harness_keeper()
                 _progress(
-                    "close_doc: start uid=%s svc=%s leftovers=%s keeper=%s pids=%s"
+                    "close_doc: skip math ole close (windows) uid=%s "
+                    "leftovers=%s keeper=%s pids=%s"
                     % (
                         uid or "-",
-                        doc_svc or "-",
                         leftover_open,
                         _HARNESS_KEEPER_UID or "-",
                         _soffice_pids(),
                     )
                 )
-                if is_writer and leftover_open > 0:
+                return
+            try:
+                is_writer = bool(
+                    doc.supportsService("com.sun.star.text.TextDocument") is True
+                )
+            except Exception:
+                is_writer = False
+            leftover_open = _windows_leftover_open()
+            if is_writer:
+                from plugin.testing_runner import _progress
+
+                _progress(
+                    "close_doc: start uid=%s leftovers=%s" % (uid or "-", leftover_open)
+                )
+                if leftover_open > 0:
                     # GHA 34602219973: close uid=34 returned; next unique
                     # _wa_factory_5 swriter hung 30s. Do not close a
                     # harness Writer while paste leftovers remain (same
@@ -1936,25 +1945,6 @@ class TestingFactory:
                     _progress(
                         "close_doc: skip writer close leftovers open=%s uid=%s"
                         % (leftover_open, uid or "-")
-                    )
-                    return
-                if doc_svc in ("draw", "impress") and _windows_should_skip_math_ole_close(
-                    doc, uid
-                ):
-                    # GHA 34607010446: close_doc dispose of Math OLE Draw
-                    # killed soffice (exit 0). Do not close; leftover is
-                    # not current after keeper reactivate.
-                    reactivate_harness_keeper()
-                    _progress(
-                        "close_doc: skip math ole close (windows) uid=%s svc=%s "
-                        "leftovers=%s keeper=%s pids=%s"
-                        % (
-                            uid or "-",
-                            doc_svc,
-                            leftover_open,
-                            _HARNESS_KEEPER_UID or "-",
-                            _soffice_pids(),
-                        )
                     )
                     return
         for key, pooled in list(_NATIVE_DOC_POOL.items()):
@@ -1980,24 +1970,10 @@ class TestingFactory:
             # settle lets ~SvxShape finish before close. Unscoped: Writer
             # ControlShape / charts use the same pool. Post-close wait did not help.
             time.sleep(_CLOSE_DOC_URP_SETTLE_S)
-            if sys.platform == "win32" and doc_svc in ("draw", "impress"):
-                from plugin.testing_runner import _progress, _soffice_pids
-
-                _progress(
-                    "close_doc: close(True) start uid=%s svc=%s leftovers=%s pids=%s"
-                    % (uid or "-", doc_svc, leftover_open, _soffice_pids())
-                )
             if hasattr(doc, "close"):
                 doc.close(True)
             elif hasattr(doc, "dispose"):
                 doc.dispose()
-            if sys.platform == "win32" and doc_svc in ("draw", "impress"):
-                from plugin.testing_runner import _progress, _soffice_pids
-
-                _progress(
-                    "close_doc: close(True) done uid=%s svc=%s pids=%s"
-                    % (uid or "-", doc_svc, _soffice_pids())
-                )
             if sys.platform == "win32" and is_writer:
                 from plugin.testing_runner import _progress
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1118,6 +1118,29 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
     return "_wa_factory_%s" % _WINDOWS_FACTORY_SEQ, _WINDOWS_FACTORY_SEARCH_FLAGS
 
 
+# Stable CREATE|GLOBAL name for Hidden .ipynb loads. Do not use "_blank"
+# after leftover Writers — consecutive Hidden _blank hung detect
+# (GHA 34619751330) the same way as leftover swriter (34597506651).
+_WINDOWS_NOTEBOOK_TARGET = "_wa_notebook"
+
+
+def windows_notebook_load_args() -> tuple[str, int]:
+    """Target + FrameSearchFlag for a Hidden Jupyter ``loadComponentFromURL``.
+
+    GHA 34619751330 (``5377a87e``, ``test_draw_uno`` already deferred):
+    leftover Math Draw had **not** run. ``test_import_filter_uno_load_component``
+    Hidden ``_blank`` + FilterName returned, then raw ``close(True)``.
+    ``test_import_filter_uno_detect_without_filtername`` Hidden ``_blank``
+    hung 30s (soffice still ``2444,5124``). Same consecutive leftover
+    Hidden ``_blank`` family as 34597506651. Use one CREATE|GLOBAL name
+    and ``TestingFactory.close_doc`` (skips Writer close while leftovers
+    remain). POSIX keeps ``_blank``.
+    """
+    if sys.platform != "win32":
+        return "_blank", 0
+    return _WINDOWS_NOTEBOOK_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
+
+
 def _reraise_native_open_failure(
     exc: BaseException, factory_url: str, pre_open: str = "no_probe"
 ) -> None:
@@ -1271,9 +1294,9 @@ def mark_windows_math_ole_doc(doc) -> None:
     Nine earlier Draw ``close_doc`` calls in the same suite survived.
     Remember the uid on both testing_utils copies so teardown can skip
     the close. The runner then defers ``test_draw_uno`` until just
-    before the peer suite so the leftover Draw does not hang later
-    factory loads (GHA 34616287301 notebook import-filter). Not a
-    product fix.
+    before the peer suite so this leftover is not ``close(True)``'d
+    (34607010446). Notebook detect hang is leftover Hidden ``_blank``
+    (34619751330), not this Draw. Not a product fix.
     """
     if sys.platform != "win32" or not doc:
         return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Harness-only follow-up after #722 / #723. No product `insert_math` behavior change. Do not use Fixes/Closes.

## Failure (master)

[34607010446](https://github.com/KeithCu/writeragent/actions/runs/34607010446) (master `3720c175`): leftover Writer reuse got past. Draw forms 4/4 OK. `test_get_draw_tree` OK. `test_insert_math_draw` inserted Math, then `close_doc` dispose of that Draw killed soffice (exit 0). 139 passed, 1 failed; remaining suites aborted.

## Follow-up: skip-path regression (fixed on tip)

[34612145495](https://github.com/KeithCu/writeragent/actions/runs/34612145495) and [34609996253](https://github.com/KeithCu/writeragent/actions/runs/34609996253): the skip helper walked pages/shapes and called `_native_doc_svc` before every Draw `close(True)`. The **first** Draw close (`draw.test_draw_forms_uno.test_draw_form_lifecycle`, uid=35) then killed soffice. Tip now skips **by uid only**.

## Follow-up: leftover Math Draw is not the notebook hang

[34616287301](https://github.com/KeithCu/writeragent/actions/runs/34616287301) (`34288586`): uid-only skip worked. `test_insert_math_draw` OK, then notebook detect hung 30s. That looked like leftover Math Draw poison.

[34619751330](https://github.com/KeithCu/writeragent/actions/runs/34619751330) (`5377a87e`): `test_draw_uno` was deferred, so leftover Math Draw had **not** been created. Draw forms 4/4 OK. Impress suites OK. `test_import_filter_uno_load_component` Hidden `_blank` + FilterName returned, then raw `close(True)`. `test_import_filter_uno_detect_without_filtername` Hidden `_blank` hung 30s (soffice still `2444,5124`, leftovers `['34','27','26']`). Same consecutive leftover Hidden `_blank` family as 34597506651.

## Latest Windows dispatch (not a harness result)

[34624995760](https://github.com/KeithCu/writeragent/actions/runs/34624995760) (`71922531`): LibreOffice install succeeded, then `make typecheck` died at `ensure-uno` (`Makefile:319`, `scripts/fix_uno_import.py -q`) in ~3s. No UNO suite ran. Not `insert_math` and not notebook detect. Same tip's Ubuntu PR CI is green ([34622576195](https://github.com/KeithCu/writeragent/actions/runs/34622576195)). Re-dispatch Windows; do not treat this as a harness regression.

## Change

- Windows `close_doc` skips only when `mark_windows_math_ole_doc` recorded the uid. Unmarked Draw close is master path (RuntimeUID + GC + 50 ms + `close(True)`).
- `test_insert_math_draw` marks the uid and runs last in `test_draw_uno.py`. On Windows the runner sorts that file just before the peer suite so the leftover Math Draw is not closed (34607010446) and is not recycled mid-run (34551644954).
- Windows notebook import-filter loads use `windows_notebook_load_args` (`_wa_notebook`, CREATE|GLOBAL) and `TestingFactory.close_doc` (skip Writer close while leftovers remain). POSIX still `_blank` + close.
- Lifecycle start/end writes both `__main__` and `plugin.testing_runner`.

## Tests

- Unit: mark-only Math skip; Windows suite order; `windows_notebook_load_args` is `_wa_notebook` on Windows and `_blank` on POSIX.
- Ubuntu PR CI on tip `71922531` is green: [34622576195](https://github.com/KeithCu/writeragent/actions/runs/34622576195).

## Windows re-dispatch

This agent cannot run `windows-latest`. Ubuntu on the tip is green. Remaining proof is a Windows `workflow_dispatch` that gets past typecheck:

1. Actions → **PR CI** → **Run workflow**
2. Use branch `cursor/windows-draw-math-close-8c16`
3. Set `os=windows-latest`, `ci_debug=true`

Success: typecheck passes, `import_filter_uno: load start target=_wa_notebook` (not `_blank`) for both notebook tests, both `TEST end … OK` (no 30s Timeout on `detect_without_filtername`), `draw.test_draw_forms_uno` four tests OK, **then** `insert_math` skip + `TEST end … test_insert_math_draw OK`, leftover-Impress, peer last, `LIFECYCLE recycle office skipped; no remaining suites`.

Do not merge from this PR; Keith merges.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a46693ad-4fc2-4947-9a68-63cf1b7f8c16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a46693ad-4fc2-4947-9a68-63cf1b7f8c16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

