### PR TITLE
Harness: Windows Hidden-open a copy of the stored Budget sibling

### DIFF
--- a/docs/chat/multi-document-dev-plan.md
+++ b/docs/chat/multi-document-dev-plan.md
@@ -85,7 +85,7 @@ flowchart LR
 ```
 
 - [`resolve_document_by_url`](../../plugin/framework/uno_context.py) scans **already open** components only — it does **not** open closed files.
-- New load props: **`Hidden=True`** and **`ReadOnly=True`** (today [`plugin/writer/format.py`](../../plugin/writer/format.py) uses `Hidden` only for temp docs). Windows uses CREATE|GLOBAL target `_wa_doc_research` instead of `_default` so leftover Hidden `_wa_calc_html` paste Writers do not raise `Could not create system bitmap!` (GHA 34636251918). POSIX keeps `_default`.
+- New load props: **`Hidden=True`** and **`ReadOnly=True`** (today [`plugin/writer/format.py`](../../plugin/writer/format.py) uses `Hidden` only for temp docs). Windows uses CREATE|GLOBAL target `_wa_doc_research` instead of `_default` (GHA 34636251918). POSIX keeps `_default`. UNO tests on Windows Hidden-open a `Budget_read.ods` copy, not the pooled Calc `storeAsURL` path (GHA 34639913692).
 - If a sibling is already open **editable** in another window, reuse that component via URL match; inner agent still gets a **read-only allowlist** (schema enforcement, not LO mode alone).
 
 ### Fuzzy name matching (Phase 0)

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -352,6 +352,15 @@ The UNO env now copies `Budget_read.ods` on Windows and Hidden-opens
 that copy — a URL the pooled Calc never owned. No second factory Calc.
 Do not close leftover paste Writers.
 
+GHA 34643210006 (`60c827a8`): `document_research_uno` 3/3 OK
+(`copied budget for hidden open`, `open_document_for_read done err=-`).
+Later `test_calc_reuse_false_still_empty` leftover `target=_wa_scalc`
+at leftover_open=5 hung 30s. `_wa_scalc` is not a safe leftover Calc
+factory. `native_doc` now wipe-and-reuses the pooled Calc instead of
+loading leftover scalc (`native_doc: leftover calc reuse`). Notebook
+`test_notebook_runner_uno` had two leftover-writer-reuse assertion
+fails on the same run; those are not this leftover-scalc path.
+
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
 `html_paste_writer: leftovers open` with a real `keeper=` uid (not

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -343,6 +343,15 @@ frames poison `_default` / `_blank` (34597506651). Product
 Hidden+ReadOnly and the reuse / close-flag contract are unchanged.
 POSIX keeps `_default`.
 
+GHA 34639913692 (`e0e75cc2`, after `_wa_doc_research`): factory hang
+stayed gone (`store budget via active`, `test_list_nearby_excludes_active`
+OK). Hidden sibling open of that same `storeAsURL` path still raised
+`Could not create system bitmap!` in ~20ms; the next sibling open hung
+30s. 34602219973 passed 3/3 when Budget lived on a closed factory Calc.
+The UNO env now copies `Budget_read.ods` on Windows and Hidden-opens
+that copy — a URL the pooled Calc never owned. No second factory Calc.
+Do not close leftover paste Writers.
+
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
 `html_paste_writer: leftovers open` with a real `keeper=` uid (not
@@ -353,8 +362,9 @@ swriter loads using `target=_wa_factory` (not `_blank` / not
 `_blank` / not `_wa_factory_N`),
 `document_research_uno: store budget via active start/done` (no
 `create budget calc` / no leftover `scalc` `target=_wa_factory_1`),
-`open_document_for_read` of the sibling using `target=_wa_doc_research`
-(not `_default` / `_blank`) on Windows,
+`copied budget for hidden open` then `open_document_for_read done err=-`
+(Windows opens `Budget_read.ods`, not the `storeAsURL` path; no
+`Could not create system bitmap`, no 30s hang),
 `create_native_doc: load done`, `native_doc: leftover writer reuse` and
 no second leftover swriter factory after the first text_helpers Writer,
 `document_research_uno` three tests

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -357,9 +357,18 @@ GHA 34643210006 (`60c827a8`): `document_research_uno` 3/3 OK
 Later `test_calc_reuse_false_still_empty` leftover `target=_wa_scalc`
 at leftover_open=5 hung 30s. `_wa_scalc` is not a safe leftover Calc
 factory. `native_doc` now wipe-and-reuses the pooled Calc instead of
-loading leftover scalc (`native_doc: leftover calc reuse`). Notebook
-`test_notebook_runner_uno` had two leftover-writer-reuse assertion
-fails on the same run; those are not this leftover-scalc path.
+loading leftover scalc (`native_doc: leftover calc reuse`).
+
+The same run's notebook fails were leftover-driven, not independent:
+HTML-paste Writers (uids 26/27, `close skipped pasted=True`) set
+`leftover_open>0`, so `close_doc` skipped **all** Writer closes —
+including import-filter `_wa_notebook` leftovers (uids 41/42) that
+still held form listeners. `form_run_listeners()` / 
+`wired_run_listener_count` counted every leftover doc
+(`duplicate listeners: 3`). Counts are now per-document. Notebook
+suites use `_wa_notebook_host` (not leftover HTML-paste reuse).
+`close_doc` still skips leftover paste Writers, but closes
+notebook-registry leftovers.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for

--- a/plugin/notebook/notebook_controls.py
+++ b/plugin/notebook/notebook_controls.py
@@ -507,10 +507,20 @@ def _hex_id_from_event(rEvent: Any) -> str | None:
     return _hex_id_from_control_name(_control_name(getattr(rEvent, "Source", None)))
 
 
-def wired_run_listener_count(hex_id: str) -> int:
-    """How many live ▶ handlers would run *hex_id* (form-level counts as one)."""
+def wired_run_listener_count(hex_id: str, doc: Any | None = None) -> int:
+    """How many live ▶ handlers would run *hex_id* (form-level counts as one).
+
+    GHA 34643210006: leftover HTML-paste Writers left leftover_open>0, so
+    ``close_doc`` skipped import-filter ``_wa_notebook`` leftovers. Global
+    ``_listener_refs`` then counted those leftover form listeners
+    (``duplicate listeners: 3``). Pass *doc* to count only that document.
+    A leftover doc's listener does not fire this doc's ▶.
+    """
+    doc_key = _doc_key(doc) if doc is not None else None
     n = 0
     for lis in _listener_refs:
+        if doc_key is not None and getattr(lis, "_doc_key_val", None) != doc_key:
+            continue
         if getattr(lis, "_form_level", False):
             n += 1
         elif getattr(lis, "_hex_id", None) == hex_id:
@@ -518,9 +528,17 @@ def wired_run_listener_count(hex_id: str) -> int:
     return n
 
 
-def form_run_listeners() -> list[Any]:
-    """Shared form-level ▶ listeners (tests fire these with a real ActionEvent)."""
-    return [lis for lis in _listener_refs if getattr(lis, "_form_level", False)]
+def form_run_listeners(doc: Any | None = None) -> list[Any]:
+    """Shared form-level ▶ listeners (tests fire these with a real ActionEvent).
+
+    Pass *doc* to exclude leftover import-filter / leftover-reuse Writers
+    (GHA 34643210006).
+    """
+    out = [lis for lis in _listener_refs if getattr(lis, "_form_level", False)]
+    if doc is None:
+        return out
+    key = _doc_key(doc)
+    return [lis for lis in out if getattr(lis, "_doc_key_val", None) == key]
 
 
 @main_thread_only

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1451,6 +1451,17 @@ def run_module_suite(ctx, module, name, doc_model=None):
     # Do not reset the lifecycle trail here: the first test of this suite may
     # fail on factory open because the *previous suite's last test* killed URP.
     _progress(f"SUITE start {name} python_pid={os.getpid()} soffice.bin={_soffice_pids()}")
+    # GHA 34643210006: leftover HTML-paste Writers forced leftover Writer
+    # reuse into notebook_runner. Isolate those suites on _wa_notebook_host.
+    try:
+        from tests.testing_utils import set_windows_notebook_host
+    except ImportError:
+        from plugin.tests.testing_utils import set_windows_notebook_host
+
+    set_windows_notebook_host(
+        name.endswith("test_notebook_runner_uno")
+        or name.endswith("test_writer_importer_uno")
+    )
     name_filters = _test_function_filters(_cli_filters)
     if _cli_exact_function_names:
         exact = set(_cli_exact_function_names)
@@ -1462,6 +1473,7 @@ def run_module_suite(ctx, module, name, doc_model=None):
     if (name_filters or _cli_exact_function_names) and not selected:
         msg = f"No tests matched filters {name_filters!r} in {name}"
         _progress(f"SUITE filter miss {name}: {name_filters}")
+        set_windows_notebook_host(False)
         _progress(f"SUITE end {name} passed=0 failed=1")
         return 0, 1, [msg]
     if name_filters:
@@ -1630,6 +1642,12 @@ def run_module_suite(ctx, module, name, doc_model=None):
                     suite_log.append(f"TEARDOWN EXCEPTION: {e}")
                     suite_log.append(traceback.format_exc())
 
+    try:
+        from tests.testing_utils import set_windows_notebook_host as _clear_nb_host
+    except ImportError:
+        from plugin.tests.testing_utils import set_windows_notebook_host as _clear_nb_host
+
+    _clear_nb_host(False)
     _progress(f"SUITE end {name} passed={total_passed} failed={total_failed}")
     return total_passed, total_failed, suite_log
 

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1453,10 +1453,7 @@ def run_module_suite(ctx, module, name, doc_model=None):
     _progress(f"SUITE start {name} python_pid={os.getpid()} soffice.bin={_soffice_pids()}")
     # GHA 34643210006: leftover HTML-paste Writers forced leftover Writer
     # reuse into notebook_runner. Isolate those suites on _wa_notebook_host.
-    try:
-        from tests.testing_utils import set_windows_notebook_host
-    except ImportError:
-        from plugin.tests.testing_utils import set_windows_notebook_host
+    from tests.testing_utils import set_windows_notebook_host
 
     set_windows_notebook_host(
         name.endswith("test_notebook_runner_uno")
@@ -1642,10 +1639,7 @@ def run_module_suite(ctx, module, name, doc_model=None):
                     suite_log.append(f"TEARDOWN EXCEPTION: {e}")
                     suite_log.append(traceback.format_exc())
 
-    try:
-        from tests.testing_utils import set_windows_notebook_host as _clear_nb_host
-    except ImportError:
-        from plugin.tests.testing_utils import set_windows_notebook_host as _clear_nb_host
+    from tests.testing_utils import set_windows_notebook_host as _clear_nb_host
 
     _clear_nb_host(False)
     _progress(f"SUITE end {name} passed={total_passed} failed={total_failed}")

--- a/tests/doc/test_document_research.py
+++ b/tests/doc/test_document_research.py
@@ -441,3 +441,7 @@ def test_nearby_uno_env_does_not_open_second_scalc_factory():
         src = handle.read()
     assert "create_native_doc" not in src
     assert "store budget via active" in src
+    # GHA 34639913692: Hidden load of the storeAsURL path still raised
+    # system bitmap after ``_wa_doc_research``. Windows opens a copy.
+    assert "Budget_read.ods" in src
+    assert "shutil.copy2" in src

--- a/tests/doc/test_document_research_uno.py
+++ b/tests/doc/test_document_research_uno.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import os
+import shutil
+import sys
 import tempfile
 
 import uno
@@ -41,6 +43,21 @@ def _create_nearby_test_env(ctx, active_doc):
     budget_path = os.path.join(temp_dir, "Budget_2026.ods")
     active_doc.storeAsURL(uno.systemPathToFileUrl(budget_path), ())
     _nearby_progress("store budget via active done")
+
+    # GHA 34639913692: Hidden+ReadOnly load of this same storeAsURL path
+    # raised ``Could not create system bitmap!`` then the next sibling
+    # open hung 30s. Product ``_wa_doc_research`` did not help.
+    # 34602219973 passed 3/3 when Budget lived on a *closed* factory
+    # Calc — a URL this pooled component never owned. Copy so the
+    # Hidden load is not the live document's recent URL. Do not open a
+    # second factory Calc (34633295036). Do not close leftover paste
+    # Writers (34556185752).
+    open_path = budget_path
+    if sys.platform == "win32":
+        open_path = os.path.join(temp_dir, "Budget_read.ods")
+        shutil.copy2(budget_path, open_path)
+        _nearby_progress("copied budget for hidden open")
+
     reset_native_doc(active_doc, "calc", ctx)
 
     active_path = os.path.join(temp_dir, "Report.ods")
@@ -48,7 +65,7 @@ def _create_nearby_test_env(ctx, active_doc):
     active_doc.storeAsURL(uno.systemPathToFileUrl(active_path), ())
     _nearby_progress("store active done")
 
-    return temp_dir, budget_path
+    return temp_dir, budget_path, open_path
 
 
 def _cleanup_nearby_test_env(temp_dir):
@@ -67,7 +84,7 @@ def _cleanup_nearby_test_env(temp_dir):
 @native_test
 @with_native_doc("calc")
 def test_list_nearby_excludes_active(ctx, doc):
-    temp_dir, _ = _create_nearby_test_env(ctx, doc)
+    temp_dir, _unused_budget, _unused_open = _create_nearby_test_env(ctx, doc)
     try:
         _nearby_progress("list_nearby_files start")
         result = list_nearby_files(ctx, doc)
@@ -83,10 +100,10 @@ def test_list_nearby_excludes_active(ctx, doc):
 @native_test
 @with_native_doc("calc")
 def test_open_document_for_read_hidden_readonly(ctx, doc):
-    temp_dir, budget_path = _create_nearby_test_env(ctx, doc)
+    temp_dir, _unused_budget, open_path = _create_nearby_test_env(ctx, doc)
     try:
         _nearby_progress("open_document_for_read start")
-        model, doc_type, err, opened_for_document_research = open_document_for_read(ctx, budget_path)
+        model, doc_type, err, opened_for_document_research = open_document_for_read(ctx, open_path)
         _nearby_progress("open_document_for_read done err=%s" % (err or "-"))
         assert err is None
         assert doc_type == "calc"
@@ -109,9 +126,9 @@ def test_open_document_for_read_hidden_readonly(ctx, doc):
 @with_native_doc("calc")
 def test_inner_read_cell_range_on_opened_sibling(ctx, doc):
     """Outer document_research path opens sibling; inner uses read_cell_range (no live LLM)."""
-    temp_dir, budget_path = _create_nearby_test_env(ctx, doc)
+    temp_dir, _unused_budget, open_path = _create_nearby_test_env(ctx, doc)
     try:
-        model, doc_type, err, _opened = open_document_for_read(ctx, budget_path)
+        model, doc_type, err, unused_opened = open_document_for_read(ctx, open_path)
         assert err is None and doc_type == "calc"
         try:
             tctx = ToolContext(model, ctx, "calc", get_services(), "test", read_only_target=True)

--- a/tests/notebook/test_notebook_controls.py
+++ b/tests/notebook/test_notebook_controls.py
@@ -11,10 +11,12 @@ from plugin.notebook.notebook_controls import (
     NotebookFormContainerListener,
     NotebookFormRunListener,
     NotebookRunButtonListener,
+    form_run_listeners,
     get_control_view_for_model,
     prune_dead_listeners,
     wire_all_notebook_run_buttons,
     wire_run_button_listener,
+    wired_run_listener_count,
 )
 from plugin.tests.testing_utils import setup_uno_mocks
 
@@ -312,6 +314,25 @@ def test_wire_all_attaches_one_form_listener_without_getcontrol():
     container.addContainerListener.assert_called_once()
     form_lis = [lis for lis in notebook_controls._listener_refs if getattr(lis, "_form_level", False)]
     assert len(form_lis) == 1
+
+
+def test_listener_counts_exclude_leftover_docs():
+    """GHA 34643210006: leftover import-filter listeners inflated global counts."""
+    leftover = MagicMock()
+    leftover._form_level = True
+    leftover._doc_key_val = "uid:41"
+    leftover._hex_id = None
+    current = MagicMock()
+    current._form_level = True
+    current._doc_key_val = "uid:99"
+    current._hex_id = None
+    notebook_controls._listener_refs = [leftover, current]
+    doc = MagicMock()
+    with patch("plugin.notebook.notebook_controls._doc_key", return_value="uid:99"):
+        assert len(form_run_listeners(doc)) == 1
+        assert wired_run_listener_count("cell1", doc) == 1
+        assert len(form_run_listeners()) == 2
+        assert wired_run_listener_count("cell1") == 2
 
 
 def test_prune_keeps_container_listener():

--- a/tests/notebook/test_notebook_runner_uno.py
+++ b/tests/notebook/test_notebook_runner_uno.py
@@ -165,7 +165,6 @@ def _fire_run_button_via_get_control(_ctx, doc, hex_id: str) -> str:
 
     from plugin.notebook.form_lookup import find_form_control_model_by_name
     from plugin.notebook.notebook_controls import (
-        _doc_key,
         _query_interface,
         form_run_listeners,
         get_control_view_for_model,
@@ -187,9 +186,8 @@ def _fire_run_button_via_get_control(_ctx, doc, hex_id: str) -> str:
     evt.Source = control
     evt.ActionCommand = str(getattr(model, "Name", "") or "")
     prune_dead_listeners()
-    key = _doc_key(doc)
-    n = wired_run_listener_count(hex_id)
-    matched = [lis for lis in form_run_listeners() if getattr(lis, "_doc_key_val", None) == key]
+    n = wired_run_listener_count(hex_id, doc)
+    matched = form_run_listeners(doc)
     assert len(matched) == 1, f"form listener list mismatch: {len(matched)} (count={n})"
     # Fire the shared listener — a real click delivers one ActionEvent with Source=button.
     for lis in matched:
@@ -214,8 +212,8 @@ def test_import_wires_form_listener_without_getcontrol_loop(ctx, doc):
         state = load_registry(doc)
         assert state is not None and len(state.code_cells) == 1
         hex_id = cell_id_to_hex(state.code_cells[0].cell_id)
-        assert len(form_run_listeners()) == 1
-        assert wired_run_listener_count(hex_id) == 1
+        assert len(form_run_listeners(doc)) == 1
+        assert wired_run_listener_count(hex_id, doc) == 1
 
         fake_result = {"status": "ok", "stdout": f"{_SENTINEL}\n", "result": None}
         runs: list[str] = []
@@ -235,8 +233,8 @@ def test_import_wires_form_listener_without_getcontrol_loop(ctx, doc):
 
         wire_all_notebook_run_buttons(ctx, doc)
         wire_all_notebook_run_buttons(ctx, doc)
-        assert len(form_run_listeners()) == 1
-        assert wired_run_listener_count(hex_id) == 1
+        assert len(form_run_listeners(doc)) == 1
+        assert wired_run_listener_count(hex_id, doc) == 1
         runs.clear()
         with (
             patch("plugin.notebook.notebook_runner.msgbox", lambda *_a, **_k: None),
@@ -515,8 +513,8 @@ def test_small_numpy_button_rerun_stays_in_cell_and_counts_from_one(ctx, doc):
         ensure_form_design_mode_off(doc)
         wire_all_notebook_run_buttons(ctx, doc)
         wire_all_notebook_run_buttons(ctx, doc)
-        assert wired_run_listener_count(hex_id) == 1, (
-            f"extra wire_all attached duplicate listeners: {wired_run_listener_count(hex_id)}"
+        assert wired_run_listener_count(hex_id, doc) == 1, (
+            f"extra wire_all attached duplicate listeners: {wired_run_listener_count(hex_id, doc)}"
         )
         _assert_controls_present(doc, cell)
 

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -753,6 +753,37 @@ def test_native_doc_windows_reuses_writer_when_leftovers_open(monkeypatch):
         tu._NATIVE_DOC_POOL.clear()
 
 
+def test_native_doc_windows_reuses_calc_when_leftovers_open(monkeypatch):
+    """GHA 34643210006: leftover _wa_scalc hung; reuse=False must not factory-load."""
+    from unittest.mock import MagicMock
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    calc = MagicMock(name="pooled_calc")
+    created = []
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(tu, "reset_native_doc", lambda *a, **k: None)
+    monkeypatch.setattr(
+        TestingFactory,
+        "create_native_doc",
+        lambda *a, **k: created.append("create") or calc,
+    )
+    tu._NATIVE_DOC_POOL.clear()
+    tu._set_windows_leftover_open(5)
+    ctx = object()
+    try:
+        with TestingFactory.native_doc(ctx, "calc") as first:
+            assert first is calc
+        with TestingFactory.native_doc(ctx, "calc", reuse=False) as second:
+            assert second is calc
+        assert created == ["create"]
+    finally:
+        tu._set_windows_leftover_open(saved)
+        tu._NATIVE_DOC_POOL.clear()
+
+
 def test_create_native_doc_posix_does_not_prepare_writer_factory(monkeypatch):
     from unittest.mock import MagicMock, patch
 

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -699,6 +699,49 @@ def test_close_doc_posix_closes_math_ole_draw(monkeypatch):
     doc.close.assert_called_once_with(True)
 
 
+def test_close_doc_closes_windows_notebook_leftover(monkeypatch):
+    """GHA 34643210006: skip-all-Writer close kept import-filter leftovers."""
+    from unittest.mock import MagicMock, patch
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    doc = MagicMock()
+    doc.supportsService.side_effect = lambda svc: svc.endswith("TextDocument")
+    doc.RuntimeUID = "41"
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(tu, "reactivate_harness_keeper", lambda desktop=None: True)
+    tu._set_windows_leftover_open(5)
+    try:
+        with patch(
+            "plugin.notebook.cell_registry.has_notebook_registry",
+            return_value=True,
+        ):
+            TestingFactory.close_doc(doc)
+        doc.close.assert_called_once_with(True)
+    finally:
+        tu._set_windows_leftover_open(saved)
+
+
+def test_windows_notebook_host_uses_dedicated_factory_target(monkeypatch):
+    """Notebook suites must not leftover-reuse HTML-paste Writers."""
+    import plugin.tests.testing_utils as tu
+
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    tu.set_windows_notebook_host(True)
+    tu._set_windows_leftover_open(5)
+    try:
+        target, flags = tu._windows_factory_load_args("private:factory/swriter", 5)
+        assert target == "_wa_notebook_host"
+        assert flags == (8 | 55)
+        assert tu._windows_should_reuse_writer(object()) is False
+    finally:
+        tu.set_windows_notebook_host(False)
+        tu._set_windows_leftover_open(saved)
+
+
 def test_close_doc_skips_windows_writer_when_leftovers_open(monkeypatch):
     """GHA 34602219973: close_doc uid=34 returned; next unique swriter hung."""
     from unittest.mock import MagicMock
@@ -713,6 +756,10 @@ def test_close_doc_skips_windows_writer_when_leftovers_open(monkeypatch):
     tu._WINDOWS_LEFTOVER_OPEN = 2
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(tu, "reactivate_harness_keeper", lambda desktop=None: True)
+    monkeypatch.setattr(
+        "plugin.notebook.cell_registry.has_notebook_registry",
+        lambda _doc: False,
+    )
     try:
         TestingFactory.close_doc(doc)
         doc.close.assert_not_called()

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1062,6 +1062,21 @@ def _windows_should_reuse_writer(ctx) -> bool:
     return prepare_windows_writer_factory(ctx) > 0
 
 
+def _windows_should_reuse_calc(ctx) -> bool:
+    """True when a leftover scalc factory would hang.
+
+    GHA 34643210006: ``test_calc_reuse_false_still_empty`` loaded leftover
+    ``target=_wa_scalc`` at leftover_open=5 and hung 30s (office alive).
+    Unique leftover ``_wa_factory_N`` already failed then hung
+    (34633295036). Cached leftover count only — do not enumerate
+    (getComponents after paste close can hang). Do not close leftover
+    paste Writers (34556185752).
+    """
+    if ctx is None or sys.platform != "win32":
+        return False
+    return _windows_leftover_open() > 0
+
+
 # Same CREATE|GLOBAL as insert_cell_html_rich (8|55=63). Named target with
 # flags 0 can search instead of creating. Do not reuse "_blank" / "_default"
 # while leftover paste Writers are open — see _windows_factory_load_args.
@@ -2038,6 +2053,13 @@ class TestingFactory:
 
                 reuse = True
                 _progress("native_doc: leftover writer reuse")
+        # reuse=False still calls create_native_doc. Leftover _wa_scalc
+        # hung 30s (34643210006). Wipe-and-reuse the pooled Calc instead.
+        if doc_type == "calc" and not reuse and _windows_should_reuse_calc(ctx):
+            from plugin.testing_runner import _progress
+
+            reuse = True
+            _progress("native_doc: leftover calc reuse")
         use_pool = bool(reuse) and doc_type in ("writer", "calc")
         doc = None
         pooled = False

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1059,6 +1059,10 @@ def _windows_should_reuse_writer(ctx) -> bool:
     """
     if ctx is None or sys.platform != "win32":
         return False
+    # Notebook suites use ``_wa_notebook_host``, not leftover HTML-paste
+    # Writers (GHA 34643210006: leftover reuse + global listener counts).
+    if _windows_notebook_host():
+        return False
     return prepare_windows_writer_factory(ctx) > 0
 
 
@@ -1139,6 +1143,8 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
     # One stable name, like rich_html._wa_calc_html. CREATE|GLOBAL finds
     # the empty frame left by the previous leftover-mode Writer close.
     if factory_url == "private:factory/swriter":
+        if _windows_notebook_host():
+            return _WINDOWS_NOTEBOOK_HOST_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
         return _WINDOWS_FACTORY_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
     if factory_url == "private:factory/scalc":
         return _WINDOWS_CALC_FACTORY_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
@@ -1150,6 +1156,30 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
 # after leftover Writers — consecutive Hidden _blank hung detect
 # (GHA 34619751330) the same way as leftover swriter (34597506651).
 _WINDOWS_NOTEBOOK_TARGET = "_wa_notebook"
+# Notebook-runner host while leftover HTML-paste Writers stay open.
+# Not leftover ``_wa_factory`` (reuses paste leftovers) and not
+# import-filter ``_wa_notebook`` (GHA 34643210006 leftover listeners).
+_WINDOWS_NOTEBOOK_HOST_TARGET = "_wa_notebook_host"
+_WINDOWS_NOTEBOOK_HOST = False
+
+
+def set_windows_notebook_host(on: bool) -> None:
+    """Writer leftover reuse off; leftover factory uses ``_wa_notebook_host``."""
+    flag = bool(on)
+    for mod in _testing_utils_holders():
+        mod._WINDOWS_NOTEBOOK_HOST = flag
+
+
+def _windows_notebook_host() -> bool:
+    if bool(_WINDOWS_NOTEBOOK_HOST):
+        return True
+    here = sys.modules.get(__name__)
+    for mod in _testing_utils_holders():
+        if mod is here:
+            continue
+        if bool(getattr(mod, "_WINDOWS_NOTEBOOK_HOST", False)):
+            return True
+    return False
 
 
 def windows_notebook_load_args() -> tuple[str, int]:
@@ -1995,12 +2025,30 @@ class TestingFactory:
                     # _wa_factory_5 swriter hung 30s. Do not close a
                     # harness Writer while paste leftovers remain (same
                     # ban as leftover paste close, 34556185752).
-                    reactivate_harness_keeper()
+                    # GHA 34643210006: that skip also kept import-filter
+                    # ``_wa_notebook`` leftovers (uids 41/42) and their
+                    # form listeners. Close notebook-registry leftovers.
+                    # Do not close leftover paste Writers.
+                    close_notebook = False
+                    try:
+                        from plugin.notebook.cell_registry import (
+                            has_notebook_registry,
+                        )
+
+                        close_notebook = has_notebook_registry(doc) is True
+                    except Exception:
+                        close_notebook = False
+                    if not close_notebook:
+                        reactivate_harness_keeper()
+                        _progress(
+                            "close_doc: skip writer close leftovers open=%s uid=%s"
+                            % (leftover_open, uid or "-")
+                        )
+                        return
                     _progress(
-                        "close_doc: skip writer close leftovers open=%s uid=%s"
-                        % (leftover_open, uid or "-")
+                        "close_doc: close notebook leftover uid=%s leftovers=%s"
+                        % (uid or "-", leftover_open)
                     )
-                    return
         for key, pooled in list(_NATIVE_DOC_POOL.items()):
             if pooled is doc:
                 del _NATIVE_DOC_POOL[key]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#725 fixed the leftover `private:factory/scalc` hang (`store budget via active`). Windows `workflow_dispatch` [34639913692](https://github.com/KeithCu/writeragent/actions/runs/34639913692) then failed Hidden-opening that same `storeAsURL` path (`Could not create system bitmap!`).

## What this changes

Harness only. Product `open_document_for_read` is unchanged. Leftover HTML-paste Writers stay open.

- On Windows, `_create_nearby_test_env` copies `Budget_read.ods` and Hidden-opens that copy. POSIX still opens the `storeAsURL` path.
- After leftovers, `native_doc` wipe-and-reuses the pooled Calc instead of leftover `_wa_scalc`.
- Notebook listener counts are per-document. Notebook suites use `_wa_notebook_host` (not leftover HTML-paste Writer reuse). `close_doc` still skips leftover paste Writers, but closes notebook-registry leftovers.

## Windows proof so far ([34643210006](https://github.com/KeithCu/writeragent/actions/runs/34643210006) on `60c827a8`)

`document_research_uno` **3/3 OK**: `copied budget for hidden open`, `open_document_for_read done err=-`.

That run then failed later. Those notebook fails were leftover-driven, not independent:

- HTML-paste Writers (uids 26/27, `close skipped pasted=True`) left `leftover_open>0`
- `close_doc` skipped **all** Writer closes, so import-filter `_wa_notebook` leftovers (uids 41/42) kept form listeners
- Global `form_run_listeners()` / `wired_run_listener_count` counted every leftover doc (`duplicate listeners: 3`)
- leftover `target=_wa_scalc` then hung in `test_calc_reuse_false_still_empty`

## Pushed — please kick Windows again

Head is `bb2960be`. Ubuntu PR CI is green ([34646042915](https://github.com/KeithCu/writeragent/actions/runs/34646042915)). Please `workflow_dispatch` PR CI: `os=windows-latest`, `ci_debug=true`.

Look for:

- `document_research_uno` 3/3 OK (copy-open unchanged)
- `close_doc: close notebook leftover` (not skip of `_wa_notebook`)
- no leftover Writer reuse into notebook_runner
- `native_doc: leftover calc reuse` (no leftover `_wa_scalc` hang)
- `notebook.test_notebook_runner_uno` all `TEST end … OK`

Related: #725, GHA 34639913692, 34643210006, 34602219973.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-718f1b82-e214-4ec8-81e6-c73e1dfe3ad8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-718f1b82-e214-4ec8-81e6-c73e1dfe3ad8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

