### PR TITLE
Harness: leftover Draw/Impress reuse one CREATE|GLOBAL name

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -206,8 +206,9 @@ on `loadComponentFromURL(scalc)`) and the next Calc `_blank` hung 30s
 in `create_native_doc`. Calc `_blank` + leftovers is not reliable.
 With leftovers open, leftover Hidden `swriter` reuses one CREATE|GLOBAL
 name `_wa_factory` (same pattern as `rich_html._wa_calc_html`). Leftover
-Draw/Impress still use a unique `_wa_factory_N`. Leftover Calc later
-moved to `_wa_scalc` (34633295036). Do not close leftovers (34556185752).
+Calc later moved to `_wa_scalc` (34633295036). Leftover Draw/Impress
+later moved to `_wa_sdraw` / `_wa_simpress` (34657826349). Do not close
+leftovers (34556185752).
 
 GHA 34601787293 (`fc34f0c6`) and 34602219973 (`ec40ed29`): Linux PR CI
 34602130908 green. Unique targets loaded leftover Calc
@@ -331,7 +332,8 @@ The pooled `@with_native_doc` Calc is still the leftover_open=0
 it. Leftover `scalc` now reuses one CREATE|GLOBAL name `_wa_scalc`.
 `document_research_uno` writes Budget/Report via that pooled Calc
 (`store budget via active`) and does **not** open a second factory
-Calc. Draw/Impress stay unique `_wa_factory_N`.
+Calc. Leftover Draw/Impress later moved to `_wa_sdraw` /
+`_wa_simpress` (34657826349).
 
 GHA 34636251918 (this branch, after store-via-active):
 `test_list_nearby_excludes_active` OK. `open_document_for_read` of
@@ -408,6 +410,23 @@ After a Windows bitmap, later Hidden sibling opens
 `skip_windows_hidden_open_after_bitmap` — do not hang. Still attempt
 the first Hidden-open. Not a product change.
 
+GHA 34657826349 / 34657808315 (master `0bf7d223`, tip of #734):
+#734's Hidden-open skip is not that hang. `document_research_uno`
+3/3 and both text_helpers tests OK. Leftover Draw/Impress unique
+`_wa_factory_1`–`_wa_factory_9` succeeded at leftover_open=1
+(uid=29 leftover Writer). Notebook / importer suites then skipped
+Writer close (`leftover_open` 1→15, `close_doc: skip writer close`).
+Stable leftover `swriter` `target=_wa_factory` at leftover_open=15
+returned (`scripting.test_document_scripts_uno`). Unique leftover
+`simpress` `target=_wa_factory_10` then hung 30s in
+`create_native_doc` (`test_lo_import_minimal_pptx_multi_slide`;
+office still `4072,8924`). Same stacking family as leftover
+swriter `_wa_factory_5` (34602219973) and leftover scalc
+`_wa_factory_2` (34633295036). Leftover `sdraw` / `simpress` now
+reuse one CREATE|GLOBAL name each (`_wa_sdraw` / `_wa_simpress`).
+Do not close leftover paste / notebook Writers (34556185752 /
+34646877587). Not a product change.
+
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
 `html_paste_writer: leftovers open` with a real `keeper=` uid (not
@@ -415,7 +434,8 @@ branch: `os=windows-latest`, `ci_debug=true`. Look for
 Windows `private:factory/` loads (Writer **and** Calc), leftover
 swriter loads using `target=_wa_factory` (not `_blank` / not
 `_wa_factory_N`) plus leftover Calc using `target=_wa_scalc` (not
-`_blank` / not `_wa_factory_N`),
+`_blank` / not `_wa_factory_N`) plus leftover Draw/Impress using
+`target=_wa_sdraw` / `target=_wa_simpress` (not `_wa_factory_N`),
 `document_research_uno: store budget via active start/done` (no
 `create budget calc` / no leftover `scalc` `target=_wa_factory_1`),
 `copied budget for hidden open` then `open_document_for_read done err=-`
@@ -440,7 +460,11 @@ for both notebook import-filter tests when leftovers are not yet
 open, `close_doc: skip writer close` or `close_doc: start` (not raw
 `doc.close(True)`), both `notebook.test_import_filter_uno` tests
 `TEST end … OK` or detect `TEST end … SKIP` if leftovers already
-exist (no 30s Timeout on `detect_without_filtername`), **then**
+exist (no 30s Timeout on `detect_without_filtername`), leftover
+`simpress` after notebook leftovers using `target=_wa_simpress`
+(not `_wa_factory_10`) then
+`TEST end uno.test_ppt_master_pptx_import_uno.test_lo_import_minimal_pptx_multi_slide OK`
+(no 30s Timeout in `create_native_doc` on leftover Impress), **then**
 `html_paste_writer: noted leftover_open=1` from deferred formulas /
 rich_html, **then**
 `TEST end draw.test_draw_uno.test_insert_math_draw OK` after

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -419,7 +419,7 @@ def test_prepare_windows_writer_factory_adopts_keeper_from_sibling(monkeypatch):
 
 
 def test_windows_factory_load_args_named_for_any_leftover_factory():
-    """GHA 34633295036: leftover swriter/_wa_factory; leftover scalc/_wa_scalc."""
+    """GHA 34633295036 / 34657826349: leftover Writer/Calc/Draw/Impress names."""
     import plugin.tests.testing_utils as tu
 
     saved = tu._WINDOWS_FACTORY_SEQ
@@ -427,6 +427,8 @@ def test_windows_factory_load_args_named_for_any_leftover_factory():
     try:
         assert tu._windows_factory_load_args("private:factory/swriter", 0) == ("_blank", 0)
         assert tu._windows_factory_load_args("private:factory/scalc", 0) == ("_blank", 0)
+        assert tu._windows_factory_load_args("private:factory/sdraw", 0) == ("_blank", 0)
+        assert tu._windows_factory_load_args("private:factory/simpress", 0) == ("_blank", 0)
         assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
             "_wa_factory",
             8 | 55,
@@ -438,25 +440,49 @@ def test_windows_factory_load_args_named_for_any_leftover_factory():
             8 | 55,
         )
         # GHA 34633295036: unique leftover scalc _wa_factory_1 failed,
-        # _wa_factory_2 hung 30s. Stable _wa_scalc; Draw stays unique.
+        # _wa_factory_2 hung 30s. Stable _wa_scalc.
         assert tu._windows_factory_load_args("private:factory/scalc", 2) == (
             "_wa_scalc",
             8 | 55,
         )
+        # GHA 34657826349: unique leftover simpress _wa_factory_10 hung
+        # 30s at leftover_open=15. Stable leftover Draw / leftover
+        # Impress names; consecutive leftover loads reuse the same name.
         assert tu._windows_factory_load_args("private:factory/sdraw", 2) == (
-            "_wa_factory_1",
+            "_wa_sdraw",
+            8 | 55,
+        )
+        assert tu._windows_factory_load_args("private:factory/simpress", 2) == (
+            "_wa_simpress",
             8 | 55,
         )
         assert tu._windows_factory_load_args("private:factory/scalc", 2) == (
             "_wa_scalc",
             8 | 55,
         )
-        # Writer reuse must not consume the Draw seq.
+        # Writer / Draw / Impress reuse must not consume the leftover
+        # seq (unknown leftover factory URLs only).
         assert tu._windows_factory_load_args("private:factory/swriter", 2) == (
             "_wa_factory",
             8 | 55,
         )
         assert tu._windows_factory_load_args("private:factory/sdraw", 2) == (
+            "_wa_sdraw",
+            8 | 55,
+        )
+        assert tu._windows_factory_load_args("private:factory/simpress", 2) == (
+            "_wa_simpress",
+            8 | 55,
+        )
+        assert tu._windows_factory_load_args("private:factory/smath", 2) == (
+            "_wa_factory_1",
+            8 | 55,
+        )
+        assert tu._windows_factory_load_args("private:factory/sdraw", 2) == (
+            "_wa_sdraw",
+            8 | 55,
+        )
+        assert tu._windows_factory_load_args("private:factory/smath", 2) == (
             "_wa_factory_2",
             8 | 55,
         )
@@ -519,8 +545,8 @@ def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
 
     Unique _wa_factory_1 failed (~766ms traceback wrap); _wa_factory_2
     hung 30s. Consecutive leftover Hidden create_native_doc(calc) must
-    reuse one CREATE|GLOBAL name. Writer reuse uses _wa_factory and
-    must not steal the Draw seq.
+    reuse one CREATE|GLOBAL name. Writer reuse uses _wa_factory.
+    Leftover Draw reuses _wa_sdraw (GHA 34657826349).
     """
     from unittest.mock import MagicMock, patch
 
@@ -567,7 +593,68 @@ def test_create_native_doc_windows_calc_prepares_factory(monkeypatch):
             TestingFactory.create_native_doc(object(), "draw")
             args = desktop.loadComponentFromURL.call_args.args
             assert args[0] == "private:factory/sdraw"
-            assert args[1] == "_wa_factory_1"
+            assert args[1] == "_wa_sdraw"
+            assert args[2] == (8 | 55)
+    finally:
+        tu._WINDOWS_FACTORY_SEQ = saved_seq
+
+
+def test_create_native_doc_windows_impress_reuses_stable_name(monkeypatch):
+    """GHA 34657826349: leftover unique simpress _wa_factory_10 hung 30s.
+
+    leftover_open climbed to 15 after notebook/importer skipped Writer
+    close. Stable leftover swriter _wa_factory at leftover_open=15
+    returned; unique leftover simpress _wa_factory_10 hung in
+    loadComponentFromURL. Consecutive leftover Hidden
+    create_native_doc(impress) must reuse one CREATE|GLOBAL name.
+    Draw reuse uses _wa_sdraw and must not steal leftover Impress.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    desktop = MagicMock()
+    desktop.loadComponentFromURL.return_value = MagicMock()
+    calls = []
+    saved_seq = tu._WINDOWS_FACTORY_SEQ
+    tu._WINDOWS_FACTORY_SEQ = 0
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    monkeypatch.setattr(
+        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 15
+    )
+    try:
+        with (
+            patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+            patch("uno.createUnoStruct", return_value=MagicMock()),
+            patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
+        ):
+            TestingFactory.create_native_doc(object(), "impress")
+            assert calls == ["prepare"]
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/simpress"
+            assert args[1] == "_wa_simpress"
+            assert args[2] == (8 | 55)
+            TestingFactory.create_native_doc(object(), "impress")
+            assert calls == ["prepare", "prepare"]
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/simpress"
+            assert args[1] == "_wa_simpress"
+            assert args[2] == (8 | 55)
+            TestingFactory.create_native_doc(object(), "draw")
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/sdraw"
+            assert args[1] == "_wa_sdraw"
+            assert args[2] == (8 | 55)
+            TestingFactory.create_native_doc(object(), "impress")
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/simpress"
+            assert args[1] == "_wa_simpress"
+            assert args[2] == (8 | 55)
+            TestingFactory.create_native_doc(object(), "writer")
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/swriter"
+            assert args[1] == "_wa_factory"
             assert args[2] == (8 | 55)
     finally:
         tu._WINDOWS_FACTORY_SEQ = saved_seq

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1100,8 +1100,14 @@ _WINDOWS_FACTORY_TARGET = "_wa_factory"
 # Leftover Calc uses one CREATE|GLOBAL name. The pooled @with_native_doc
 # Calc is opened at leftover_open=0 as Hidden ``_blank`` — ``_wa_scalc``
 # does not replace it. Unique ``_wa_factory_N`` stacked after a failed
-# leftover scalc load (GHA 34633295036). Draw/Impress still increment.
+# leftover scalc load (GHA 34633295036). Leftover Draw / leftover
+# Impress use the same stable-name rule (GHA 34657826349).
 _WINDOWS_CALC_FACTORY_TARGET = "_wa_scalc"
+_WINDOWS_DRAW_FACTORY_TARGET = "_wa_sdraw"
+_WINDOWS_IMPRESS_FACTORY_TARGET = "_wa_simpress"
+# Unknown leftover factory URLs only (not sdraw / simpress). Unique
+# leftover Draw/Impress names hung after notebook leftovers
+# (GHA 34657826349, leftover_open=15, target=_wa_factory_10).
 _WINDOWS_FACTORY_SEQ = 0
 
 
@@ -1142,8 +1148,18 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
     30s — same stacking family as leftover swriter unique names.
     Pooled Calc is still the leftover_open=0 ``_blank`` workbook.
     Leftover ``scalc`` now reuses one CREATE|GLOBAL name ``_wa_scalc``.
-    Draw/Impress stay unique. Do not close leftover paste Writers
-    (34556185752).
+    Do not close leftover paste Writers (34556185752).
+
+    GHA 34657826349 / 34657808315 (master ``0bf7d223``, tip of #734):
+    leftover Draw/Impress unique ``_wa_factory_1``–``_wa_factory_9``
+    succeeded at leftover_open=1. Notebook / importer suites then
+    skipped Writer close (``leftover_open`` 1→15). Stable leftover
+    ``swriter`` ``target=_wa_factory`` at leftover_open=15 returned.
+    Unique leftover ``simpress`` ``target=_wa_factory_10`` hung 30s
+    in ``loadComponentFromURL`` — same stacking family as leftover
+    swriter ``_wa_factory_5`` and leftover scalc ``_wa_factory_2``.
+    Leftover ``sdraw`` / ``simpress`` now reuse one CREATE|GLOBAL
+    name each (``_wa_sdraw`` / ``_wa_simpress``).
     """
     global _WINDOWS_FACTORY_SEQ
     if leftover_open <= 0 or not factory_url.startswith("private:factory/"):
@@ -1156,6 +1172,10 @@ def _windows_factory_load_args(factory_url: str, leftover_open: int) -> tuple[st
         return _WINDOWS_FACTORY_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
     if factory_url == "private:factory/scalc":
         return _WINDOWS_CALC_FACTORY_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
+    if factory_url == "private:factory/sdraw":
+        return _WINDOWS_DRAW_FACTORY_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
+    if factory_url == "private:factory/simpress":
+        return _WINDOWS_IMPRESS_FACTORY_TARGET, _WINDOWS_FACTORY_SEARCH_FLAGS
     _WINDOWS_FACTORY_SEQ += 1
     return "_wa_factory_%s" % _WINDOWS_FACTORY_SEQ, _WINDOWS_FACTORY_SEARCH_FLAGS
 
@@ -2065,7 +2085,9 @@ class TestingFactory:
         # (30s). #720 only prepared swriter. Reactivate the keeper.
         # Leftover swriter reuses one CREATE|GLOBAL name (_wa_factory).
         # Leftover Calc reuses _wa_scalc (unique _wa_factory_N failed
-        # then hung, 34633295036). Draw/Impress stay unique.
+        # then hung, 34633295036). Leftover Draw / leftover Impress
+        # reuse _wa_sdraw / _wa_simpress (unique _wa_factory_10 hung
+        # at leftover_open=15, 34657826349).
         if sys.platform == "win32" and factory_url.startswith("private:factory/"):
             leftover_open = prepare_windows_writer_factory(ctx)
             target, flags = _windows_factory_load_args(factory_url, leftover_open)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Master Windows [34657826349](https://github.com/KeithCu/writeragent/actions/runs/34657826349) and twin [34657808315](https://github.com/KeithCu/writeragent/actions/runs/34657808315) (`0bf7d223`, #734) are red.

## What failed

`#734`'s Hidden-open skip is not this hang. `document_research_uno` 3/3 and both text_helpers tests OK. Leftover Draw/Impress unique `_wa_factory_1`–`_wa_factory_9` succeeded at leftover_open=1 (uid=29 leftover Writer).

Notebook / importer suites then skipped Writer close (`leftover_open` 1→15, `close_doc: skip writer close leftovers open=N`). Stable leftover `swriter` `target=_wa_factory` at leftover_open=15 returned (`scripting.test_document_scripts_uno`). Unique leftover `simpress` `target=_wa_factory_10` then hung 30s in `create_native_doc` (`test_lo_import_minimal_pptx_multi_slide`; office still `4072,8924`).

Same stacking family as leftover swriter `_wa_factory_5` (34602219973) and leftover scalc `_wa_factory_2` (34633295036). Product pptx import is not the hung call.

## Harness

- Leftover `sdraw` / `simpress` reuse one CREATE|GLOBAL name each (`_wa_sdraw` / `_wa_simpress`), same pattern as leftover `_wa_scalc`.
- POSIX and leftover_open=0 still use `_blank`.
- Do not close leftover paste / notebook Writers (34556185752 / 34646877587).
- Not a product API change. Dual-module: one `tests/testing_utils.py`.

Please kick `workflow_dispatch` of PR CI: `os=windows-latest`, `ci_debug=true`. Look for leftover Draw/Impress `target=_wa_sdraw` / `target=_wa_simpress` (not `_wa_factory_10`) then `TEST end uno.test_ppt_master_pptx_import_uno.test_lo_import_minimal_pptx_multi_slide OK` (no 30s Timeout in `create_native_doc` after notebook leftovers).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fe3d1fd-58c1-4979-b611-558379c79223?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fe3d1fd-58c1-4979-b611-558379c79223&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

