### PR TITLE
Eval-2: cost-for-results fields and HAPPY cost chart

### DIFF
--- a/docs/eval/benchmarks.md
+++ b/docs/eval/benchmarks.md
@@ -2,6 +2,8 @@
 
 WriterAgent includes an in-LibreOffice **LLM Evaluation Suite** for real-world tasks in Writer, Calc, and Draw. Runs track accuracy and **Intelligence-per-Dollar**: **Value (C²/$)** = average metric score squared ÷ average dollars per task (higher is better), using live OpenRouter pricing where available.
 
+Headed sibling (same hard / partial / cost axes, much harder tasks): [`eval-2/benchmarks.md`](eval-2/benchmarks.md). Do **not** merge those tables into this pack.
+
 How to run evals from the repo: [scripts/prompt_optimization/README.md](../../scripts/prompt_optimization/README.md). Broader plan notes: [eval-dev-plan.md](eval-dev-plan.md). String harness (no LO ranking): [string-harness-upgrade.md](string-harness-upgrade.md).
 
 ## Snapshot ranking (2026-09-11)

--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -2,11 +2,11 @@
 
 **Eval-2 is for debugging the harness.** Iterate here. Do **not** edit
 `docs/eval/gdpval/` gold trees except by **adding** a new untouched gold
-id. Headed **task × model** scoreboard (product bar + oracle, optional
-partial and cost among comparable cells; not the string-pack Pareto):
-[`benchmarks.md`](benchmarks.md). Catalog-wide numeric sweeps still
-wait — empty cells mean no in-repo headed stamp. Empty cost or
-partial stays empty — do not invent run costs or check counts.
+id. Headed sibling of the string-pack Pareto (same hard / partial /
+cost axes, harder tasks): [`benchmarks.md`](benchmarks.md). Stores stay
+separate — do not fold into `benchmark_results.json`. Catalog-wide
+sweeps still wait; empty cells mean no in-repo headed stamp. Empty
+cost or partial stays empty — do not invent run costs or check counts.
 
 `test_gold_prompt_is_byte_copy_of_hf_tree` compares `prompt.txt` and
 `prompt.gdpval.txt` as bytes to the HF `task.json` `prompt` (LF).

--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -3,10 +3,10 @@
 **Eval-2 is for debugging the harness.** Iterate here. Do **not** edit
 `docs/eval/gdpval/` gold trees except by **adding** a new untouched gold
 id. Headed **task × model** scoreboard (product bar + oracle, optional
-cost for results among HAPPY; not string-pack Pareto):
+partial and cost among comparable cells; not the string-pack Pareto):
 [`benchmarks.md`](benchmarks.md). Catalog-wide numeric sweeps still
-wait — empty cells mean no in-repo headed stamp. Empty cost stays
-empty — do not invent run costs.
+wait — empty cells mean no in-repo headed stamp. Empty cost or
+partial stays empty — do not invent run costs or check counts.
 
 `test_gold_prompt_is_byte_copy_of_hf_tree` compares `prompt.txt` and
 `prompt.gdpval.txt` as bytes to the HF `task.json` `prompt` (LF).

--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -1,12 +1,17 @@
 # eval-2 — WriterAgent hard-task variants
 
+**Different benchmark from the 17-task string pack**
+([`docs/eval/benchmarks.md`](../benchmarks.md) / Pareto). Same scoring
+philosophy (hard / partial / cost), but headed multi-doc GDPval-style
+tasks that are much harder. One filled task (AFC or any Ready slot)
+still counts as a hard benchmark. Sibling charts:
+[`benchmarks.md`](benchmarks.md) — do not fold into the string-pack Pareto.
+
 **Eval-2 is for debugging the harness.** Iterate here. Do **not** edit
 `docs/eval/gdpval/` gold trees except by **adding** a new untouched gold
-id. Headed sibling of the string-pack Pareto (same hard / partial /
-cost axes, harder tasks): [`benchmarks.md`](benchmarks.md). Stores stay
-separate — do not fold into `benchmark_results.json`. Catalog-wide
-sweeps still wait; empty cells mean no in-repo headed stamp. Empty
-cost or partial stays empty — do not invent run costs or check counts.
+id. Catalog-wide sweeps still wait; empty cells mean no in-repo headed
+stamp. Empty cost or partial stays empty — do not invent run costs or
+check counts.
 
 `test_gold_prompt_is_byte_copy_of_hf_tree` compares `prompt.txt` and
 `prompt.gdpval.txt` as bytes to the HF `task.json` `prompt` (LF).

--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -2,9 +2,11 @@
 
 **Eval-2 is for debugging the harness.** Iterate here. Do **not** edit
 `docs/eval/gdpval/` gold trees except by **adding** a new untouched gold
-id. Headed **task × model** scoreboard (product bar + oracle, not
-string-pack Pareto): [`benchmarks.md`](benchmarks.md). Catalog-wide
-numeric sweeps still wait — empty cells mean no in-repo headed stamp.
+id. Headed **task × model** scoreboard (product bar + oracle, optional
+cost for results among HAPPY; not string-pack Pareto):
+[`benchmarks.md`](benchmarks.md). Catalog-wide numeric sweeps still
+wait — empty cells mean no in-repo headed stamp. Empty cost stays
+empty — do not invent run costs.
 
 `test_gold_prompt_is_byte_copy_of_hf_tree` compares `prompt.txt` and
 `prompt.gdpval.txt` as bytes to the HF `task.json` `prompt` (LF).

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -1,9 +1,12 @@
 # Eval-2 headed benchmarks
 
-Eval-2 is the **headed sibling** of the 17-task string pack: the same
-kind of benchmark (hard / partial-quality / cost), on much harder
-GDPval-shaped Writer, Calc, and Draw tasks. Runs track product success
-and **Intelligence-per-Dollar**. **Value (C²/$)** = oracle
+**Different benchmark** from the 17-task string pack
+([`docs/eval/benchmarks.md`](../benchmarks.md) / Pareto): same hard /
+partial / cost philosophy, but headed multi-doc GDPval-style tasks that
+are much harder. One filled task still counts.
+
+Eval-2 is the **headed sibling** of that pack. Runs track product
+success and **Intelligence-per-Dollar**. **Value (C²/$)** = oracle
 `partial_score` squared ÷ recorded USD on a HAPPY cell (higher is
 better), when both were measured.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -1,39 +1,49 @@
-# Eval-2 headed scoreboard
+# Eval-2 headed benchmarks
 
-Headed **task × model** matrix for Ready eval-2 experiments. This is
-**not** the 17-task string harness.
+Eval-2 is the **headed sibling** of the 17-task string pack: the same
+kind of benchmark (hard / partial-quality / cost), on much harder
+GDPval-shaped Writer, Calc, and Draw tasks. Runs track product success
+and **Intelligence-per-Dollar**. **Value (C²/$)** = oracle
+`partial_score` squared ÷ recorded USD on a HAPPY cell (higher is
+better), when both were measured.
 
-String-pack ranking lives in [`docs/eval/benchmarks.md`](../benchmarks.md)
-and `docs/eval/pareto-*.svg` (`hard_pass_rate`, C²/$, OpenRouter
-`--backend string`). Do **not** merge these tables or fold headed stamps
-into `scripts/prompt_optimization/benchmark_results.json`.
+String-pack snapshot: [`docs/eval/benchmarks.md`](../benchmarks.md)
+(`hard_pass_rate`, C²/$, `pareto-*.svg`). How to run the headed helper:
+[`README.md`](README.md). Living autopsy:
+[`headed-failure-autopsy.md`](headed-failure-autopsy.md).
 
-| | String pack | Eval-2 headed |
-|---|-------------|---------------|
-| Tasks | 17 short Writer/Calc/Draw worlds | 9 Ready / Headed-ready GDPval-shaped siblings (slot 7 PARKED) |
+Keep the stores separate. Do **not** fold headed stamps into
+`scripts/prompt_optimization/benchmark_results.json` or overwrite
+`docs/eval/pareto-*.svg`.
+
+| Axis | String pack | Eval-2 (sibling) |
+|---|---|---|
+| Tasks | 17 short Writer/Calc/Draw worlds | 9 Ready / Headed-ready siblings (slot 7 PARKED) |
+| Hard | `hard_pass_rate` (substring + result + process oracles) | **Product HAPPY** (oracle PASS when that is the hard gate — AFC after the smoother) |
+| Partial | correctness / quality | **Oracle partial** (`1 − failures/checks`; AFC S/R, husks) |
+| Cost | C²/$ = metric² ÷ avg $/task | C²/$ = `partial_score`² ÷ USD among HAPPY |
 | Gate | Catalog sweep on OpenRouter | **`google/gemini-3.8-flash`** until HAPPY (gpt-oss is not the product gate) |
-| Pass | `hard_pass_rate` (substring + result + process oracles) | **Product bar** HAPPY / NOT_HAPPY, plus CLI **oracle** PASS / FAIL |
-| Cost | C²/$ = metric² ÷ avg $/task | **HAPPY first**; among comparable, higher oracle partial, then lower USD |
 | Charts | `pareto-fronts.svg` / `pareto-distance.svg` | [`eval2-heatmap.svg`](eval2-heatmap.svg), [`eval2-coverage.svg`](eval2-coverage.svg), [`eval2-cost.svg`](eval2-cost.svg), [`eval2-partial.svg`](eval2-partial.svg) |
 
-**HAPPY** means the deliverable did the job (Keith: product over
-oracle). A soft oracle FAIL on a HAPPY cell is a false-red or a
-secondary cite — not a product miss. **NOT_HAPPY** + oracle FAIL is
-usually an honest empty or wrong-facts deliverable. **—** means no
-in-repo headed stamp for that pair; do not invent a score.
+Ranked by **hard → partial → cost**. **Hard** = product HAPPY (the
+deliverable did the job). **Partial** = oracle quality among recorded
+checks. **C²/$** is secondary, among HAPPY cells that recorded both
+partial and USD.
 
-Catalog columns (GPT-OSS 20B, Grok 4.6, Muse Spark 1.3) are
-placeholders. Tasks that work on Gemini 3.8 Flash should eventually be
-run across the string catalog — that sweep has **not** happened.
+**HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
+cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
+deliverable. **—** means no in-repo headed stamp; do not invent a
+score. Catalog columns (GPT-OSS 20B, Grok 4.6, Muse Spark 1.3) are
+placeholders. The catalog-wide headed sweep has **not** happened.
 
-Living autopsy: [`headed-failure-autopsy.md`](headed-failure-autopsy.md).
-Harness index: [`README.md`](README.md).
-
-## Snapshot (2026-09-12)
+## Snapshot ranking (2026-09-12)
 
 Seeded from the autopsy and sibling notes. Run dirs are typically
-untracked on the shared machine — `run_artifacts_committed` is false
-for every cell. No OpenRouter eval-2 CI job.
+untracked — `run_artifacts_committed` is false for every cell. No
+OpenRouter eval-2 CI job. Cost and most partial counts are still empty.
+
+Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
+(+ [schema](eval2_benchmark_results.schema.json)).
 
 | # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-OSS 20B | Grok 4.6 | Muse Spark 1.3 |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -55,69 +65,22 @@ for every cell. No OpenRouter eval-2 CI job.
 
 <img src="eval2-partial.svg" alt="Eval-2 headed partial/cost view. Bars only when oracle PASS or recorded fails/checks; no invented ratios." />
 
-## Ranking stack
+## Key insights
 
-Product bar still wins: **HAPPY first**. A cheaper or higher-partial
-NOT_HAPPY run does not outrank an expensive HAPPY one.
-
-Among **comparable** outcomes (same HAPPY / NOT_HAPPY, usually the
-same task):
-
-1. Prefer **higher oracle partial** when a ratio exists.
-2. Then prefer **lower recorded USD**.
-
-Missing partial or cost sorts last in that step — unknown does not
-beat a recorded value. Heatmap stays HAPPY / NOT.
-
-## Oracle partial
-
-AFC (`eval_2_ods_oracle`) and the Writer/Calc/Draw siblings are
-fail-closed (`passed` iff `failures` is empty) but still expose
-useful soft signals: the `failures` list, AFC `s_flags` / `r_required`,
-and husk / scored cell counts.
-
-`partial_score` is oracle quality in [0, 1], computed only when honest:
-
-- `1` when the oracle passed (`oracle` is PASS, or `oracle_passed` is
-  true).
-- Otherwise `1 − oracle_failure_count / oracle_check_count` when
-  **both** counts were recorded from that stamp's `--score` JSON.
-- Omit when FAIL and `oracle_check_count` is unknown. Do **not**
-  invent a denominator from the failure strings, autopsy prose, or
-  a guessed “typical” check count.
-
-Optional result fields: `oracle_passed`, `oracle_failure_count`,
-`oracle_check_count`, `oracle_failures` (short strings), `afc_s_flags`,
-`afc_r_required`, `husk_cells`, `scored_cells`, `partial_score`.
-The 2026-09-12 seed omits them. AFC catalog stamps can fill them
-from `eval_2_ods_oracle --json` (S/R and husks) without claiming
-more precision than fails/checks.
-
-The partial chart draws a coarse bar only when `partial_score` exists.
-S/R and husk counts can label a row; they do not become a fake 0–1
-axis.
-
-## Cost for results
-
-Among HAPPY cells that recorded `total_cost_usd` > 0, after partial
-when it exists, rank by **lower cost** (cheaper success).
-
-`intelligence_per_dollar` is **successes per USD**, computed when
-HAPPY and cost > 0:
-
-`1 / total_cost_usd`
-
-Omit the field (and the cost-chart bar) when cost is unknown or zero.
-Do **not** invent run costs from tokens, list prices, or wall time.
-This is **not** the string-harness C²/$
-(`correctness² / avg $/task` in [`docs/eval/benchmarks.md`](../benchmarks.md)).
-Eval-2 has no continuous correctness — HAPPY is binary.
-
-Optional cost fields (`total_tokens`, `input_tokens`,
-`output_tokens`, `total_cost_usd`, `wall_time_s`,
-`intelligence_per_dollar`) are empty on the 2026-09-12 seed. The
-heatmap stays HAPPY / NOT. Fill cost and oracle-partial only from a
-real headed stamp (AFC catalog sweep and later tasks).
+1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
+   AFC. gpt-oss-120b is HAPPY only on GMP-0225. Floorstand is NOT HAPPY
+   on both. Overnight slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
+2. **Partial:** AFC Gemini is oracle PASS (`partial_score` = 1). Tenant /
+   Cadaver / GMP HAPPY cells are still oracle FAIL without a recorded
+   `oracle_check_count`, so they have no ratio yet. Do not invent one
+   from autopsy prose.
+3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
+   chart stays empty until the AFC catalog sweep (and later tasks) fill
+   USD. Then Value is `partial_score`² ÷ that USD.
+4. **Coverage:** catalog peers (20B, Grok 4.6, Muse Spark) are entirely
+   no data. Gemini has no stamp yet for GMP, Calc-primary, Draw-primary,
+   Reverse Tenant, or Long Writer. gpt-oss has no stamp for Tenant,
+   Cadaver, or AFC.
 
 ### Cell notes (only scored pairs)
 
@@ -134,10 +97,41 @@ real headed stamp (AFC catalog sweep and later tasks).
 | Reverse Tenant | GPT-OSS 120B | `20260909-0414-gpt-oss-120b` | Talk-not-write; 0 cells + PreContractError. |
 | Long Writer pack | GPT-OSS 120B | `20260909-0419-gpt-oss-120b` | Invented $12.5M / wrong dates; 0 comments. |
 
-Gemini has **no** in-repo headed stamp yet for GMP, Calc-primary,
-Draw-primary, Reverse Tenant, or Long Writer. gpt-oss-120b has **no**
-in-repo stamp for Tenant, Cadaver, or AFC. Overnight slots 6/8/9/10
-were gpt-oss only.
+## Scoring approach
+
+Hard is the product bar: **HAPPY first**. A cheaper or higher-partial
+NOT_HAPPY run does not outrank an expensive HAPPY one. When the headed
+bar *is* the oracle (AFC after the smoother), **oracle PASS** is the
+hard gate for that task.
+
+Partial is oracle quality in [0, 1], computed only when honest:
+
+- `1` when the oracle passed (`oracle` is PASS, or `oracle_passed` is
+  true).
+- Otherwise `1 − oracle_failure_count / oracle_check_count` when
+  **both** counts were recorded from that stamp's `--score` JSON.
+- Omit when FAIL and `oracle_check_count` is unknown. Do **not**
+  invent a denominator from the failure strings or a guessed check
+  count.
+
+AFC (`eval_2_ods_oracle`) and the Writer/Calc/Draw oracles are
+fail-closed (`passed` iff `failures` is empty) but still expose S/R,
+husks, and the `failures` list. Those label a row; they are not a
+fake 0–1 axis by themselves.
+
+**C²/$** among successes: `partial_score`² ÷ `total_cost_usd` when
+the cell is HAPPY and both values were recorded (same shape as the
+string-pack Value). Omit when cost is unknown or zero, or when
+partial is unknown. Do **not** invent run costs from tokens, list
+prices, or wall time.
+
+Optional result fields (`oracle_passed`, `oracle_failure_count`,
+`oracle_check_count`, `oracle_failures`, `afc_s_flags`,
+`afc_r_required`, `husk_cells`, `scored_cells`, `partial_score`,
+`total_tokens`, `input_tokens`, `output_tokens`, `total_cost_usd`,
+`wall_time_s`, `intelligence_per_dollar`) are empty on the 2026-09-12
+seed except the derived PASS → `partial_score` = 1 on AFC Gemini.
+Fill the rest only from a real headed stamp.
 
 ## How to refresh
 
@@ -146,15 +140,14 @@ were gpt-oss only.
    (`task_id` × `model`). Leave unknown pairs **out** of `results`.
 2. Fields: `product_bar` (`HAPPY` \| `NOT_HAPPY`), `oracle`
    (`PASS` \| `FAIL`), optional `oracle_note` / `stamp` / `source` /
-   `patches`. Optional cost axis (omit when unknown): `total_tokens` /
-   `input_tokens` / `output_tokens` (ints), `total_cost_usd`,
-   `wall_time_s`, `intelligence_per_dollar` (computed as
-   `1 / total_cost_usd` when HAPPY and cost > 0). Optional partial
-   (omit when unknown): `oracle_passed`, `oracle_failure_count`,
-   `oracle_check_count`, `oracle_failures`, `afc_s_flags` /
-   `afc_r_required`, `husk_cells` / `scored_cells`, `partial_score`
-   (`1` on PASS; else `1 − failures/checks` only when both counts
-   were recorded). Schema:
+   `patches`. Optional hard/partial/cost extras (omit when unknown):
+   `oracle_passed`, `oracle_failure_count`, `oracle_check_count`,
+   `oracle_failures`, `afc_s_flags` / `afc_r_required`, `husk_cells` /
+   `scored_cells`, `partial_score` (`1` on PASS; else
+   `1 − failures/checks` when both counts were recorded),
+   `total_tokens` / `input_tokens` / `output_tokens`,
+   `total_cost_usd`, `wall_time_s`, `intelligence_per_dollar`
+   (`partial_score`² ÷ USD when HAPPY and both recorded). Schema:
    [`eval2_benchmark_results.schema.json`](eval2_benchmark_results.schema.json).
 3. `task_id` must match `scripts/eval_2_headed.py --task` (`afc`,
    `tenant-retention`, …). Slot 7 stays omitted.
@@ -167,10 +160,10 @@ were gpt-oss only.
 
 5. Paste the printed matrix into the snapshot table above if the
    cells changed. `--print-matrix` also prints the HAPPY cost table
-   and the HAPPY → partial → cost ranking (empty extras stay
-   em-dash). Update `updated` in the JSON.
-   Do **not** copy rows into the string-pack leaderboard. Do **not**
-   invent `total_cost_usd`, `oracle_check_count`, or `partial_score`.
+   and the hard → partial → cost ranking. Update `updated` in the
+   JSON. Do **not** copy rows into the string-pack leaderboard. Do
+   **not** invent `total_cost_usd`, `oracle_check_count`, or
+   `partial_score`.
 
 `--check` validates the JSON only. The plot script refuses
 `benchmark_results.json` so a wrong `--in` cannot overwrite Pareto

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -13,7 +13,8 @@ into `scripts/prompt_optimization/benchmark_results.json`.
 | Tasks | 17 short Writer/Calc/Draw worlds | 9 Ready / Headed-ready GDPval-shaped siblings (slot 7 PARKED) |
 | Gate | Catalog sweep on OpenRouter | **`google/gemini-3.8-flash`** until HAPPY (gpt-oss is not the product gate) |
 | Pass | `hard_pass_rate` (substring + result + process oracles) | **Product bar** HAPPY / NOT_HAPPY, plus CLI **oracle** PASS / FAIL |
-| Charts | `pareto-fronts.svg` / `pareto-distance.svg` | [`eval2-heatmap.svg`](eval2-heatmap.svg), [`eval2-coverage.svg`](eval2-coverage.svg) |
+| Cost | C²/$ = metric² ÷ avg $/task | **HAPPY first**; among HAPPY, lower recorded USD / higher successes/$ |
+| Charts | `pareto-fronts.svg` / `pareto-distance.svg` | [`eval2-heatmap.svg`](eval2-heatmap.svg), [`eval2-coverage.svg`](eval2-coverage.svg), [`eval2-cost.svg`](eval2-cost.svg) |
 
 **HAPPY** means the deliverable did the job (Keith: product over
 oracle). A soft oracle FAIL on a HAPPY cell is a false-red or a
@@ -50,6 +51,31 @@ for every cell. No OpenRouter eval-2 CI job.
 
 <img src="eval2-coverage.svg" alt="Eval-2 headed coverage bars per model. Most catalog peers are entirely no data." />
 
+<img src="eval2-cost.svg" alt="Eval-2 headed cost for results. HAPPY cells with recorded USD; empty until a stamp records cost." />
+
+## Cost for results
+
+Product bar still wins: **HAPPY first**. A cheaper NOT_HAPPY run does
+not outrank an expensive HAPPY one. Among HAPPY cells that recorded
+`total_cost_usd` > 0, rank by **lower cost** (cheaper success).
+
+`intelligence_per_dollar` is **successes per USD**, computed when
+HAPPY and cost > 0:
+
+`1 / total_cost_usd`
+
+Omit the field (and the cost-chart bar) when cost is unknown or zero.
+Do **not** invent run costs from tokens, list prices, or wall time.
+This is **not** the string-harness C²/$
+(`correctness² / avg $/task` in [`docs/eval/benchmarks.md`](../benchmarks.md)).
+Eval-2 has no continuous correctness — HAPPY is binary.
+
+Optional result fields (`total_tokens`, `input_tokens`,
+`output_tokens`, `total_cost_usd`, `wall_time_s`,
+`intelligence_per_dollar`) are empty on the 2026-09-12 seed. The
+heatmap stays HAPPY / NOT. Fill cost only from a real headed stamp
+(AFC catalog sweep and later tasks).
+
 ### Cell notes (only scored pairs)
 
 | Task | Model | Stamp | Soft note |
@@ -77,7 +103,10 @@ were gpt-oss only.
    (`task_id` × `model`). Leave unknown pairs **out** of `results`.
 2. Fields: `product_bar` (`HAPPY` \| `NOT_HAPPY`), `oracle`
    (`PASS` \| `FAIL`), optional `oracle_note` / `stamp` / `source` /
-   `patches`. Schema:
+   `patches`. Optional cost axis (omit when unknown): `total_tokens` /
+   `input_tokens` / `output_tokens` (ints), `total_cost_usd`,
+   `wall_time_s`, `intelligence_per_dollar` (computed as
+   `1 / total_cost_usd` when HAPPY and cost > 0). Schema:
    [`eval2_benchmark_results.schema.json`](eval2_benchmark_results.schema.json).
 3. `task_id` must match `scripts/eval_2_headed.py --task` (`afc`,
    `tenant-retention`, …). Slot 7 stays omitted.
@@ -89,8 +118,10 @@ were gpt-oss only.
    ```
 
 5. Paste the printed matrix into the snapshot table above if the
-   cells changed. Update `updated` in the JSON. Do **not** copy rows
-   into the string-pack leaderboard.
+   cells changed. `--print-matrix` also prints the HAPPY cost table
+   (empty until a stamp records USD). Update `updated` in the JSON.
+   Do **not** copy rows into the string-pack leaderboard. Do **not**
+   invent `total_cost_usd`.
 
 `--check` validates the JSON only. The plot script refuses
 `benchmark_results.json` so a wrong `--in` cannot overwrite Pareto

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -13,8 +13,8 @@ into `scripts/prompt_optimization/benchmark_results.json`.
 | Tasks | 17 short Writer/Calc/Draw worlds | 9 Ready / Headed-ready GDPval-shaped siblings (slot 7 PARKED) |
 | Gate | Catalog sweep on OpenRouter | **`google/gemini-3.8-flash`** until HAPPY (gpt-oss is not the product gate) |
 | Pass | `hard_pass_rate` (substring + result + process oracles) | **Product bar** HAPPY / NOT_HAPPY, plus CLI **oracle** PASS / FAIL |
-| Cost | C²/$ = metric² ÷ avg $/task | **HAPPY first**; among HAPPY, lower recorded USD / higher successes/$ |
-| Charts | `pareto-fronts.svg` / `pareto-distance.svg` | [`eval2-heatmap.svg`](eval2-heatmap.svg), [`eval2-coverage.svg`](eval2-coverage.svg), [`eval2-cost.svg`](eval2-cost.svg) |
+| Cost | C²/$ = metric² ÷ avg $/task | **HAPPY first**; among comparable, higher oracle partial, then lower USD |
+| Charts | `pareto-fronts.svg` / `pareto-distance.svg` | [`eval2-heatmap.svg`](eval2-heatmap.svg), [`eval2-coverage.svg`](eval2-coverage.svg), [`eval2-cost.svg`](eval2-cost.svg), [`eval2-partial.svg`](eval2-partial.svg) |
 
 **HAPPY** means the deliverable did the job (Keith: product over
 oracle). A soft oracle FAIL on a HAPPY cell is a false-red or a
@@ -53,11 +53,54 @@ for every cell. No OpenRouter eval-2 CI job.
 
 <img src="eval2-cost.svg" alt="Eval-2 headed cost for results. HAPPY cells with recorded USD; empty until a stamp records cost." />
 
+<img src="eval2-partial.svg" alt="Eval-2 headed partial/cost view. Bars only when oracle PASS or recorded fails/checks; no invented ratios." />
+
+## Ranking stack
+
+Product bar still wins: **HAPPY first**. A cheaper or higher-partial
+NOT_HAPPY run does not outrank an expensive HAPPY one.
+
+Among **comparable** outcomes (same HAPPY / NOT_HAPPY, usually the
+same task):
+
+1. Prefer **higher oracle partial** when a ratio exists.
+2. Then prefer **lower recorded USD**.
+
+Missing partial or cost sorts last in that step — unknown does not
+beat a recorded value. Heatmap stays HAPPY / NOT.
+
+## Oracle partial
+
+AFC (`eval_2_ods_oracle`) and the Writer/Calc/Draw siblings are
+fail-closed (`passed` iff `failures` is empty) but still expose
+useful soft signals: the `failures` list, AFC `s_flags` / `r_required`,
+and husk / scored cell counts.
+
+`partial_score` is oracle quality in [0, 1], computed only when honest:
+
+- `1` when the oracle passed (`oracle` is PASS, or `oracle_passed` is
+  true).
+- Otherwise `1 − oracle_failure_count / oracle_check_count` when
+  **both** counts were recorded from that stamp's `--score` JSON.
+- Omit when FAIL and `oracle_check_count` is unknown. Do **not**
+  invent a denominator from the failure strings, autopsy prose, or
+  a guessed “typical” check count.
+
+Optional result fields: `oracle_passed`, `oracle_failure_count`,
+`oracle_check_count`, `oracle_failures` (short strings), `afc_s_flags`,
+`afc_r_required`, `husk_cells`, `scored_cells`, `partial_score`.
+The 2026-09-12 seed omits them. AFC catalog stamps can fill them
+from `eval_2_ods_oracle --json` (S/R and husks) without claiming
+more precision than fails/checks.
+
+The partial chart draws a coarse bar only when `partial_score` exists.
+S/R and husk counts can label a row; they do not become a fake 0–1
+axis.
+
 ## Cost for results
 
-Product bar still wins: **HAPPY first**. A cheaper NOT_HAPPY run does
-not outrank an expensive HAPPY one. Among HAPPY cells that recorded
-`total_cost_usd` > 0, rank by **lower cost** (cheaper success).
+Among HAPPY cells that recorded `total_cost_usd` > 0, after partial
+when it exists, rank by **lower cost** (cheaper success).
 
 `intelligence_per_dollar` is **successes per USD**, computed when
 HAPPY and cost > 0:
@@ -70,11 +113,11 @@ This is **not** the string-harness C²/$
 (`correctness² / avg $/task` in [`docs/eval/benchmarks.md`](../benchmarks.md)).
 Eval-2 has no continuous correctness — HAPPY is binary.
 
-Optional result fields (`total_tokens`, `input_tokens`,
+Optional cost fields (`total_tokens`, `input_tokens`,
 `output_tokens`, `total_cost_usd`, `wall_time_s`,
 `intelligence_per_dollar`) are empty on the 2026-09-12 seed. The
-heatmap stays HAPPY / NOT. Fill cost only from a real headed stamp
-(AFC catalog sweep and later tasks).
+heatmap stays HAPPY / NOT. Fill cost and oracle-partial only from a
+real headed stamp (AFC catalog sweep and later tasks).
 
 ### Cell notes (only scored pairs)
 
@@ -106,7 +149,12 @@ were gpt-oss only.
    `patches`. Optional cost axis (omit when unknown): `total_tokens` /
    `input_tokens` / `output_tokens` (ints), `total_cost_usd`,
    `wall_time_s`, `intelligence_per_dollar` (computed as
-   `1 / total_cost_usd` when HAPPY and cost > 0). Schema:
+   `1 / total_cost_usd` when HAPPY and cost > 0). Optional partial
+   (omit when unknown): `oracle_passed`, `oracle_failure_count`,
+   `oracle_check_count`, `oracle_failures`, `afc_s_flags` /
+   `afc_r_required`, `husk_cells` / `scored_cells`, `partial_score`
+   (`1` on PASS; else `1 − failures/checks` only when both counts
+   were recorded). Schema:
    [`eval2_benchmark_results.schema.json`](eval2_benchmark_results.schema.json).
 3. `task_id` must match `scripts/eval_2_headed.py --task` (`afc`,
    `tenant-retention`, …). Slot 7 stays omitted.
@@ -119,9 +167,10 @@ were gpt-oss only.
 
 5. Paste the printed matrix into the snapshot table above if the
    cells changed. `--print-matrix` also prints the HAPPY cost table
-   (empty until a stamp records USD). Update `updated` in the JSON.
+   and the HAPPY → partial → cost ranking (empty extras stay
+   em-dash). Update `updated` in the JSON.
    Do **not** copy rows into the string-pack leaderboard. Do **not**
-   invent `total_cost_usd`.
+   invent `total_cost_usd`, `oracle_check_count`, or `partial_score`.
 
 `--check` validates the JSON only. The plot script refuses
 `benchmark_results.json` so a wrong `--in` cannot overwrite Pareto

--- a/docs/eval/eval-2/eval2-cost.svg
+++ b/docs/eval/eval-2/eval2-cost.svg
@@ -3,7 +3,7 @@
   <title>Eval-2 headed cost for results (empty — no recorded USD)</title>
   <rect width="820" height="140" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed cost for results (HAPPY cells)</text>
-  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">HAPPY first; among HAPPY, lower recorded USD ranks higher. Successes/$ = 1 / total_cost_usd (not string-harness C²/$).</text>
+  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first. C²/$ = partial² / USD among successes (same shape as the string pack).</text>
   <rect x="24" y="64" width="772" height="40" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="410.0" y="89" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#5f6368">No HAPPY cell has recorded total_cost_usd yet</text>
 </svg>

--- a/docs/eval/eval-2/eval2-cost.svg
+++ b/docs/eval/eval-2/eval2-cost.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="140" viewBox="0 0 820 140" role="img">
+  <title>Eval-2 headed cost for results (empty — no recorded USD)</title>
+  <rect width="820" height="140" fill="#ffffff"/>
+  <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed cost for results (HAPPY cells)</text>
+  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">HAPPY first; among HAPPY, lower recorded USD ranks higher. Successes/$ = 1 / total_cost_usd (not string-harness C²/$).</text>
+  <rect x="24" y="64" width="772" height="40" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="410.0" y="89" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#5f6368">No HAPPY cell has recorded total_cost_usd yet</text>
+</svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -167,5 +167,5 @@
   <rect x="838.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
-  <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Source: headed eval-2 autopsy notes, not a catalog sweep. Empty = no in-repo stamp. Metrics are product HAPPY / oracle PASS|FAIL (not string-harness hard_pass_rate).</text>
+  <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="166" viewBox="0 0 860 166" role="img">
+  <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
+  <rect width="860" height="166" fill="#ffffff"/>
+  <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
+  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">HAPPY first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse — not C²/$.</text>
+  <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
+  <text x="296.0" y="94.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.8 Flash</text>
+  <rect x="304.0" y="82.0" width="280.0" height="16" rx="3" fill="#009E73" stroke="#dadce0" data-partial-score="1.00"/>
+  <text x="592.0" y="94.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1.00</text>
+  <text x="24" y="150" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+</svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -3,7 +3,7 @@
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
   <rect width="860" height="166" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
-  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">HAPPY first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse — not C²/$.</text>
+  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
   <text x="296.0" y="94.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.8 Flash</text>
   <rect x="304.0" y="82.0" width="280.0" height="16" rx="3" fill="#009E73" stroke="#dadce0" data-partial-score="1.00"/>

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Seeded only from in-repo autopsy / sibling notes. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Seeded only from in-repo autopsy / sibling notes. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall fields are omitted until a stamp records them — do not invent run costs. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Seeded only from in-repo autopsy / sibling notes. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields (failures/checks, AFC S/R, husks) are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded only from in-repo autopsy / sibling notes. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Seeded only from in-repo autopsy / sibling notes. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall fields are omitted until a stamp records them — do not invent run costs. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Seeded only from in-repo autopsy / sibling notes. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields (failures/checks, AFC S/R, husks) are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",

--- a/docs/eval/eval-2/eval2_benchmark_results.schema.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/KeithCu/writeragent/docs/eval/eval-2/eval2_benchmark_results.schema.json",
   "title": "Eval-2 headed multi-model results",
-  "description": "Task × model cells for headed eval-2 experiments. Metrics are product_bar (HAPPY / NOT_HAPPY) and oracle (PASS / FAIL). Optional per-result oracle partial (failures/checks, AFC S/R, husks) and cost/token/wall fields rank comparable cells: HAPPY first, then higher partial, then lower cost. Omit optional fields when unknown; never invent scores, check counts, or run costs. This is not the 17-task string-harness hard_pass_rate / C²/$ schema.",
+  "description": "Headed sibling of the 17-task string pack (hard / partial / cost). Hard is product_bar HAPPY (oracle PASS when that is the hard gate). Partial is oracle quality (failures/checks, AFC S/R, husks). C²/$ is partial_score² / total_cost_usd among HAPPY. Store separately from benchmark_results.json — never invent scores, check counts, or run costs.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -171,7 +171,7 @@
         "intelligence_per_dollar": {
           "type": ["number", "null"],
           "minimum": 0,
-          "description": "HAPPY successes per USD: 1 / total_cost_usd when product_bar is HAPPY and total_cost_usd > 0. Omit otherwise. Distinct from string-harness C²/$ (correctness² / avg $/task)."
+          "description": "Value (C²/$) among headed successes: partial_score² / total_cost_usd when product_bar is HAPPY and both values were recorded. Same shape as the string-pack metric² / avg $/task. Omit when unknown."
         },
         "oracle_passed": {
           "type": ["boolean", "null"],

--- a/docs/eval/eval-2/eval2_benchmark_results.schema.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/KeithCu/writeragent/docs/eval/eval-2/eval2_benchmark_results.schema.json",
   "title": "Eval-2 headed multi-model results",
-  "description": "Task × model cells for headed eval-2 experiments. Metrics are product_bar (HAPPY / NOT_HAPPY) and oracle (PASS / FAIL). This is not the 17-task string-harness hard_pass_rate schema. Omit a cell or set product_bar and oracle to null when no in-repo headed stamp exists — never invent scores.",
+  "description": "Task × model cells for headed eval-2 experiments. Metrics are product_bar (HAPPY / NOT_HAPPY) and oracle (PASS / FAIL). Optional per-result cost/token/wall fields rank HAPPY cells on cost for results — omit them when unknown; never invent scores or run costs. This is not the 17-task string-harness hard_pass_rate / C²/$ schema.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -142,6 +142,36 @@
               "note": { "type": "string" }
             }
           }
+        },
+        "total_tokens": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Prompt + completion tokens for this headed stamp. Omit when unknown — do not invent."
+        },
+        "input_tokens": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Prompt / input tokens for this headed stamp. Omit when unknown."
+        },
+        "output_tokens": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Completion / output tokens for this headed stamp. Omit when unknown."
+        },
+        "total_cost_usd": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "USD cost of this headed stamp (live OpenRouter pricing when known). Omit when unknown — do not invent."
+        },
+        "wall_time_s": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Wall time of the headed run in seconds. Omit when unknown."
+        },
+        "intelligence_per_dollar": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "HAPPY successes per USD: 1 / total_cost_usd when product_bar is HAPPY and total_cost_usd > 0. Omit otherwise. Distinct from string-harness C²/$ (correctness² / avg $/task)."
         }
       }
     }

--- a/docs/eval/eval-2/eval2_benchmark_results.schema.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/KeithCu/writeragent/docs/eval/eval-2/eval2_benchmark_results.schema.json",
   "title": "Eval-2 headed multi-model results",
-  "description": "Task × model cells for headed eval-2 experiments. Metrics are product_bar (HAPPY / NOT_HAPPY) and oracle (PASS / FAIL). Optional per-result cost/token/wall fields rank HAPPY cells on cost for results — omit them when unknown; never invent scores or run costs. This is not the 17-task string-harness hard_pass_rate / C²/$ schema.",
+  "description": "Task × model cells for headed eval-2 experiments. Metrics are product_bar (HAPPY / NOT_HAPPY) and oracle (PASS / FAIL). Optional per-result oracle partial (failures/checks, AFC S/R, husks) and cost/token/wall fields rank comparable cells: HAPPY first, then higher partial, then lower cost. Omit optional fields when unknown; never invent scores, check counts, or run costs. This is not the 17-task string-harness hard_pass_rate / C²/$ schema.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -172,6 +172,51 @@
           "type": ["number", "null"],
           "minimum": 0,
           "description": "HAPPY successes per USD: 1 / total_cost_usd when product_bar is HAPPY and total_cost_usd > 0. Omit otherwise. Distinct from string-harness C²/$ (correctness² / avg $/task)."
+        },
+        "oracle_passed": {
+          "type": ["boolean", "null"],
+          "description": "CLI oracle passed flag (same as OracleResult.passed). Omit when the oracle was not re-run. When omitted, plot code may derive it from oracle PASS/FAIL."
+        },
+        "oracle_failure_count": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "len(OracleResult.failures). Omit when unknown — do not invent. When omitted, plot code may use len(oracle_failures) if that list was recorded."
+        },
+        "oracle_check_count": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "How many fail-closed checks that oracle attempted on this stamp. Omit when unknown — do not invent a denominator."
+        },
+        "oracle_failures": {
+          "type": ["array", "null"],
+          "items": { "type": "string" },
+          "description": "Short OracleResult.failures strings. Omit when unknown."
+        },
+        "afc_s_flags": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "AFC Sample column-K flag=1 count (eval_2_ods_oracle s_flags). Omit on non-AFC or when unknown."
+        },
+        "afc_r_required": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "AFC required sample size R from the SSC sheet. Omit when unknown."
+        },
+        "husk_cells": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Husk / residue cell count from the task oracle. Omit when unknown."
+        },
+        "scored_cells": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Scored-cell count from the task oracle (husk ratio denominator). Omit when unknown."
+        },
+        "partial_score": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Oracle quality in [0, 1]: 1 when oracle passed; otherwise 1 − oracle_failure_count / oracle_check_count when both counts are recorded. Omit when the ratio cannot be formed — do not invent checks."
         }
       }
     }

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -98,7 +98,7 @@ Start here by task.
 | LLM Hacks & Workarounds | [chat/llm-hacks.md](chat/llm-hacks.md) |
 | Experimental memory / roadmap | [archive/hermes-agent-patterns.md](archive/hermes-agent-patterns.md), [ROADMAP.md](ROADMAP.md), [framework/robustness-roadmap.md](framework/robustness-roadmap.md) |
 | LLM evals / benchmarks | [eval/benchmarks.md](eval/benchmarks.md), [eval/string-harness-upgrade.md](eval/string-harness-upgrade.md), [scripts/prompt_optimization/README.md](../scripts/prompt_optimization/README.md) |
-| Eval-2 headed scoreboard (separate from string-pack Pareto) | [eval/eval-2/benchmarks.md](eval/eval-2/benchmarks.md), [eval/eval-2/README.md](eval/eval-2/README.md) |
+| Eval-2 headed benchmarks (sibling of string-pack hard/partial/cost; separate JSON/charts) | [eval/eval-2/benchmarks.md](eval/eval-2/benchmarks.md), [eval/eval-2/README.md](eval/eval-2/README.md) |
 
 ## References
 

--- a/scripts/plot_eval2_leaderboard.py
+++ b/scripts/plot_eval2_leaderboard.py
@@ -5,13 +5,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Write eval-2 headed task×model SVGs from a results JSON.
 
-Separate from the 17-task string-harness Pareto (`plot_pareto.py` /
-``docs/eval/pareto-*.svg``). Reads only the eval-2 headed results file —
-no OpenRouter, no ``benchmark_results.json`` merge.
+Headed sibling of the 17-task string pack (hard / partial / cost).
+Reads only the eval-2 results file — no OpenRouter, no merge into
+``benchmark_results.json`` or ``docs/eval/pareto-*.svg``.
 
-Heatmap / coverage stay HAPPY / NOT_HAPPY. Optional per-result cost
-and oracle-partial fields rank comparable cells (HAPPY first, then
-higher partial, then lower cost). Missing cost or partial stays empty.
+Heatmap / coverage stay HAPPY / NOT_HAPPY. Rank hard (HAPPY) → oracle
+partial → C²/$ among successes. Missing cost or partial stays empty.
 """
 from __future__ import annotations
 
@@ -47,9 +46,8 @@ COST_NAME = "eval2-cost.svg"
 PARTIAL_NAME = "eval2-partial.svg"
 
 FOOTNOTE = (
-    "Source: headed eval-2 autopsy notes, not a catalog sweep. "
-    "Empty = no in-repo stamp. Metrics are product HAPPY / oracle PASS|FAIL "
-    "(not string-harness hard_pass_rate)."
+    "Headed sibling of the string pack (hard / partial / cost). "
+    "Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON."
 )
 
 
@@ -221,16 +219,20 @@ def _optional_unit_interval(row: Mapping[str, Any], key: str) -> float | None:
 
 
 def compute_intelligence_per_dollar(
-    product_bar: str | None, total_cost_usd: float | None
+    product_bar: str | None,
+    total_cost_usd: float | None,
+    partial_score: float | None = None,
 ) -> float | None:
-    """HAPPY successes per USD. None when not HAPPY or cost is missing/zero.
+    """C²/$ among headed successes: partial² / USD.
 
-    Distinct from string-harness C²/$ (correctness² / avg $/task). Eval-2
-    product bar is binary, so this is ``1 / total_cost_usd``.
+    Same shape as the string-pack Value (metric² / avg $/task). Omit when
+    not HAPPY, cost is missing/zero, or partial is unknown.
     """
     if product_bar != "HAPPY" or total_cost_usd is None or total_cost_usd <= 0:
         return None
-    return 1.0 / total_cost_usd
+    if partial_score is None:
+        return None
+    return (partial_score**2) / total_cost_usd
 
 
 def compute_partial_score(
@@ -355,6 +357,11 @@ def _parse_result(
     oracle_check_count = _optional_positive_int(raw, "oracle_check_count")
     oracle_passed = resolve_oracle_passed(oracle, _optional_bool(raw, "oracle_passed"))
     stored_partial = _optional_unit_interval(raw, "partial_score")
+    partial_score = (
+        stored_partial
+        if stored_partial is not None
+        else compute_partial_score(oracle_passed, oracle_failure_count, oracle_check_count)
+    )
     return Eval2Result(
         task_id=task_id,
         model=model,
@@ -372,7 +379,7 @@ def _parse_result(
         wall_time_s=_optional_nonneg_float(raw, "wall_time_s"),
         intelligence_per_dollar=stored_ipd
         if stored_ipd is not None
-        else compute_intelligence_per_dollar(product_bar, total_cost_usd),
+        else compute_intelligence_per_dollar(product_bar, total_cost_usd, partial_score),
         oracle_passed=oracle_passed,
         oracle_failure_count=oracle_failure_count,
         oracle_check_count=oracle_check_count,
@@ -381,9 +388,7 @@ def _parse_result(
         afc_r_required=_optional_nonneg_int(raw, "afc_r_required"),
         husk_cells=_optional_nonneg_int(raw, "husk_cells"),
         scored_cells=_optional_nonneg_int(raw, "scored_cells"),
-        partial_score=stored_partial
-        if stored_partial is not None
-        else compute_partial_score(oracle_passed, oracle_failure_count, oracle_check_count),
+        partial_score=partial_score,
     )
 
 
@@ -470,7 +475,9 @@ def happy_cost_rows(board: Eval2Board) -> tuple[HappyCostRow, ...]:
             continue
         ipd = result.intelligence_per_dollar
         if ipd is None:
-            ipd = compute_intelligence_per_dollar(result.product_bar, cost)
+            ipd = compute_intelligence_per_dollar(
+                result.product_bar, cost, result.partial_score
+            )
         if ipd is None:
             continue
         rows.append(
@@ -500,7 +507,7 @@ def render_cost_markdown(board: Eval2Board) -> str:
     if not rows:
         return "No HAPPY cell has recorded `total_cost_usd` — cost chart stays empty.\n"
     lines = [
-        "| # | Task | Model | Cost (USD) | Tokens | Wall (s) | Successes/$ |",
+        "| # | Task | Model | Cost (USD) | Tokens | Wall (s) | C²/$ |",
         "| --- | --- | --- | --- | --- | --- | --- |",
     ]
     for row in rows:
@@ -833,8 +840,8 @@ def write_cost_svg(board: Eval2Board, out_path: Path) -> Path:
             f"Eval-2 headed cost for results (HAPPY cells)</text>\n",
             f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
             f'font-size="11" fill="{COLOR_MUTED}">'
-            f"HAPPY first; among HAPPY, lower recorded USD ranks higher. "
-            f"Successes/$ = 1 / total_cost_usd (not string-harness C²/$).</text>\n",
+            f"Hard (HAPPY) first. C²/$ = partial² / USD among successes "
+            f"(same shape as the string pack).</text>\n",
             f'  <rect x="{left}" y="64" width="{width - 48}" height="40" rx="6" '
             f'fill="{COLOR_EMPTY}" stroke="{COLOR_LINE}"/>\n',
             f'  <text x="{width / 2:.1f}" y="89" text-anchor="middle" '
@@ -873,8 +880,8 @@ def write_cost_svg(board: Eval2Board, out_path: Path) -> Path:
         f"Eval-2 headed cost for results (HAPPY cells)</text>\n",
         f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
         f'font-size="11" fill="{COLOR_MUTED}">'
-        f"HAPPY first; among HAPPY, lower recorded USD ranks higher. "
-        f"Successes/$ = 1 / total_cost_usd. NOT_HAPPY and missing cost omitted.</text>\n",
+        f"Hard (HAPPY) first; among HAPPY, higher partial then lower USD. "
+        f"C²/$ = partial² / USD. NOT_HAPPY and missing cost omitted.</text>\n",
     ]
     y = top
     for task, group in groups:
@@ -901,7 +908,7 @@ def write_cost_svg(board: Eval2Board, out_path: Path) -> Path:
             parts.append(
                 f'  <text x="{x + bar_w + 8:.1f}" y="{y - 6:.1f}" '
                 f'font-family="DejaVu Sans, sans-serif" font-size="10" fill="{COLOR_MUTED}">'
-                f"${row.cost_usd:.4f} · {row.intelligence_per_dollar:.2f} succ/$</text>\n"
+                f"${row.cost_usd:.4f} · {row.intelligence_per_dollar:.2f} C²/$</text>\n"
             )
         y += group_gap
     parts.append(
@@ -935,8 +942,7 @@ def write_partial_svg(board: Eval2Board, out_path: Path) -> Path:
             f"Eval-2 headed partial / cost (recorded oracle quality)</text>\n",
             f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
             f'font-size="11" fill="{COLOR_MUTED}">'
-            f"HAPPY first, then higher 1 − fails/checks, then lower USD. "
-            f"No invented denominators.</text>\n",
+            f"Hard (HAPPY) → partial → C²/$. No invented denominators.</text>\n",
             f'  <rect x="{left}" y="64" width="{width - 48}" height="40" rx="6" '
             f'fill="{COLOR_EMPTY}" stroke="{COLOR_LINE}"/>\n',
             f'  <text x="{width / 2:.1f}" y="89" text-anchor="middle" '
@@ -973,8 +979,8 @@ def write_partial_svg(board: Eval2Board, out_path: Path) -> Path:
         f"Eval-2 headed partial / cost (recorded oracle quality)</text>\n",
         f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
         f'font-size="11" fill="{COLOR_MUTED}">'
-        f"HAPPY first; among comparable, higher partial then lower USD. "
-        f"Bars only when PASS or fails/checks recorded. Coarse — not C²/$.</text>\n",
+        f"Hard (HAPPY) first; among comparable, higher partial then lower USD. "
+        f"Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>\n",
     ]
     y = top
     for task, group in groups:

--- a/scripts/plot_eval2_leaderboard.py
+++ b/scripts/plot_eval2_leaderboard.py
@@ -10,7 +10,8 @@ Separate from the 17-task string-harness Pareto (`plot_pareto.py` /
 no OpenRouter, no ``benchmark_results.json`` merge.
 
 Heatmap / coverage stay HAPPY / NOT_HAPPY. Optional per-result cost
-fields rank HAPPY cells on cost for results; missing cost stays empty.
+and oracle-partial fields rank comparable cells (HAPPY first, then
+higher partial, then lower cost). Missing cost or partial stays empty.
 """
 from __future__ import annotations
 
@@ -43,6 +44,7 @@ COLOR_LINE = "#dadce0"
 HEATMAP_NAME = "eval2-heatmap.svg"
 COVERAGE_NAME = "eval2-coverage.svg"
 COST_NAME = "eval2-cost.svg"
+PARTIAL_NAME = "eval2-partial.svg"
 
 FOOTNOTE = (
     "Source: headed eval-2 autopsy notes, not a catalog sweep. "
@@ -88,6 +90,15 @@ class Eval2Result:
     total_cost_usd: float | None = None
     wall_time_s: float | None = None
     intelligence_per_dollar: float | None = None
+    oracle_passed: bool | None = None
+    oracle_failure_count: int | None = None
+    oracle_check_count: int | None = None
+    oracle_failures: tuple[str, ...] | None = None
+    afc_s_flags: int | None = None
+    afc_r_required: int | None = None
+    husk_cells: int | None = None
+    scored_cells: int | None = None
+    partial_score: float | None = None
 
 
 @dataclass(frozen=True)
@@ -99,6 +110,17 @@ class HappyCostRow:
     result: Eval2Result
     cost_usd: float
     intelligence_per_dollar: float
+
+
+@dataclass(frozen=True)
+class RankedRow:
+    """One scored cell in HAPPY → partial → cost order (missing metrics sort last)."""
+
+    task: Eval2Task
+    model: Eval2Model
+    result: Eval2Result
+    partial_score: float | None
+    cost_usd: float | None
 
 
 @dataclass(frozen=True)
@@ -166,6 +188,38 @@ def _optional_nonneg_float(row: Mapping[str, Any], key: str) -> float | None:
     return float(value)
 
 
+def _optional_bool(row: Mapping[str, Any], key: str) -> bool | None:
+    if key not in row or row[key] is None:
+        return None
+    value = row[key]
+    if not isinstance(value, bool):
+        raise Eval2ResultsError(f"{key!r} must be a boolean or null")
+    return value
+
+
+def _optional_str_list(row: Mapping[str, Any], key: str) -> tuple[str, ...] | None:
+    if key not in row or row[key] is None:
+        return None
+    value = row[key]
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise Eval2ResultsError(f"{key!r} must be an array of strings or null")
+    return tuple(value)
+
+
+def _optional_positive_int(row: Mapping[str, Any], key: str) -> int | None:
+    value = _optional_nonneg_int(row, key)
+    if value == 0:
+        raise Eval2ResultsError(f"{key!r} must be >= 1")
+    return value
+
+
+def _optional_unit_interval(row: Mapping[str, Any], key: str) -> float | None:
+    value = _optional_nonneg_float(row, key)
+    if value is not None and value > 1.0:
+        raise Eval2ResultsError(f"{key!r} must be between 0 and 1")
+    return value
+
+
 def compute_intelligence_per_dollar(
     product_bar: str | None, total_cost_usd: float | None
 ) -> float | None:
@@ -177,6 +231,38 @@ def compute_intelligence_per_dollar(
     if product_bar != "HAPPY" or total_cost_usd is None or total_cost_usd <= 0:
         return None
     return 1.0 / total_cost_usd
+
+
+def compute_partial_score(
+    oracle_passed: bool | None,
+    oracle_failure_count: int | None,
+    oracle_check_count: int | None,
+) -> float | None:
+    """Oracle quality in [0, 1]. None when the ratio cannot be formed honestly.
+
+    ``1`` when the fail-closed oracle passed. Otherwise
+    ``1 - failure_count / check_count`` only when both counts were recorded
+    and ``check_count > 0``. Do not invent a denominator from failure text.
+    """
+    if oracle_passed is True:
+        return 1.0
+    if (
+        oracle_failure_count is None
+        or oracle_check_count is None
+        or oracle_check_count <= 0
+    ):
+        return None
+    return max(0.0, min(1.0, 1.0 - (oracle_failure_count / oracle_check_count)))
+
+
+def resolve_oracle_passed(oracle: str | None, stored: bool | None) -> bool | None:
+    if stored is not None:
+        return stored
+    if oracle == "PASS":
+        return True
+    if oracle == "FAIL":
+        return False
+    return None
 
 
 def _enum_or_none(value: object, allowed: frozenset[str], *, field: str) -> str | None:
@@ -258,6 +344,17 @@ def _parse_result(
         )
     total_cost_usd = _optional_nonneg_float(raw, "total_cost_usd")
     stored_ipd = _optional_nonneg_float(raw, "intelligence_per_dollar")
+    oracle_failures = _optional_str_list(raw, "oracle_failures")
+    stored_fail_count = _optional_nonneg_int(raw, "oracle_failure_count")
+    if stored_fail_count is not None:
+        oracle_failure_count = stored_fail_count
+    elif oracle_failures is not None:
+        oracle_failure_count = len(oracle_failures)
+    else:
+        oracle_failure_count = None
+    oracle_check_count = _optional_positive_int(raw, "oracle_check_count")
+    oracle_passed = resolve_oracle_passed(oracle, _optional_bool(raw, "oracle_passed"))
+    stored_partial = _optional_unit_interval(raw, "partial_score")
     return Eval2Result(
         task_id=task_id,
         model=model,
@@ -276,6 +373,17 @@ def _parse_result(
         intelligence_per_dollar=stored_ipd
         if stored_ipd is not None
         else compute_intelligence_per_dollar(product_bar, total_cost_usd),
+        oracle_passed=oracle_passed,
+        oracle_failure_count=oracle_failure_count,
+        oracle_check_count=oracle_check_count,
+        oracle_failures=oracle_failures,
+        afc_s_flags=_optional_nonneg_int(raw, "afc_s_flags"),
+        afc_r_required=_optional_nonneg_int(raw, "afc_r_required"),
+        husk_cells=_optional_nonneg_int(raw, "husk_cells"),
+        scored_cells=_optional_nonneg_int(raw, "scored_cells"),
+        partial_score=stored_partial
+        if stored_partial is not None
+        else compute_partial_score(oracle_passed, oracle_failure_count, oracle_check_count),
     )
 
 
@@ -374,7 +482,15 @@ def happy_cost_rows(board: Eval2Board) -> tuple[HappyCostRow, ...]:
                 intelligence_per_dollar=ipd,
             )
         )
-    rows.sort(key=lambda row: (row.task.slot, row.cost_usd, row.model.openrouter_id))
+    # Among HAPPY+cost: higher recorded partial first, then cheaper.
+    rows.sort(
+        key=lambda row: (
+            row.task.slot,
+            *_partial_sort_tuple(row.result.partial_score),
+            row.cost_usd,
+            row.model.openrouter_id,
+        )
+    )
     return tuple(rows)
 
 
@@ -394,6 +510,121 @@ def render_cost_markdown(board: Eval2Board) -> str:
             f"| {row.task.slot} | {row.task.title} | {row.model.display_name} | "
             f"{row.cost_usd:.4f} | {tokens} | {wall} | "
             f"{row.intelligence_per_dollar:.2f} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _partial_sort_tuple(score: float | None) -> tuple[int, float]:
+    """Missing partial sorts last; recorded scores sort high-to-low."""
+    if score is None:
+        return (1, 0.0)
+    return (0, -score)
+
+
+def _cost_sort_tuple(cost: float | None) -> tuple[int, float]:
+    if cost is None:
+        return (1, 0.0)
+    return (0, cost)
+
+
+def has_recorded_partial(result: Eval2Result) -> bool:
+    """True when a stamp recorded oracle quality — not merely HAPPY/NOT."""
+    return any(
+        value is not None
+        for value in (
+            result.partial_score,
+            result.oracle_failure_count,
+            result.oracle_check_count,
+            result.afc_s_flags,
+            result.afc_r_required,
+            result.husk_cells,
+            result.scored_cells,
+        )
+    ) or result.oracle_failures is not None
+
+
+def rank_sort_key(row: RankedRow) -> tuple[object, ...]:
+    """HAPPY first, then higher partial, then lower cost; missing metrics last."""
+    if row.result.product_bar == "HAPPY":
+        bar = 0
+    elif row.result.product_bar == "NOT_HAPPY":
+        bar = 1
+    else:
+        bar = 2
+    return (
+        row.task.slot,
+        bar,
+        *_partial_sort_tuple(row.partial_score),
+        *_cost_sort_tuple(row.cost_usd),
+        row.model.openrouter_id,
+    )
+
+
+def ranked_rows(board: Eval2Board) -> tuple[RankedRow, ...]:
+    task_by_id = {task.id: task for task in board.tasks}
+    model_by_id = {model.openrouter_id: model for model in board.models}
+    rows = [
+        RankedRow(
+            task=task_by_id[result.task_id],
+            model=model_by_id[result.model],
+            result=result,
+            partial_score=result.partial_score,
+            cost_usd=result.total_cost_usd if result.total_cost_usd else None,
+        )
+        for result in board.results
+    ]
+    rows.sort(key=rank_sort_key)
+    return tuple(rows)
+
+
+def _format_partial(score: float | None) -> str:
+    if score is None:
+        return "—"
+    return f"{score:.2f}"
+
+
+def _format_fails_checks(result: Eval2Result) -> str:
+    fails = result.oracle_failure_count
+    checks = result.oracle_check_count
+    if fails is None and checks is None:
+        return "—"
+    fail_s = "—" if fails is None else str(fails)
+    check_s = "—" if checks is None else str(checks)
+    return f"{fail_s}/{check_s}"
+
+
+def _format_afc_sr(result: Eval2Result) -> str:
+    if result.afc_s_flags is None and result.afc_r_required is None:
+        return "—"
+    s_text = "—" if result.afc_s_flags is None else str(result.afc_s_flags)
+    r_text = "—" if result.afc_r_required is None else str(result.afc_r_required)
+    return f"S={s_text} R={r_text}"
+
+
+def render_partial_markdown(board: Eval2Board) -> str:
+    """HAPPY → partial → cost ranking. Empty extras stay em-dash — no invented ratios."""
+    rows = ranked_rows(board)
+    if not rows:
+        return "No scored cells.\n"
+    if not any(has_recorded_partial(row.result) for row in rows):
+        return (
+            "No cell has recorded oracle partial (failures/checks or AFC S/R) — "
+            "partial chart stays empty of ratios except oracle PASS → 1.\n"
+        )
+    lines = [
+        "| # | Task | Model | Bar | Partial | Fails/checks | AFC S/R | Cost |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        if not has_recorded_partial(row.result) and row.cost_usd is None:
+            continue
+        cost = "—" if row.cost_usd is None else f"{row.cost_usd:.4f}"
+        bar = row.result.product_bar or "—"
+        lines.append(
+            f"| {row.task.slot} | {row.task.title} | {row.model.display_name} | "
+            f"{bar} | {_format_partial(row.partial_score)} | "
+            f"{_format_fails_checks(row.result)} | {_format_afc_sr(row.result)} | "
+            f"{cost} |"
         )
     return "\n".join(lines) + "\n"
 
@@ -691,11 +922,135 @@ def write_cost_svg(board: Eval2Board, out_path: Path) -> Path:
     return out_path
 
 
+def write_partial_svg(board: Eval2Board, out_path: Path) -> Path:
+    """Coarse HAPPY/partial/cost view. No bar unless a ratio or oracle PASS exists."""
+    rows = [row for row in ranked_rows(board) if has_recorded_partial(row.result)]
+    left = 24
+    width = 860
+    if not rows:
+        height = 140
+        parts = [
+            f'  <text x="{left}" y="28" font-family="DejaVu Sans, sans-serif" '
+            f'font-size="16" font-weight="700" fill="{COLOR_INK}">'
+            f"Eval-2 headed partial / cost (recorded oracle quality)</text>\n",
+            f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
+            f'font-size="11" fill="{COLOR_MUTED}">'
+            f"HAPPY first, then higher 1 − fails/checks, then lower USD. "
+            f"No invented denominators.</text>\n",
+            f'  <rect x="{left}" y="64" width="{width - 48}" height="40" rx="6" '
+            f'fill="{COLOR_EMPTY}" stroke="{COLOR_LINE}"/>\n',
+            f'  <text x="{width / 2:.1f}" y="89" text-anchor="middle" '
+            f'font-family="DejaVu Sans, sans-serif" font-size="12" fill="{COLOR_MUTED}">'
+            f"No cell has recorded oracle partial yet</text>\n",
+        ]
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            _svg_wrap(
+                "".join(parts),
+                width=width,
+                height=height,
+                title="Eval-2 headed partial / cost (empty — no recorded oracle quality)",
+            ),
+            encoding="utf-8",
+        )
+        return out_path
+
+    label_w = 280
+    bar_max_w = 280
+    row_h = 28
+    group_gap = 18
+    top = 64
+    groups: list[tuple[Eval2Task, list[RankedRow]]] = []
+    for row in rows:
+        if not groups or groups[-1][0].id != row.task.id:
+            groups.append((row.task, [row]))
+        else:
+            groups[-1][1].append(row)
+    height = top + len(rows) * row_h + len(groups) * group_gap + 56
+    parts = [
+        f'  <text x="{left}" y="28" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="16" font-weight="700" fill="{COLOR_INK}">'
+        f"Eval-2 headed partial / cost (recorded oracle quality)</text>\n",
+        f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="11" fill="{COLOR_MUTED}">'
+        f"HAPPY first; among comparable, higher partial then lower USD. "
+        f"Bars only when PASS or fails/checks recorded. Coarse — not C²/$.</text>\n",
+    ]
+    y = top
+    for task, group in groups:
+        parts.append(
+            f'  <text x="{left}" y="{y}" font-family="DejaVu Sans, sans-serif" '
+            f'font-size="12" font-weight="700" fill="{COLOR_INK}">'
+            f"{task.slot}. {_esc(task.title)}</text>\n"
+        )
+        y += 8
+        for row in group:
+            y += row_h
+            fill = (
+                COLOR_HAPPY
+                if row.result.product_bar == "HAPPY"
+                else COLOR_NOT_HAPPY
+                if row.result.product_bar == "NOT_HAPPY"
+                else COLOR_EMPTY
+            )
+            x = left + label_w
+            parts.append(
+                f'  <text x="{x - 8:.1f}" y="{y - 6:.1f}" text-anchor="end" '
+                f'font-family="DejaVu Sans, sans-serif" font-size="11" fill="{COLOR_INK}">'
+                f"{_esc(row.model.display_name)}</text>\n"
+            )
+            extras: list[str] = []
+            if row.partial_score is not None:
+                bar_w = row.partial_score * bar_max_w
+                parts.append(
+                    f'  <rect x="{x:.1f}" y="{y - 18:.1f}" width="{bar_w:.1f}" '
+                    f'height="16" rx="3" fill="{fill}" stroke="{COLOR_LINE}" '
+                    f'data-partial-score="{row.partial_score:.2f}"/>\n'
+                )
+                extras.append(_format_partial(row.partial_score))
+                label_x = x + bar_w + 8
+            else:
+                extras.append("no ratio")
+                label_x = x + 8
+            fails_checks = _format_fails_checks(row.result)
+            if fails_checks != "—":
+                extras.append(fails_checks)
+            afc = _format_afc_sr(row.result)
+            if afc != "—":
+                extras.append(afc)
+            if row.cost_usd is not None:
+                extras.append(f"${row.cost_usd:.4f}")
+            parts.append(
+                f'  <text x="{label_x:.1f}" y="{y - 6:.1f}" '
+                f'font-family="DejaVu Sans, sans-serif" font-size="10" fill="{COLOR_MUTED}">'
+                f"{_esc(' · '.join(extras))}</text>\n"
+            )
+        y += group_gap
+    parts.append(
+        f'  <text x="{left}" y="{height - 16}" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="10" fill="{COLOR_MUTED}">'
+        f"partial = 1 when oracle PASS; else 1 − fails/checks. "
+        f"Do not invent check counts.</text>\n"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        _svg_wrap(
+            "".join(parts),
+            width=width,
+            height=height,
+            title="Eval-2 headed partial / cost (recorded oracle quality)",
+        ),
+        encoding="utf-8",
+    )
+    return out_path
+
+
 def write_eval2_svgs(board: Eval2Board, out_dir: Path) -> list[Path]:
     written = [
         write_heatmap_svg(board, out_dir / HEATMAP_NAME),
         write_coverage_svg(board, out_dir / COVERAGE_NAME),
         write_cost_svg(board, out_dir / COST_NAME),
+        write_partial_svg(board, out_dir / PARTIAL_NAME),
     ]
     return written
 
@@ -735,6 +1090,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stdout.write(render_matrix_markdown(board))
         sys.stdout.write("\n")
         sys.stdout.write(render_cost_markdown(board))
+        sys.stdout.write("\n")
+        sys.stdout.write(render_partial_markdown(board))
     if args.check:
         print(f"OK {args.in_path} ({len(board.results)} scored cells, gate={board.gate_model})")
         return 0

--- a/scripts/plot_eval2_leaderboard.py
+++ b/scripts/plot_eval2_leaderboard.py
@@ -8,6 +8,9 @@
 Separate from the 17-task string-harness Pareto (`plot_pareto.py` /
 ``docs/eval/pareto-*.svg``). Reads only the eval-2 headed results file —
 no OpenRouter, no ``benchmark_results.json`` merge.
+
+Heatmap / coverage stay HAPPY / NOT_HAPPY. Optional per-result cost
+fields rank HAPPY cells on cost for results; missing cost stays empty.
 """
 from __future__ import annotations
 
@@ -39,6 +42,7 @@ COLOR_LINE = "#dadce0"
 
 HEATMAP_NAME = "eval2-heatmap.svg"
 COVERAGE_NAME = "eval2-coverage.svg"
+COST_NAME = "eval2-cost.svg"
 
 FOOTNOTE = (
     "Source: headed eval-2 autopsy notes, not a catalog sweep. "
@@ -78,6 +82,23 @@ class Eval2Result:
     source: str
     run_artifacts_committed: bool
     patches: str | None
+    total_tokens: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_cost_usd: float | None = None
+    wall_time_s: float | None = None
+    intelligence_per_dollar: float | None = None
+
+
+@dataclass(frozen=True)
+class HappyCostRow:
+    """One HAPPY cell that recorded a positive USD cost (no invented numbers)."""
+
+    task: Eval2Task
+    model: Eval2Model
+    result: Eval2Result
+    cost_usd: float
+    intelligence_per_dollar: float
 
 
 @dataclass(frozen=True)
@@ -121,6 +142,41 @@ def _optional_str(row: Mapping[str, Any], key: str) -> str:
     if not isinstance(value, str):
         raise Eval2ResultsError(f"{key!r} must be a string or null")
     return value
+
+
+def _optional_nonneg_int(row: Mapping[str, Any], key: str) -> int | None:
+    if key not in row or row[key] is None:
+        return None
+    value = row[key]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise Eval2ResultsError(f"{key!r} must be a non-negative int or null")
+    if value < 0:
+        raise Eval2ResultsError(f"{key!r} must be >= 0")
+    return value
+
+
+def _optional_nonneg_float(row: Mapping[str, Any], key: str) -> float | None:
+    if key not in row or row[key] is None:
+        return None
+    value = row[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise Eval2ResultsError(f"{key!r} must be a non-negative number or null")
+    if value < 0:
+        raise Eval2ResultsError(f"{key!r} must be >= 0")
+    return float(value)
+
+
+def compute_intelligence_per_dollar(
+    product_bar: str | None, total_cost_usd: float | None
+) -> float | None:
+    """HAPPY successes per USD. None when not HAPPY or cost is missing/zero.
+
+    Distinct from string-harness C²/$ (correctness² / avg $/task). Eval-2
+    product bar is binary, so this is ``1 / total_cost_usd``.
+    """
+    if product_bar != "HAPPY" or total_cost_usd is None or total_cost_usd <= 0:
+        return None
+    return 1.0 / total_cost_usd
 
 
 def _enum_or_none(value: object, allowed: frozenset[str], *, field: str) -> str | None:
@@ -200,6 +256,8 @@ def _parse_result(
         raise Eval2ResultsError(
             f"{task_id} × {model}: omit empty cells instead of storing a null/null result"
         )
+    total_cost_usd = _optional_nonneg_float(raw, "total_cost_usd")
+    stored_ipd = _optional_nonneg_float(raw, "intelligence_per_dollar")
     return Eval2Result(
         task_id=task_id,
         model=model,
@@ -210,6 +268,14 @@ def _parse_result(
         source=_optional_str(raw, "source"),
         run_artifacts_committed=bool(raw.get("run_artifacts_committed", False)),
         patches=raw.get("patches") if isinstance(raw.get("patches"), str) else None,
+        total_tokens=_optional_nonneg_int(raw, "total_tokens"),
+        input_tokens=_optional_nonneg_int(raw, "input_tokens"),
+        output_tokens=_optional_nonneg_int(raw, "output_tokens"),
+        total_cost_usd=total_cost_usd,
+        wall_time_s=_optional_nonneg_float(raw, "wall_time_s"),
+        intelligence_per_dollar=stored_ipd
+        if stored_ipd is not None
+        else compute_intelligence_per_dollar(product_bar, total_cost_usd),
     )
 
 
@@ -280,6 +346,55 @@ def render_matrix_markdown(board: Eval2Board) -> str:
         for model in board.models:
             cells.append(cell_label(board.result_for(task.id, model.openrouter_id)))
         lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def happy_cost_rows(board: Eval2Board) -> tuple[HappyCostRow, ...]:
+    """HAPPY cells with recorded cost > 0, cheapest success first within a task."""
+    task_by_id = {task.id: task for task in board.tasks}
+    model_by_id = {model.openrouter_id: model for model in board.models}
+    rows: list[HappyCostRow] = []
+    for result in board.results:
+        if result.product_bar != "HAPPY":
+            continue
+        cost = result.total_cost_usd
+        if cost is None or cost <= 0:
+            continue
+        ipd = result.intelligence_per_dollar
+        if ipd is None:
+            ipd = compute_intelligence_per_dollar(result.product_bar, cost)
+        if ipd is None:
+            continue
+        rows.append(
+            HappyCostRow(
+                task=task_by_id[result.task_id],
+                model=model_by_id[result.model],
+                result=result,
+                cost_usd=cost,
+                intelligence_per_dollar=ipd,
+            )
+        )
+    rows.sort(key=lambda row: (row.task.slot, row.cost_usd, row.model.openrouter_id))
+    return tuple(rows)
+
+
+def render_cost_markdown(board: Eval2Board) -> str:
+    """Per-task HAPPY cost ranking. Empty when no stamp recorded USD."""
+    rows = happy_cost_rows(board)
+    if not rows:
+        return "No HAPPY cell has recorded `total_cost_usd` — cost chart stays empty.\n"
+    lines = [
+        "| # | Task | Model | Cost (USD) | Tokens | Wall (s) | Successes/$ |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        tokens = "—" if row.result.total_tokens is None else str(row.result.total_tokens)
+        wall = "—" if row.result.wall_time_s is None else f"{row.result.wall_time_s:g}"
+        lines.append(
+            f"| {row.task.slot} | {row.task.title} | {row.model.display_name} | "
+            f"{row.cost_usd:.4f} | {tokens} | {wall} | "
+            f"{row.intelligence_per_dollar:.2f} |"
+        )
     return "\n".join(lines) + "\n"
 
 
@@ -473,10 +588,114 @@ def write_coverage_svg(board: Eval2Board, out_path: Path) -> Path:
     return out_path
 
 
+def write_cost_svg(board: Eval2Board, out_path: Path) -> Path:
+    """Bar of recorded USD for HAPPY cells. Missing cost stays empty — no invented bars."""
+    rows = happy_cost_rows(board)
+    left = 24
+    top = 64
+    width = 820
+    if not rows:
+        height = 140
+        parts = [
+            f'  <text x="{left}" y="28" font-family="DejaVu Sans, sans-serif" '
+            f'font-size="16" font-weight="700" fill="{COLOR_INK}">'
+            f"Eval-2 headed cost for results (HAPPY cells)</text>\n",
+            f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
+            f'font-size="11" fill="{COLOR_MUTED}">'
+            f"HAPPY first; among HAPPY, lower recorded USD ranks higher. "
+            f"Successes/$ = 1 / total_cost_usd (not string-harness C²/$).</text>\n",
+            f'  <rect x="{left}" y="64" width="{width - 48}" height="40" rx="6" '
+            f'fill="{COLOR_EMPTY}" stroke="{COLOR_LINE}"/>\n',
+            f'  <text x="{width / 2:.1f}" y="89" text-anchor="middle" '
+            f'font-family="DejaVu Sans, sans-serif" font-size="12" fill="{COLOR_MUTED}">'
+            f"No HAPPY cell has recorded total_cost_usd yet</text>\n",
+        ]
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            _svg_wrap(
+                "".join(parts),
+                width=width,
+                height=height,
+                title="Eval-2 headed cost for results (empty — no recorded USD)",
+            ),
+            encoding="utf-8",
+        )
+        return out_path
+
+    label_w = 280
+    bar_max_w = 360
+    row_h = 28
+    group_gap = 18
+    max_cost = max(row.cost_usd for row in rows)
+    # Group by task so AFC (and later tasks) rank among their HAPPY models.
+    groups: list[tuple[Eval2Task, list[HappyCostRow]]] = []
+    for row in rows:
+        if not groups or groups[-1][0].id != row.task.id:
+            groups.append((row.task, [row]))
+        else:
+            groups[-1][1].append(row)
+    n_bars = len(rows)
+    height = top + n_bars * row_h + len(groups) * group_gap + 56
+    parts = [
+        f'  <text x="{left}" y="28" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="16" font-weight="700" fill="{COLOR_INK}">'
+        f"Eval-2 headed cost for results (HAPPY cells)</text>\n",
+        f'  <text x="{left}" y="46" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="11" fill="{COLOR_MUTED}">'
+        f"HAPPY first; among HAPPY, lower recorded USD ranks higher. "
+        f"Successes/$ = 1 / total_cost_usd. NOT_HAPPY and missing cost omitted.</text>\n",
+    ]
+    y = top
+    for task, group in groups:
+        parts.append(
+            f'  <text x="{left}" y="{y}" font-family="DejaVu Sans, sans-serif" '
+            f'font-size="12" font-weight="700" fill="{COLOR_INK}">'
+            f"{task.slot}. {_esc(task.title)}</text>\n"
+        )
+        y += 8
+        for row in group:
+            y += row_h
+            bar_w = (row.cost_usd / max_cost) * bar_max_w if max_cost > 0 else 0.0
+            x = left + label_w
+            parts.append(
+                f'  <text x="{x - 8:.1f}" y="{y - 6:.1f}" text-anchor="end" '
+                f'font-family="DejaVu Sans, sans-serif" font-size="11" fill="{COLOR_INK}">'
+                f"{_esc(row.model.display_name)}</text>\n"
+            )
+            parts.append(
+                f'  <rect x="{x:.1f}" y="{y - 18:.1f}" width="{bar_w:.1f}" height="16" '
+                f'rx="3" fill="{COLOR_HAPPY}" stroke="{COLOR_LINE}" '
+                f'data-cost-usd="{row.cost_usd:.6f}"/>\n'
+            )
+            parts.append(
+                f'  <text x="{x + bar_w + 8:.1f}" y="{y - 6:.1f}" '
+                f'font-family="DejaVu Sans, sans-serif" font-size="10" fill="{COLOR_MUTED}">'
+                f"${row.cost_usd:.4f} · {row.intelligence_per_dollar:.2f} succ/$</text>\n"
+            )
+        y += group_gap
+    parts.append(
+        f'  <text x="{left}" y="{height - 16}" font-family="DejaVu Sans, sans-serif" '
+        f'font-size="10" fill="{COLOR_MUTED}">'
+        f"Recorded USD only. Empty cost stays empty — do not invent run costs.</text>\n"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        _svg_wrap(
+            "".join(parts),
+            width=width,
+            height=height,
+            title="Eval-2 headed cost for results (HAPPY cells with recorded USD)",
+        ),
+        encoding="utf-8",
+    )
+    return out_path
+
+
 def write_eval2_svgs(board: Eval2Board, out_dir: Path) -> list[Path]:
     written = [
         write_heatmap_svg(board, out_dir / HEATMAP_NAME),
         write_coverage_svg(board, out_dir / COVERAGE_NAME),
+        write_cost_svg(board, out_dir / COST_NAME),
     ]
     return written
 
@@ -514,6 +733,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     board = load_eval2_board(args.in_path)
     if args.print_matrix:
         sys.stdout.write(render_matrix_markdown(board))
+        sys.stdout.write("\n")
+        sys.stdout.write(render_cost_markdown(board))
     if args.check:
         print(f"OK {args.in_path} ({len(board.results)} scored cells, gate={board.gate_model})")
         return 0

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -82,6 +82,15 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "total_cost_usd",
         "wall_time_s",
         "intelligence_per_dollar",
+        "oracle_passed",
+        "oracle_failure_count",
+        "oracle_check_count",
+        "oracle_failures",
+        "afc_s_flags",
+        "afc_r_required",
+        "husk_cells",
+        "scored_cells",
+        "partial_score",
     ):
         assert key in result_props
         assert key not in schema["$defs"]["result"]["required"]
@@ -165,7 +174,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.scored_count(mid) == 0
         assert board.happy_count(mid) == 0
 
-    # Seed must not invent run costs (AFC catalog sweep fills these later).
+    # Seed must not invent run costs or oracle-partial counts.
     for row in board.results:
         assert row.total_tokens is None
         assert row.input_tokens is None
@@ -173,7 +182,23 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert row.total_cost_usd is None
         assert row.wall_time_s is None
         assert row.intelligence_per_dollar is None
+        assert row.oracle_failure_count is None
+        assert row.oracle_check_count is None
+        assert row.oracle_failures is None
+        assert row.afc_s_flags is None
+        assert row.afc_r_required is None
+        assert row.husk_cells is None
+        assert row.scored_cells is None
+        if row.oracle == "PASS":
+            assert row.oracle_passed is True
+            assert row.partial_score == 1.0
+        else:
+            assert row.oracle_passed is False
+            assert row.partial_score is None
     assert pel.happy_cost_rows(board) == ()
+    afc = board.result_for("afc", gemini)
+    assert afc is not None
+    assert pel.has_recorded_partial(afc)
 
 
 def test_every_seed_source_points_at_an_in_repo_doc() -> None:
@@ -192,6 +217,15 @@ def test_every_seed_source_points_at_an_in_repo_doc() -> None:
             "total_cost_usd",
             "wall_time_s",
             "intelligence_per_dollar",
+            "oracle_passed",
+            "oracle_failure_count",
+            "oracle_check_count",
+            "oracle_failures",
+            "afc_s_flags",
+            "afc_r_required",
+            "husk_cells",
+            "scored_cells",
+            "partial_score",
         ):
             assert key not in row or row[key] is None, row
 
@@ -208,8 +242,10 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "eval2-heatmap.svg" in text
     assert "eval2-coverage.svg" in text
     assert "eval2-cost.svg" in text
+    assert "eval2-partial.svg" in text
     assert "HAPPY first" in text
     assert "1 / total_cost_usd" in text
+    assert "1 − oracle_failure_count / oracle_check_count" in text
     assert "do **not** invent run costs" in text.lower()
     assert "Catalog-wide" in text or "catalog" in text.lower()
     assert "sweep has **not** happened" in text
@@ -223,11 +259,17 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     heatmap = (_EVAL2 / pel.HEATMAP_NAME).read_text(encoding="utf-8")
     coverage = (_EVAL2 / pel.COVERAGE_NAME).read_text(encoding="utf-8")
     cost = (_EVAL2 / pel.COST_NAME).read_text(encoding="utf-8")
+    partial = (_EVAL2 / pel.PARTIAL_NAME).read_text(encoding="utf-8")
     assert "no data" in heatmap
     assert "HAPPY" in heatmap
     assert "0 HAPPY / 0 scored" in coverage
     assert "No HAPPY cell has recorded total_cost_usd yet" in cost
     assert "data-cost-usd=" not in cost
+    # Seed has one oracle PASS (AFC) → partial 1; no invented FAIL ratios.
+    assert "data-partial-score=\"1.00\"" in partial
+    assert "Gemini 3.8 Flash" in partial
+    assert "AFC Population" in partial
+    assert "S=" not in partial
 
 
 def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> None:
@@ -255,6 +297,11 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "No HAPPY cell has recorded total_cost_usd yet" in cost_text
     assert "data-cost-usd=" not in cost_text
     assert "$0." not in cost_text
+    assert pel.PARTIAL_NAME != "pareto-fronts.svg"
+    partial_svg = pel.write_partial_svg(board, tmp_path / "eval2-partial.svg")
+    partial_text = partial_svg.read_text(encoding="utf-8")
+    assert 'data-partial-score="1.00"' in partial_text
+    assert "0.50" not in partial_text
 
 
 def test_cli_check_and_refuse_string_harness_json(
@@ -283,9 +330,11 @@ def test_cli_writes_svgs_and_print_matrix(tmp_path: Path, capsys: pytest.Capture
     printed = capsys.readouterr().out
     assert "| 3 | AFC Population | HAPPY / oracle PASS | — |" in printed
     assert "No HAPPY cell has recorded `total_cost_usd`" in printed
+    assert "| 3 | AFC Population | Gemini 3.8 Flash | HAPPY | 1.00 |" in printed
     assert (out_dir / pel.HEATMAP_NAME).is_file()
     assert (out_dir / pel.COVERAGE_NAME).is_file()
     assert (out_dir / pel.COST_NAME).is_file()
+    assert (out_dir / pel.PARTIAL_NAME).is_file()
 
 
 def test_loader_rejects_parked_slot_and_null_null_cells(tmp_path: Path) -> None:
@@ -465,3 +514,130 @@ def test_cost_chart_ranks_happy_by_lower_cost_and_skips_empty(
     )
     assert "No HAPPY cell has recorded total_cost_usd yet" in empty_svg
     assert "data-cost-usd=" not in empty_svg
+
+
+def test_partial_score_only_when_pass_or_both_counts() -> None:
+    assert pel.compute_partial_score(True, None, None) == 1.0
+    assert pel.compute_partial_score(True, 2, 6) == 1.0
+    assert pel.compute_partial_score(False, 2, 6) == pytest.approx(4 / 6)
+    assert pel.compute_partial_score(False, 0, 6) == 1.0
+    assert pel.compute_partial_score(False, 6, 6) == 0.0
+    assert pel.compute_partial_score(False, 2, None) is None
+    assert pel.compute_partial_score(False, None, 6) is None
+    assert pel.compute_partial_score(None, 2, 6) == pytest.approx(4 / 6)
+
+
+def test_loader_accepts_oracle_partial_and_ranks_happy_then_quality_then_cost(
+    tmp_path: Path,
+) -> None:
+    payload = _minimal_board_payload()
+    payload["results"][0].update(
+        {
+            "total_cost_usd": 0.40,
+            "afc_s_flags": 65,
+            "afc_r_required": 2,
+            "husk_cells": 0,
+            "scored_cells": 80,
+        }
+    )
+    payload["results"].append(
+        {
+            "task_id": "afc",
+            "model": "openai/gpt-oss-20b",
+            "product_bar": "HAPPY",
+            "oracle": "FAIL",
+            "oracle_failures": ["S=10 flag=1 in column K is < R=40"],
+            "oracle_check_count": 6,
+            "afc_s_flags": 10,
+            "afc_r_required": 40,
+            "total_cost_usd": 0.05,
+        }
+    )
+    payload["models"].append(
+        {
+            "openrouter_id": "x-ai/grok-4.6",
+            "display_name": "Grok 4.6",
+            "role": "catalog",
+        }
+    )
+    payload["results"].append(
+        {
+            "task_id": "afc",
+            "model": "x-ai/grok-4.6",
+            "product_bar": "NOT_HAPPY",
+            "oracle": "FAIL",
+            "oracle_failures": ["Sample has no data rows"],
+            "oracle_check_count": 6,
+            "total_cost_usd": 0.01,
+        }
+    )
+    path = tmp_path / "partial.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    board = pel.load_eval2_board(path)
+    gemini = board.result_for("afc", "google/gemini-3.8-flash")
+    oss = board.result_for("afc", "openai/gpt-oss-20b")
+    grok = board.result_for("afc", "x-ai/grok-4.6")
+    assert gemini is not None and oss is not None and grok is not None
+    assert gemini.partial_score == 1.0
+    assert gemini.afc_s_flags == 65
+    assert oss.oracle_failure_count == 1
+    assert oss.partial_score == pytest.approx(5 / 6)
+    assert grok.partial_score == pytest.approx(5 / 6)
+    assert grok.product_bar == "NOT_HAPPY"
+    ranked = pel.ranked_rows(board)
+    assert [row.model.openrouter_id for row in ranked] == [
+        "google/gemini-3.8-flash",
+        "openai/gpt-oss-20b",
+        "x-ai/grok-4.6",
+    ]
+    table = pel.render_partial_markdown(board)
+    assert "| 3 | AFC Population | Gemini 3.8 Flash | HAPPY | 1.00 |" in table
+    assert "S=65 R=2" in table
+    assert "S=10 R=40" in table
+    svg = pel.write_partial_svg(board, tmp_path / "eval2-partial.svg").read_text(
+        encoding="utf-8"
+    )
+    assert 'data-partial-score="1.00"' in svg
+    assert 'data-partial-score="0.83"' in svg
+    assert "Grok 4.6" in svg
+    assert "No cell has recorded oracle partial yet" not in svg
+
+
+def test_loader_does_not_invent_partial_ratio_without_check_count(tmp_path: Path) -> None:
+    payload = _minimal_board_payload()
+    payload["results"][0]["product_bar"] = "NOT_HAPPY"
+    payload["results"][0]["oracle"] = "FAIL"
+    payload["results"][0]["oracle_failures"] = ["missing Harborview Flats"]
+    path = tmp_path / "no_denom.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    board = pel.load_eval2_board(path)
+    row = board.results[0]
+    assert row.oracle_failure_count == 1
+    assert row.oracle_check_count is None
+    assert row.partial_score is None
+    svg = pel.write_partial_svg(board, tmp_path / "eval2-partial.svg").read_text(
+        encoding="utf-8"
+    )
+    assert "no ratio" in svg
+    assert "data-partial-score=" not in svg
+
+
+def test_loader_rejects_bad_partial_fields(tmp_path: Path) -> None:
+    payload = _minimal_board_payload()
+    payload["results"][0]["partial_score"] = 1.5
+    path = tmp_path / "bad_partial.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="partial_score"):
+        pel.load_eval2_board(path)
+
+    payload = _minimal_board_payload()
+    payload["results"][0]["oracle_check_count"] = 0
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="oracle_check_count"):
+        pel.load_eval2_board(path)
+
+    payload = _minimal_board_payload()
+    payload["results"][0]["oracle_failures"] = [1]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="oracle_failures"):
+        pel.load_eval2_board(path)

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -247,6 +247,8 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "partial_score`²" in text or "partial_score²" in text
     assert "1 − oracle_failure_count / oracle_check_count" in text
     assert "headed sibling" in text.lower()
+    assert "Different benchmark" in text
+    assert "One filled task still counts" in text
     assert "do **not** invent run costs" in text.lower()
     assert "Catalog-wide" in text or "catalog" in text.lower()
     assert "sweep has **not** happened" in text
@@ -257,6 +259,8 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     readme = _README.read_text(encoding="utf-8")
     assert "[`benchmarks.md`](benchmarks.md)" in readme
     assert "string-pack Pareto" in readme
+    assert "Different benchmark from the 17-task string pack" in readme
+    assert "One filled task" in readme
     heatmap = (_EVAL2 / pel.HEATMAP_NAME).read_text(encoding="utf-8")
     coverage = (_EVAL2 / pel.COVERAGE_NAME).read_text(encoding="utf-8")
     cost = (_EVAL2 / pel.COST_NAME).read_text(encoding="utf-8")

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -74,6 +74,17 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
     assert schema["properties"]["schema_version"]["const"] == 1
     assert "hard_pass_rate" not in schema["properties"]
     assert "hard_pass_rate" not in schema["$defs"]["result"]["properties"]
+    result_props = schema["$defs"]["result"]["properties"]
+    for key in (
+        "total_tokens",
+        "input_tokens",
+        "output_tokens",
+        "total_cost_usd",
+        "wall_time_s",
+        "intelligence_per_dollar",
+    ):
+        assert key in result_props
+        assert key not in schema["$defs"]["result"]["required"]
     assert {task.slot for task in board.tasks} == {1, 2, 3, 4, 5, 6, 8, 9, 10}
     assert all(task.slot != 7 for task in board.tasks)
     assert {model.openrouter_id for model in board.models} >= {
@@ -154,6 +165,16 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.scored_count(mid) == 0
         assert board.happy_count(mid) == 0
 
+    # Seed must not invent run costs (AFC catalog sweep fills these later).
+    for row in board.results:
+        assert row.total_tokens is None
+        assert row.input_tokens is None
+        assert row.output_tokens is None
+        assert row.total_cost_usd is None
+        assert row.wall_time_s is None
+        assert row.intelligence_per_dollar is None
+    assert pel.happy_cost_rows(board) == ()
+
 
 def test_every_seed_source_points_at_an_in_repo_doc() -> None:
     payload = json.loads(_RESULTS.read_text(encoding="utf-8"))
@@ -164,6 +185,15 @@ def test_every_seed_source_points_at_an_in_repo_doc() -> None:
         path = _REPO / first
         assert path.is_file(), first
         assert row.get("run_artifacts_committed") is False
+        for key in (
+            "total_tokens",
+            "input_tokens",
+            "output_tokens",
+            "total_cost_usd",
+            "wall_time_s",
+            "intelligence_per_dollar",
+        ):
+            assert key not in row or row[key] is None, row
 
 
 def test_scoreboard_markdown_matches_seed_matrix() -> None:
@@ -177,6 +207,10 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "[`docs/eval/benchmarks.md`](../benchmarks.md)" in text
     assert "eval2-heatmap.svg" in text
     assert "eval2-coverage.svg" in text
+    assert "eval2-cost.svg" in text
+    assert "HAPPY first" in text
+    assert "1 / total_cost_usd" in text
+    assert "do **not** invent run costs" in text.lower()
     assert "Catalog-wide" in text or "catalog" in text.lower()
     assert "sweep has **not** happened" in text
     for line in matrix.strip().splitlines():
@@ -188,9 +222,12 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "string-pack Pareto" in readme
     heatmap = (_EVAL2 / pel.HEATMAP_NAME).read_text(encoding="utf-8")
     coverage = (_EVAL2 / pel.COVERAGE_NAME).read_text(encoding="utf-8")
+    cost = (_EVAL2 / pel.COST_NAME).read_text(encoding="utf-8")
     assert "no data" in heatmap
     assert "HAPPY" in heatmap
     assert "0 HAPPY / 0 scored" in coverage
+    assert "No HAPPY cell has recorded total_cost_usd yet" in cost
+    assert "data-cost-usd=" not in cost
 
 
 def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> None:
@@ -211,6 +248,13 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "0 HAPPY / 0 scored" in cov
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
+    assert pel.COST_NAME != "pareto-fronts.svg"
+
+    cost_svg = pel.write_cost_svg(board, tmp_path / "eval2-cost.svg")
+    cost_text = cost_svg.read_text(encoding="utf-8")
+    assert "No HAPPY cell has recorded total_cost_usd yet" in cost_text
+    assert "data-cost-usd=" not in cost_text
+    assert "$0." not in cost_text
 
 
 def test_cli_check_and_refuse_string_harness_json(
@@ -238,8 +282,10 @@ def test_cli_writes_svgs_and_print_matrix(tmp_path: Path, capsys: pytest.Capture
     assert pel.main(["--in", str(src), "--out-dir", str(out_dir), "--print-matrix"]) == 0
     printed = capsys.readouterr().out
     assert "| 3 | AFC Population | HAPPY / oracle PASS | — |" in printed
+    assert "No HAPPY cell has recorded `total_cost_usd`" in printed
     assert (out_dir / pel.HEATMAP_NAME).is_file()
     assert (out_dir / pel.COVERAGE_NAME).is_file()
+    assert (out_dir / pel.COST_NAME).is_file()
 
 
 def test_loader_rejects_parked_slot_and_null_null_cells(tmp_path: Path) -> None:
@@ -293,3 +339,129 @@ def test_plot_module_does_not_import_string_harness() -> None:
     assert "from run_eval_multi" not in source
     assert "import plot_pareto" not in source
     assert "merge_benchmark_results" not in source
+
+
+def test_intelligence_per_dollar_only_when_happy_and_cost_positive() -> None:
+    assert pel.compute_intelligence_per_dollar("HAPPY", 0.25) == 4.0
+    assert pel.compute_intelligence_per_dollar("HAPPY", 0.0) is None
+    assert pel.compute_intelligence_per_dollar("HAPPY", None) is None
+    assert pel.compute_intelligence_per_dollar("NOT_HAPPY", 0.25) is None
+    assert pel.compute_intelligence_per_dollar(None, 0.25) is None
+
+
+def test_loader_accepts_optional_cost_fields_and_computes_ipd(tmp_path: Path) -> None:
+    payload = _minimal_board_payload()
+    payload["results"][0].update(
+        {
+            "total_tokens": 12000,
+            "input_tokens": 8000,
+            "output_tokens": 4000,
+            "total_cost_usd": 0.5,
+            "wall_time_s": 90,
+        }
+    )
+    path = tmp_path / "with_cost.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    board = pel.load_eval2_board(path)
+    row = board.results[0]
+    assert row.total_tokens == 12000
+    assert row.input_tokens == 8000
+    assert row.output_tokens == 4000
+    assert row.total_cost_usd == 0.5
+    assert row.wall_time_s == 90.0
+    assert row.intelligence_per_dollar == 2.0
+    ranked = pel.happy_cost_rows(board)
+    assert len(ranked) == 1
+    assert ranked[0].cost_usd == 0.5
+    assert ranked[0].intelligence_per_dollar == 2.0
+    table = pel.render_cost_markdown(board)
+    assert "| 3 | AFC Population | Gemini 3.8 Flash | 0.5000 | 12000 | 90 | 2.00 |" in table
+
+
+def test_loader_does_not_compute_ipd_for_not_happy_cost(tmp_path: Path) -> None:
+    payload = _minimal_board_payload()
+    payload["results"][0]["product_bar"] = "NOT_HAPPY"
+    payload["results"][0]["oracle"] = "FAIL"
+    payload["results"][0]["total_cost_usd"] = 0.01
+    path = tmp_path / "not_happy_cost.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    board = pel.load_eval2_board(path)
+    assert board.results[0].total_cost_usd == 0.01
+    assert board.results[0].intelligence_per_dollar is None
+    assert pel.happy_cost_rows(board) == ()
+    assert "stays empty" in pel.render_cost_markdown(board)
+
+
+def test_loader_rejects_negative_or_bool_cost_fields(tmp_path: Path) -> None:
+    payload = _minimal_board_payload()
+    payload["results"][0]["total_cost_usd"] = -0.1
+    path = tmp_path / "bad_cost.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="total_cost_usd"):
+        pel.load_eval2_board(path)
+
+    payload = _minimal_board_payload()
+    payload["results"][0]["total_tokens"] = True
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(pel.Eval2ResultsError, match="total_tokens"):
+        pel.load_eval2_board(path)
+
+
+def test_cost_chart_ranks_happy_by_lower_cost_and_skips_empty(
+    tmp_path: Path,
+) -> None:
+    payload = _minimal_board_payload()
+    # Cheaper HAPPY ranks first on AFC; the seed board (no costs) stays empty.
+    payload["results"][0].update({"total_cost_usd": 0.20, "total_tokens": 4000})
+    payload["results"].append(
+        {
+            "task_id": "afc",
+            "model": "openai/gpt-oss-20b",
+            "product_bar": "HAPPY",
+            "oracle": "PASS",
+            "total_cost_usd": 0.05,
+            "total_tokens": 2500,
+        }
+    )
+    payload["models"].append(
+        {
+            "openrouter_id": "x-ai/grok-4.6",
+            "display_name": "Grok 4.6",
+            "role": "catalog",
+        }
+    )
+    payload["results"].append(
+        {
+            "task_id": "afc",
+            "model": "x-ai/grok-4.6",
+            "product_bar": "HAPPY",
+            "oracle": "PASS",
+            "total_tokens": 9999,
+        }
+    )
+    path = tmp_path / "ranked.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    board = pel.load_eval2_board(path)
+    ranked = pel.happy_cost_rows(board)
+    assert [row.model.openrouter_id for row in ranked] == [
+        "openai/gpt-oss-20b",
+        "google/gemini-3.8-flash",
+    ]
+    svg = pel.write_cost_svg(board, tmp_path / "eval2-cost.svg").read_text(encoding="utf-8")
+    assert "data-cost-usd=" in svg
+    assert "0.0500" in svg
+    assert "0.2000" in svg
+    assert "GPT-OSS 20B" in svg
+    assert "Gemini 3.8 Flash" in svg
+    assert "AFC Population" in svg
+    assert "No HAPPY cell has recorded total_cost_usd yet" not in svg
+    # HAPPY without recorded USD must not invent a bar from tokens.
+    assert "Grok 4.6" not in svg
+    assert "9999" not in svg
+
+    empty_board = pel.load_eval2_board(_RESULTS)
+    empty_svg = pel.write_cost_svg(empty_board, tmp_path / "empty-cost.svg").read_text(
+        encoding="utf-8"
+    )
+    assert "No HAPPY cell has recorded total_cost_usd yet" in empty_svg
+    assert "data-cost-usd=" not in empty_svg

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -244,8 +244,9 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "eval2-cost.svg" in text
     assert "eval2-partial.svg" in text
     assert "HAPPY first" in text
-    assert "1 / total_cost_usd" in text
+    assert "partial_score`²" in text or "partial_score²" in text
     assert "1 − oracle_failure_count / oracle_check_count" in text
+    assert "headed sibling" in text.lower()
     assert "do **not** invent run costs" in text.lower()
     assert "Catalog-wide" in text or "catalog" in text.lower()
     assert "sweep has **not** happened" in text
@@ -282,7 +283,8 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "HAPPY" in heat
     assert "NOT_HAPPY" in heat
     assert "no data" in heat
-    assert "not string-harness hard_pass_rate" in heat
+    assert "sibling of the string pack" in heat
+    assert "hard_pass_rate" in heat
     assert "pareto-fronts" not in heat
     assert "google/gemini-3.8-flash" in heat
     assert "Tenant Retention" in heat
@@ -390,12 +392,14 @@ def test_plot_module_does_not_import_string_harness() -> None:
     assert "merge_benchmark_results" not in source
 
 
-def test_intelligence_per_dollar_only_when_happy_and_cost_positive() -> None:
-    assert pel.compute_intelligence_per_dollar("HAPPY", 0.25) == 4.0
-    assert pel.compute_intelligence_per_dollar("HAPPY", 0.0) is None
-    assert pel.compute_intelligence_per_dollar("HAPPY", None) is None
-    assert pel.compute_intelligence_per_dollar("NOT_HAPPY", 0.25) is None
-    assert pel.compute_intelligence_per_dollar(None, 0.25) is None
+def test_intelligence_per_dollar_is_partial_squared_over_cost() -> None:
+    assert pel.compute_intelligence_per_dollar("HAPPY", 0.25, 1.0) == 4.0
+    assert pel.compute_intelligence_per_dollar("HAPPY", 0.25, 0.5) == 1.0
+    assert pel.compute_intelligence_per_dollar("HAPPY", 0.25, None) is None
+    assert pel.compute_intelligence_per_dollar("HAPPY", 0.0, 1.0) is None
+    assert pel.compute_intelligence_per_dollar("HAPPY", None, 1.0) is None
+    assert pel.compute_intelligence_per_dollar("NOT_HAPPY", 0.25, 1.0) is None
+    assert pel.compute_intelligence_per_dollar(None, 0.25, 1.0) is None
 
 
 def test_loader_accepts_optional_cost_fields_and_computes_ipd(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Eval-2 is a **different benchmark** from the 17-task string pack, with the same scoring philosophy (hard / partial / cost). Headed multi-doc GDPval-style tasks; one filled task still counts. Stores stay separate — no fold into `benchmark_results.json` or `pareto-*.svg`.

Prominent blurb at the top of `docs/eval/eval-2/README.md`, plus a line on `docs/eval/eval-2/benchmarks.md`.

| Axis | String pack | Eval-2 |
|---|---|---|
| Hard | `hard_pass_rate` | Product HAPPY (oracle PASS when that is the hard gate) |
| Partial | correctness / quality | Oracle `1 − failures/checks` (AFC S/R, husks) |
| Cost | C²/$ = metric² / $/task | C²/$ = `partial_score`² / USD among HAPPY |

Rank **hard → partial → cost**. Missing cost or partial stays empty; no invented run data.

[Eval-2 cost chart empty until a stamp records USD](https://cursor.com/agents/bc-d34e2da2-80fc-4036-824c-1492131cc449/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feval2_cost_empty.svg)

[Eval-2 partial chart: seed AFC oracle PASS is 1.00; no invented FAIL ratios](https://cursor.com/agents/bc-d34e2da2-80fc-4036-824c-1492131cc449/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feval2_partial_seed.svg)

## Test plan

- `tests/scripts/test_plot_eval2_leaderboard.py`: 19 passed
- `make typecheck`: passed
- Pins the README / scoreboard “Different benchmark” blurbs

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d34e2da2-80fc-4036-824c-1492131cc449?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d34e2da2-80fc-4036-824c-1492131cc449&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

