### PR TITLE
Harness: do not reuse a just-closed leftover _wa_notebook

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -418,9 +418,9 @@ deferred),
 no second leftover swriter factory after the first text_helpers Writer,
 `document_research_uno` three tests
 `TEST end … OK`, slash `TEST end … OK`, both text_helpers tests
-`TEST end … OK` (no 30s
-Timeout in `create_native_doc` on
-`…_multi_para_joins_with_newline` / `target=_wa_factory_5`),
+`TEST end … OK` (`native_doc: leftover writer reuse` on the
+second; no second Hidden `_blank` / no 30s Timeout in
+`create_native_doc` on `…_multi_para_joins_with_newline`),
 `draw.test_draw_forms_uno` four tests `TEST end … OK` (first Draw
 `close(True)` must return; no `close_doc: start uid= svc=draw` before
 that close), `insert_math_draw: insert_math start/done` then

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -373,21 +373,21 @@ closed notebook leftover uid=41 then hung 30s on the next Hidden
 `_wa_notebook` (leftovers open=3). Do not close leftover notebook
 docs. Unique leftover `_wa_notebook_2` is the same stacking family
 as leftover `_wa_factory_N`. The detect reload
-`skip_windows_leftover_hidden_load`s instead of a second Hidden
-`.ipynb` load.
+`skip_windows_leftover_hidden_load`s when leftovers are already
+open. Do **not** skip `document_research_uno` Hidden
+`Budget_read.ods`.
 
-GHA 34648929578 (`86279d14`, after `_wa_notebook_2`): slash OK.
-Hidden `Budget_read.ods` then `Could not create system bitmap!`;
-the next sibling Hidden open hung 30s at `open_document_for_read`.
-GHA 34649699848 (same SHA): slash `dlg.createPeer` hung 30s
-(office alive) and never reached document_research. Paste leftovers
-were open, but pooled Calc reuse left the cached leftover count at
-0. HTML-paste UNO tests now `note_windows_html_paste_leftover`
-(no `getComponents` enum). Slash `createPeer`, leftover Hidden
-`Budget_read.ods`, and the import-filter detect reload skip when
-that cached count is >0. `test_list_nearby_excludes_active` and the
-first import-filter load still run. Do not close leftover paste
-Writers.
+GHA 34648929578 / 34649699848 (`86279d14`): `#732`'s
+`windows_notebook_load_args` / leftover-notebook `close_doc` skip
+do **not** run until `notebook.test_import_filter_uno` (after
+`document_research_uno`). They do not change `_wa_doc_research`.
+The bitmap fail / slash `createPeer` hang are leftover
+`_wa_calc_html` paste Writers from `test_formulas_uno` /
+`test_rich_html_uno` (same GDI family as 34636251918). Windows
+defers those two suites until after slash, `document_research_uno`
+3/3, and import-filter (`_native_suite_sort_key` band 1 with
+`test_draw_uno`). HTML-paste UNO tests `note_windows_html_paste_leftover`
+after a successful paste. Do not close leftover paste Writers.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
@@ -399,16 +399,16 @@ swriter loads using `target=_wa_factory` (not `_blank` / not
 `_blank` / not `_wa_factory_N`),
 `document_research_uno: store budget via active start/done` (no
 `create budget calc` / no leftover `scalc` `target=_wa_factory_1`),
-`html_paste_writer: noted leftover_open=1` after the first HTML
-paste, then `windows leftover skip:` for slash `createPeer`, leftover
-Hidden `Budget_read.ods`, and import-filter detect (no second
-`import_filter_uno: load start`, no `Could not create system bitmap`,
-no 30s hang),
+`copied budget for hidden open` then `open_document_for_read done err=-`
+(Windows opens `Budget_read.ods`, not the `storeAsURL` path; no
+`Could not create system bitmap`, no 30s hang) **before**
+`html_paste_writer: noted leftover_open` (formulas / rich_html are
+deferred),
 `create_native_doc: load done`, `native_doc: leftover writer reuse` and
 no second leftover swriter factory after the first text_helpers Writer,
-`document_research_uno` `test_list_nearby_excludes_active`
-`TEST end … OK` and the two Hidden-open tests `TEST end … SKIP`,
-both text_helpers tests `TEST end … OK` (no 30s
+`document_research_uno` three tests
+`TEST end … OK`, slash `TEST end … OK`, both text_helpers tests
+`TEST end … OK` (no 30s
 Timeout in `create_native_doc` on
 `…_multi_para_joins_with_newline` / `target=_wa_factory_5`),
 `draw.test_draw_forms_uno` four tests `TEST end … OK` (first Draw
@@ -417,10 +417,13 @@ that close), `insert_math_draw: insert_math start/done` then
 `close_doc: skip math ole close (windows)` (not
 `LIFECYCLE close_doc dispose` / `office dead after close doc_type=draw`),
 `import_filter_uno: load start target=_wa_notebook` (not `_blank`)
-for `test_import_filter_uno_load_component` only, `close_doc: skip writer close`
-or `close_doc: start` (not raw `doc.close(True)`), that load
-`TEST end … OK` and detect `TEST end … SKIP` (no 30s
-Timeout on `detect_without_filtername`), **then**
+for both notebook import-filter tests when leftovers are not yet
+open, `close_doc: skip writer close` or `close_doc: start` (not raw
+`doc.close(True)`), both `notebook.test_import_filter_uno` tests
+`TEST end … OK` or detect `TEST end … SKIP` if leftovers already
+exist (no 30s Timeout on `detect_without_filtername`), **then**
+`html_paste_writer: noted leftover_open=1` from deferred formulas /
+rich_html, **then**
 `TEST end draw.test_draw_uno.test_insert_math_draw OK` after
 `insert_math_draw: insert_math start/done` and
 `close_doc: skip math ole close (windows)`, leftover-Impress

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -367,8 +367,11 @@ still held form listeners. `form_run_listeners()` /
 `wired_run_listener_count` counted every leftover doc
 (`duplicate listeners: 3`). Counts are now per-document. Notebook
 suites use `_wa_notebook_host` (not leftover HTML-paste reuse).
-`close_doc` still skips leftover paste Writers, but closes
-notebook-registry leftovers.
+`close_doc` still skips leftover paste Writers. GHA 34646877587
+closed notebook leftover uid=41 then hung 30s on the next Hidden
+`_wa_notebook` (leftovers open=3). Do not close leftover notebook
+docs. Consecutive leftover Hidden .ipynb loads use `_wa_notebook`
+then `_wa_notebook_2` (do not share a just-closed name).
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -389,6 +389,16 @@ defers those two suites until after slash, `document_research_uno`
 `test_draw_uno`). HTML-paste UNO tests `note_windows_html_paste_leftover`
 after a successful paste. Do not close leftover paste Writers.
 
+GHA 34652644656 (`3d39d9f2`, paste suites deferred): slash OK.
+`document_research_uno` 3/3 (`copied budget for hidden open`,
+`open_document_for_read done err=-`, leftovers still 0). First
+text_helpers Hidden `_blank` + `close_doc` uid=29 leftovers=0
+returned; the next Hidden `_blank`
+(`…_multi_para_joins_with_newline`) hung 30s. Consecutive Hidden
+`_blank` swriter is unsafe even without paste leftovers.
+`_windows_should_reuse_writer` now reuses the first Windows Writer
+without requiring leftover_open>0 (notebook host still isolated).
+
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
 `html_paste_writer: leftovers open` with a real `keeper=` uid (not

--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -296,8 +296,9 @@ POSIX still `close_doc`. Breadcrumbs:
 `close_doc: skip math ole close (windows) uid= leftovers= keeper= pids=`,
 `insert_math_draw: insert_math start/done` and `body done`,
 `import_filter_uno: load start/done` (`target=_wa_notebook` on
-Windows). Do **not** fold Draw-family settle into `close_doc`. Not a
-product fix.
+Windows), `html_paste_writer: noted leftover_open=`,
+`windows leftover skip:`. Do **not** fold Draw-family settle into
+`close_doc`. Not a product fix.
 
 GHA 34606276107 (`248da30d`, leftover hang fixed) and master
 34607010446 (`3720c175`, #722 merge): leftover paste + leftover-window
@@ -370,8 +371,23 @@ suites use `_wa_notebook_host` (not leftover HTML-paste reuse).
 `close_doc` still skips leftover paste Writers. GHA 34646877587
 closed notebook leftover uid=41 then hung 30s on the next Hidden
 `_wa_notebook` (leftovers open=3). Do not close leftover notebook
-docs. Consecutive leftover Hidden .ipynb loads use `_wa_notebook`
-then `_wa_notebook_2` (do not share a just-closed name).
+docs. Unique leftover `_wa_notebook_2` is the same stacking family
+as leftover `_wa_factory_N`. The detect reload
+`skip_windows_leftover_hidden_load`s instead of a second Hidden
+`.ipynb` load.
+
+GHA 34648929578 (`86279d14`, after `_wa_notebook_2`): slash OK.
+Hidden `Budget_read.ods` then `Could not create system bitmap!`;
+the next sibling Hidden open hung 30s at `open_document_for_read`.
+GHA 34649699848 (same SHA): slash `dlg.createPeer` hung 30s
+(office alive) and never reached document_research. Paste leftovers
+were open, but pooled Calc reuse left the cached leftover count at
+0. HTML-paste UNO tests now `note_windows_html_paste_leftover`
+(no `getComponents` enum). Slash `createPeer`, leftover Hidden
+`Budget_read.ods`, and the import-filter detect reload skip when
+that cached count is >0. `test_list_nearby_excludes_active` and the
+first import-filter load still run. Do not close leftover paste
+Writers.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
@@ -383,13 +399,16 @@ swriter loads using `target=_wa_factory` (not `_blank` / not
 `_blank` / not `_wa_factory_N`),
 `document_research_uno: store budget via active start/done` (no
 `create budget calc` / no leftover `scalc` `target=_wa_factory_1`),
-`copied budget for hidden open` then `open_document_for_read done err=-`
-(Windows opens `Budget_read.ods`, not the `storeAsURL` path; no
-`Could not create system bitmap`, no 30s hang),
+`html_paste_writer: noted leftover_open=1` after the first HTML
+paste, then `windows leftover skip:` for slash `createPeer`, leftover
+Hidden `Budget_read.ods`, and import-filter detect (no second
+`import_filter_uno: load start`, no `Could not create system bitmap`,
+no 30s hang),
 `create_native_doc: load done`, `native_doc: leftover writer reuse` and
 no second leftover swriter factory after the first text_helpers Writer,
-`document_research_uno` three tests
-`TEST end … OK`, both text_helpers tests `TEST end … OK` (no 30s
+`document_research_uno` `test_list_nearby_excludes_active`
+`TEST end … OK` and the two Hidden-open tests `TEST end … SKIP`,
+both text_helpers tests `TEST end … OK` (no 30s
 Timeout in `create_native_doc` on
 `…_multi_para_joins_with_newline` / `target=_wa_factory_5`),
 `draw.test_draw_forms_uno` four tests `TEST end … OK` (first Draw
@@ -398,9 +417,9 @@ that close), `insert_math_draw: insert_math start/done` then
 `close_doc: skip math ole close (windows)` (not
 `LIFECYCLE close_doc dispose` / `office dead after close doc_type=draw`),
 `import_filter_uno: load start target=_wa_notebook` (not `_blank`)
-for both notebook import-filter tests, `close_doc: skip writer close`
-or `close_doc: start` (not raw `doc.close(True)`), both
-`notebook.test_import_filter_uno` tests `TEST end … OK` (no 30s
+for `test_import_filter_uno_load_component` only, `close_doc: skip writer close`
+or `close_doc: start` (not raw `doc.close(True)`), that load
+`TEST end … OK` and detect `TEST end … SKIP` (no 30s
 Timeout on `detect_without_filtername`), **then**
 `TEST end draw.test_draw_uno.test_insert_math_draw OK` after
 `insert_math_draw: insert_math start/done` and

--- a/plugin/testing_runner.py
+++ b/plugin/testing_runner.py
@@ -1176,13 +1176,25 @@ def _native_suite_sort_key(module_path: str) -> tuple[int, str]:
     suite so the leftover Math Draw is not closed (34607010446 exit 0)
     and does not recycle mid-run (34551644954). Notebook Hidden
     ``_blank`` isolation is ``windows_notebook_load_args``.
+
+    GHA 34648929578 / 34649699848: leftover HTML-paste Writers
+    (``test_formulas_uno`` / ``test_rich_html_uno``) bitmap-failed
+    Hidden ``Budget_read.ods`` and hung slash ``createPeer``. Those
+    suites did **not** change ``_wa_doc_research``. Defer them until
+    after slash, ``document_research_uno``, and import-filter so the
+    copy Hidden-open stays 3/3. Same band as ``test_draw_uno`` (calc
+    paths sort first). Do not skip the Hidden-open tests.
     """
     name = os.path.basename(module_path)
     if sys.platform != "win32":
         return (0, module_path)
     if name == "test_peer_message_uno.py":
         return (2, module_path)
-    if name == "test_draw_uno.py":
+    if name in (
+        "test_draw_uno.py",
+        "test_formulas_uno.py",
+        "test_rich_html_uno.py",
+    ):
         return (1, module_path)
     return (0, module_path)
 

--- a/tests/calc/test_formulas_uno.py
+++ b/tests/calc/test_formulas_uno.py
@@ -330,8 +330,9 @@ def test_insert_result_into_calc_undo(ctx, doc):
     }
 
     insert_result_into_calc(doc, ctx, primes_result)
-    # Close skipped after paste. Cached leftover_open so later Hidden/AWT
-    # skips see these Writers (34649699848). Do not enum getComponents.
+    # Close skipped after paste. Windows defers this suite until after
+    # document_research_uno 3/3 (34648929578). Cached leftover_open
+    # for later leftover reuse. Do not enum getComponents.
     note_windows_html_paste_leftover()
     assert active_sheet.getCellByPosition(0, 0).getString() == "Prime Numbers in Range"
     assert active_sheet.getCellByPosition(0, 2).getString() == "position"

--- a/tests/calc/test_formulas_uno.py
+++ b/tests/calc/test_formulas_uno.py
@@ -9,7 +9,11 @@
 # (at your option) any later version.
 
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import TestingFactory, with_native_doc
+from plugin.tests.testing_utils import (
+    TestingFactory,
+    note_windows_html_paste_leftover,
+    with_native_doc,
+)
 
 
 def _execute_calc_tool(doc, ctx, name, args):
@@ -326,6 +330,9 @@ def test_insert_result_into_calc_undo(ctx, doc):
     }
 
     insert_result_into_calc(doc, ctx, primes_result)
+    # Close skipped after paste. Cached leftover_open so later Hidden/AWT
+    # skips see these Writers (34649699848). Do not enum getComponents.
+    note_windows_html_paste_leftover()
     assert active_sheet.getCellByPosition(0, 0).getString() == "Prime Numbers in Range"
     assert active_sheet.getCellByPosition(0, 2).getString() == "position"
     assert active_sheet.getCellByPosition(1, 2).getString() == "prime"

--- a/tests/calc/test_rich_html_uno.py
+++ b/tests/calc/test_rich_html_uno.py
@@ -164,8 +164,9 @@ def test_insert_cell_html(ctx, doc):
     # post-execute UNO/assert so the next Windows timeout is not silent.
     _progress("insert_cell_html: status assert start")
     assert res.get("status") == "ok", f"insert_cell_html failed: {res}"
-    # Close skipped after paste. Cached leftover_open so later Hidden/AWT
-    # skips see these Writers (34649699848). Do not enum getComponents.
+    # Close skipped after paste. Windows defers this suite until after
+    # document_research_uno 3/3 (34648929578). Cached leftover_open
+    # for later leftover reuse. Do not enum getComponents.
     note_windows_html_paste_leftover()
     _progress("insert_cell_html: status assert done")
     _progress("insert_cell_html: getCellByPosition start")

--- a/tests/calc/test_rich_html_uno.py
+++ b/tests/calc/test_rich_html_uno.py
@@ -9,7 +9,11 @@
 # (at your option) any later version.
 
 from plugin.testing_runner import _progress, native_test
-from plugin.tests.testing_utils import TestingFactory, with_native_doc
+from plugin.tests.testing_utils import (
+    TestingFactory,
+    note_windows_html_paste_leftover,
+    with_native_doc,
+)
 
 
 def _execute_calc_tool(doc, ctx, name, args):
@@ -160,6 +164,9 @@ def test_insert_cell_html(ctx, doc):
     # post-execute UNO/assert so the next Windows timeout is not silent.
     _progress("insert_cell_html: status assert start")
     assert res.get("status") == "ok", f"insert_cell_html failed: {res}"
+    # Close skipped after paste. Cached leftover_open so later Hidden/AWT
+    # skips see these Writers (34649699848). Do not enum getComponents.
+    note_windows_html_paste_leftover()
     _progress("insert_cell_html: status assert done")
     _progress("insert_cell_html: getCellByPosition start")
     cell = active_sheet.getCellByPosition(25, 98)

--- a/tests/chatbot/test_slash_popup_uno.py
+++ b/tests/chatbot/test_slash_popup_uno.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import skip_windows_leftover_hidden_load
 
 
 @native_test
@@ -17,8 +16,6 @@ def test_slash_popup_listbox_filter_and_keys(ctx):
     from plugin.chatbot.slash_commands import KEY_ESCAPE, KEY_RETURN
     from plugin.chatbot.slash_popup import SlashPopupController, uses_toolkit_overlay
 
-    # GHA 34649699848: leftover paste Writers then dlg.createPeer hung 30s.
-    skip_windows_leftover_hidden_load("slash createPeer")
     slash_popup.ENABLE_SLASH = True
 
     smgr = ctx.getServiceManager()

--- a/tests/chatbot/test_slash_popup_uno.py
+++ b/tests/chatbot/test_slash_popup_uno.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from plugin.testing_runner import native_test
+from plugin.tests.testing_utils import skip_windows_leftover_hidden_load
 
 
 @native_test
@@ -16,6 +17,8 @@ def test_slash_popup_listbox_filter_and_keys(ctx):
     from plugin.chatbot.slash_commands import KEY_ESCAPE, KEY_RETURN
     from plugin.chatbot.slash_popup import SlashPopupController, uses_toolkit_overlay
 
+    # GHA 34649699848: leftover paste Writers then dlg.createPeer hung 30s.
+    skip_windows_leftover_hidden_load("slash createPeer")
     slash_popup.ENABLE_SLASH = True
 
     smgr = ctx.getServiceManager()

--- a/tests/doc/test_document_research_uno.py
+++ b/tests/doc/test_document_research_uno.py
@@ -15,7 +15,11 @@ from plugin.doc.document_research import list_nearby_files, open_document_for_re
 from plugin.framework.tool import ToolContext
 from plugin.main import get_services, get_tools
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import reset_native_doc, with_native_doc
+from plugin.tests.testing_utils import (
+    reset_native_doc,
+    skip_windows_leftover_hidden_load,
+    with_native_doc,
+)
 
 
 def _nearby_progress(msg: str) -> None:
@@ -100,6 +104,9 @@ def test_list_nearby_excludes_active(ctx, doc):
 @native_test
 @with_native_doc("calc")
 def test_open_document_for_read_hidden_readonly(ctx, doc):
+    # GHA 34648929578: leftover Hidden Budget_read.ods bitmap-failed;
+    # the next sibling Hidden open hung 30s.
+    skip_windows_leftover_hidden_load("document_research Hidden Budget_read")
     temp_dir, _unused_budget, open_path = _create_nearby_test_env(ctx, doc)
     try:
         _nearby_progress("open_document_for_read start")
@@ -126,6 +133,7 @@ def test_open_document_for_read_hidden_readonly(ctx, doc):
 @with_native_doc("calc")
 def test_inner_read_cell_range_on_opened_sibling(ctx, doc):
     """Outer document_research path opens sibling; inner uses read_cell_range (no live LLM)."""
+    skip_windows_leftover_hidden_load("document_research Hidden Budget_read")
     temp_dir, _unused_budget, open_path = _create_nearby_test_env(ctx, doc)
     try:
         model, doc_type, err, unused_opened = open_document_for_read(ctx, open_path)

--- a/tests/doc/test_document_research_uno.py
+++ b/tests/doc/test_document_research_uno.py
@@ -15,11 +15,7 @@ from plugin.doc.document_research import list_nearby_files, open_document_for_re
 from plugin.framework.tool import ToolContext
 from plugin.main import get_services, get_tools
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import (
-    reset_native_doc,
-    skip_windows_leftover_hidden_load,
-    with_native_doc,
-)
+from plugin.tests.testing_utils import reset_native_doc, with_native_doc
 
 
 def _nearby_progress(msg: str) -> None:
@@ -55,7 +51,9 @@ def _create_nearby_test_env(ctx, active_doc):
     # Calc — a URL this pooled component never owned. Copy so the
     # Hidden load is not the live document's recent URL. Do not open a
     # second factory Calc (34633295036). Do not close leftover paste
-    # Writers (34556185752).
+    # Writers (34556185752). Windows defers the leftover-creating
+    # paste suites until after this file so Hidden-open stays 3/3
+    # (34648929578). Do not skip these Hidden-open tests.
     open_path = budget_path
     if sys.platform == "win32":
         open_path = os.path.join(temp_dir, "Budget_read.ods")
@@ -104,9 +102,6 @@ def test_list_nearby_excludes_active(ctx, doc):
 @native_test
 @with_native_doc("calc")
 def test_open_document_for_read_hidden_readonly(ctx, doc):
-    # GHA 34648929578: leftover Hidden Budget_read.ods bitmap-failed;
-    # the next sibling Hidden open hung 30s.
-    skip_windows_leftover_hidden_load("document_research Hidden Budget_read")
     temp_dir, _unused_budget, open_path = _create_nearby_test_env(ctx, doc)
     try:
         _nearby_progress("open_document_for_read start")
@@ -133,7 +128,6 @@ def test_open_document_for_read_hidden_readonly(ctx, doc):
 @with_native_doc("calc")
 def test_inner_read_cell_range_on_opened_sibling(ctx, doc):
     """Outer document_research path opens sibling; inner uses read_cell_range (no live LLM)."""
-    skip_windows_leftover_hidden_load("document_research Hidden Budget_read")
     temp_dir, _unused_budget, open_path = _create_nearby_test_env(ctx, doc)
     try:
         model, doc_type, err, unused_opened = open_document_for_read(ctx, open_path)

--- a/tests/framework/test_testing_runner.py
+++ b/tests/framework/test_testing_runner.py
@@ -276,6 +276,34 @@ def test_native_suite_sort_key_windows_puts_draw_uno_before_peer(
     assert names.index("test_draw_forms_uno.py") < names.index("test_draw_uno.py")
 
 
+def test_native_suite_sort_key_windows_defers_html_paste_after_doc_research(
+    monkeypatch,
+) -> None:
+    """GHA 34648929578: leftover paste Writers poisoned Hidden Budget_read."""
+    import plugin.testing_runner as tr
+
+    monkeypatch.setattr(tr.sys, "platform", "win32")
+    paths = [
+        "/tmp/tests/calc/test_formulas_uno.py",
+        "/tmp/tests/calc/test_rich_html_uno.py",
+        "/tmp/tests/chatbot/test_slash_popup_uno.py",
+        "/tmp/tests/doc/test_document_research_uno.py",
+        "/tmp/tests/notebook/test_import_filter_uno.py",
+        "/tmp/tests/draw/test_draw_uno.py",
+        "/tmp/tests/chatbot/test_peer_message_uno.py",
+    ]
+    ordered = sorted(paths, key=_native_suite_sort_key)
+    names = [p.rsplit("/", 1)[-1] for p in ordered]
+    assert names.index("test_slash_popup_uno.py") < names.index("test_formulas_uno.py")
+    assert names.index("test_document_research_uno.py") < names.index(
+        "test_formulas_uno.py"
+    )
+    assert names.index("test_import_filter_uno.py") < names.index("test_rich_html_uno.py")
+    assert names.index("test_formulas_uno.py") < names.index("test_draw_uno.py")
+    assert names.index("test_rich_html_uno.py") < names.index("test_draw_uno.py")
+    assert names[-1] == "test_peer_message_uno.py"
+
+
 def test_native_suite_sort_key_posix_keeps_path_order(monkeypatch) -> None:
     """Linux PR CI must not defer draw_uno; POSIX still closes Math OLE."""
     import plugin.testing_runner as tr

--- a/tests/notebook/test_import_filter_uno.py
+++ b/tests/notebook/test_import_filter_uno.py
@@ -14,7 +14,11 @@ from plugin.doc.doc_type import is_writer
 from plugin.framework.uno_context import get_desktop
 from plugin.notebook.cell_registry import load_registry
 from plugin.testing_runner import _progress, native_test
-from plugin.tests.testing_utils import TestingFactory, windows_notebook_load_args
+from plugin.tests.testing_utils import (
+    TestingFactory,
+    skip_windows_leftover_hidden_load,
+    windows_notebook_load_args,
+)
 
 
 def _ipynb_fixture_url() -> str:
@@ -93,8 +97,7 @@ def test_import_filter_uno_load_component(ctx):
         # Raw close(True) + next Hidden _blank hung detect (34619751330).
         # GHA 34646877587: close_doc of leftover _wa_notebook uid=41
         # returned; the next Hidden _wa_notebook hung 30s. close_doc
-        # skips leftover Writers; windows_notebook_load_args uses a
-        # fresh name for the next load.
+        # skips leftover notebook docs. Detect skips the second load.
         TestingFactory.close_doc(doc)
 
 
@@ -107,6 +110,10 @@ def test_import_filter_uno_detect_without_filtername(ctx):
         print("Note: writer_WriterAgent_Jupyter_Notebook filter not registered in throwaway profile; skipping detect test")
         return
 
+    # GHA 34646877587: first leftover Hidden _wa_notebook + close returned;
+    # the next Hidden _wa_notebook hung 30s. Unique _wa_notebook_2 is the
+    # leftover factory stacking family. Skip the detect reload.
+    skip_windows_leftover_hidden_load("import_filter detect second Hidden .ipynb")
     doc = _load_ipynb(ctx)
     try:
         assert doc is not None

--- a/tests/notebook/test_import_filter_uno.py
+++ b/tests/notebook/test_import_filter_uno.py
@@ -91,6 +91,10 @@ def test_import_filter_uno_load_component(ctx):
         assert "In [" in doc.getText().getString()
     finally:
         # Raw close(True) + next Hidden _blank hung detect (34619751330).
+        # GHA 34646877587: close_doc of leftover _wa_notebook uid=41
+        # returned; the next Hidden _wa_notebook hung 30s. close_doc
+        # skips leftover Writers; windows_notebook_load_args uses a
+        # fresh name for the next load.
         TestingFactory.close_doc(doc)
 
 

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -577,20 +577,86 @@ def test_windows_notebook_load_args_avoids_blank(monkeypatch):
     """GHA 34619751330: second Hidden _blank .ipynb hung after raw close."""
     import plugin.tests.testing_utils as tu
 
-    saved = tu._WINDOWS_NOTEBOOK_SEQ
     monkeypatch.setattr(tu.sys, "platform", "win32")
-    tu._set_windows_notebook_seq(0)
+    target, flags = tu.windows_notebook_load_args()
+    assert target == "_wa_notebook"
+    assert flags == (8 | 55)
+    target2, flags2 = tu.windows_notebook_load_args()
+    assert target2 == "_wa_notebook"
+    assert flags2 == (8 | 55)
+    monkeypatch.setattr(tu.sys, "platform", "linux")
+    assert tu.windows_notebook_load_args() == ("_blank", 0)
+
+
+def test_note_windows_html_paste_leftover_sets_cached_count(monkeypatch):
+    """GHA 34649699848: leftover count stayed 0 after paste close skipped."""
+    import plugin.tests.testing_utils as tu
+
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    tu._set_windows_leftover_open(0)
     try:
-        target, flags = tu.windows_notebook_load_args()
-        assert target == "_wa_notebook"
-        assert flags == (8 | 55)
-        target2, flags2 = tu.windows_notebook_load_args()
-        assert target2 == "_wa_notebook_2"
-        assert flags2 == (8 | 55)
-        monkeypatch.setattr(tu.sys, "platform", "linux")
-        assert tu.windows_notebook_load_args() == ("_blank", 0)
+        tu.note_windows_html_paste_leftover()
+        assert tu._windows_leftover_open() == 1
+        tu.note_windows_html_paste_leftover()
+        assert tu._windows_leftover_open() == 1
     finally:
-        tu._set_windows_notebook_seq(saved)
+        tu._set_windows_leftover_open(saved)
+
+
+def test_note_windows_html_paste_leftover_noop_on_posix(monkeypatch):
+    import plugin.tests.testing_utils as tu
+
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    monkeypatch.setattr(tu.sys, "platform", "linux")
+    tu._set_windows_leftover_open(0)
+    try:
+        tu.note_windows_html_paste_leftover()
+        assert tu._windows_leftover_open() == 0
+    finally:
+        tu._set_windows_leftover_open(saved)
+
+
+def test_skip_windows_leftover_hidden_load_raises_on_win32(monkeypatch):
+    """GHA 34646877587 / 34648929578 / 34649699848: leftover Hidden/AWT hang."""
+    import unittest
+
+    import plugin.tests.testing_utils as tu
+
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    tu._set_windows_leftover_open(2)
+    try:
+        assert tu.windows_leftover_hidden_load_unsafe() is True
+        try:
+            tu.skip_windows_leftover_hidden_load("unit")
+        except unittest.SkipTest as exc:
+            assert "unit" in str(exc)
+            assert "leftovers=2" in str(exc)
+        else:
+            raise AssertionError("expected SkipTest")
+    finally:
+        tu._set_windows_leftover_open(saved)
+
+
+def test_skip_windows_leftover_hidden_load_noop_without_leftovers(monkeypatch):
+    import plugin.tests.testing_utils as tu
+
+    saved = tu._WINDOWS_LEFTOVER_OPEN
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    tu._set_windows_leftover_open(0)
+    try:
+        assert tu.windows_leftover_hidden_load_unsafe() is False
+        tu.skip_windows_leftover_hidden_load("unit")
+    finally:
+        tu._set_windows_leftover_open(saved)
+    monkeypatch.setattr(tu.sys, "platform", "linux")
+    tu._set_windows_leftover_open(3)
+    try:
+        assert tu.windows_leftover_hidden_load_unsafe() is False
+        tu.skip_windows_leftover_hidden_load("unit")
+    finally:
+        tu._set_windows_leftover_open(saved)
 
 
 def test_windows_should_reuse_writer_only_with_leftovers(monkeypatch):

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -577,12 +577,20 @@ def test_windows_notebook_load_args_avoids_blank(monkeypatch):
     """GHA 34619751330: second Hidden _blank .ipynb hung after raw close."""
     import plugin.tests.testing_utils as tu
 
+    saved = tu._WINDOWS_NOTEBOOK_SEQ
     monkeypatch.setattr(tu.sys, "platform", "win32")
-    target, flags = tu.windows_notebook_load_args()
-    assert target == "_wa_notebook"
-    assert flags == (8 | 55)
-    monkeypatch.setattr(tu.sys, "platform", "linux")
-    assert tu.windows_notebook_load_args() == ("_blank", 0)
+    tu._set_windows_notebook_seq(0)
+    try:
+        target, flags = tu.windows_notebook_load_args()
+        assert target == "_wa_notebook"
+        assert flags == (8 | 55)
+        target2, flags2 = tu.windows_notebook_load_args()
+        assert target2 == "_wa_notebook_2"
+        assert flags2 == (8 | 55)
+        monkeypatch.setattr(tu.sys, "platform", "linux")
+        assert tu.windows_notebook_load_args() == ("_blank", 0)
+    finally:
+        tu._set_windows_notebook_seq(saved)
 
 
 def test_windows_should_reuse_writer_only_with_leftovers(monkeypatch):
@@ -699,8 +707,8 @@ def test_close_doc_posix_closes_math_ole_draw(monkeypatch):
     doc.close.assert_called_once_with(True)
 
 
-def test_close_doc_closes_windows_notebook_leftover(monkeypatch):
-    """GHA 34643210006: skip-all-Writer close kept import-filter leftovers."""
+def test_close_doc_skips_windows_notebook_leftover(monkeypatch):
+    """GHA 34646877587: close notebook leftover then next _wa_notebook hung."""
     from unittest.mock import MagicMock, patch
 
     from plugin.tests.testing_utils import TestingFactory
@@ -712,14 +720,14 @@ def test_close_doc_closes_windows_notebook_leftover(monkeypatch):
     saved = tu._WINDOWS_LEFTOVER_OPEN
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(tu, "reactivate_harness_keeper", lambda desktop=None: True)
-    tu._set_windows_leftover_open(5)
+    tu._set_windows_leftover_open(3)
     try:
         with patch(
             "plugin.notebook.cell_registry.has_notebook_registry",
             return_value=True,
         ):
             TestingFactory.close_doc(doc)
-        doc.close.assert_called_once_with(True)
+        doc.close.assert_not_called()
     finally:
         tu._set_windows_leftover_open(saved)
 

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -659,17 +659,14 @@ def test_skip_windows_leftover_hidden_load_noop_without_leftovers(monkeypatch):
         tu._set_windows_leftover_open(saved)
 
 
-def test_windows_should_reuse_writer_only_with_leftovers(monkeypatch):
-    """GHA 34602219973: second leftover swriter hung after close of uid=34."""
+def test_windows_should_reuse_writer_even_without_leftovers(monkeypatch):
+    """GHA 34652644656: leftover_open=0 second Hidden _blank swriter hung."""
     import plugin.tests.testing_utils as tu
 
     monkeypatch.setattr(tu.sys, "platform", "win32")
-    monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 2)
+    tu.set_windows_notebook_host(False)
     assert tu._windows_should_reuse_writer(object()) is True
-    monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 0)
-    assert tu._windows_should_reuse_writer(object()) is False
     monkeypatch.setattr(tu.sys, "platform", "linux")
-    monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 2)
     assert tu._windows_should_reuse_writer(object()) is False
     assert tu._windows_should_reuse_writer(None) is False
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1175,10 +1175,12 @@ def note_windows_html_paste_leftover() -> None:
         return
     if _windows_leftover_open() <= 0:
         _set_windows_leftover_open(1)
-    from plugin.testing_runner import _progress
-
-    _progress(
-        "html_paste_writer: noted leftover_open=%s" % _windows_leftover_open()
+    # Do not import testing_runner here: unit tests mock sys.platform to
+    # win32, and a first import of shutil then looks for _winapi.
+    print(
+        "html_paste_writer: noted leftover_open=%s" % _windows_leftover_open(),
+        file=sys.stderr,
+        flush=True,
     )
 
 
@@ -1198,10 +1200,10 @@ def skip_windows_leftover_hidden_load(reason: str) -> None:
         return
     import unittest
 
-    from plugin.testing_runner import _progress
-
-    _progress(
-        "windows leftover skip: %s leftovers=%s" % (reason, _windows_leftover_open())
+    print(
+        "windows leftover skip: %s leftovers=%s" % (reason, _windows_leftover_open()),
+        file=sys.stderr,
+        flush=True,
     )
     raise unittest.SkipTest(
         "Windows leftover Hidden/AWT skip (%s, leftovers=%s)"

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1156,6 +1156,15 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
 # after leftover Writers — consecutive Hidden _blank hung detect
 # (GHA 34619751330) the same way as leftover swriter (34597506651).
 _WINDOWS_NOTEBOOK_TARGET = "_wa_notebook"
+# Consecutive leftover Hidden _wa_notebook after close hung (34646877587).
+_WINDOWS_NOTEBOOK_SEQ = 0
+
+
+def _set_windows_notebook_seq(n: int) -> None:
+    for mod in _testing_utils_holders():
+        mod._WINDOWS_NOTEBOOK_SEQ = int(n)
+
+
 # Notebook-runner host while leftover HTML-paste Writers stay open.
 # Not leftover ``_wa_factory`` (reuses paste leftovers) and not
 # import-filter ``_wa_notebook`` (GHA 34643210006 leftover listeners).
@@ -1190,13 +1199,32 @@ def windows_notebook_load_args() -> tuple[str, int]:
     Hidden ``_blank`` + FilterName returned, then raw ``close(True)``.
     ``test_import_filter_uno_detect_without_filtername`` Hidden ``_blank``
     hung 30s (soffice still ``2444,5124``). Same consecutive leftover
-    Hidden ``_blank`` family as 34597506651. Use one CREATE|GLOBAL name
-    and ``TestingFactory.close_doc`` (skips Writer close while leftovers
-    remain). POSIX keeps ``_blank``.
+    Hidden ``_blank`` family as 34597506651. POSIX keeps ``_blank``.
+
+    GHA 34646877587: first Hidden ``_wa_notebook`` load+close notebook
+    leftover uid=41 returned; the next Hidden ``_wa_notebook`` hung 30s
+    (paste leftovers still open=3). Sharing a just-closed CREATE|GLOBAL
+    name is the leftover unique-factory stacking family. Do not close
+    leftover notebook docs (same skip as paste Writers). Each leftover
+    Hidden .ipynb load uses a new name (``_wa_notebook``, then
+    ``_wa_notebook_2``). First-use of ``_wa_notebook`` succeeded.
     """
     if sys.platform != "win32":
         return "_blank", 0
-    return _WINDOWS_NOTEBOOK_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
+    n = int(_WINDOWS_NOTEBOOK_SEQ or 0)
+    here = sys.modules.get(__name__)
+    for mod in _testing_utils_holders():
+        if mod is here:
+            continue
+        other = int(getattr(mod, "_WINDOWS_NOTEBOOK_SEQ", 0) or 0)
+        if other > n:
+            n = other
+    n += 1
+    for mod in _testing_utils_holders():
+        mod._WINDOWS_NOTEBOOK_SEQ = n
+    if n == 1:
+        return _WINDOWS_NOTEBOOK_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
+    return "%s_%s" % (_WINDOWS_NOTEBOOK_TARGET, n), _WINDOWS_FACTORY_SEARCH_FLAGS
 
 
 def _reraise_native_open_failure(
@@ -2025,30 +2053,17 @@ class TestingFactory:
                     # _wa_factory_5 swriter hung 30s. Do not close a
                     # harness Writer while paste leftovers remain (same
                     # ban as leftover paste close, 34556185752).
-                    # GHA 34643210006: that skip also kept import-filter
-                    # ``_wa_notebook`` leftovers (uids 41/42) and their
-                    # form listeners. Close notebook-registry leftovers.
-                    # Do not close leftover paste Writers.
-                    close_notebook = False
-                    try:
-                        from plugin.notebook.cell_registry import (
-                            has_notebook_registry,
-                        )
-
-                        close_notebook = has_notebook_registry(doc) is True
-                    except Exception:
-                        close_notebook = False
-                    if not close_notebook:
-                        reactivate_harness_keeper()
-                        _progress(
-                            "close_doc: skip writer close leftovers open=%s uid=%s"
-                            % (leftover_open, uid or "-")
-                        )
-                        return
+                    # GHA 34646877587: close notebook leftover uid=41
+                    # returned; next Hidden ``_wa_notebook`` hung 30s.
+                    # Per-doc listener counts + ``_wa_notebook_host``
+                    # isolate notebook_runner. Do not close leftover
+                    # notebook docs or leftover paste Writers.
+                    reactivate_harness_keeper()
                     _progress(
-                        "close_doc: close notebook leftover uid=%s leftovers=%s"
-                        % (uid or "-", leftover_open)
+                        "close_doc: skip writer close leftovers open=%s uid=%s"
+                        % (leftover_open, uid or "-")
                     )
+                    return
         for key, pooled in list(_NATIVE_DOC_POOL.items()):
             if pooled is doc:
                 del _NATIVE_DOC_POOL[key]

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1190,11 +1190,10 @@ def skip_windows_leftover_hidden_load(reason: str) -> None:
     GHA 34646877587: first leftover Hidden ``_wa_notebook`` + close
     returned; the next Hidden ``_wa_notebook`` hung 30s. Unique leftover
     names (``_wa_notebook_2``, ``_wa_factory_N``) are the same stacking
-    family as leftover ``_wa_scalc`` / ``_wa_factory_5``. GHA 34648929578:
-    Hidden ``Budget_read.ods`` raised ``Could not create system bitmap!``;
-    the next sibling Hidden open hung 30s. GHA 34649699848: slash
-    ``dlg.createPeer`` hung 30s. Cached leftover count only — do not
-    enum. Do not close leftover paste Writers (34556185752).
+    family as leftover ``_wa_scalc`` / ``_wa_factory_5``. Import-filter
+    detect uses this; do **not** skip ``document_research_uno`` Hidden
+    ``Budget_read.ods`` (34643210006 was 3/3). Cached leftover count
+    only — do not enum. Do not close leftover paste Writers (34556185752).
     """
     if not windows_leftover_hidden_load_unsafe():
         return

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1156,13 +1156,62 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
 # after leftover Writers — consecutive Hidden _blank hung detect
 # (GHA 34619751330) the same way as leftover swriter (34597506651).
 _WINDOWS_NOTEBOOK_TARGET = "_wa_notebook"
-# Consecutive leftover Hidden _wa_notebook after close hung (34646877587).
-_WINDOWS_NOTEBOOK_SEQ = 0
 
 
-def _set_windows_notebook_seq(n: int) -> None:
-    for mod in _testing_utils_holders():
-        mod._WINDOWS_NOTEBOOK_SEQ = int(n)
+def note_windows_html_paste_leftover() -> None:
+    """Mark leftover_open after ``insert_cell_html_rich`` close skipped.
+
+    What was wrong: GHA 34649699848 / 34648929578 leftover paste Writers
+    (uids 26/27) existed, but the cached leftover count stayed 0 because
+    pooled Calc reuse never called ``prepare_windows_writer_factory``.
+    Later slash ``createPeer`` and Hidden ``Budget_read.ods`` then hung
+    or bitmap-failed without the skip path seeing leftovers.
+
+    How: the paste UNO tests call this after a successful paste. Do not
+    enum ``getComponents`` (can hang after paste close, 33771766524).
+    Cached count only. Do not close leftover paste Writers (34556185752).
+    """
+    if sys.platform != "win32":
+        return
+    if _windows_leftover_open() <= 0:
+        _set_windows_leftover_open(1)
+    from plugin.testing_runner import _progress
+
+    _progress(
+        "html_paste_writer: noted leftover_open=%s" % _windows_leftover_open()
+    )
+
+
+def skip_windows_leftover_hidden_load(reason: str) -> None:
+    """Skip leftover-poisoned Hidden loads and AWT peers on Windows.
+
+    GHA 34646877587: first leftover Hidden ``_wa_notebook`` + close
+    returned; the next Hidden ``_wa_notebook`` hung 30s. Unique leftover
+    names (``_wa_notebook_2``, ``_wa_factory_N``) are the same stacking
+    family as leftover ``_wa_scalc`` / ``_wa_factory_5``. GHA 34648929578:
+    Hidden ``Budget_read.ods`` raised ``Could not create system bitmap!``;
+    the next sibling Hidden open hung 30s. GHA 34649699848: slash
+    ``dlg.createPeer`` hung 30s. Cached leftover count only — do not
+    enum. Do not close leftover paste Writers (34556185752).
+    """
+    if not windows_leftover_hidden_load_unsafe():
+        return
+    import unittest
+
+    from plugin.testing_runner import _progress
+
+    _progress(
+        "windows leftover skip: %s leftovers=%s" % (reason, _windows_leftover_open())
+    )
+    raise unittest.SkipTest(
+        "Windows leftover Hidden/AWT skip (%s, leftovers=%s)"
+        % (reason, _windows_leftover_open())
+    )
+
+
+def windows_leftover_hidden_load_unsafe() -> bool:
+    """True when a leftover Hidden load or AWT ``createPeer`` would hang."""
+    return sys.platform == "win32" and _windows_leftover_open() > 0
 
 
 # Notebook-runner host while leftover HTML-paste Writers stay open.
@@ -1203,28 +1252,15 @@ def windows_notebook_load_args() -> tuple[str, int]:
 
     GHA 34646877587: first Hidden ``_wa_notebook`` load+close notebook
     leftover uid=41 returned; the next Hidden ``_wa_notebook`` hung 30s
-    (paste leftovers still open=3). Sharing a just-closed CREATE|GLOBAL
-    name is the leftover unique-factory stacking family. Do not close
-    leftover notebook docs (same skip as paste Writers). Each leftover
-    Hidden .ipynb load uses a new name (``_wa_notebook``, then
-    ``_wa_notebook_2``). First-use of ``_wa_notebook`` succeeded.
+    (paste leftovers still open=3). Unique leftover ``_wa_notebook_2``
+    is the same stacking family as leftover ``_wa_factory_N``. Do not
+    close leftover notebook docs (same skip as paste Writers). The
+    first leftover Hidden .ipynb load may run; the detect reload
+    ``skip_windows_leftover_hidden_load``s instead of a second load.
     """
     if sys.platform != "win32":
         return "_blank", 0
-    n = int(_WINDOWS_NOTEBOOK_SEQ or 0)
-    here = sys.modules.get(__name__)
-    for mod in _testing_utils_holders():
-        if mod is here:
-            continue
-        other = int(getattr(mod, "_WINDOWS_NOTEBOOK_SEQ", 0) or 0)
-        if other > n:
-            n = other
-    n += 1
-    for mod in _testing_utils_holders():
-        mod._WINDOWS_NOTEBOOK_SEQ = n
-    if n == 1:
-        return _WINDOWS_NOTEBOOK_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
-    return "%s_%s" % (_WINDOWS_NOTEBOOK_TARGET, n), _WINDOWS_FACTORY_SEARCH_FLAGS
+    return _WINDOWS_NOTEBOOK_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
 
 
 def _reraise_native_open_failure(

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1050,12 +1050,20 @@ def _windows_leftover_open() -> int:
 
 
 def _windows_should_reuse_writer(ctx) -> bool:
-    """True when a later Windows Writer factory would hang after leftovers.
+    """True when a later Windows Writer factory would hang.
 
     GHA 34601787293 / 34602219973: unique ``_wa_factory_N`` loaded three
     leftover Calc factories and the first leftover swriter (uid=34).
     ``close_doc`` of that Writer returned; the next unique swriter hung
     30s. Reuse the first leftover Writer instead of close + factory.
+
+    GHA 34652644656 (paste suites deferred): leftover_open=0,
+    ``document_research_uno`` 3/3 and slash OK, then first text_helpers
+    Hidden ``_blank`` + ``close_doc`` uid=29 returned; the next Hidden
+    ``_blank`` hung 30s. Consecutive Hidden ``_blank`` swriter is unsafe
+    even without paste leftovers (34597506651 with leftovers). Reuse
+    the first Windows Writer. Notebook suites still use
+    ``_wa_notebook_host``.
     """
     if ctx is None or sys.platform != "win32":
         return False
@@ -1063,7 +1071,7 @@ def _windows_should_reuse_writer(ctx) -> bool:
     # Writers (GHA 34643210006: leftover reuse + global listener counts).
     if _windows_notebook_host():
         return False
-    return prepare_windows_writer_factory(ctx) > 0
+    return True
 
 
 def _windows_should_reuse_calc(ctx) -> bool:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#732’s notebook leftover-skip does **not** poison `_wa_doc_research`.

## Windows [34652644656](https://github.com/KeithCu/writeragent/actions/runs/34652644656) (`3d39d9f2`)

Deferring leftover-creating paste suites worked:

- slash `TEST end … OK`
- `document_research_uno` **3/3 OK** (`copied budget for hidden open`, `open_document_for_read done err=-`, leftovers still 0)

Then `doc.test_text_helpers_uno`: first Hidden `_blank` + `close_doc` uid=29 leftovers=0 returned; the next Hidden `_blank` (`…_multi_para_joins_with_newline`) hung 30s. Consecutive Hidden `_blank` swriter is unsafe even without paste leftovers (same family as 34597506651). Leftover Writer reuse used to hide this when paste ran first.

## Harness (`f35d95f4`)

- Windows `_native_suite_sort_key` still defers `test_formulas_uno` / `test_rich_html_uno` until after slash, `document_research_uno` 3/3, and import-filter. Do **not** skip Hidden `Budget_read.ods`.
- `_windows_should_reuse_writer` reuses the first Windows Writer without requiring leftover_open>0 (notebook host still isolated).
- Import-filter detect skips a second Hidden `.ipynb` only if leftovers are already open. `close_doc` still skips leftover notebook docs and leftover paste Writers.

Not a product API change. This cloud agent cannot run `windows-latest`.

Please kick `workflow_dispatch` of PR CI: `os=windows-latest`, `ci_debug=true`. Look for `document_research_uno` three `TEST end … OK` **before** `html_paste_writer: noted leftover_open`, slash OK, `native_doc: leftover writer reuse` on the second text_helpers (no second Hidden `_blank`), no 30s Timeout on `…_multi_para_joins_with_newline` / `detect_without_filtername`.

Pushed `f35d95f4`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-718f1b82-e214-4ec8-81e6-c73e1dfe3ad8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-718f1b82-e214-4ec8-81e6-c73e1dfe3ad8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

