### PR TITLE
Sync EXPECTED_DEFAULT_IDS after DeepSeek V4.1 Flash catalog add

### DIFF
--- a/tests/scripts/test_model_configs.py
+++ b/tests/scripts/test_model_configs.py
@@ -42,6 +42,7 @@ EXPECTED_DEFAULT_IDS = [
     "bytedance-seed/seed-2.0-mini",
     "minimax/minimax-m3",
     "deepseek/deepseek-v4-flash-0731",
+    "deepseek/deepseek-v4.1-flash",
 ]
 
 EXPECTED_GOLD_ONLY_IDS: list[str] = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#726 added `deepseek/deepseek-v4.1-flash` to `MODELS` but left `EXPECTED_DEFAULT_IDS` ending at `deepseek/deepseek-v4-flash-0731`. `pull_request` CI merges master, so unrelated PRs go red on:

- `test_default_models_excludes_gold_only`
- `test_models_catalog_matches_defaults_plus_gold`

## Change

One line: append `"deepseek/deepseek-v4.1-flash"` to `EXPECTED_DEFAULT_IDS`. `EXPECTED_GOLD_ONLY_IDS` and `DROPPED_SLUGS` stay as they are. No product-default or harness changes.

This PR is intentionally tiny and independent so other open PRs (#727 and later) can merge master / pass CI without waiting on #725's Windows harness work.

#725 already carries the same lockstep on its branch (`e0e75cc2`, after merging master). That does not unblock other PRs.

## Refs

#726 #725 #727

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89e635c7-21a3-41d9-aa9f-5ea5bfb98ee1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89e635c7-21a3-41d9-aa9f-5ea5bfb98ee1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

