### PR TITLE
Harness: Calc fill-down matches production formula_fill

### DIFF
--- a/docs/eval/eval-dev-plan.md
+++ b/docs/eval/eval-dev-plan.md
@@ -114,6 +114,9 @@ Source plan: [`oss-20b-eval.md`](oss-20b-eval.md). Scores:
   without loosening wrong-row, wrong-factor, or Price-column junk.
 - `write_formula_range` fails loud when a JSON leaf count does not match
   the A1 cell count (string `CalcWorld` too).
+- String `CalcWorld` fill-down of one formula into a 1-D range uses
+  `formula_fill.expand_single_formula` (production); JSON arrays stay
+  pinned. Snapshot `formulas` stores the per-cell expanded text.
 - Ranking catalog: `z-ai/glm-5.3-flash` only.
 
 #### What shipped

--- a/docs/eval/string-harness-upgrade.md
+++ b/docs/eval/string-harness-upgrade.md
@@ -137,6 +137,13 @@ No formula evaluator. Tax column can still write `0.8` as a value.
 `=PY("result = …"; A1:H500)` is stored as formula text at dest; process
 oracles parse dest vs DataRange.
 
+A single formula string into a **1-D** range fill-down/across-adjusts
+relative A1 refs via [`formula_fill.expand_single_formula`](../../plugin/calc/formula_fill.py)
+(same as production `write_formula_range`). A JSON array of formula
+strings stays exact per-cell (pin). 2-D + one formula, or an import
+failure, falls back to the honest pin. Snapshot `formulas` stores the
+**per-cell** text, not the original pin source on every address.
+
 `sort_range` is production-shaped: one 0-based column, stable,
 non-numeric last (tie-break = two calls). `get_sheet_summary` returns
 the full grid. Snapshot JSON grows `formulas` / `writes` without

--- a/scripts/prompt_optimization/eval_worlds.py
+++ b/scripts/prompt_optimization/eval_worlds.py
@@ -976,7 +976,25 @@ class CalcWorld:
                 cells.append((row_i, col_i))
         if not cells:
             return 0
-        if len(values) == 1 and len(cells) > 1:
+        # Production write_formula_range fill-down-adjusts relative A1 refs
+        # (plugin.calc.formula_fill) when one formula string hits a 1-D range.
+        # The harness used values * n and pinned the same text on every cell,
+        # so Tip A / tax_column false-red'd a correct =B2*0.08 into C2:C5
+        # (Banana stayed =B2*0.08). JSON arrays stay exact. 2-D / import
+        # failure keeps the honest pin.
+        formula_src = raw_values if isinstance(raw_values, str) else ""
+        single = values[0] if values else None
+        is_formula = isinstance(single, str) and single.lstrip().startswith("=")
+        if len(values) == 1 and len(cells) > 1 and is_formula:
+            num_rows = r1 - r0 + 1
+            num_cols = c1 - c0 + 1
+            try:
+                from plugin.calc.formula_fill import expand_single_formula
+
+                fill = expand_single_formula(str(values[0]), num_rows, num_cols)
+            except Exception:
+                fill = values * len(cells)
+        elif len(values) == 1 and len(cells) > 1:
             fill = values * len(cells)
         else:
             fill = values
@@ -988,11 +1006,15 @@ class CalcWorld:
             row = self._grid[row_i]
             while len(row) <= max_col:
                 row.append("")
-        formula_src = raw_values if isinstance(raw_values, str) else ""
         for (row_i, col_i), val in zip(cells, fill):
             self._grid[row_i][col_i] = val
             addr = col_row_to_a1(col_i, row_i)
-            if formula_src.lstrip().startswith("="):
+            # Prefer the per-cell fill (adjusted or exact array entry), not
+            # the original pin source on every addr.
+            cell_txt = val if isinstance(val, str) else ""
+            if cell_txt.lstrip().startswith("="):
+                self.formulas[addr] = cell_txt
+            elif formula_src.lstrip().startswith("="):
                 self.formulas[addr] = formula_src
         if self._grid:
             self._headers = [str(c) if c is not None else "" for c in self._grid[0]]

--- a/tests/scripts/test_eval_worlds.py
+++ b/tests/scripts/test_eval_worlds.py
@@ -116,6 +116,34 @@ def test_calc_write_formula_range_accepts_scalar_fill() -> None:
     assert res["written"] == 4
 
 
+def test_calc_single_formula_fill_down_adjusts_relative_refs() -> None:
+    """One formula string into a 1-D Tax column matches production fill-down."""
+    calc = CalcWorld("Item\tPrice\nApple\t10\nBanana\t5\nOrange\t8\nPear\t12.5")
+    res = calc.write_formula_range(range=["C2:C5"], values="=B2*0.08")
+    assert res["status"] == "ok"
+    assert res["written"] == 4
+    assert calc.formulas["C2"] == "=B2*0.08"
+    assert calc.formulas["C3"] == "=B3*0.08"
+    assert calc.formulas["C4"] == "=B4*0.08"
+    assert calc.formulas["C5"] == "=B5*0.08"
+    assert calc._grid[2][2] == "=B3*0.08"
+    assert calc._grid[3][2] == "=B4*0.08"
+
+
+def test_calc_json_array_of_identical_formulas_stays_pinned() -> None:
+    """JSON array is exact per-cell; repeating =B2*0.08 still pins every row."""
+    calc = CalcWorld("Item\tPrice\nApple\t10\nBanana\t5\nOrange\t8\nPear\t12.5")
+    pinned = '["=B2*0.08","=B2*0.08","=B2*0.08","=B2*0.08"]'
+    res = calc.write_formula_range(range=["C2:C5"], values=pinned)
+    assert res["status"] == "ok"
+    assert res["written"] == 4
+    assert calc.formulas["C2"] == "=B2*0.08"
+    assert calc.formulas["C3"] == "=B2*0.08"
+    assert calc.formulas["C4"] == "=B2*0.08"
+    assert calc.formulas["C5"] == "=B2*0.08"
+    assert calc._grid[2][2] == "=B2*0.08"
+
+
 def test_sheet_summary_includes_all_rows() -> None:
     calc = CalcWorld("Item\tPrice\nApple\t10\nBanana\t5\nOrange\t8\nPear\t12.5\nNote\tn/a\nTotal\t?")
     summary = calc.get_sheet_summary()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
String-harness `CalcWorld._write_a1_range` treated a single formula string into a multi-cell 1-D range as `values * n` and stored the **same** formula text on every cell (e.g. `=B2*0.08` pinned on Banana/Orange/Pear).

Production LibreOffice / `plugin.calc.formula_fill.expand_single_formula` fill-down-adjusts relative A1 refs. That mismatch made Tip A / `tax_column` **false-red**: models that correctly passed one formula string still failed `Banana Tax is not a relative 8% formula`.

This PR does **not** change Tip A/B product tool descriptions, oracles, or MIPRO prompts. Production behavior was already correct.

## Change

When `len(values)==1` and `len(cells)>1` and the value is a formula (`=` prefix):

- Use `plugin.calc.formula_fill.expand_single_formula` with the range’s `num_rows` / `num_cols`.
- On failure (2-D single formula / import): fall back to legacy `values * n` (honest pin).
- Non-formula single-string fills keep the legacy broadcast.
- Snapshot `formulas[addr]` stores the **per-cell** expanded string, not the original pin source on every address.
- JSON arrays of identical `=B2*0.08` stay exact per-cell (pin path unchanged).

## Tests

`tests/scripts/test_eval_worlds.py`:

- Single `=B2*0.08` into `C2:C5` → Banana/Orange/Pear get `=B3*0.08`, `=B4*0.08`, `=B5*0.08`.
- JSON array of identical `=B2*0.08` still pins every row.

Unchanged `oracle_tax_column` now **passes** a single-string fill-down write and still **fails** a JSON pin of `=B2*0.08` on Banana (same message as before). Local: 128 targeted pytest passed; `make typecheck` clean.

Docs: `docs/eval/string-harness-upgrade.md`, `docs/eval/eval-dev-plan.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdb28db2-f4a2-4f78-bf36-87f77e930028?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdb28db2-f4a2-4f78-bf36-87f77e930028&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

