### PR TITLE
Eval-2: separate headed multi-model scoreboard

### DIFF
--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -2,7 +2,9 @@
 
 **Eval-2 is for debugging the harness.** Iterate here. Do **not** edit
 `docs/eval/gdpval/` gold trees except by **adding** a new untouched gold
-id. A multi-model benchmark comes later, when ~10 siblings exist.
+id. Headed **task × model** scoreboard (product bar + oracle, not
+string-pack Pareto): [`benchmarks.md`](benchmarks.md). Catalog-wide
+numeric sweeps still wait — empty cells mean no in-repo headed stamp.
 
 `test_gold_prompt_is_byte_copy_of_hf_tree` compares `prompt.txt` and
 `prompt.gdpval.txt` as bytes to the HF `task.json` `prompt` (LF).
@@ -10,6 +12,7 @@ id. A multi-model benchmark comes later, when ~10 siblings exist.
 not rewrite them as CRLF.
 
 Living headed autopsy (product bar + peer polarity + next experiments): [`headed-failure-autopsy.md`](headed-failure-autopsy.md).
+Scoreboard + SVG charts: [`benchmarks.md`](benchmarks.md).
 
 Each subdirectory is one experiment. **Ready** means headed helper +
 oracle exist. **Stub** means fixture notes only — not headed-ready gold.

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -1,0 +1,97 @@
+# Eval-2 headed scoreboard
+
+Headed **task × model** matrix for Ready eval-2 experiments. This is
+**not** the 17-task string harness.
+
+String-pack ranking lives in [`docs/eval/benchmarks.md`](../benchmarks.md)
+and `docs/eval/pareto-*.svg` (`hard_pass_rate`, C²/$, OpenRouter
+`--backend string`). Do **not** merge these tables or fold headed stamps
+into `scripts/prompt_optimization/benchmark_results.json`.
+
+| | String pack | Eval-2 headed |
+|---|-------------|---------------|
+| Tasks | 17 short Writer/Calc/Draw worlds | 9 Ready / Headed-ready GDPval-shaped siblings (slot 7 PARKED) |
+| Gate | Catalog sweep on OpenRouter | **`google/gemini-3.8-flash`** until HAPPY (gpt-oss is not the product gate) |
+| Pass | `hard_pass_rate` (substring + result + process oracles) | **Product bar** HAPPY / NOT_HAPPY, plus CLI **oracle** PASS / FAIL |
+| Charts | `pareto-fronts.svg` / `pareto-distance.svg` | [`eval2-heatmap.svg`](eval2-heatmap.svg), [`eval2-coverage.svg`](eval2-coverage.svg) |
+
+**HAPPY** means the deliverable did the job (Keith: product over
+oracle). A soft oracle FAIL on a HAPPY cell is a false-red or a
+secondary cite — not a product miss. **NOT_HAPPY** + oracle FAIL is
+usually an honest empty or wrong-facts deliverable. **—** means no
+in-repo headed stamp for that pair; do not invent a score.
+
+Catalog columns (GPT-OSS 20B, Grok 4.6, Muse Spark 1.3) are
+placeholders. Tasks that work on Gemini 3.8 Flash should eventually be
+run across the string catalog — that sweep has **not** happened.
+
+Living autopsy: [`headed-failure-autopsy.md`](headed-failure-autopsy.md).
+Harness index: [`README.md`](README.md).
+
+## Snapshot (2026-09-12)
+
+Seeded from the autopsy and sibling notes. Run dirs are typically
+untracked on the shared machine — `run_artifacts_committed` is false
+for every cell. No OpenRouter eval-2 CI job.
+
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-OSS 20B | Grok 4.6 | Muse Spark 1.3 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | — | — | — | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — |
+
+<img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
+
+<img src="eval2-coverage.svg" alt="Eval-2 headed coverage bars per model. Most catalog peers are entirely no data." />
+
+### Cell notes (only scored pairs)
+
+| Task | Model | Stamp | Soft note |
+|------|-------|-------|-----------|
+| Tenant Retention | Gemini 3.8 Flash | `20260908-0121-gemini-3.8-flash-r200` | Oracle false-red (titles in `text:h`, table cells, length); later softened. |
+| Cadaver Proposal | Gemini 3.8 Flash | `20260908-2246-gemini-3.8-flash-r200` | Oracle false-red (aliases, Figure/`draw:frame`, length). |
+| AFC Population | Gemini 3.8 Flash | `20260908-0030-retry2` | Oracle PASS after smoother (S=65 R=2). Autopsy abbreviates the stamp with `…`. |
+| Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
+| GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
+| Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
+| Calc-primary | GPT-OSS 120B | `20260909-0400-gpt-oss-120b` | CSV-row dump + wrong ARPU factor + phantom `headcount` sheet. |
+| Draw-primary | GPT-OSS 120B | `20260909-0411-gpt-oss-120b` | Garbled layout; missing Clearbend / failure / triage. |
+| Reverse Tenant | GPT-OSS 120B | `20260909-0414-gpt-oss-120b` | Talk-not-write; 0 cells + PreContractError. |
+| Long Writer pack | GPT-OSS 120B | `20260909-0419-gpt-oss-120b` | Invented $12.5M / wrong dates; 0 comments. |
+
+Gemini has **no** in-repo headed stamp yet for GMP, Calc-primary,
+Draw-primary, Reverse Tenant, or Long Writer. gpt-oss-120b has **no**
+in-repo stamp for Tenant, Cadaver, or AFC. Overnight slots 6/8/9/10
+were gpt-oss only.
+
+## How to refresh
+
+1. After a headed `--launch` / `--score`, add or replace **one** object
+   in [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
+   (`task_id` × `model`). Leave unknown pairs **out** of `results`.
+2. Fields: `product_bar` (`HAPPY` \| `NOT_HAPPY`), `oracle`
+   (`PASS` \| `FAIL`), optional `oracle_note` / `stamp` / `source` /
+   `patches`. Schema:
+   [`eval2_benchmark_results.schema.json`](eval2_benchmark_results.schema.json).
+3. `task_id` must match `scripts/eval_2_headed.py --task` (`afc`,
+   `tenant-retention`, …). Slot 7 stays omitted.
+4. Redraw charts (no API key):
+
+   ```bash
+   .venv/bin/python scripts/plot_eval2_leaderboard.py
+   .venv/bin/python scripts/plot_eval2_leaderboard.py --print-matrix
+   ```
+
+5. Paste the printed matrix into the snapshot table above if the
+   cells changed. Update `updated` in the JSON. Do **not** copy rows
+   into the string-pack leaderboard.
+
+`--check` validates the JSON only. The plot script refuses
+`benchmark_results.json` so a wrong `--in` cannot overwrite Pareto
+charts.

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="716" height="414" viewBox="0 0 716 414" role="img">
+  <title>Eval-2 headed coverage by model</title>
+  <rect width="716" height="414" fill="#ffffff"/>
+  <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
+  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
+  <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="56.0" y="150.7" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <rect x="56.0" y="64.0" width="88" height="86.7" fill="#009E73" stroke="#dadce0" data-segment="HAPPY"/>
+  <text x="100.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash</text>
+  <text x="100.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">3 HAPPY / 4 scored</text>
+  <rect x="180.0" y="237.3" width="88" height="86.7" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="180.0" y="92.9" width="88" height="144.4" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <rect x="180.0" y="64.0" width="88" height="28.9" fill="#009E73" stroke="#dadce0" data-segment="HAPPY"/>
+  <text x="224.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 120B</text>
+  <text x="224.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1 HAPPY / 6 scored</text>
+  <rect x="304.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="348.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
+  <text x="348.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="428.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="472.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="472.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="552.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="596.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="596.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
+  <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
+  <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>
+  <text x="152" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">NOT_HAPPY</text>
+  <rect x="244" y="376" width="12" height="12" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="262" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">no data</text>
+</svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1008" height="714" viewBox="0 0 1008 714" role="img">
+  <title>Eval-2 headed task × model heatmap</title>
+  <rect width="1008" height="714" fill="#ffffff"/>
+  <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
+  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
+  <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
+  <text x="309.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemini-3.8-flash</text>
+  <text x="459.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 120B</text>
+  <text x="459.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-oss-120b</text>
+  <text x="609.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
+  <text x="609.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-oss-20b</text>
+  <text x="759.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="759.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
+  <text x="909.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="909.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
+  <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
+  <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
+  <text x="309.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">HAPPY</text>
+  <text x="309.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="388.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="459.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="459.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="538.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
+  <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
+  <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
+  <text x="309.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">HAPPY</text>
+  <text x="309.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="388.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="459.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="459.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="538.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
+  <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
+  <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
+  <text x="309.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">HAPPY</text>
+  <text x="309.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle PASS</text>
+  <rect x="388.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="459.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="459.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="538.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
+  <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
+  <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="309.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="309.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="388.0" y="308.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
+  <text x="459.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">HAPPY</text>
+  <text x="459.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="538.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
+  <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
+  <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="309.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="309.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="388.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="459.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="459.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="538.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
+  <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
+  <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="309.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="309.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="388.0" y="424.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="459.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="459.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="538.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
+  <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
+  <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="309.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="309.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="388.0" y="482.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="459.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="459.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="538.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
+  <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
+  <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="309.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="309.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="388.0" y="540.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="459.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="459.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="538.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
+  <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
+  <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="309.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="309.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="388.0" y="598.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="459.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="459.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="538.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="609.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="609.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="759.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="759.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="909.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="909.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Source: headed eval-2 autopsy notes, not a catalog sweep. Empty = no in-repo stamp. Metrics are product HAPPY / oracle PASS|FAIL (not string-harness hard_pass_rate).</text>
+</svg>

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -1,0 +1,227 @@
+{
+  "schema_version": 1,
+  "updated": "2026-09-12",
+  "gate_model": "google/gemini-3.8-flash",
+  "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
+  "notes": "Seeded only from in-repo autopsy / sibling notes. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "tasks": [
+    {
+      "id": "tenant-retention",
+      "slot": 1,
+      "slug": "tenant-retention-ed2bc14c",
+      "title": "Tenant Retention",
+      "status": "Ready"
+    },
+    {
+      "id": "cadaver-proposal",
+      "slot": 2,
+      "slug": "cadaver-proposal-61b0946a",
+      "title": "Cadaver Proposal",
+      "status": "Ready"
+    },
+    {
+      "id": "afc",
+      "slot": 3,
+      "slug": "afc-sample-83d10b06",
+      "title": "AFC Population",
+      "status": "Ready"
+    },
+    {
+      "id": "gmp-change-control",
+      "slot": 4,
+      "slug": "gmp-change-control-58ac1cc5",
+      "title": "GMP Change Control",
+      "status": "Ready"
+    },
+    {
+      "id": "writer-calc-peer-write",
+      "slot": 5,
+      "slug": "writer-calc-peer-write",
+      "title": "Floorstand Writer→Calc",
+      "status": "Ready"
+    },
+    {
+      "id": "calc-primary-model",
+      "slot": 6,
+      "slug": "calc-primary-model",
+      "title": "Calc-primary model",
+      "status": "Ready"
+    },
+    {
+      "id": "draw-primary",
+      "slot": 8,
+      "slug": "draw-primary-deliverable",
+      "title": "Draw-primary",
+      "status": "Ready"
+    },
+    {
+      "id": "reverse-tenant",
+      "slot": 9,
+      "slug": "reverse-tenant",
+      "title": "Reverse Tenant",
+      "status": "Ready"
+    },
+    {
+      "id": "long-writer-pack",
+      "slot": 10,
+      "slug": "long-writer-pack",
+      "title": "Long Writer pack",
+      "status": "Headed-ready"
+    }
+  ],
+  "models": [
+    {
+      "openrouter_id": "google/gemini-3.8-flash",
+      "display_name": "Gemini 3.8 Flash",
+      "role": "gate"
+    },
+    {
+      "openrouter_id": "openai/gpt-oss-120b",
+      "display_name": "GPT-OSS 120B",
+      "role": "headed"
+    },
+    {
+      "openrouter_id": "openai/gpt-oss-20b",
+      "display_name": "GPT-OSS 20B",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "x-ai/grok-4.6",
+      "display_name": "Grok 4.6",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "meta/muse-spark-1.3-contributor",
+      "display_name": "Muse Spark 1.3",
+      "role": "catalog"
+    }
+  ],
+  "results": [
+    {
+      "task_id": "tenant-retention",
+      "model": "google/gemini-3.8-flash",
+      "product_bar": "HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "False-red (titles in text:h, table cells, length); later softened. Product bar HAPPY.",
+      "stamp": "20260908-0121-gemini-3.8-flash-r200",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §1; docs/eval/eval-2/tenant-retention-ed2bc14c/notes.md",
+      "run_artifacts_committed": false,
+      "patches": null
+    },
+    {
+      "task_id": "cadaver-proposal",
+      "model": "google/gemini-3.8-flash",
+      "product_bar": "HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "False-red (aliases, Figure/draw:frame, length); soften PR. Product bar HAPPY.",
+      "stamp": "20260908-2246-gemini-3.8-flash-r200",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §1; docs/eval/eval-2/cadaver-proposal-61b0946a/notes.md",
+      "run_artifacts_committed": false,
+      "patches": null
+    },
+    {
+      "task_id": "afc",
+      "model": "google/gemini-3.8-flash",
+      "product_bar": "HAPPY",
+      "oracle": "PASS",
+      "oracle_note": "Sample+SSC after smoother (S=65 R=2). Earlier thrash was fixture/prompt key mismatch.",
+      "stamp": "20260908-0030-retry2",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §1; docs/eval/eval-2/afc-sample-83d10b06/SMOOTHER_CHANGES.md",
+      "run_artifacts_committed": false,
+      "patches": null
+    },
+    {
+      "task_id": "writer-calc-peer-write",
+      "model": "google/gemini-3.8-flash",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Polarity HIT (fill/write asks) but empty Cost Comparison (titles only) + 0-word email + stall >3 min. Honest empty FAIL.",
+      "stamp": "20260909-1748-gemini-3.8-flash-private-patch",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §2.4",
+      "run_artifacts_committed": false,
+      "patches": "Private PEER_INNER polarity sentence + write_formula_range teaching; not PR'd (.bak-scrolly-*)."
+    },
+    {
+      "task_id": "gmp-change-control",
+      "model": "openai/gpt-oss-120b",
+      "product_bar": "HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "0225 cite-only fail (memo does not cite filled form) — secondary vs headed HAPPY.",
+      "stamp": "20260909-0225-gpt-oss-120b",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §2.1",
+      "run_artifacts_committed": false,
+      "patches": "Local str_bounded peer-task truncate (not yet the cloud PR).",
+      "prior_stamps": [
+        {
+          "stamp": "20260909-0103-gpt-oss-120b",
+          "product_bar": "NOT_HAPPY",
+          "oracle": "FAIL",
+          "note": "Dump/research polarity; filled_fields=0."
+        }
+      ]
+    },
+    {
+      "task_id": "writer-calc-peer-write",
+      "model": "openai/gpt-oss-120b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Extract/JSON polarity MISS; nonempty_cells=2; blank email; LO crash after peer. Honest empty FAIL.",
+      "stamp": "20260909-0323-gpt-oss-120b",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §2.2",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "prior_stamps": [
+        {
+          "stamp": "20260909-1733-gpt-oss-120b-private-patch",
+          "product_bar": "NOT_HAPPY",
+          "oracle": "FAIL",
+          "note": "Private patches did not flip gpt-oss polarity; still extract/JSON."
+        }
+      ]
+    },
+    {
+      "task_id": "calc-primary-model",
+      "model": "openai/gpt-oss-120b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "CSV-row dump into col A + wrong ARPU factor + #NAME? invented headcount sheet; Regions A–G sparse.",
+      "stamp": "20260909-0400-gpt-oss-120b",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §5.6",
+      "run_artifacts_committed": false,
+      "patches": null
+    },
+    {
+      "task_id": "draw-primary",
+      "model": "openai/gpt-oss-120b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Non-empty map but garbled layout; missing Clearbend / failure / triage labels.",
+      "stamp": "20260909-0411-gpt-oss-120b",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §5.8",
+      "run_artifacts_committed": false,
+      "patches": null
+    },
+    {
+      "task_id": "reverse-tenant",
+      "model": "openai/gpt-oss-120b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Talk-not-write: blank Sheet1 (0 cells) + PreContractError; Sheet2/3 only in chat.",
+      "stamp": "20260909-0414-gpt-oss-120b",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §5.9",
+      "run_artifacts_committed": false,
+      "patches": null
+    },
+    {
+      "task_id": "long-writer-pack",
+      "model": "openai/gpt-oss-120b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "TOC+headings OK; invented $12.5M / wrong dates; 0 review comments.",
+      "stamp": "20260909-0419-gpt-oss-120b",
+      "source": "docs/eval/eval-2/headed-failure-autopsy.md §5.10",
+      "run_artifacts_committed": false,
+      "patches": null
+    }
+  ]
+}

--- a/docs/eval/eval-2/eval2_benchmark_results.schema.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KeithCu/writeragent/docs/eval/eval-2/eval2_benchmark_results.schema.json",
+  "title": "Eval-2 headed multi-model results",
+  "description": "Task × model cells for headed eval-2 experiments. Metrics are product_bar (HAPPY / NOT_HAPPY) and oracle (PASS / FAIL). This is not the 17-task string-harness hard_pass_rate schema. Omit a cell or set product_bar and oracle to null when no in-repo headed stamp exists — never invent scores.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "updated",
+    "gate_model",
+    "source_of_truth",
+    "tasks",
+    "models",
+    "results"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "updated": {
+      "type": "string",
+      "description": "ISO date (YYYY-MM-DD) of the last honest edit to this file."
+    },
+    "gate_model": {
+      "type": "string",
+      "description": "OpenRouter id of the headed / GDPval gate model. Keith: Gemini 3.8 Flash until HAPPY; gpt-oss is not the product gate."
+    },
+    "source_of_truth": {
+      "type": "string",
+      "description": "Repo-relative path of the living headed autopsy (or later notes) used to seed cells."
+    },
+    "notes": {
+      "type": "string"
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/task" }
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/model" }
+    },
+    "results": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/result" }
+    }
+  },
+  "$defs": {
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "slot", "slug", "title", "status"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "scripts/eval_2_headed.py --task id (not the parked letterhead stub)."
+        },
+        "slot": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "slug": {
+          "type": "string",
+          "description": "docs/eval/eval-2/<slug>/ directory name."
+        },
+        "title": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["Ready", "Headed-ready"]
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["openrouter_id", "display_name", "role"],
+      "properties": {
+        "openrouter_id": { "type": "string" },
+        "display_name": { "type": "string" },
+        "role": {
+          "type": "string",
+          "enum": ["gate", "headed", "catalog"]
+        }
+      }
+    },
+    "product_bar": {
+      "description": "Headed product/task success. HAPPY means the deliverable did the job even if a soft oracle is red.",
+      "type": ["string", "null"],
+      "enum": ["HAPPY", "NOT_HAPPY", null]
+    },
+    "oracle": {
+      "description": "CLI oracle PASS/FAIL for the saved deliverable. Fail-closed. Soft notes go in oracle_note.",
+      "type": ["string", "null"],
+      "enum": ["PASS", "FAIL", null]
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "task_id",
+        "model",
+        "product_bar",
+        "oracle"
+      ],
+      "properties": {
+        "task_id": { "type": "string" },
+        "model": { "type": "string" },
+        "product_bar": { "$ref": "#/$defs/product_bar" },
+        "oracle": { "$ref": "#/$defs/oracle" },
+        "oracle_note": { "type": "string" },
+        "stamp": {
+          "type": "string",
+          "description": "Headed runs/<stamp>/ directory name as cited in-repo (may be abbreviated with … in autopsy)."
+        },
+        "source": {
+          "type": "string",
+          "description": "Repo-relative doc citation for this cell."
+        },
+        "run_artifacts_committed": {
+          "type": "boolean",
+          "description": "True only when the stamp dir is in git. Autopsy paths are often box-local / untracked."
+        },
+        "patches": {
+          "type": ["string", "null"],
+          "description": "Private / unmerged product patches on that stamp, if any."
+        },
+        "prior_stamps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["stamp", "product_bar"],
+            "properties": {
+              "stamp": { "type": "string" },
+              "product_bar": { "$ref": "#/$defs/product_bar" },
+              "oracle": { "$ref": "#/$defs/oracle" },
+              "note": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -98,7 +98,7 @@ Start here by task.
 | LLM Hacks & Workarounds | [chat/llm-hacks.md](chat/llm-hacks.md) |
 | Experimental memory / roadmap | [archive/hermes-agent-patterns.md](archive/hermes-agent-patterns.md), [ROADMAP.md](ROADMAP.md), [framework/robustness-roadmap.md](framework/robustness-roadmap.md) |
 | LLM evals / benchmarks | [eval/benchmarks.md](eval/benchmarks.md), [eval/string-harness-upgrade.md](eval/string-harness-upgrade.md), [scripts/prompt_optimization/README.md](../scripts/prompt_optimization/README.md) |
-| Eval-2 harness debug (not a multi-model benchmark yet) | [eval/eval-2/README.md](eval/eval-2/README.md) |
+| Eval-2 headed scoreboard (separate from string-pack Pareto) | [eval/eval-2/benchmarks.md](eval/eval-2/benchmarks.md), [eval/eval-2/README.md](eval/eval-2/README.md) |
 
 ## References
 

--- a/scripts/plot_eval2_leaderboard.py
+++ b/scripts/plot_eval2_leaderboard.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+# WriterAgent - eval-2 headed leaderboard plots
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Write eval-2 headed task×model SVGs from a results JSON.
+
+Separate from the 17-task string-harness Pareto (`plot_pareto.py` /
+``docs/eval/pareto-*.svg``). Reads only the eval-2 headed results file —
+no OpenRouter, no ``benchmark_results.json`` merge.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RESULTS = REPO_ROOT / "docs" / "eval" / "eval-2" / "eval2_benchmark_results.json"
+DEFAULT_OUT_DIR = REPO_ROOT / "docs" / "eval" / "eval-2"
+
+SCHEMA_VERSION = 1
+PRODUCT_BARS = frozenset({"HAPPY", "NOT_HAPPY"})
+ORACLES = frozenset({"PASS", "FAIL"})
+TASK_STATUSES = frozenset({"Ready", "Headed-ready"})
+MODEL_ROLES = frozenset({"gate", "headed", "catalog"})
+PARKED_SLOT = 7
+
+# Okabe–Ito (same family as plot_pareto.py) plus an honest empty fill.
+COLOR_HAPPY = "#009E73"
+COLOR_NOT_HAPPY = "#D55E00"
+COLOR_EMPTY = "#F1F3F4"
+COLOR_INK = "#202124"
+COLOR_MUTED = "#5f6368"
+COLOR_LINE = "#dadce0"
+
+HEATMAP_NAME = "eval2-heatmap.svg"
+COVERAGE_NAME = "eval2-coverage.svg"
+
+FOOTNOTE = (
+    "Source: headed eval-2 autopsy notes, not a catalog sweep. "
+    "Empty = no in-repo stamp. Metrics are product HAPPY / oracle PASS|FAIL "
+    "(not string-harness hard_pass_rate)."
+)
+
+
+class Eval2ResultsError(ValueError):
+    """Results JSON failed the headed scoreboard schema."""
+
+
+@dataclass(frozen=True)
+class Eval2Task:
+    id: str
+    slot: int
+    slug: str
+    title: str
+    status: str
+
+
+@dataclass(frozen=True)
+class Eval2Model:
+    openrouter_id: str
+    display_name: str
+    role: str
+
+
+@dataclass(frozen=True)
+class Eval2Result:
+    task_id: str
+    model: str
+    product_bar: str | None
+    oracle: str | None
+    oracle_note: str
+    stamp: str
+    source: str
+    run_artifacts_committed: bool
+    patches: str | None
+
+
+@dataclass(frozen=True)
+class Eval2Board:
+    schema_version: int
+    updated: str
+    gate_model: str
+    source_of_truth: str
+    notes: str
+    tasks: tuple[Eval2Task, ...]
+    models: tuple[Eval2Model, ...]
+    results: tuple[Eval2Result, ...]
+
+    def result_for(self, task_id: str, model: str) -> Eval2Result | None:
+        for row in self.results:
+            if row.task_id == task_id and row.model == model:
+                return row
+        return None
+
+    def scored_count(self, model: str) -> int:
+        return sum(1 for row in self.results if row.model == model and row.product_bar)
+
+    def happy_count(self, model: str) -> int:
+        return sum(1 for row in self.results if row.model == model and row.product_bar == "HAPPY")
+
+    def not_happy_count(self, model: str) -> int:
+        return sum(1 for row in self.results if row.model == model and row.product_bar == "NOT_HAPPY")
+
+
+def _require_str(row: Mapping[str, Any], key: str, *, ctx: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise Eval2ResultsError(f"{ctx}: {key!r} must be a non-empty string")
+    return value
+
+
+def _optional_str(row: Mapping[str, Any], key: str) -> str:
+    value = row.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise Eval2ResultsError(f"{key!r} must be a string or null")
+    return value
+
+
+def _enum_or_none(value: object, allowed: frozenset[str], *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or value not in allowed:
+        raise Eval2ResultsError(f"{field} must be one of {sorted(allowed)} or null, got {value!r}")
+    return value
+
+
+def _parse_task(raw: object, *, seen_ids: set[str], seen_slots: set[int]) -> Eval2Task:
+    if not isinstance(raw, Mapping):
+        raise Eval2ResultsError("each task must be an object")
+    task_id = _require_str(raw, "id", ctx="task")
+    if task_id in seen_ids:
+        raise Eval2ResultsError(f"duplicate task id {task_id!r}")
+    seen_ids.add(task_id)
+    slot = raw.get("slot")
+    if not isinstance(slot, int) or isinstance(slot, bool):
+        raise Eval2ResultsError(f"task {task_id!r}: slot must be an int")
+    if slot == PARKED_SLOT:
+        raise Eval2ResultsError("slot 7 is PARKED and must not appear on the scoreboard")
+    if slot in seen_slots:
+        raise Eval2ResultsError(f"duplicate slot {slot}")
+    seen_slots.add(slot)
+    status = _require_str(raw, "status", ctx=f"task {task_id}")
+    if status not in TASK_STATUSES:
+        raise Eval2ResultsError(f"task {task_id!r}: status {status!r} is not Ready/Headed-ready")
+    return Eval2Task(
+        id=task_id,
+        slot=slot,
+        slug=_require_str(raw, "slug", ctx=f"task {task_id}"),
+        title=_require_str(raw, "title", ctx=f"task {task_id}"),
+        status=status,
+    )
+
+
+def _parse_model(raw: object, *, seen: set[str]) -> Eval2Model:
+    if not isinstance(raw, Mapping):
+        raise Eval2ResultsError("each model must be an object")
+    mid = _require_str(raw, "openrouter_id", ctx="model")
+    if mid in seen:
+        raise Eval2ResultsError(f"duplicate model {mid!r}")
+    seen.add(mid)
+    role = _require_str(raw, "role", ctx=f"model {mid}")
+    if role not in MODEL_ROLES:
+        raise Eval2ResultsError(f"model {mid!r}: role {role!r} is not gate/headed/catalog")
+    return Eval2Model(
+        openrouter_id=mid,
+        display_name=_require_str(raw, "display_name", ctx=f"model {mid}"),
+        role=role,
+    )
+
+
+def _parse_result(
+    raw: object,
+    *,
+    task_ids: set[str],
+    model_ids: set[str],
+    seen_pairs: set[tuple[str, str]],
+) -> Eval2Result:
+    if not isinstance(raw, Mapping):
+        raise Eval2ResultsError("each result must be an object")
+    task_id = _require_str(raw, "task_id", ctx="result")
+    model = _require_str(raw, "model", ctx="result")
+    if task_id not in task_ids:
+        raise Eval2ResultsError(f"result task_id {task_id!r} is not in tasks")
+    if model not in model_ids:
+        raise Eval2ResultsError(f"result model {model!r} is not in models")
+    pair = (task_id, model)
+    if pair in seen_pairs:
+        raise Eval2ResultsError(f"duplicate result for {task_id} × {model}")
+    seen_pairs.add(pair)
+    product_bar = _enum_or_none(raw.get("product_bar"), PRODUCT_BARS, field="product_bar")
+    oracle = _enum_or_none(raw.get("oracle"), ORACLES, field="oracle")
+    if product_bar is None and oracle is None:
+        raise Eval2ResultsError(
+            f"{task_id} × {model}: omit empty cells instead of storing a null/null result"
+        )
+    return Eval2Result(
+        task_id=task_id,
+        model=model,
+        product_bar=product_bar,
+        oracle=oracle,
+        oracle_note=_optional_str(raw, "oracle_note"),
+        stamp=_optional_str(raw, "stamp"),
+        source=_optional_str(raw, "source"),
+        run_artifacts_committed=bool(raw.get("run_artifacts_committed", False)),
+        patches=raw.get("patches") if isinstance(raw.get("patches"), str) else None,
+    )
+
+
+def load_eval2_board(path: Path) -> Eval2Board:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise Eval2ResultsError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise Eval2ResultsError(f"{path} must be a JSON object")
+    version = payload.get("schema_version")
+    if version != SCHEMA_VERSION:
+        raise Eval2ResultsError(f"schema_version must be {SCHEMA_VERSION}, got {version!r}")
+    raw_tasks = payload.get("tasks")
+    raw_models = payload.get("models")
+    raw_results = payload.get("results")
+    if not isinstance(raw_tasks, list) or not raw_tasks:
+        raise Eval2ResultsError("tasks must be a non-empty array")
+    if not isinstance(raw_models, list) or not raw_models:
+        raise Eval2ResultsError("models must be a non-empty array")
+    if not isinstance(raw_results, list):
+        raise Eval2ResultsError("results must be an array (use [] when nothing is scored)")
+    seen_ids: set[str] = set()
+    seen_slots: set[int] = set()
+    tasks = tuple(_parse_task(item, seen_ids=seen_ids, seen_slots=seen_slots) for item in raw_tasks)
+    seen_models: set[str] = set()
+    models = tuple(_parse_model(item, seen=seen_models) for item in raw_models)
+    gate_model = _require_str(payload, "gate_model", ctx="board")
+    if gate_model not in seen_models:
+        raise Eval2ResultsError(f"gate_model {gate_model!r} must appear in models")
+    seen_pairs: set[tuple[str, str]] = set()
+    results = tuple(
+        _parse_result(item, task_ids=seen_ids, model_ids=seen_models, seen_pairs=seen_pairs)
+        for item in raw_results
+    )
+    return Eval2Board(
+        schema_version=SCHEMA_VERSION,
+        updated=_require_str(payload, "updated", ctx="board"),
+        gate_model=gate_model,
+        source_of_truth=_require_str(payload, "source_of_truth", ctx="board"),
+        notes=_optional_str(payload, "notes"),
+        tasks=tasks,
+        models=models,
+        results=results,
+    )
+
+
+def cell_label(row: Eval2Result | None) -> str:
+    """Short matrix token: HAPPY / oracle FAIL, or an em dash when unscored."""
+    if row is None or (row.product_bar is None and row.oracle is None):
+        return "—"
+    bits: list[str] = []
+    if row.product_bar:
+        bits.append(row.product_bar)
+    if row.oracle:
+        bits.append(f"oracle {row.oracle}")
+    return " / ".join(bits)
+
+
+def render_matrix_markdown(board: Eval2Board) -> str:
+    headers = ["#", "Task", *(model.display_name for model in board.models)]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(["---"] * len(headers)) + " |",
+    ]
+    for task in board.tasks:
+        cells = [str(task.slot), task.title]
+        for model in board.models:
+            cells.append(cell_label(board.result_for(task.id, model.openrouter_id)))
+        lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def _esc(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def _svg_wrap(body: str, *, width: int, height: int, title: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}" role="img">\n'
+        f"  <title>{_esc(title)}</title>\n"
+        f'  <rect width="{width}" height="{height}" fill="#ffffff"/>\n'
+        f"{body}</svg>\n"
+    )
+
+
+def write_heatmap_svg(board: Eval2Board, out_path: Path) -> Path:
+    label_w = 210
+    head_h = 72
+    cell_w = 150
+    cell_h = 58
+    left = 24
+    top = 56
+    n_models = len(board.models)
+    n_tasks = len(board.tasks)
+    width = left + label_w + n_models * cell_w + 24
+    height = top + head_h + n_tasks * cell_h + 64
+    parts: list[str] = [
+        f'  <text x="{left}" y="28" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="16" font-weight="700" fill="{COLOR_INK}">'
+        f"Eval-2 headed scoreboard (product bar × oracle)</text>\n",
+        f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="11" fill="{COLOR_MUTED}">'
+        f"Gate {_esc(board.gate_model)} · updated {_esc(board.updated)} · "
+        f"empty cells have no headed stamp</text>\n",
+    ]
+    for col, model in enumerate(board.models):
+        x = left + label_w + col * cell_w + cell_w / 2
+        suffix = " (gate)" if model.role == "gate" else ""
+        parts.append(
+            f'  <text x="{x:.1f}" y="{top + 28}" text-anchor="middle" '
+            f'font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" '
+            f'fill="{COLOR_INK}">{_esc(model.display_name + suffix)}</text>\n'
+        )
+        parts.append(
+            f'  <text x="{x:.1f}" y="{top + 44}" text-anchor="middle" '
+            f'font-family="DejaVu Sans, sans-serif" font-size="9" fill="{COLOR_MUTED}">'
+            f"{_esc(model.openrouter_id)}</text>\n"
+        )
+    for row_i, task in enumerate(board.tasks):
+        y = top + head_h + row_i * cell_h
+        parts.append(
+            f'  <text x="{left + label_w - 10}" y="{y + 26}" text-anchor="end" '
+            f'font-family="DejaVu Sans, sans-serif" font-size="12" fill="{COLOR_INK}">'
+            f"{task.slot}. {_esc(task.title)}</text>\n"
+        )
+        parts.append(
+            f'  <text x="{left + label_w - 10}" y="{y + 42}" text-anchor="end" '
+            f'font-family="DejaVu Sans, sans-serif" font-size="9" fill="{COLOR_MUTED}">'
+            f"{_esc(task.slug)}</text>\n"
+        )
+        for col, model in enumerate(board.models):
+            x = left + label_w + col * cell_w
+            row = board.result_for(task.id, model.openrouter_id)
+            if row is None or row.product_bar is None:
+                fill = COLOR_EMPTY
+                bar_text = "no data"
+                oracle_text = "—"
+                ink = COLOR_MUTED
+            else:
+                fill = COLOR_HAPPY if row.product_bar == "HAPPY" else COLOR_NOT_HAPPY
+                bar_text = row.product_bar
+                ink = "#ffffff"
+                if row.oracle is None:
+                    oracle_text = "oracle unknown"
+                else:
+                    oracle_text = f"oracle {row.oracle}"
+            parts.append(
+                f'  <rect x="{x + 4:.1f}" y="{y + 6:.1f}" width="{cell_w - 8}" '
+                f'height="{cell_h - 12}" rx="6" fill="{fill}" stroke="{COLOR_LINE}"/>\n'
+            )
+            parts.append(
+                f'  <text x="{x + cell_w / 2:.1f}" y="{y + 26:.1f}" text-anchor="middle" '
+                f'font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" '
+                f'fill="{ink}">{_esc(bar_text)}</text>\n'
+            )
+            parts.append(
+                f'  <text x="{x + cell_w / 2:.1f}" y="{y + 42:.1f}" text-anchor="middle" '
+                f'font-family="DejaVu Sans, sans-serif" font-size="10" '
+                f'fill="{ink}">{_esc(oracle_text)}</text>\n'
+            )
+    parts.append(
+        f'  <text x="{left}" y="{height - 18}" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="10" fill="{COLOR_MUTED}">{_esc(FOOTNOTE)}</text>\n'
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        _svg_wrap(
+            "".join(parts),
+            width=width,
+            height=height,
+            title="Eval-2 headed task × model heatmap",
+        ),
+        encoding="utf-8",
+    )
+    return out_path
+
+
+def write_coverage_svg(board: Eval2Board, out_path: Path) -> Path:
+    """Stacked HAPPY / NOT_HAPPY / no-data counts — honest when most cells are empty."""
+    n_tasks = len(board.tasks)
+    left = 56
+    top = 64
+    bar_w = 88
+    gap = 36
+    plot_h = 260
+    width = max(640, left + len(board.models) * (bar_w + gap) + 40)
+    height = top + plot_h + 90
+    parts: list[str] = [
+        f'  <text x="24" y="28" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="16" font-weight="700" fill="{COLOR_INK}">'
+        f"Eval-2 headed coverage (Ready tasks scored)</text>\n",
+        f'  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="11" fill="{COLOR_MUTED}">'
+        f"{n_tasks} Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands."
+        f"</text>\n",
+    ]
+    for col, model in enumerate(board.models):
+        x = left + col * (bar_w + gap)
+        happy = board.happy_count(model.openrouter_id)
+        not_happy = board.not_happy_count(model.openrouter_id)
+        empty = n_tasks - happy - not_happy
+        # Stack from the axis: empty, then NOT_HAPPY, then HAPPY on top.
+        scale = plot_h / n_tasks
+        y = top + plot_h
+        for count, fill, label in (
+            (empty, COLOR_EMPTY, "no data"),
+            (not_happy, COLOR_NOT_HAPPY, "NOT_HAPPY"),
+            (happy, COLOR_HAPPY, "HAPPY"),
+        ):
+            if count <= 0:
+                continue
+            h = count * scale
+            y -= h
+            parts.append(
+                f'  <rect x="{x:.1f}" y="{y:.1f}" width="{bar_w}" height="{h:.1f}" '
+                f'fill="{fill}" stroke="{COLOR_LINE}" data-segment="{_esc(label)}"/>\n'
+            )
+        parts.append(
+            f'  <text x="{x + bar_w / 2:.1f}" y="{top + plot_h + 20}" text-anchor="middle" '
+            f'font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" '
+            f'fill="{COLOR_INK}">{_esc(model.display_name)}</text>\n'
+        )
+        scored = happy + not_happy
+        parts.append(
+            f'  <text x="{x + bar_w / 2:.1f}" y="{top + plot_h + 36}" text-anchor="middle" '
+            f'font-family="DejaVu Sans, sans-serif" font-size="10" fill="{COLOR_MUTED}">'
+            f"{happy} HAPPY / {scored} scored</text>\n"
+        )
+    # Legend
+    legend_y = height - 28
+    for i, (fill, label) in enumerate(
+        ((COLOR_HAPPY, "HAPPY"), (COLOR_NOT_HAPPY, "NOT_HAPPY"), (COLOR_EMPTY, "no data"))
+    ):
+        lx = 24 + i * 110
+        parts.append(
+            f'  <rect x="{lx}" y="{legend_y - 10}" width="12" height="12" fill="{fill}" '
+            f'stroke="{COLOR_LINE}"/>\n'
+        )
+        parts.append(
+            f'  <text x="{lx + 18}" y="{legend_y}" font-family="DejaVu Sans, sans-serif" '
+            f'font-size="11" fill="{COLOR_INK}">{label}</text>\n'
+        )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        _svg_wrap(
+            "".join(parts),
+            width=width,
+            height=height,
+            title="Eval-2 headed coverage by model",
+        ),
+        encoding="utf-8",
+    )
+    return out_path
+
+
+def write_eval2_svgs(board: Eval2Board, out_dir: Path) -> list[Path]:
+    written = [
+        write_heatmap_svg(board, out_dir / HEATMAP_NAME),
+        write_coverage_svg(board, out_dir / COVERAGE_NAME),
+    ]
+    return written
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--in",
+        dest="in_path",
+        type=Path,
+        default=DEFAULT_RESULTS,
+        help="Eval-2 headed results JSON (not string-harness benchmark_results.json).",
+    )
+    parser.add_argument(
+        "--out-dir",
+        dest="out_dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate JSON only; do not write SVGs.",
+    )
+    parser.add_argument(
+        "--print-matrix",
+        action="store_true",
+        help="Print the markdown task×model table to stdout.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.in_path.name == "benchmark_results.json":
+        raise Eval2ResultsError(
+            "refusing string-harness benchmark_results.json — use eval2_benchmark_results.json"
+        )
+    board = load_eval2_board(args.in_path)
+    if args.print_matrix:
+        sys.stdout.write(render_matrix_markdown(board))
+    if args.check:
+        print(f"OK {args.in_path} ({len(board.results)} scored cells, gate={board.gate_model})")
+        return 0
+    for path in write_eval2_svgs(board, args.out_dir):
+        print(f"Wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -72,7 +72,8 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
     assert (_REPO / board.source_of_truth).is_file()
     schema = json.loads(_SCHEMA.read_text(encoding="utf-8"))
     assert schema["properties"]["schema_version"]["const"] == 1
-    assert "hard_pass_rate" not in _SCHEMA.read_text(encoding="utf-8")
+    assert "hard_pass_rate" not in schema["properties"]
+    assert "hard_pass_rate" not in schema["$defs"]["result"]["properties"]
     assert {task.slot for task in board.tasks} == {1, 2, 3, 4, 5, 6, 8, 9, 10}
     assert all(task.slot != 7 for task in board.tasks)
     assert {model.openrouter_id for model in board.models} >= {
@@ -169,7 +170,8 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     board = pel.load_eval2_board(_RESULTS)
     matrix = pel.render_matrix_markdown(board)
     text = _SCOREBOARD.read_text(encoding="utf-8")
-    assert "hard_pass_rate" not in text
+    assert "| Hard pass |" not in text
+    assert "product_bar" in text or "Product bar" in text
     assert "google/gemini-3.8-flash" in text
     assert "not" in text.lower() and "string" in text.lower()
     assert "[`docs/eval/benchmarks.md`](../benchmarks.md)" in text
@@ -201,8 +203,8 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "HAPPY" in heat
     assert "NOT_HAPPY" in heat
     assert "no data" in heat
-    assert "hard_pass_rate" not in heat
-    assert "pareto" not in heat.lower()
+    assert "not string-harness hard_pass_rate" in heat
+    assert "pareto-fronts" not in heat
     assert "google/gemini-3.8-flash" in heat
     assert "Tenant Retention" in heat
     assert "no data" in cov

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -1,0 +1,293 @@
+# WriterAgent tests for scripts/plot_eval2_leaderboard.py
+# Copyright (c) 2026 KeithCu (modifications and relicensing)
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Eval-2 headed scoreboard stays separate from the string-pack Pareto."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO / "scripts"
+_EVAL2 = _REPO / "docs" / "eval" / "eval-2"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import plot_eval2_leaderboard as pel  # noqa: E402
+
+_RESULTS = _EVAL2 / "eval2_benchmark_results.json"
+_SCHEMA = _EVAL2 / "eval2_benchmark_results.schema.json"
+_SCOREBOARD = _EVAL2 / "benchmarks.md"
+_README = _EVAL2 / "README.md"
+
+
+def _minimal_board_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "updated": "2026-09-12",
+        "gate_model": "google/gemini-3.8-flash",
+        "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
+        "tasks": [
+            {
+                "id": "afc",
+                "slot": 3,
+                "slug": "afc-sample-83d10b06",
+                "title": "AFC Population",
+                "status": "Ready",
+            }
+        ],
+        "models": [
+            {
+                "openrouter_id": "google/gemini-3.8-flash",
+                "display_name": "Gemini 3.8 Flash",
+                "role": "gate",
+            },
+            {
+                "openrouter_id": "openai/gpt-oss-20b",
+                "display_name": "GPT-OSS 20B",
+                "role": "catalog",
+            },
+        ],
+        "results": [
+            {
+                "task_id": "afc",
+                "model": "google/gemini-3.8-flash",
+                "product_bar": "HAPPY",
+                "oracle": "PASS",
+            }
+        ],
+    }
+
+
+def test_seed_json_loads_and_matches_schema_enums() -> None:
+    board = pel.load_eval2_board(_RESULTS)
+    assert board.schema_version == 1
+    assert board.gate_model == "google/gemini-3.8-flash"
+    assert board.source_of_truth == "docs/eval/eval-2/headed-failure-autopsy.md"
+    assert (_REPO / board.source_of_truth).is_file()
+    schema = json.loads(_SCHEMA.read_text(encoding="utf-8"))
+    assert schema["properties"]["schema_version"]["const"] == 1
+    assert "hard_pass_rate" not in _SCHEMA.read_text(encoding="utf-8")
+    assert {task.slot for task in board.tasks} == {1, 2, 3, 4, 5, 6, 8, 9, 10}
+    assert all(task.slot != 7 for task in board.tasks)
+    assert {model.openrouter_id for model in board.models} >= {
+        "google/gemini-3.8-flash",
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-20b",
+        "x-ai/grok-4.6",
+        "meta/muse-spark-1.3-contributor",
+    }
+
+
+def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
+    board = pel.load_eval2_board(_RESULTS)
+    gemini = "google/gemini-3.8-flash"
+    oss = "openai/gpt-oss-120b"
+
+    tenant = board.result_for("tenant-retention", gemini)
+    assert tenant is not None
+    assert tenant.product_bar == "HAPPY"
+    assert tenant.oracle == "FAIL"
+
+    cadaver = board.result_for("cadaver-proposal", gemini)
+    assert cadaver is not None
+    assert cadaver.product_bar == "HAPPY"
+    assert cadaver.oracle == "FAIL"
+
+    afc = board.result_for("afc", gemini)
+    assert afc is not None
+    assert afc.product_bar == "HAPPY"
+    assert afc.oracle == "PASS"
+
+    floor_g = board.result_for("writer-calc-peer-write", gemini)
+    assert floor_g is not None
+    assert floor_g.product_bar == "NOT_HAPPY"
+    assert floor_g.oracle == "FAIL"
+    assert floor_g.patches and "not PR" in floor_g.patches
+
+    gmp = board.result_for("gmp-change-control", oss)
+    assert gmp is not None
+    assert gmp.product_bar == "HAPPY"
+    assert gmp.oracle == "FAIL"
+
+    floor_o = board.result_for("writer-calc-peer-write", oss)
+    assert floor_o is not None
+    assert floor_o.product_bar == "NOT_HAPPY"
+
+    for task_id in (
+        "calc-primary-model",
+        "draw-primary",
+        "reverse-tenant",
+        "long-writer-pack",
+    ):
+        row = board.result_for(task_id, oss)
+        assert row is not None
+        assert row.product_bar == "NOT_HAPPY"
+        assert row.oracle == "FAIL"
+
+    # No invented Gemini scores for overnight gpt-oss-only siblings.
+    for task_id in (
+        "gmp-change-control",
+        "calc-primary-model",
+        "draw-primary",
+        "reverse-tenant",
+        "long-writer-pack",
+    ):
+        assert board.result_for(task_id, gemini) is None
+
+    # No invented gpt-oss scores for Gemini-only Writer/AFC stamps.
+    for task_id in ("tenant-retention", "cadaver-proposal", "afc"):
+        assert board.result_for(task_id, oss) is None
+
+    # Catalog peers stay empty until a real stamp lands.
+    for mid in (
+        "openai/gpt-oss-20b",
+        "x-ai/grok-4.6",
+        "meta/muse-spark-1.3-contributor",
+    ):
+        assert board.scored_count(mid) == 0
+        assert board.happy_count(mid) == 0
+
+
+def test_every_seed_source_points_at_an_in_repo_doc() -> None:
+    payload = json.loads(_RESULTS.read_text(encoding="utf-8"))
+    for row in payload["results"]:
+        source = str(row.get("source") or "")
+        assert source, row
+        first = source.split(";")[0].strip().split()[0]
+        path = _REPO / first
+        assert path.is_file(), first
+        assert row.get("run_artifacts_committed") is False
+
+
+def test_scoreboard_markdown_matches_seed_matrix() -> None:
+    board = pel.load_eval2_board(_RESULTS)
+    matrix = pel.render_matrix_markdown(board)
+    text = _SCOREBOARD.read_text(encoding="utf-8")
+    assert "hard_pass_rate" not in text
+    assert "google/gemini-3.8-flash" in text
+    assert "not" in text.lower() and "string" in text.lower()
+    assert "[`docs/eval/benchmarks.md`](../benchmarks.md)" in text
+    assert "eval2-heatmap.svg" in text
+    assert "eval2-coverage.svg" in text
+    assert "Catalog-wide" in text or "catalog" in text.lower()
+    assert "sweep has **not** happened" in text
+    for line in matrix.strip().splitlines():
+        if line.startswith("| # |"):
+            continue
+        assert line in text, line
+    readme = _README.read_text(encoding="utf-8")
+    assert "[`benchmarks.md`](benchmarks.md)" in readme
+    assert "string-pack Pareto" in readme
+    heatmap = (_EVAL2 / pel.HEATMAP_NAME).read_text(encoding="utf-8")
+    coverage = (_EVAL2 / pel.COVERAGE_NAME).read_text(encoding="utf-8")
+    assert "no data" in heatmap
+    assert "HAPPY" in heatmap
+    assert "0 HAPPY / 0 scored" in coverage
+
+
+def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> None:
+    board = pel.load_eval2_board(_RESULTS)
+    heatmap = pel.write_heatmap_svg(board, tmp_path / "eval2-heatmap.svg")
+    coverage = pel.write_coverage_svg(board, tmp_path / "eval2-coverage.svg")
+    heat = heatmap.read_text(encoding="utf-8")
+    cov = coverage.read_text(encoding="utf-8")
+    assert heat.startswith("<?xml")
+    assert "HAPPY" in heat
+    assert "NOT_HAPPY" in heat
+    assert "no data" in heat
+    assert "hard_pass_rate" not in heat
+    assert "pareto" not in heat.lower()
+    assert "google/gemini-3.8-flash" in heat
+    assert "Tenant Retention" in heat
+    assert "no data" in cov
+    assert "0 HAPPY / 0 scored" in cov
+    assert pel.HEATMAP_NAME != "pareto-fronts.svg"
+    assert pel.COVERAGE_NAME != "pareto-distance.svg"
+
+
+def test_cli_check_and_refuse_string_harness_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload = _minimal_board_payload()
+    src = tmp_path / "eval2_benchmark_results.json"
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    assert pel.main(["--in", str(src), "--check"]) == 0
+    out = capsys.readouterr().out
+    assert "OK" in out
+    assert "1 scored cells" in out
+
+    forbidden = tmp_path / "benchmark_results.json"
+    forbidden.write_text("[]", encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="string-harness"):
+        pel.main(["--in", str(forbidden), "--check"])
+
+
+def test_cli_writes_svgs_and_print_matrix(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    payload = _minimal_board_payload()
+    src = tmp_path / "eval2_benchmark_results.json"
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    out_dir = tmp_path / "charts"
+    assert pel.main(["--in", str(src), "--out-dir", str(out_dir), "--print-matrix"]) == 0
+    printed = capsys.readouterr().out
+    assert "| 3 | AFC Population | HAPPY / oracle PASS | — |" in printed
+    assert (out_dir / pel.HEATMAP_NAME).is_file()
+    assert (out_dir / pel.COVERAGE_NAME).is_file()
+
+
+def test_loader_rejects_parked_slot_and_null_null_cells(tmp_path: Path) -> None:
+    payload = _minimal_board_payload()
+    payload["tasks"].append(
+        {
+            "id": "writer-headed-template",
+            "slot": 7,
+            "slug": "writer-headed-template",
+            "title": "Parked letterhead",
+            "status": "Ready",
+        }
+    )
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="PARKED"):
+        pel.load_eval2_board(path)
+
+    payload = _minimal_board_payload()
+    payload["results"].append(
+        {
+            "task_id": "afc",
+            "model": "openai/gpt-oss-20b",
+            "product_bar": None,
+            "oracle": None,
+        }
+    )
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="omit empty"):
+        pel.load_eval2_board(path)
+
+
+def test_loader_rejects_unknown_task_and_wrong_schema(tmp_path: Path) -> None:
+    payload = _minimal_board_payload()
+    payload["schema_version"] = 2
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="schema_version"):
+        pel.load_eval2_board(path)
+
+    payload = _minimal_board_payload()
+    payload["results"][0]["task_id"] = "not-a-task"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="not in tasks"):
+        pel.load_eval2_board(path)
+
+
+def test_plot_module_does_not_import_string_harness() -> None:
+    source = Path(pel.__file__).read_text(encoding="utf-8")
+    assert "benchmark_results.json" in source  # refusal path
+    assert "from run_eval_multi" not in source
+    assert "import plot_pareto" not in source
+    assert "merge_benchmark_results" not in source


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a **separate** eval-2 headed scoreboard. This does not merge into the 17-task string harness (`docs/eval/benchmarks.md` / `pareto-*.svg`) and does not claim a catalog-wide eval-2 sweep.

## Why separate
Headed eval-2 scores **product HAPPY / NOT_HAPPY** plus CLI **oracle PASS / FAIL**. That is not `hard_pass_rate` / C²/$. Keith’s gate is `google/gemini-3.8-flash`; gpt-oss is not the product gate.

## What’s in
- [`docs/eval/eval-2/benchmarks.md`](docs/eval/eval-2/benchmarks.md) — task × model matrix, design note, refresh steps
- [`docs/eval/eval-2/eval2_benchmark_results.json`](docs/eval/eval-2/eval2_benchmark_results.json) + [schema](docs/eval/eval-2/eval2_benchmark_results.schema.json)
- [`scripts/plot_eval2_leaderboard.py`](scripts/plot_eval2_leaderboard.py) → `eval2-heatmap.svg` / `eval2-coverage.svg` (no OpenRouter)
- Link from [`docs/eval/eval-2/README.md`](docs/eval/eval-2/README.md)

## Seed honesty
Cells are only from in-repo autopsy / sibling notes (Gemini HAPPY on Tenant / Cadaver / AFC; Floorstand NOT HAPPY; gpt-oss overnight 6/8/9/10 NOT HAPPY; GMP-0225 HAPPY). Catalog peer columns (GPT-OSS 20B, Grok 4.6, Muse Spark 1.3) and missing Gemini/gpt-oss pairs stay **empty**. Slot 7 stays omitted. Run artifacts are not committed.

```bash
.venv/bin/python scripts/plot_eval2_leaderboard.py --check
.venv/bin/python scripts/plot_eval2_leaderboard.py
```

[Eval-2 headed task by model heatmap](https://cursor.com/agents/bc-8b06498d-4b88-49e4-a6e9-a405d24808e5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feval2-heatmap.svg)
[Eval-2 headed coverage bars](https://cursor.com/agents/bc-8b06498d-4b88-49e4-a6e9-a405d24808e5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feval2-coverage.svg)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b06498d-4b88-49e4-a6e9-a405d24808e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b06498d-4b88-49e4-a6e9-a405d24808e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

