### PR TITLE
Eval-2: AFC catalog FIFO complete (oss-120b through deepseek-v4.1-flash)

### DIFF
--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -27,3 +27,13 @@ Gold `Sample v2` is a **different** deliverable (variance in **I**, flags in **J
 The gold rubric still describes a separate Excel file named `Sample`. This variant is for iterating WriterAgent/Calc in-workbook behavior; do not treat gold rubric items about a separate deliverable filename as automatically rewritten.
 
 Harness pass/fail for this variant is [`rubric.eval2.md`](rubric.eval2.md) (fixture + in-workbook oracle), not a letter-shift of `rubric_pretty.txt`.
+
+## Catalog stamps
+
+First multi-model catalog cell: `openai/gpt-oss-120b` as `:nitro`, stamp
+`20260912-0142-gpt-oss-120b` (Scrolly headed). Product bar **NOT_HAPPY**,
+oracle **FAIL** (`R from Sample Size Calculation is missing or < 1`).
+Sample+SSC nonempty but wrong shape (`sample_data_rows=1516`); S=585,
+R=None, husks 0/15159. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0142-gpt-oss-120b/`.
+Scoreboard cell: [`../eval2_benchmark_results.json`](../eval2_benchmark_results.json).

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -93,3 +93,13 @@ totals were higher (not stored). OpenRouter second-send usage sum
 ~$0.04282 stored; model_configs estimate ~$0.06145 is an alternate
 only. Wall ~540–600s. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0310-nemotron-3.5-lightning/`.
+
+Eighth catalog cell: `inception/mercury-2.5-preview`, stamp
+`20260912-0330-mercury-2.5-preview`. First non-gate catalog **HAPPY** /
+oracle **PASS** (`failure_count=0`). Sample is a near-full Population
+copy (`sample_data_rows=1518`) but S=494 ≥ R=68. Husks 2/16680.
+Attempt1 contaminated; attempt2 wipe. OpenRouter usage sum ~$0.00468
+stored; model_configs estimate ~$0.03144 is an alternate only. First
+HAPPY cell with recorded USD (C²/$ lights). Run dir is box-local /
+untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0330-mercury-2.5-preview/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -45,3 +45,12 @@ husks 0/810) — better shape than the 120b dump. OpenRouter usage sum
 ~$0.0419 stored; model_configs estimate ~$0.1252 is an alternate only.
 Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0150-gpt-5.6-luna/`.
+
+Third catalog cell: `openai/gpt-oss-20b` as `:nitro` (resolved to bare
+20b; no batch 404), stamp `20260912-0202-gpt-oss-20b-nitro`. Product
+bar **NOT_HAPPY**, oracle **FAIL** (same R hole). Sample/SSC present
+but incomplete (`sample_data_rows=80`; S=0; husks 0/800) — weaker
+than Luna’s S=68. OpenRouter usage sum ~$0.00122 stored; model_configs
+estimate ~$0.00049 is an alternate only. Nitro routing OK. Run dir is
+box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0202-gpt-oss-20b-nitro/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -167,3 +167,15 @@ tip_at_run `6c6017b7`. OpenRouter usage sum ~$1.42823 stored;
 model_configs estimate ~$1.31711 is an alternate only. Run dir is
 box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0443-qwen3.8-27b/`.
+
+Fifteenth catalog cell: `qwen/qwen3.8-flash`, stamp
+`20260912-0502-qwen3.8-flash`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=1`: R from Sample Size Calculation is
+missing or < 1). Sample+SSC present (`sample_data_rows=68`); S=68;
+R=None; husks 0/680. Same R hole as Luna; slightly smaller Sample.
+SSC Err:508/509/#VALUE!; Scratch Err:513. Tokens are n=51
+OpenRouter generations. UNO/assert/PreContract=0. Recorded wall
+~540s (9 min LLM; observer ~12 min). tip_at_run `6c6017b7`.
+OpenRouter usage sum ~$0.11382 stored; model_configs estimate
+~$0.35238 is an alternate only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0502-qwen3.8-flash/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -103,3 +103,11 @@ stored; model_configs estimate ~$0.03144 is an alternate only. First
 HAPPY cell with recorded USD (C²/$ lights). Run dir is box-local /
 untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0330-mercury-2.5-preview/`.
+
+Ninth catalog cell: `x-ai/grok-4.6`, stamp `20260912-0342-grok-4.6`.
+Product bar **NOT_HAPPY**, oracle **FAIL** (`failure_count=2`: Sample
+has no data rows; R missing). SSC present; Sample empty
+(`sample_data_rows=0`); S=0; R=None; husks 0/0. OpenRouter usage sum
+~$0.02375 stored; model_configs estimate ~$0.05831 is an alternate
+only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0342-grok-4.6/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -73,3 +73,12 @@ Husk-heavy Sample flags, still under the 50% husk-dominate fail.
 OpenRouter usage sum ~$0.10841 stored; model_configs estimate ~$0.01404
 is an alternate only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0224-gemma-4-31b-it/`.
+
+Sixth catalog cell: `google/gemma-4-26b-a4b-it`, stamp
+`20260912-0240-gemma-4-26b-a4b-it`. First catalog model besides the
+Gemini 3.8 gate to produce a parseable R (**R=65**). Product bar
+**NOT_HAPPY**, oracle **FAIL** (`S=0 < R=65`). Sample undersized
+(`sample_data_rows=10`; husks 0/70). Attempt1 contaminated; attempt2
+wipe. OpenRouter usage sum ~$0.04316 stored; model_configs estimate
+~$0.05011 is an alternate only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0240-gemma-4-26b-a4b-it/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -64,3 +64,12 @@ truncated “Required Sar”=73; oracle parsed R=None — do not store 73.
 OpenRouter usage sum ~$0.00629 stored; model_configs estimate ~$0.00821
 is an alternate only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0216-gemini-3.5-flash-lite/`.
+
+Fifth catalog cell: `google/gemma-4-31b-it`, stamp
+`20260912-0224-gemma-4-31b-it`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (same R hole). Sample+SSC present (`sample_data_rows=81`;
+S=0; husks 81/810). SSC R is Err:508/#NAME?; oracle parsed R=None.
+Husk-heavy Sample flags, still under the 50% husk-dominate fail.
+OpenRouter usage sum ~$0.10841 stored; model_configs estimate ~$0.01404
+is an alternate only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0224-gemma-4-31b-it/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -179,3 +179,16 @@ OpenRouter generations. UNO/assert/PreContract=0. Recorded wall
 OpenRouter usage sum ~$0.11382 stored; model_configs estimate
 ~$0.35238 is an alternate only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0502-qwen3.8-flash/`.
+
+Sixteenth catalog cell: `z-ai/glm-5.3-flash`, stamp
+`20260912-0515-glm-5.3-flash`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=2`: missing sheet 'Sample'; missing sheet
+'Sample Size Calculation'). Population only
+(`sample_data_rows=0`); S=0; R=None; husks 0/0. Hung
+`tool_loop` at round 0 — `finish_reason=length`; no tools; truncated
+reasoning dump. Tokens are n=1 (`reasoning_tokens=15160` noted, not
+stored). UNO/assert/PreContract=0. Recorded wall ~155s. tip_at_run
+`6c6017b7`. OpenRouter usage sum ~$0.00900 stored; model_configs
+estimate ~$0.00450 is an alternate only. Run dir is box-local /
+untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0515-glm-5.3-flash/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -226,3 +226,15 @@ tip_at_run `71640e30`. OpenRouter usage sum ~$0.00973 stored;
 model_configs estimate ~$0.02475 is an alternate only. Run dir is
 box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0603-mistral-small-2603/`.
+
+Twentieth catalog cell: `bytedance-seed/seed-2.0-mini`, stamp
+`20260912-0610-seed-2.0-mini`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=2`: R from Sample Size Calculation is
+missing or < 1; husk-dominated Sample (1/1 scored cells)). Sample
+malformed (`sample_data_rows=1`; A2 is `=PY("""`); SSC Err:501 with
+a visual ~65 — oracle R=None. S=0; husks 1/1. Tokens are n=2.
+UNO/assert/PreContract=0. Recorded wall ~131s. tip_at_run
+`71640e30`. OpenRouter usage sum ~$0.00814 stored; model_configs
+estimate ~$0.00814 matches and is an alternate only. Run dir is
+box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0610-seed-2.0-mini/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -249,3 +249,15 @@ Recorded wall ~66s. tip_at_run `71640e30`. OpenRouter usage sum
 ~$0.07965 stored; model_configs estimate ~$0.10003 is an alternate
 only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0617-minimax-m3/`.
+
+Twenty-second catalog cell: `deepseek/deepseek-v4-flash-0731`, stamp
+`20260912-0621-deepseek-v4-flash-0731`. Product bar **NOT_HAPPY**,
+oracle **FAIL** (`failure_count=2`: Sample has no data rows; R from
+Sample Size Calculation is missing or < 1). Ready; Sample+SSC
+present but empty (`sample_data_rows=0`); Sample errored
+`deal.PreContractError expected__deal_wire_dict_ok`; SSC blank;
+S=0; R=None; husks 0/0. Tokens are n=51. PreContract=18;
+UNO/assert=0. Recorded wall ~330s. tip_at_run `71640e30`.
+OpenRouter usage sum ~$0.17007 stored; model_configs estimate
+~$0.18897 is an alternate only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0621-deepseek-v4-flash-0731/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -82,3 +82,14 @@ Gemini 3.8 gate to produce a parseable R (**R=65**). Product bar
 wipe. OpenRouter usage sum ~$0.04316 stored; model_configs estimate
 ~$0.05011 is an alternate only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0240-gemma-4-26b-a4b-it/`.
+
+Seventh catalog cell: `nvidia/nemotron-3.5-lightning`, stamp
+`20260912-0310-nemotron-3.5-lightning`. Product bar **NOT_HAPPY**,
+oracle **FAIL** (`failure_count=2`: missing Sample and Sample Size
+Calculation). Population only; Err:507 in J/K; `sample_data_rows=0`;
+S=0; R=None; husks 0/0. Save dialog flicker mid-flight. Tokens stored
+are the second-send OpenRouter usage (in=760171 out=3189); all-from-first
+totals were higher (not stored). OpenRouter second-send usage sum
+~$0.04282 stored; model_configs estimate ~$0.06145 is an alternate
+only. Wall ~540–600s. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0310-nemotron-3.5-lightning/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -261,3 +261,16 @@ UNO/assert=0. Recorded wall ~330s. tip_at_run `71640e30`.
 OpenRouter usage sum ~$0.17007 stored; model_configs estimate
 ~$0.18897 is an alternate only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0621-deepseek-v4-flash-0731/`.
+
+Twenty-third catalog cell (FIFO tail): `deepseek/deepseek-v4.1-flash`,
+stamp `20260912-0630-deepseek-v4.1-flash`. Product bar **NOT_HAPPY**
+(not BLOCKED — Send ran; API timed out mid loop). Oracle **FAIL**
+(`failure_count=2`: missing sheet 'Sample'; missing sheet 'Sample
+Size Calculation'). API Request Timed Out mid `tool_loop` at round
+5 on `read_cell_range` (`NetworkError`); model never finished.
+`sample_data_rows=0`; S=0; R=None; husks 0/0. Tokens are n=5
+(last send timed out). UNO/assert/PreContract=0. Recorded wall
+~270s. tip_at_run `71640e30`. OpenRouter usage sum ~$0.01832
+stored; model_configs estimate ~$0.01043 is an alternate only.
+CATALOG FIFO COMPLETE. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0630-deepseek-v4.1-flash/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -111,3 +111,14 @@ has no data rows; R missing). SSC present; Sample empty
 ~$0.02375 stored; model_configs estimate ~$0.05831 is an alternate
 only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0342-grok-4.6/`.
+
+Tenth catalog cell: `meta/muse-glimmer-30b`, stamp
+`20260912-0353-muse-glimmer-30b`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (same R hole; `failure_count=1`). Sample+SSC present
+(`sample_data_rows=81`; S=0; husks 0/729). SSC B9 visually 65; oracle
+parsed R=None — do not store 65. Hit max 50 tool rounds. Recorded
+wall ~155s (observer ~16 min). tip_at_run `e0bb6321`. PreContract
+lines=2 (PY deal); UNO/assert_main_thread=0. OpenRouter usage sum
+~$0.15404 stored; model_configs estimate ~$0.66230 is an alternate
+only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0353-muse-glimmer-30b/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -192,3 +192,14 @@ stored). UNO/assert/PreContract=0. Recorded wall ~155s. tip_at_run
 estimate ~$0.00450 is an alternate only. Run dir is box-local /
 untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0515-glm-5.3-flash/`.
+
+Seventeenth catalog cell: `upstage/solar-pro4`, stamp
+`20260912-0522-solar-pro4`. Product bar **BLOCKED** (infra, not a
+model **NOT_HAPPY**). Oracle unscored — Send never ran, so missing
+Sample+SSC is not an oracle FAIL. `SendButton` crashed before any
+LLM call (`sqlite3.OperationalError: no such table: message_store`;
+`writeragent_history.db` wiped empty/broken between trials). Send
+failed twice. Tokens 0; cost $0. Headed wait ~1080s. tip_at_run
+`6c6017b7`. Scrolly recreating schema before the next trial. Run
+dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0522-solar-pro4/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -142,3 +142,15 @@ tool loop. tip_at_run `6c6017b7`. UNO/assert/PreContract=0.
 OpenRouter usage sum ~$0.01480 stored; model_configs estimate
 ~$0.02142 is an alternate only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0419-laguna-s-2.1/`.
+
+Thirteenth catalog cell: `poolside/laguna-xs-2.1`, stamp
+`20260912-0429-laguna-xs-2.1`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=2`: missing sheet 'Sample Size
+Calculation'; Sample has no data rows). SSC tab named
+`Sample_Size_Calculation`, not "Sample Size Calculation"; Sample
+empty (`sample_data_rows=0`); S=0; R=None; husks 0/0. Raw
+`tool_call` text in the reply. Recorded wall ~85s (observer
+~3m12s). tip_at_run `6c6017b7`. UNO/assert/PreContract=0.
+OpenRouter usage sum ~$0.04341 stored; model_configs estimate
+~$0.07804 is an alternate only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0429-laguna-xs-2.1/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -203,3 +203,15 @@ failed twice. Tokens 0; cost $0. Headed wait ~1080s. tip_at_run
 `6c6017b7`. Scrolly recreating schema before the next trial. Run
 dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0522-solar-pro4/`.
+
+Eighteenth catalog cell: `ibm-granite/granite-4.2-8b`, stamp
+`20260912-0546-granite-4.2-8b`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=2`: Sample has no data rows; R from Sample
+Size Calculation is missing or < 1). SSC present; Sample blank
+(`sample_data_rows=0`); S=0; R=None; husks 0/0. Hung `tool_loop` at
+round 46 on `read_cell_range`; all `finish_reason=tool_calls`.
+Tokens are n=48. UNO/assert/PreContract=0. Recorded wall ~840s
+(14 min LLM). tip_at_run `71640e30`. OpenRouter usage sum ~$0.14353
+stored; model_configs estimate ~$0.24564 is an alternate only. Run
+dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0546-granite-4.2-8b/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -54,3 +54,13 @@ than Luna’s S=68. OpenRouter usage sum ~$0.00122 stored; model_configs
 estimate ~$0.00049 is an alternate only. Nitro routing OK. Run dir is
 box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0202-gpt-oss-20b-nitro/`.
+
+Fourth catalog cell: `google/gemini-3.5-flash-lite`, stamp
+`20260912-0216-gemini-3.5-flash-lite`. Attempt1 aborted (nitro
+contamination); attempt2 used a clean history. Product bar
+**NOT_HAPPY**, oracle **FAIL** (same R hole). Sample/SSC present
+(`sample_data_rows=81`; S=0; husks 0/648). Shot showed SSC label
+truncated “Required Sar”=73; oracle parsed R=None — do not store 73.
+OpenRouter usage sum ~$0.00629 stored; model_configs estimate ~$0.00821
+is an alternate only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0216-gemini-3.5-flash-lite/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -238,3 +238,14 @@ UNO/assert/PreContract=0. Recorded wall ~131s. tip_at_run
 estimate ~$0.00814 matches and is an alternate only. Run dir is
 box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0610-seed-2.0-mini/`.
+
+Twenty-first catalog cell: `minimax/minimax-m3`, stamp
+`20260912-0617-minimax-m3`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=2`: missing sheet 'Sample'; missing sheet
+'Sample Size Calculation'). Ready; no Sample/SSC
+(`sample_data_rows=0`); S=0; R=None; husks 0/0. Analysis sheet
+A1=`#NAME?` A2=8. Tokens are n=30. UNO/assert/PreContract=0.
+Recorded wall ~66s. tip_at_run `71640e30`. OpenRouter usage sum
+~$0.07965 stored; model_configs estimate ~$0.10003 is an alternate
+only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0617-minimax-m3/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -122,3 +122,13 @@ lines=2 (PY deal); UNO/assert_main_thread=0. OpenRouter usage sum
 ~$0.15404 stored; model_configs estimate ~$0.66230 is an alternate
 only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0353-muse-glimmer-30b/`.
+
+Eleventh catalog cell: `meta/muse-spark-1.3-contributor`, stamp
+`20260912-0409-muse-spark-1.3-contributor`. Product bar **NOT_HAPPY**,
+oracle **FAIL** (`failure_count=2`: Sample has no data rows; R
+missing). SSC present; Sample empty (`sample_data_rows=0`); S=0;
+R=None; husks 0/0. Same empty-Sample shape as Grok. tip_at_run
+`6c6017b7`. UNO/assert/PreContract=0. OpenRouter usage sum ~$0.00157
+stored; model_configs estimate ~$0.00247 is an alternate only. Run
+dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0409-muse-spark-1.3-contributor/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -215,3 +215,14 @@ Tokens are n=48. UNO/assert/PreContract=0. Recorded wall ~840s
 stored; model_configs estimate ~$0.24564 is an alternate only. Run
 dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0546-granite-4.2-8b/`.
+
+Nineteenth catalog cell: `mistralai/mistral-small-2603`, stamp
+`20260912-0603-mistral-small-2603`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=1`: R from Sample Size Calculation is
+missing or < 1). Ready with Sample+SSC
+(`sample_data_rows=81`); S=0; R=None (unparseable); husks 0/648.
+Tokens are n=14. UNO/assert/PreContract=0. Recorded wall ~32s.
+tip_at_run `71640e30`. OpenRouter usage sum ~$0.00973 stored;
+model_configs estimate ~$0.02475 is an alternate only. Run dir is
+box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0603-mistral-small-2603/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -132,3 +132,13 @@ R=None; husks 0/0. Same empty-Sample shape as Grok. tip_at_run
 stored; model_configs estimate ~$0.00247 is an alternate only. Run
 dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0409-muse-spark-1.3-contributor/`.
+
+Twelfth catalog cell: `poolside/laguna-s-2.1`, stamp
+`20260912-0419-laguna-s-2.1`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=1`: missing sheet 'Sample'). SSC present
+with parseable R=66; Sample sheet missing (`sample_data_rows=0`);
+S=0; husks 0/0. `finish_reason=length` — response truncated mid
+tool loop. tip_at_run `6c6017b7`. UNO/assert/PreContract=0.
+OpenRouter usage sum ~$0.01480 stored; model_configs estimate
+~$0.02142 is an alternate only. Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0419-laguna-s-2.1/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -154,3 +154,16 @@ empty (`sample_data_rows=0`); S=0; R=None; husks 0/0. Raw
 OpenRouter usage sum ~$0.04341 stored; model_configs estimate
 ~$0.07804 is an alternate only. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0429-laguna-xs-2.1/`.
+
+Fourteenth catalog cell: `qwen/qwen3.8-27b`, stamp
+`20260912-0443-qwen3.8-27b`. Product bar **NOT_HAPPY**, oracle
+**FAIL** (`failure_count=2`: missing sheet 'Sample'; missing sheet
+'Sample Size Calculation'). No Sample/SSC sheets
+(`sample_data_rows=0`); S=0; R=None; husks 0/0. Stayed on
+Population with `=PY` attempts. ~50 tool rounds, all
+`finish_reason=tool_calls`. Tokens are n=51 OpenRouter generations.
+PreContract=63; UNO/assert=0. Recorded wall ~720s (12 min LLM).
+tip_at_run `6c6017b7`. OpenRouter usage sum ~$1.42823 stored;
+model_configs estimate ~$1.31711 is an alternate only. Run dir is
+box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0443-qwen3.8-27b/`.

--- a/docs/eval/eval-2/afc-sample-83d10b06/notes.md
+++ b/docs/eval/eval-2/afc-sample-83d10b06/notes.md
@@ -37,3 +37,11 @@ Sample+SSC nonempty but wrong shape (`sample_data_rows=1516`); S=585,
 R=None, husks 0/15159. Run dir is box-local / untracked:
 `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0142-gpt-oss-120b/`.
 Scoreboard cell: [`../eval2_benchmark_results.json`](../eval2_benchmark_results.json).
+
+Second catalog cell: `openai/gpt-5.6-luna`, stamp `20260912-0150-gpt-5.6-luna`
+(Scrolly headed). Product bar **NOT_HAPPY**, oracle **FAIL** (same R
+hole). Sample+SSC present but incomplete (`sample_data_rows=81`; S=68;
+husks 0/810) — better shape than the 120b dump. OpenRouter usage sum
+~$0.0419 stored; model_configs estimate ~$0.1252 is an alternate only.
+Run dir is box-local / untracked:
+`docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0150-gpt-5.6-luna/`.

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -38,9 +38,9 @@ cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
 Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, GLM 5.3 Flash,
-Solar Pro 4, Granite 4.2 8B, Mistral Small 4, and Seed 2.0 Mini).
-Solar is **BLOCKED** infra (Send never ran) — not NOT_HAPPY. The
-catalog-wide headed
+Solar Pro 4, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini, and
+MiniMax M3). Solar is **BLOCKED** infra (Send never ran) — not
+NOT_HAPPY. The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -62,7 +62,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0522-solar-pro4`,
 `20260912-0546-granite-4.2-8b`,
 `20260912-0603-mistral-small-2603`,
-`20260912-0610-seed-2.0-mini`, box-local). Run dirs are typically
+`20260912-0610-seed-2.0-mini`,
+`20260912-0617-minimax-m3`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -71,17 +72,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini | MiniMax M3 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, blue BLOCKED infra, gray no data." />
 
@@ -103,16 +104,17 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
    Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, GLM 5.3
-   Flash, Granite 4.2 8B, Mistral Small 4, and Seed 2.0 Mini) are NOT
-   HAPPY except Mercury. Solar Pro
+   Flash, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini, and MiniMax
+   M3) are NOT HAPPY except Mercury. Solar Pro
    4 is **BLOCKED** infra (`SendButton` / `message_store` sqlite
    crash; Send never ran) — not a model fail. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
    produced parseable R=66 but the Sample sheet is missing
    (`failure_count=1`; truncated mid tool loop). Laguna XS is
    `failure_count=2` (SSC tab named `Sample_Size_Calculation`; Sample
-   empty). Nemotron, Qwen3.8 27B, and GLM 5.3 Flash are
-   `failure_count=2` (missing Sample+SSC). GLM hung at `tool_loop`
+   empty). Nemotron, Qwen3.8 27B, GLM 5.3 Flash, and MiniMax M3 are
+   `failure_count=2` (missing Sample+SSC). MiniMax is Ready with an
+   Analysis sheet (`A1=#NAME?`, `A2=8`) but no Sample/SSC. GLM hung at `tool_loop`
    round 0 (`finish_reason=length`; no tools; n=1). Qwen3.8 27B stayed on Population
    with `=PY` (~50 tool rounds; PreContract 63). Qwen3.8 Flash is a
    Luna-like incomplete Sample (68 rows, S=68) with SSC
@@ -132,7 +134,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -172,6 +174,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Granite 4.2 8B | `20260912-0546-granite-4.2-8b` | Eighteenth catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Hung `tool_loop` round 46 on `read_cell_range`; all `finish_reason=tool_calls`. Tokens n=48. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~840s (14 min LLM). OpenRouter usage ~$0.14353 (model_configs alt ~$0.24564 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0546-granite-4.2-8b/`. |
 | AFC Population | Mistral Small 4 | `20260912-0603-mistral-small-2603` | Nineteenth catalog cell. Ready with Sample+SSC (81 rows; S=0; husks 0/648); same R hole as Flash Lite (`failure_count=1`). Tokens n=14. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~32s. OpenRouter usage ~$0.00973 (model_configs alt ~$0.02475 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0603-mistral-small-2603/`. |
 | AFC Population | Seed 2.0 Mini | `20260912-0610-seed-2.0-mini` | Twentieth catalog cell. Sample malformed (`=PY("""` in A2; 1 row; S=0; husks 1/1 — first husk-dominated Sample). SSC Err:501 / visual ~65; oracle R=None (`failure_count=2`). Tokens n=2. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~131s. OpenRouter usage ~$0.00814 (model_configs alt matches, not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0610-seed-2.0-mini/`. |
+| AFC Population | MiniMax M3 | `20260912-0617-minimax-m3` | Twenty-first catalog cell. Ready; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Analysis A1=`#NAME?` A2=8. Tokens n=30. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~66s. OpenRouter usage ~$0.07965 (model_configs alt ~$0.10003 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0617-minimax-m3/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -230,10 +233,11 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0515-glm-5.3-flash`,
 `20260912-0546-granite-4.2-8b`,
 `20260912-0603-mistral-small-2603`,
-`20260912-0610-seed-2.0-mini`) recorded tokens, wall,
+`20260912-0610-seed-2.0-mini`,
+`20260912-0617-minimax-m3`) recorded tokens, wall,
 USD, and S/husks. `20260912-0522-solar-pro4` is **BLOCKED** infra
 (tokens/cost 0; oracle omitted). FAIL cells have `failure_count` 1 (or 2 on
-Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini) and no `oracle_check_count` / `partial_score`.
+Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
 renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
 missing Sample+SSC shape at far higher USD. Qwen3.8 Flash is the
@@ -245,6 +249,8 @@ Mistral Small 4 matches Flash Lite’s 81-row S=0 husks-0/648 R hole
 (`failure_count=1`).
 Seed 2.0 Mini is the first husk-dominated Sample (`1/1`) plus R
 missing (`failure_count=2`); visual SSC ~65 is not stored as R.
+MiniMax M3 matches Nemotron/GLM’s missing Sample+SSC with a Ready
+Analysis sheet (`#NAME?` / 8).
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -38,8 +38,9 @@ cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
 Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, GLM 5.3 Flash,
-Solar Pro 4, and Granite 4.2 8B). Solar is **BLOCKED** infra (Send
-never ran) — not NOT_HAPPY. The catalog-wide headed
+Solar Pro 4, Granite 4.2 8B, and Mistral Small 4). Solar is
+**BLOCKED** infra (Send never ran) — not NOT_HAPPY. The
+catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -59,7 +60,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0502-qwen3.8-flash`,
 `20260912-0515-glm-5.3-flash`,
 `20260912-0522-solar-pro4`,
-`20260912-0546-granite-4.2-8b`, box-local). Run dirs are typically
+`20260912-0546-granite-4.2-8b`,
+`20260912-0603-mistral-small-2603`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -68,17 +70,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, blue BLOCKED infra, gray no data." />
 
@@ -100,7 +102,8 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
    Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, GLM 5.3
-   Flash, and Granite 4.2 8B) are NOT HAPPY except Mercury. Solar Pro
+   Flash, Granite 4.2 8B, and Mistral Small 4) are NOT HAPPY except
+   Mercury. Solar Pro
    4 is **BLOCKED** infra (`SendButton` / `message_store` sqlite
    crash; Send never ran) — not a model fail. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
@@ -116,7 +119,9 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    4.2 8B are also `failure_count=2` (SSC present, Sample empty, R
    missing). Granite hung `tool_loop` at round 46 on
    `read_cell_range` (n=48; all `finish_reason=tool_calls`). Glimmer
-   is the same R hole as Luna/20b on an 81-row Sample with S=0; SSC
+   and Mistral Small 4 are the same R hole as Luna/20b/Flash Lite on
+   an 81-row Sample with S=0 (Mistral husks 0/648, same as Flash
+   Lite; Glimmer husks 0/729). Glimmer SSC
    B9 looked like 65 but oracle R=None. Luna’s Sample is a better
    incomplete shape (81 rows, S=68) than 120b’s 1516-row dump.
    Floorstand is NOT HAPPY on both Gemini 3.8 and 120b. Overnight
@@ -161,6 +166,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | GLM 5.3 Flash | `20260912-0515-glm-5.3-flash` | Sixteenth catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Hung `tool_loop` round 0 — `finish_reason=length`; no tools; truncated reasoning dump. Tokens n=1 (`reasoning_tokens=15160` noted, not stored). tip `6c6017b7`. UNO/assert/PreContract 0. Recorded wall ~155s. OpenRouter usage ~$0.00900 (model_configs alt ~$0.00450 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0515-glm-5.3-flash/`. |
 | AFC Population | Solar Pro 4 | `20260912-0522-solar-pro4` | Seventeenth catalog cell — **BLOCKED** infra, not a model fail. `SendButton` crashed before any LLM call (`sqlite3.OperationalError: no such table: message_store`). Send failed twice. Oracle unscored (missing Sample+SSC only because Send never ran). Tokens 0; cost $0. Headed wait ~1080s. tip `6c6017b7`. Scrolly recreating schema before next trial. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0522-solar-pro4/`. |
 | AFC Population | Granite 4.2 8B | `20260912-0546-granite-4.2-8b` | Eighteenth catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Hung `tool_loop` round 46 on `read_cell_range`; all `finish_reason=tool_calls`. Tokens n=48. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~840s (14 min LLM). OpenRouter usage ~$0.14353 (model_configs alt ~$0.24564 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0546-granite-4.2-8b/`. |
+| AFC Population | Mistral Small 4 | `20260912-0603-mistral-small-2603` | Nineteenth catalog cell. Ready with Sample+SSC (81 rows; S=0; husks 0/648); same R hole as Flash Lite (`failure_count=1`). Tokens n=14. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~32s. OpenRouter usage ~$0.00973 (model_configs alt ~$0.02475 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0603-mistral-small-2603/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -217,7 +223,8 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0443-qwen3.8-27b`,
 `20260912-0502-qwen3.8-flash`,
 `20260912-0515-glm-5.3-flash`,
-`20260912-0546-granite-4.2-8b`) recorded tokens, wall,
+`20260912-0546-granite-4.2-8b`,
+`20260912-0603-mistral-small-2603`) recorded tokens, wall,
 USD, and S/husks. `20260912-0522-solar-pro4` is **BLOCKED** infra
 (tokens/cost 0; oracle omitted). FAIL cells have `failure_count` 1 (or 2 on
 Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B) and no `oracle_check_count` / `partial_score`.
@@ -228,6 +235,8 @@ Luna-like S=68 R-missing Sample on 68 rows. GLM 5.3 Flash hung at
 round 0 with no tools and the same missing Sample+SSC shape.
 Granite 4.2 8B matches Grok/Spark’s empty-Sample + SSC-present R
 hole, hung at round 46 on `read_cell_range`.
+Mistral Small 4 matches Flash Lite’s 81-row S=0 husks-0/648 R hole
+(`failure_count=1`).
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,7 +36,7 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. Luna, 20B, and Gemini 3.5 Flash Lite have an AFC stamp only.
+score. Luna, 20B, Flash Lite, and Gemma 4 31B have an AFC stamp only.
 Remaining catalog columns (Grok 4.6, Muse Spark 1.3) are placeholders.
 The catalog-wide headed sweep has **not** happened.
 
@@ -45,24 +45,25 @@ The catalog-wide headed sweep has **not** happened.
 Seeded from the autopsy, sibling notes, and Scrolly AFC catalog
 stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0202-gpt-oss-20b-nitro`,
-`20260912-0216-gemini-3.5-flash-lite`, box-local). Run dirs are
-typically untracked — `run_artifacts_committed` is false for every
-cell. No OpenRouter eval-2 CI job. No HAPPY cell has recorded USD yet.
+`20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
+box-local). Run dirs are typically untracked —
+`run_artifacts_committed` is false for every cell. No OpenRouter
+eval-2 CI job. No HAPPY cell has recorded USD yet.
 
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Grok 4.6 | Muse Spark 1.3 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Grok 4.6 | Muse Spark 1.3 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -77,25 +78,24 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
    AFC. gpt-oss-120b is HAPPY only on GMP-0225. Catalog AFC cells
    (`20260912-0142` 120b, `20260912-0150` Luna, `20260912-0202` 20b,
-   `20260912-0216` Flash Lite) are all NOT HAPPY (missing R). Luna’s
-   Sample is a better shape (81 rows, S=68) than 120b’s 1516-row dump;
-   20b and Flash Lite are similar size (80–81 rows) but S=0. Floorstand
-   is NOT HAPPY on both Gemini 3.8 and 120b. Overnight slots 6/8/9/10
-   (gpt-oss only) are all NOT HAPPY.
+   `20260912-0216` Flash Lite, `20260912-0224` Gemma) are all NOT
+   HAPPY (missing R). Luna’s Sample is a better shape (81 rows, S=68)
+   than 120b’s 1516-row dump; 20b / Flash Lite / Gemma are similar size
+   (80–81 rows) but S=0. Gemma is husk-heavy (81/810) with SSC
+   Err:508/#NAME?. Floorstand is NOT HAPPY on both Gemini 3.8 and 120b.
+   Overnight slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 is oracle PASS (`partial_score` = 1).
    Catalog AFC cells each recorded `failure_count=1` (R missing) plus
-   S/husks but no `oracle_check_count`, so no FAIL ratio. Flash Lite’s
-   shot showed a truncated SSC label “Required Sar”=73; oracle still
-   parsed R=None. Tenant / Cadaver / GMP HAPPY cells are still oracle
-   FAIL without a recorded check count. Do not invent one from autopsy
-   prose.
+   S/husks but no `oracle_check_count`, so no FAIL ratio. Tenant /
+   Cadaver / GMP HAPPY cells are still oracle FAIL without a recorded
+   check count. Do not invent one from autopsy prose.
 3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
    chart stays empty (AFC catalog USD is on NOT_HAPPY cells). Then
    Value is `partial_score`² ÷ that USD among HAPPY.
 4. **Coverage:** Grok 4.6 and Muse Spark are entirely no data. Luna,
-   20b, and Flash Lite have AFC only. Gemini 3.8 has no stamp yet for
-   GMP, Calc-primary, Draw-primary, Reverse Tenant, or Long Writer.
-   gpt-oss-120b has no stamp for Tenant or Cadaver.
+   20b, Flash Lite, and Gemma have AFC only. Gemini 3.8 has no stamp
+   yet for GMP, Calc-primary, Draw-primary, Reverse Tenant, or Long
+   Writer. gpt-oss-120b has no stamp for Tenant or Cadaver.
 
 ### Cell notes (only scored pairs)
 
@@ -108,6 +108,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | GPT-5.6 Luna | `20260912-0150-gpt-5.6-luna` | Second catalog cell. Sample+SSC present but incomplete (81 rows; S=68; husks 0/810); same R hole as 120b. OpenRouter usage ~$0.0419 (model_configs alt ~$0.1252 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0150-gpt-5.6-luna/`. |
 | AFC Population | GPT-OSS 20B | `20260912-0202-gpt-oss-20b-nitro` | Third catalog cell. Ran as `:nitro` (resolved to bare 20b). Sample/SSC present but incomplete (80 rows; S=0; husks 0/800); same R hole, weaker than Luna. OpenRouter usage ~$0.00122 (model_configs alt ~$0.00049 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0202-gpt-oss-20b-nitro/`. |
 | AFC Population | Gemini 3.5 Flash Lite | `20260912-0216-gemini-3.5-flash-lite` | Fourth catalog cell. Attempt1 aborted (nitro contamination); attempt2 clean history. Sample/SSC present (81 rows; S=0; husks 0/648). Shot SSC label truncated “Required Sar”=73; oracle R=None. OpenRouter usage ~$0.00629 (model_configs alt ~$0.00821 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0216-gemini-3.5-flash-lite/`. |
+| AFC Population | Gemma 4 31B | `20260912-0224-gemma-4-31b-it` | Fifth catalog cell. Sample+SSC present (81 rows; S=0; husks 81/810). SSC R is Err:508/#NAME?; oracle R=None. OpenRouter usage ~$0.10841 (model_configs alt ~$0.01404 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0224-gemma-4-31b-it/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -153,9 +154,9 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `partial_score` = 1 on AFC Gemini. Catalog AFC stamps
 (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0202-gpt-oss-20b-nitro`,
-`20260912-0216-gemini-3.5-flash-lite`) recorded tokens, wall, USD,
-`failure_count=1`, S/husks — not `oracle_check_count` or
-`partial_score`.
+`20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`)
+recorded tokens, wall, USD, `failure_count=1`, S/husks — not
+`oracle_check_count` or `partial_score`.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -41,9 +41,10 @@ placeholders. The catalog-wide headed sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 
-Seeded from the autopsy and sibling notes. Run dirs are typically
-untracked — `run_artifacts_committed` is false for every cell. No
-OpenRouter eval-2 CI job. Cost and most partial counts are still empty.
+Seeded from the autopsy, sibling notes, and the first Scrolly AFC
+catalog stamp (`20260912-0142-gpt-oss-120b`, box-local). Run dirs are
+typically untracked — `run_artifacts_committed` is false for every
+cell. No OpenRouter eval-2 CI job. No HAPPY cell has recorded USD yet.
 
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
@@ -52,7 +53,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — |
 | 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | — | — | — |
 | 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — |
 | 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — |
 | 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — |
@@ -71,19 +72,22 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 ## Key insights
 
 1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
-   AFC. gpt-oss-120b is HAPPY only on GMP-0225. Floorstand is NOT HAPPY
-   on both. Overnight slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
-2. **Partial:** AFC Gemini is oracle PASS (`partial_score` = 1). Tenant /
+   AFC. gpt-oss-120b is HAPPY only on GMP-0225. First catalog AFC cell
+   (`20260912-0142`) is NOT HAPPY (near-full dump, missing R). Floorstand
+   is NOT HAPPY on both. Overnight slots 6/8/9/10 (gpt-oss only) are
+   all NOT HAPPY.
+2. **Partial:** AFC Gemini is oracle PASS (`partial_score` = 1). AFC
+   gpt-oss-120b recorded `failure_count=1` (R missing) plus S=585 /
+   husks 0/15159, but no `oracle_check_count`, so no FAIL ratio. Tenant /
    Cadaver / GMP HAPPY cells are still oracle FAIL without a recorded
-   `oracle_check_count`, so they have no ratio yet. Do not invent one
-   from autopsy prose.
+   check count. Do not invent one from autopsy prose.
 3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
-   chart stays empty until the AFC catalog sweep (and later tasks) fill
-   USD. Then Value is `partial_score`² ÷ that USD.
+   chart stays empty (the AFC 120b USD is on a NOT_HAPPY cell). Then
+   Value is `partial_score`² ÷ that USD among HAPPY.
 4. **Coverage:** catalog peers (20B, Grok 4.6, Muse Spark) are entirely
    no data. Gemini has no stamp yet for GMP, Calc-primary, Draw-primary,
-   Reverse Tenant, or Long Writer. gpt-oss has no stamp for Tenant,
-   Cadaver, or AFC.
+   Reverse Tenant, or Long Writer. gpt-oss has no stamp for Tenant or
+   Cadaver.
 
 ### Cell notes (only scored pairs)
 
@@ -92,6 +96,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | Tenant Retention | Gemini 3.8 Flash | `20260908-0121-gemini-3.8-flash-r200` | Oracle false-red (titles in `text:h`, table cells, length); later softened. |
 | Cadaver Proposal | Gemini 3.8 Flash | `20260908-2246-gemini-3.8-flash-r200` | Oracle false-red (aliases, Figure/`draw:frame`, length). |
 | AFC Population | Gemini 3.8 Flash | `20260908-0030-retry2` | Oracle PASS after smoother (S=65 R=2). Autopsy abbreviates the stamp with `…`. |
+| AFC Population | GPT-OSS 120B | `20260912-0142-gpt-oss-120b` | First catalog cell. Sample+SSC nonempty but wrong shape (1516 rows); R missing; S=585; husks 0/15159; Ready then kept iterating. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0142-gpt-oss-120b/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -132,9 +137,12 @@ Optional result fields (`oracle_passed`, `oracle_failure_count`,
 `oracle_check_count`, `oracle_failures`, `afc_s_flags`,
 `afc_r_required`, `husk_cells`, `scored_cells`, `partial_score`,
 `total_tokens`, `input_tokens`, `output_tokens`, `total_cost_usd`,
-`wall_time_s`, `intelligence_per_dollar`) are empty on the 2026-09-12
-seed except the derived PASS → `partial_score` = 1 on AFC Gemini.
-Fill the rest only from a real headed stamp.
+`wall_time_s`, `intelligence_per_dollar`) stay empty unless a stamp
+recorded them. The 2026-09-12 seed still has derived PASS →
+`partial_score` = 1 on AFC Gemini. The first catalog AFC stamp
+(`20260912-0142-gpt-oss-120b`) recorded tokens, wall, est. USD,
+`failure_count=1`, S/husks — not `oracle_check_count` or
+`partial_score`.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,9 +36,10 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. Luna, 20B, Flash Lite, Gemma 4 31B, and Gemma 4 26B A4B have an
-AFC stamp only. Remaining catalog columns (Grok 4.6, Muse Spark 1.3)
-are placeholders. The catalog-wide headed sweep has **not** happened.
+score. Luna, 20B, Flash Lite, Gemma 4 31B, Gemma 4 26B A4B, and
+Nemotron 3.5 Lightning have an AFC stamp only. Remaining catalog
+columns (Grok 4.6, Muse Spark 1.3) are placeholders. The catalog-wide
+headed sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 
@@ -46,7 +47,8 @@ Seeded from the autopsy, sibling notes, and Scrolly AFC catalog
 stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0202-gpt-oss-20b-nitro`,
 `20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
-`20260912-0240-gemma-4-26b-a4b-it`, box-local). Run dirs are typically
+`20260912-0240-gemma-4-26b-a4b-it`,
+`20260912-0310-nemotron-3.5-lightning`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. No HAPPY cell has recorded USD yet.
@@ -54,17 +56,17 @@ eval-2 CI job. No HAPPY cell has recorded USD yet.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Grok 4.6 | Muse Spark 1.3 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Grok 4.6 | Muse Spark 1.3 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -78,16 +80,18 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 
 1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
    AFC. gpt-oss-120b is HAPPY only on GMP-0225. Catalog AFC cells
-   (`20260912-0142` 120b through `20260912-0240` 26B A4B) are all NOT
+   (`20260912-0142` 120b through `20260912-0310` Nemotron) are all NOT
    HAPPY. Most miss R. Gemma 4 26B A4B is the first catalog model
    besides the Gemini 3.8 gate to produce R=65, then fails S=0 < R on
-   a 10-row Sample. Luna’s Sample is a better shape (81 rows, S=68)
-   than 120b’s 1516-row dump. Floorstand is NOT HAPPY on both Gemini
-   3.8 and 120b. Overnight slots 6/8/9/10 (gpt-oss only) are all NOT
-   HAPPY.
+   a 10-row Sample. Nemotron is the first catalog cell with
+   `failure_count=2` (Population only; no Sample/SSC). Luna’s Sample
+   is a better shape (81 rows, S=68) than 120b’s 1516-row dump.
+   Floorstand is NOT HAPPY on both Gemini 3.8 and 120b. Overnight
+   slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 is oracle PASS (`partial_score` = 1).
-   Catalog AFC cells each recorded `failure_count=1` plus S/husks but
-   no `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
+   Catalog AFC cells recorded `failure_count` (1, or 2 on Nemotron)
+   plus S/husks but no `oracle_check_count`, so no FAIL ratio.
+   Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
 3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
@@ -111,6 +115,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Gemini 3.5 Flash Lite | `20260912-0216-gemini-3.5-flash-lite` | Fourth catalog cell. Attempt1 aborted (nitro contamination); attempt2 clean history. Sample/SSC present (81 rows; S=0; husks 0/648). Shot SSC label truncated “Required Sar”=73; oracle R=None. OpenRouter usage ~$0.00629 (model_configs alt ~$0.00821 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0216-gemini-3.5-flash-lite/`. |
 | AFC Population | Gemma 4 31B | `20260912-0224-gemma-4-31b-it` | Fifth catalog cell. Sample+SSC present (81 rows; S=0; husks 81/810). SSC R is Err:508/#NAME?; oracle R=None. OpenRouter usage ~$0.10841 (model_configs alt ~$0.01404 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0224-gemma-4-31b-it/`. |
 | AFC Population | Gemma 4 26B A4B | `20260912-0240-gemma-4-26b-a4b-it` | Sixth catalog cell. First catalog R=65 besides the Gemini gate; Sample undersized (10 rows, S=0 < R). Attempt1 contaminated; attempt2 wipe. OpenRouter usage ~$0.04316 (model_configs alt ~$0.05011 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0240-gemma-4-26b-a4b-it/`. |
+| AFC Population | Nemotron 3.5 Lightning | `20260912-0310-nemotron-3.5-lightning` | Seventh catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0; Err:507 in J/K; Save dialog flicker. Tokens are second-send (all-from-first higher, not stored). OpenRouter second-send ~$0.04282 (model_configs alt ~$0.06145 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0310-nemotron-3.5-lightning/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -157,9 +162,10 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0202-gpt-oss-20b-nitro`,
 `20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
-`20260912-0240-gemma-4-26b-a4b-it`) recorded tokens, wall, USD,
-`failure_count=1`, S/husks — not `oracle_check_count` or
-`partial_score`.
+`20260912-0240-gemma-4-26b-a4b-it`,
+`20260912-0310-nemotron-3.5-lightning`) recorded tokens, wall, USD,
+`failure_count` (1, or 2 on Nemotron), S/husks — not
+`oracle_check_count` or `partial_score`.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -37,7 +37,7 @@ partial and USD.
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
-Glimmer 30B, Muse Spark 1.3, and Laguna S 2.1). The catalog-wide headed
+Glimmer 30B, Muse Spark 1.3, Laguna S 2.1, and Laguna XS 2.1). The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -51,7 +51,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
 `20260912-0353-muse-glimmer-30b`,
 `20260912-0409-muse-spark-1.3-contributor`,
-`20260912-0419-laguna-s-2.1`, box-local). Run dirs are typically
+`20260912-0419-laguna-s-2.1`,
+`20260912-0429-laguna-xs-2.1`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -60,17 +61,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -91,10 +92,12 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok, plus Glimmer, Spark, and Laguna) are NOT HAPPY except Mercury. Most
-   miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna
+   Grok, plus Glimmer, Spark, and both Lagunas) are NOT HAPPY except Mercury. Most
+   miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
    produced parseable R=66 but the Sample sheet is missing
-   (`failure_count=1`; truncated mid tool loop). Nemotron
+   (`failure_count=1`; truncated mid tool loop). Laguna XS is
+   `failure_count=2` (SSC tab named `Sample_Size_Calculation`; Sample
+   empty). Nemotron
    is `failure_count=2` (missing Sample+SSC). Grok and Spark are also
    `failure_count=2` (SSC present, Sample empty, R missing). Glimmer
    is the same R hole as Luna/20b on an 81-row Sample with S=0; SSC
@@ -104,7 +107,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok/Spark) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -136,6 +139,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Muse Glimmer 30B | `20260912-0353-muse-glimmer-30b` | Tenth catalog cell. Sample+SSC present (81 rows; S=0; husks 0/729); same R hole. SSC B9 visually 65; oracle R=None. Hit max 50 tool rounds; recorded wall ~155s (observer ~16 min). tip `e0bb6321`. OpenRouter usage ~$0.15404 (model_configs alt ~$0.66230 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0353-muse-glimmer-30b/`. |
 | AFC Population | Muse Spark 1.3 | `20260912-0409-muse-spark-1.3-contributor` | Eleventh catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Same empty-Sample shape as Grok. tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.00157 (model_configs alt ~$0.00247 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0409-muse-spark-1.3-contributor/`. |
 | AFC Population | Laguna S 2.1 | `20260912-0419-laguna-s-2.1` | Twelfth catalog cell. SSC present with parseable R=66; Sample sheet missing (`failure_count=1`); S=0 R=66; husks 0/0. `finish_reason=length` — truncated mid tool loop. tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.01480 (model_configs alt ~$0.02142 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0419-laguna-s-2.1/`. |
+| AFC Population | Laguna XS 2.1 | `20260912-0429-laguna-xs-2.1` | Thirteenth catalog cell. SSC tab named `Sample_Size_Calculation` (oracle missing SSC); Sample empty (`failure_count=2`); S=0 R=None; husks 0/0. Raw `tool_call` text in the reply. Recorded wall ~85s (observer ~3m12s). tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.04341 (model_configs alt ~$0.07804 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0429-laguna-xs-2.1/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -187,10 +191,12 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
 `20260912-0353-muse-glimmer-30b`,
 `20260912-0409-muse-spark-1.3-contributor`,
-`20260912-0419-laguna-s-2.1`) recorded tokens, wall,
+`20260912-0419-laguna-s-2.1`,
+`20260912-0429-laguna-xs-2.1`) recorded tokens, wall,
 USD, and S/husks. FAIL cells have `failure_count` 1 (or 2 on
-Nemotron/Grok/Spark) and no `oracle_check_count` / `partial_score`.
-Laguna stored parseable R=66 with a missing Sample sheet.
+Nemotron/Grok/Spark/Laguna XS) and no `oracle_check_count` / `partial_score`.
+Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
+renamed the SSC tab so R is missing.
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,10 +36,10 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. Luna, 20B, Flash Lite, Gemma 4 31B, Gemma 4 26B A4B, and
-Nemotron 3.5 Lightning have an AFC stamp only. Remaining catalog
-columns (Grok 4.6, Muse Spark 1.3) are placeholders. The catalog-wide
-headed sweep has **not** happened.
+score. Luna, 20B, Flash Lite, Gemma 4 31B, Gemma 4 26B A4B, Nemotron
+3.5 Lightning, and Mercury 2.5 Preview have an AFC stamp only.
+Remaining catalog columns (Grok 4.6, Muse Spark 1.3) are placeholders.
+The catalog-wide headed sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 
@@ -48,55 +48,63 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0202-gpt-oss-20b-nitro`,
 `20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
 `20260912-0240-gemma-4-26b-a4b-it`,
-`20260912-0310-nemotron-3.5-lightning`, box-local). Run dirs are typically
+`20260912-0310-nemotron-3.5-lightning`,
+`20260912-0330-mercury-2.5-preview`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
-eval-2 CI job. No HAPPY cell has recorded USD yet.
+eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
+recorded USD.
 
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Grok 4.6 | Muse Spark 1.3 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Spark 1.3 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | — | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
 <img src="eval2-coverage.svg" alt="Eval-2 headed coverage bars per model. Most catalog peers are entirely no data." />
 
-<img src="eval2-cost.svg" alt="Eval-2 headed cost for results. HAPPY cells with recorded USD; empty until a stamp records cost." />
+<img src="eval2-cost.svg" alt="Eval-2 headed cost for results. HAPPY cells with recorded USD; Mercury 2.5 Preview is the first bar." />
+
+| # | Task | Model | Cost (USD) | Tokens | Wall (s) | C²/$ |
+| --- | --- | --- | --- | --- | --- | --- |
+| 3 | AFC Population | Mercury 2.5 Preview | 0.0047 | 118650 | 479 | 213.68 |
 
 <img src="eval2-partial.svg" alt="Eval-2 headed partial/cost view. Bars only when oracle PASS or recorded fails/checks; no invented ratios." />
 
 ## Key insights
 
 1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
-   AFC. gpt-oss-120b is HAPPY only on GMP-0225. Catalog AFC cells
-   (`20260912-0142` 120b through `20260912-0310` Nemotron) are all NOT
-   HAPPY. Most miss R. Gemma 4 26B A4B is the first catalog model
-   besides the Gemini 3.8 gate to produce R=65, then fails S=0 < R on
-   a 10-row Sample. Nemotron is the first catalog cell with
-   `failure_count=2` (Population only; no Sample/SSC). Luna’s Sample
-   is a better shape (81 rows, S=68) than 120b’s 1516-row dump.
-   Floorstand is NOT HAPPY on both Gemini 3.8 and 120b. Overnight
-   slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
-2. **Partial:** AFC Gemini 3.8 is oracle PASS (`partial_score` = 1).
-   Catalog AFC cells recorded `failure_count` (1, or 2 on Nemotron)
-   plus S/husks but no `oracle_check_count`, so no FAIL ratio.
-   Tenant / Cadaver / GMP
+   AFC. gpt-oss-120b is HAPPY only on GMP-0225. Mercury 2.5 Preview
+   (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
+   PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
+   catalog AFC cells (`20260912-0142` 120b through `20260912-0310`
+   Nemotron) are NOT HAPPY. Most miss R. Gemma 4 26B A4B produced
+   R=65 then failed S=0 < R. Nemotron is the first `failure_count=2`
+   cell (Population only). Luna’s Sample is a better incomplete shape
+   (81 rows, S=68) than 120b’s 1516-row dump. Floorstand is NOT HAPPY
+   on both Gemini 3.8 and 120b. Overnight slots 6/8/9/10 (gpt-oss
+   only) are all NOT HAPPY.
+2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
+   (`partial_score` = 1). Other catalog AFC cells recorded
+   `failure_count` (1, or 2 on Nemotron) plus S/husks but no
+   `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
-3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
-   chart stays empty (AFC catalog USD is on NOT_HAPPY cells). Then
-   Value is `partial_score`² ÷ that USD among HAPPY.
+3. **C²/$:** Mercury 2.5 Preview is the first HAPPY cell with
+   recorded `total_cost_usd` (~$0.00468 OpenRouter). The cost chart
+   now has one bar. Value is `partial_score`² ÷ that USD among HAPPY
+   (≈213.68). Other catalog USD stays on NOT_HAPPY cells.
 4. **Coverage:** Grok 4.6 and Muse Spark are entirely no data. The
    new catalog columns have AFC only. Gemini 3.8 has no stamp yet for
    GMP, Calc-primary, Draw-primary, Reverse Tenant, or Long Writer.
@@ -116,6 +124,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Gemma 4 31B | `20260912-0224-gemma-4-31b-it` | Fifth catalog cell. Sample+SSC present (81 rows; S=0; husks 81/810). SSC R is Err:508/#NAME?; oracle R=None. OpenRouter usage ~$0.10841 (model_configs alt ~$0.01404 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0224-gemma-4-31b-it/`. |
 | AFC Population | Gemma 4 26B A4B | `20260912-0240-gemma-4-26b-a4b-it` | Sixth catalog cell. First catalog R=65 besides the Gemini gate; Sample undersized (10 rows, S=0 < R). Attempt1 contaminated; attempt2 wipe. OpenRouter usage ~$0.04316 (model_configs alt ~$0.05011 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0240-gemma-4-26b-a4b-it/`. |
 | AFC Population | Nemotron 3.5 Lightning | `20260912-0310-nemotron-3.5-lightning` | Seventh catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0; Err:507 in J/K; Save dialog flicker. Tokens are second-send (all-from-first higher, not stored). OpenRouter second-send ~$0.04282 (model_configs alt ~$0.06145 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0310-nemotron-3.5-lightning/`. |
+| AFC Population | Mercury 2.5 Preview | `20260912-0330-mercury-2.5-preview` | Eighth catalog cell. First non-gate HAPPY / oracle PASS. Near-full Sample (1518 rows) but S=494 ≥ R=68; husks 2/16680. Attempt1 contaminated; attempt2 wipe. OpenRouter usage ~$0.00468 (model_configs alt ~$0.03144 not stored). First HAPPY USD — lights the cost chart. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0330-mercury-2.5-preview/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -163,9 +172,12 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0202-gpt-oss-20b-nitro`,
 `20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
 `20260912-0240-gemma-4-26b-a4b-it`,
-`20260912-0310-nemotron-3.5-lightning`) recorded tokens, wall, USD,
-`failure_count` (1, or 2 on Nemotron), S/husks — not
-`oracle_check_count` or `partial_score`.
+`20260912-0310-nemotron-3.5-lightning`,
+`20260912-0330-mercury-2.5-preview`) recorded tokens, wall, USD,
+and S/husks. FAIL cells have `failure_count` 1 (or 2 on Nemotron) and
+no `oracle_check_count` / `partial_score`. Mercury is PASS
+(`failure_count=0`) so `partial_score` = 1 and C²/$ is derived from
+the recorded USD.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -38,8 +38,8 @@ cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
 Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, GLM 5.3 Flash,
-Solar Pro 4, Granite 4.2 8B, and Mistral Small 4). Solar is
-**BLOCKED** infra (Send never ran) — not NOT_HAPPY. The
+Solar Pro 4, Granite 4.2 8B, Mistral Small 4, and Seed 2.0 Mini).
+Solar is **BLOCKED** infra (Send never ran) — not NOT_HAPPY. The
 catalog-wide headed
 sweep has **not** happened.
 
@@ -61,7 +61,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0515-glm-5.3-flash`,
 `20260912-0522-solar-pro4`,
 `20260912-0546-granite-4.2-8b`,
-`20260912-0603-mistral-small-2603`, box-local). Run dirs are typically
+`20260912-0603-mistral-small-2603`,
+`20260912-0610-seed-2.0-mini`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -70,17 +71,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, blue BLOCKED infra, gray no data." />
 
@@ -102,8 +103,8 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
    Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, GLM 5.3
-   Flash, Granite 4.2 8B, and Mistral Small 4) are NOT HAPPY except
-   Mercury. Solar Pro
+   Flash, Granite 4.2 8B, Mistral Small 4, and Seed 2.0 Mini) are NOT
+   HAPPY except Mercury. Solar Pro
    4 is **BLOCKED** infra (`SendButton` / `message_store` sqlite
    crash; Send never ran) — not a model fail. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
@@ -121,14 +122,17 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    `read_cell_range` (n=48; all `finish_reason=tool_calls`). Glimmer
    and Mistral Small 4 are the same R hole as Luna/20b/Flash Lite on
    an 81-row Sample with S=0 (Mistral husks 0/648, same as Flash
-   Lite; Glimmer husks 0/729). Glimmer SSC
+   Lite; Glimmer husks 0/729). Seed 2.0 Mini is the first catalog
+   husk-dominated Sample (`1/1`; `failure_count=2` with R missing);
+   A2 is malformed `=PY("""` and SSC is Err:501 with a visual ~65
+   (oracle R=None). Glimmer SSC
    B9 looked like 65 but oracle R=None. Luna’s Sample is a better
    incomplete shape (81 rows, S=68) than 120b’s 1516-row dump.
    Floorstand is NOT HAPPY on both Gemini 3.8 and 120b. Overnight
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -167,6 +171,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Solar Pro 4 | `20260912-0522-solar-pro4` | Seventeenth catalog cell — **BLOCKED** infra, not a model fail. `SendButton` crashed before any LLM call (`sqlite3.OperationalError: no such table: message_store`). Send failed twice. Oracle unscored (missing Sample+SSC only because Send never ran). Tokens 0; cost $0. Headed wait ~1080s. tip `6c6017b7`. Scrolly recreating schema before next trial. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0522-solar-pro4/`. |
 | AFC Population | Granite 4.2 8B | `20260912-0546-granite-4.2-8b` | Eighteenth catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Hung `tool_loop` round 46 on `read_cell_range`; all `finish_reason=tool_calls`. Tokens n=48. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~840s (14 min LLM). OpenRouter usage ~$0.14353 (model_configs alt ~$0.24564 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0546-granite-4.2-8b/`. |
 | AFC Population | Mistral Small 4 | `20260912-0603-mistral-small-2603` | Nineteenth catalog cell. Ready with Sample+SSC (81 rows; S=0; husks 0/648); same R hole as Flash Lite (`failure_count=1`). Tokens n=14. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~32s. OpenRouter usage ~$0.00973 (model_configs alt ~$0.02475 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0603-mistral-small-2603/`. |
+| AFC Population | Seed 2.0 Mini | `20260912-0610-seed-2.0-mini` | Twentieth catalog cell. Sample malformed (`=PY("""` in A2; 1 row; S=0; husks 1/1 — first husk-dominated Sample). SSC Err:501 / visual ~65; oracle R=None (`failure_count=2`). Tokens n=2. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~131s. OpenRouter usage ~$0.00814 (model_configs alt matches, not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0610-seed-2.0-mini/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -224,10 +229,11 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0502-qwen3.8-flash`,
 `20260912-0515-glm-5.3-flash`,
 `20260912-0546-granite-4.2-8b`,
-`20260912-0603-mistral-small-2603`) recorded tokens, wall,
+`20260912-0603-mistral-small-2603`,
+`20260912-0610-seed-2.0-mini`) recorded tokens, wall,
 USD, and S/husks. `20260912-0522-solar-pro4` is **BLOCKED** infra
 (tokens/cost 0; oracle omitted). FAIL cells have `failure_count` 1 (or 2 on
-Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B) and no `oracle_check_count` / `partial_score`.
+Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
 renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
 missing Sample+SSC shape at far higher USD. Qwen3.8 Flash is the
@@ -237,6 +243,8 @@ Granite 4.2 8B matches Grok/Spark’s empty-Sample + SSC-present R
 hole, hung at round 46 on `read_cell_range`.
 Mistral Small 4 matches Flash Lite’s 81-row S=0 husks-0/648 R hole
 (`failure_count=1`).
+Seed 2.0 Mini is the first husk-dominated Sample (`1/1`) plus R
+missing (`failure_count=2`); visual SSC ~65 is not stored as R.
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,10 +36,8 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. Luna, 20B, Flash Lite, Gemma 4 31B, Gemma 4 26B A4B, Nemotron
-3.5 Lightning, Mercury 2.5 Preview, and Grok 4.6 have an AFC stamp
-only. Muse Glimmer 30B also has an AFC stamp only. Muse Spark 1.3 is
-still a placeholder. The catalog-wide headed
+score. Every catalog column now has an AFC stamp only (including Muse
+Glimmer 30B and Muse Spark 1.3). The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -51,7 +49,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0240-gemma-4-26b-a4b-it`,
 `20260912-0310-nemotron-3.5-lightning`,
 `20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
-`20260912-0353-muse-glimmer-30b`, box-local). Run dirs are typically
+`20260912-0353-muse-glimmer-30b`,
+`20260912-0409-muse-spark-1.3-contributor`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -64,7 +63,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
 | 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
 | 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
 | 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
 | 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
@@ -74,7 +73,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
-<img src="eval2-coverage.svg" alt="Eval-2 headed coverage bars per model. Most catalog peers are entirely no data." />
+<img src="eval2-coverage.svg" alt="Eval-2 headed coverage bars per model. Catalog peers have AFC only." />
 
 <img src="eval2-cost.svg" alt="Eval-2 headed cost for results. HAPPY cells with recorded USD; Mercury 2.5 Preview is the first bar." />
 
@@ -91,9 +90,9 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok, plus Glimmer) are NOT HAPPY except Mercury. Most miss R.
-   Gemma 4 26B A4B produced R=65 then failed S=0 < R. Nemotron is
-   `failure_count=2` (missing Sample+SSC). Grok is also
+   Grok, plus Glimmer and Spark) are NOT HAPPY except Mercury. Most
+   miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Nemotron
+   is `failure_count=2` (missing Sample+SSC). Grok and Spark are also
    `failure_count=2` (SSC present, Sample empty, R missing). Glimmer
    is the same R hole as Luna/20b on an 81-row Sample with S=0; SSC
    B9 looked like 65 but oracle R=None. Luna’s Sample is a better
@@ -102,7 +101,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -110,9 +109,9 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    recorded `total_cost_usd` (~$0.00468 OpenRouter). The cost chart
    now has one bar. Value is `partial_score`² ÷ that USD among HAPPY
    (≈213.68). Other catalog USD stays on NOT_HAPPY cells.
-4. **Coverage:** Muse Spark is entirely no data. The other catalog
-   columns have AFC only. Gemini 3.8 has no stamp yet for GMP,
-   Calc-primary, Draw-primary, Reverse Tenant, or Long Writer.
+4. **Coverage:** every catalog column now has AFC only. Gemini 3.8
+   has no stamp yet for GMP, Calc-primary, Draw-primary, Reverse
+   Tenant, or Long Writer.
    gpt-oss-120b has no stamp for Tenant or Cadaver.
 
 ### Cell notes (only scored pairs)
@@ -132,6 +131,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Mercury 2.5 Preview | `20260912-0330-mercury-2.5-preview` | Eighth catalog cell. First non-gate HAPPY / oracle PASS. Near-full Sample (1518 rows) but S=494 ≥ R=68; husks 2/16680. Attempt1 contaminated; attempt2 wipe. OpenRouter usage ~$0.00468 (model_configs alt ~$0.03144 not stored). First HAPPY USD — lights the cost chart. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0330-mercury-2.5-preview/`. |
 | AFC Population | Grok 4.6 | `20260912-0342-grok-4.6` | Ninth catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. OpenRouter usage ~$0.02375 (model_configs alt ~$0.05831 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0342-grok-4.6/`. |
 | AFC Population | Muse Glimmer 30B | `20260912-0353-muse-glimmer-30b` | Tenth catalog cell. Sample+SSC present (81 rows; S=0; husks 0/729); same R hole. SSC B9 visually 65; oracle R=None. Hit max 50 tool rounds; recorded wall ~155s (observer ~16 min). tip `e0bb6321`. OpenRouter usage ~$0.15404 (model_configs alt ~$0.66230 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0353-muse-glimmer-30b/`. |
+| AFC Population | Muse Spark 1.3 | `20260912-0409-muse-spark-1.3-contributor` | Eleventh catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Same empty-Sample shape as Grok. tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.00157 (model_configs alt ~$0.00247 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0409-muse-spark-1.3-contributor/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -181,11 +181,12 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0240-gemma-4-26b-a4b-it`,
 `20260912-0310-nemotron-3.5-lightning`,
 `20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
-`20260912-0353-muse-glimmer-30b`) recorded tokens, wall, USD, and
-S/husks. FAIL cells have `failure_count` 1 (or 2 on Nemotron/Grok)
-and no `oracle_check_count` / `partial_score`. Mercury is PASS
-(`failure_count=0`) so `partial_score` = 1 and C²/$ is derived from
-the recorded USD.
+`20260912-0353-muse-glimmer-30b`,
+`20260912-0409-muse-spark-1.3-contributor`) recorded tokens, wall,
+USD, and S/husks. FAIL cells have `failure_count` 1 (or 2 on
+Nemotron/Grok/Spark) and no `oracle_check_count` / `partial_score`.
+Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
+is derived from the recorded USD.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -39,8 +39,10 @@ deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
 Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, GLM 5.3 Flash,
 Solar Pro 4, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini,
-MiniMax M3, and DeepSeek V4 Flash 0731). Solar is **BLOCKED**
-infra (Send never ran) — not NOT_HAPPY. The catalog-wide headed
+MiniMax M3, DeepSeek V4 Flash 0731, and DeepSeek V4.1 Flash).
+AFC catalog FIFO is complete (oss-120b through V4.1 Flash). Solar
+is **BLOCKED** infra (Send never ran) — not NOT_HAPPY. The
+catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -64,7 +66,9 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0603-mistral-small-2603`,
 `20260912-0610-seed-2.0-mini`,
 `20260912-0617-minimax-m3`,
-`20260912-0621-deepseek-v4-flash-0731`, box-local). Run dirs are typically
+`20260912-0621-deepseek-v4-flash-0731`,
+`20260912-0630-deepseek-v4.1-flash`, box-local). AFC catalog FIFO
+is complete. Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -73,17 +77,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini | MiniMax M3 | DeepSeek V4 Flash 0731 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini | MiniMax M3 | DeepSeek V4 Flash 0731 | DeepSeek V4.1 Flash |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, blue BLOCKED infra, gray no data." />
 
@@ -106,15 +110,19 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
    Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, GLM 5.3
    Flash, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini, MiniMax M3,
-   and DeepSeek V4 Flash 0731) are NOT HAPPY except Mercury. Solar Pro
+   DeepSeek V4 Flash 0731, and DeepSeek V4.1 Flash) are NOT HAPPY
+   except Mercury. Solar Pro
    4 is **BLOCKED** infra (`SendButton` / `message_store` sqlite
    crash; Send never ran) — not a model fail. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
    produced parseable R=66 but the Sample sheet is missing
    (`failure_count=1`; truncated mid tool loop). Laguna XS is
    `failure_count=2` (SSC tab named `Sample_Size_Calculation`; Sample
-   empty). Nemotron, Qwen3.8 27B, GLM 5.3 Flash, and MiniMax M3 are
-   `failure_count=2` (missing Sample+SSC). MiniMax is Ready with an
+   empty). Nemotron, Qwen3.8 27B, GLM 5.3 Flash, MiniMax M3, and
+   DeepSeek V4.1 Flash are `failure_count=2` (missing Sample+SSC).
+   V4.1 Flash API-timed-out mid `tool_loop` round 5 on
+   `read_cell_range` (`NetworkError`; n=5) — NOT_HAPPY, not BLOCKED,
+   because Send ran. MiniMax is Ready with an
    Analysis sheet (`A1=#NAME?`, `A2=8`) but no Sample/SSC. GLM hung at `tool_loop`
    round 0 (`finish_reason=length`; no tools; n=1). Qwen3.8 27B stayed on Population
    with `=PY` (~50 tool rounds; PreContract 63). Qwen3.8 Flash is a
@@ -137,7 +145,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3/DeepSeek V4 Flash 0731) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3/DeepSeek V4 Flash 0731/DeepSeek V4.1 Flash) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -179,6 +187,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Seed 2.0 Mini | `20260912-0610-seed-2.0-mini` | Twentieth catalog cell. Sample malformed (`=PY("""` in A2; 1 row; S=0; husks 1/1 — first husk-dominated Sample). SSC Err:501 / visual ~65; oracle R=None (`failure_count=2`). Tokens n=2. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~131s. OpenRouter usage ~$0.00814 (model_configs alt matches, not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0610-seed-2.0-mini/`. |
 | AFC Population | MiniMax M3 | `20260912-0617-minimax-m3` | Twenty-first catalog cell. Ready; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Analysis A1=`#NAME?` A2=8. Tokens n=30. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~66s. OpenRouter usage ~$0.07965 (model_configs alt ~$0.10003 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0617-minimax-m3/`. |
 | AFC Population | DeepSeek V4 Flash 0731 | `20260912-0621-deepseek-v4-flash-0731` | Twenty-second catalog cell. Ready; Sample empty + SSC blank (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Sample `deal.PreContractError expected__deal_wire_dict_ok`. Tokens n=51. tip `71640e30`. PreContract 18; UNO/assert 0. Recorded wall ~330s. OpenRouter usage ~$0.17007 (model_configs alt ~$0.18897 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0621-deepseek-v4-flash-0731/`. |
+| AFC Population | DeepSeek V4.1 Flash | `20260912-0630-deepseek-v4.1-flash` | Twenty-third catalog cell — **FIFO tail**. API timed out mid `tool_loop` round 5 on `read_cell_range` (`NetworkError`); model never finished. NOT_HAPPY (Send ran; leftover workbook scored). Missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Tokens n=5. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~270s. OpenRouter usage ~$0.01832 (model_configs alt ~$0.01043 not stored). CATALOG FIFO COMPLETE. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0630-deepseek-v4.1-flash/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -239,10 +248,11 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0603-mistral-small-2603`,
 `20260912-0610-seed-2.0-mini`,
 `20260912-0617-minimax-m3`,
-`20260912-0621-deepseek-v4-flash-0731`) recorded tokens, wall,
+`20260912-0621-deepseek-v4-flash-0731`,
+`20260912-0630-deepseek-v4.1-flash`) recorded tokens, wall,
 USD, and S/husks. `20260912-0522-solar-pro4` is **BLOCKED** infra
 (tokens/cost 0; oracle omitted). FAIL cells have `failure_count` 1 (or 2 on
-Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3/DeepSeek V4 Flash 0731) and no `oracle_check_count` / `partial_score`.
+Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3/DeepSeek V4 Flash 0731/DeepSeek V4.1 Flash) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
 renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
 missing Sample+SSC shape at far higher USD. Qwen3.8 Flash is the
@@ -258,6 +268,8 @@ MiniMax M3 matches Nemotron/GLM’s missing Sample+SSC with a Ready
 Analysis sheet (`#NAME?` / 8).
 DeepSeek V4 Flash 0731 matches Grok/Spark’s empty-Sample + blank-SSC
 R hole with PreContract 18 on Sample.
+DeepSeek V4.1 Flash matches Nemotron/GLM’s missing Sample+SSC after
+an API timeout mid `read_cell_range` (NOT_HAPPY, not BLOCKED).
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,17 +36,17 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. GPT-5.6 Luna has an AFC stamp only. Remaining catalog columns
-(GPT-OSS 20B, Grok 4.6, Muse Spark 1.3) are placeholders. The
+score. GPT-5.6 Luna and GPT-OSS 20B have an AFC stamp only. Remaining
+catalog columns (Grok 4.6, Muse Spark 1.3) are placeholders. The
 catalog-wide headed sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 
 Seeded from the autopsy, sibling notes, and Scrolly AFC catalog
 stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
-box-local). Run dirs are typically untracked —
-`run_artifacts_committed` is false for every cell. No OpenRouter
-eval-2 CI job. No HAPPY cell has recorded USD yet.
+`20260912-0202-gpt-oss-20b-nitro`, box-local). Run dirs are typically
+untracked — `run_artifacts_committed` is false for every cell. No
+OpenRouter eval-2 CI job. No HAPPY cell has recorded USD yet.
 
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
@@ -55,7 +55,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — |
 | 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
 | 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — |
 | 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — |
 | 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
@@ -75,23 +75,24 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 
 1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
    AFC. gpt-oss-120b is HAPPY only on GMP-0225. Catalog AFC cells
-   (`20260912-0142` 120b, `20260912-0150` Luna) are both NOT HAPPY
-   (missing R). Luna’s Sample is a better shape (81 rows vs 120b’s
-   1516-row dump) but the same R hole. Floorstand is NOT HAPPY on both
-   Gemini and 120b. Overnight slots 6/8/9/10 (gpt-oss only) are all
-   NOT HAPPY.
+   (`20260912-0142` 120b, `20260912-0150` Luna, `20260912-0202` 20b)
+   are all NOT HAPPY (missing R). Luna’s Sample is a better shape (81
+   rows, S=68) than 120b’s 1516-row dump; 20b is similar size (80 rows)
+   but S=0. Floorstand is NOT HAPPY on both Gemini and 120b. Overnight
+   slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini is oracle PASS (`partial_score` = 1). AFC
-   120b and Luna each recorded `failure_count=1` (R missing) plus S/husks
-   (585 / 0 of 15159; 68 / 0 of 810) but no `oracle_check_count`, so no
-   FAIL ratio. Tenant / Cadaver / GMP HAPPY cells are still oracle FAIL
-   without a recorded check count. Do not invent one from autopsy prose.
+   120b / Luna / 20b each recorded `failure_count=1` (R missing) plus
+   S/husks (585 / 0 of 15159; 68 / 0 of 810; 0 / 0 of 800) but no
+   `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP HAPPY
+   cells are still oracle FAIL without a recorded check count. Do not
+   invent one from autopsy prose.
 3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
-   chart stays empty (AFC 120b / Luna USD are on NOT_HAPPY cells). Then
+   chart stays empty (AFC catalog USD is on NOT_HAPPY cells). Then
    Value is `partial_score`² ÷ that USD among HAPPY.
-4. **Coverage:** 20B, Grok 4.6, and Muse Spark are entirely no data.
-   Luna has AFC only. Gemini has no stamp yet for GMP, Calc-primary,
-   Draw-primary, Reverse Tenant, or Long Writer. gpt-oss has no stamp
-   for Tenant or Cadaver.
+4. **Coverage:** Grok 4.6 and Muse Spark are entirely no data. Luna
+   and 20b have AFC only. Gemini has no stamp yet for GMP, Calc-primary,
+   Draw-primary, Reverse Tenant, or Long Writer. gpt-oss-120b has no
+   stamp for Tenant or Cadaver.
 
 ### Cell notes (only scored pairs)
 
@@ -102,6 +103,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Gemini 3.8 Flash | `20260908-0030-retry2` | Oracle PASS after smoother (S=65 R=2). Autopsy abbreviates the stamp with `…`. |
 | AFC Population | GPT-OSS 120B | `20260912-0142-gpt-oss-120b` | First catalog cell. Sample+SSC nonempty but wrong shape (1516 rows); R missing; S=585; husks 0/15159; Ready then kept iterating. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0142-gpt-oss-120b/`. |
 | AFC Population | GPT-5.6 Luna | `20260912-0150-gpt-5.6-luna` | Second catalog cell. Sample+SSC present but incomplete (81 rows; S=68; husks 0/810); same R hole as 120b. OpenRouter usage ~$0.0419 (model_configs alt ~$0.1252 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0150-gpt-5.6-luna/`. |
+| AFC Population | GPT-OSS 20B | `20260912-0202-gpt-oss-20b-nitro` | Third catalog cell. Ran as `:nitro` (resolved to bare 20b). Sample/SSC present but incomplete (80 rows; S=0; husks 0/800); same R hole, weaker than Luna. OpenRouter usage ~$0.00122 (model_configs alt ~$0.00049 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0202-gpt-oss-20b-nitro/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -145,9 +147,10 @@ Optional result fields (`oracle_passed`, `oracle_failure_count`,
 `wall_time_s`, `intelligence_per_dollar`) stay empty unless a stamp
 recorded them. The 2026-09-12 seed still has derived PASS →
 `partial_score` = 1 on AFC Gemini. Catalog AFC stamps
-(`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`) recorded
-tokens, wall, USD, `failure_count=1`, S/husks — not
-`oracle_check_count` or `partial_score`.
+(`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
+`20260912-0202-gpt-oss-20b-nitro`) recorded tokens, wall, USD,
+`failure_count=1`, S/husks — not `oracle_check_count` or
+`partial_score`.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -37,9 +37,9 @@ partial and USD.
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Luna, 20B, Flash Lite, Gemma 4 31B, Gemma 4 26B A4B, Nemotron
-3.5 Lightning, and Mercury 2.5 Preview have an AFC stamp only.
-Remaining catalog columns (Grok 4.6, Muse Spark 1.3) are placeholders.
-The catalog-wide headed sweep has **not** happened.
+3.5 Lightning, Mercury 2.5 Preview, and Grok 4.6 have an AFC stamp
+only. Muse Spark 1.3 is still a placeholder. The catalog-wide headed
+sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 
@@ -49,7 +49,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
 `20260912-0240-gemma-4-26b-a4b-it`,
 `20260912-0310-nemotron-3.5-lightning`,
-`20260912-0330-mercury-2.5-preview`, box-local). Run dirs are typically
+`20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
+box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -62,7 +63,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
 | 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | — |
 | 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
 | 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
 | 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
@@ -88,16 +89,17 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    AFC. gpt-oss-120b is HAPPY only on GMP-0225. Mercury 2.5 Preview
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
-   catalog AFC cells (`20260912-0142` 120b through `20260912-0310`
-   Nemotron) are NOT HAPPY. Most miss R. Gemma 4 26B A4B produced
-   R=65 then failed S=0 < R. Nemotron is the first `failure_count=2`
-   cell (Population only). Luna’s Sample is a better incomplete shape
-   (81 rows, S=68) than 120b’s 1516-row dump. Floorstand is NOT HAPPY
-   on both Gemini 3.8 and 120b. Overnight slots 6/8/9/10 (gpt-oss
-   only) are all NOT HAPPY.
+   catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
+   Grok) are NOT HAPPY except Mercury. Most miss R. Gemma 4 26B A4B
+   produced R=65 then failed S=0 < R. Nemotron is `failure_count=2`
+   (missing Sample+SSC). Grok is also `failure_count=2` (SSC present,
+   Sample empty, R missing). Luna’s Sample is a better incomplete
+   shape (81 rows, S=68) than 120b’s 1516-row dump. Floorstand is NOT
+   HAPPY on both Gemini 3.8 and 120b. Overnight slots 6/8/9/10
+   (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -105,9 +107,9 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    recorded `total_cost_usd` (~$0.00468 OpenRouter). The cost chart
    now has one bar. Value is `partial_score`² ÷ that USD among HAPPY
    (≈213.68). Other catalog USD stays on NOT_HAPPY cells.
-4. **Coverage:** Grok 4.6 and Muse Spark are entirely no data. The
-   new catalog columns have AFC only. Gemini 3.8 has no stamp yet for
-   GMP, Calc-primary, Draw-primary, Reverse Tenant, or Long Writer.
+4. **Coverage:** Muse Spark is entirely no data. The other catalog
+   columns have AFC only. Gemini 3.8 has no stamp yet for GMP,
+   Calc-primary, Draw-primary, Reverse Tenant, or Long Writer.
    gpt-oss-120b has no stamp for Tenant or Cadaver.
 
 ### Cell notes (only scored pairs)
@@ -125,6 +127,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Gemma 4 26B A4B | `20260912-0240-gemma-4-26b-a4b-it` | Sixth catalog cell. First catalog R=65 besides the Gemini gate; Sample undersized (10 rows, S=0 < R). Attempt1 contaminated; attempt2 wipe. OpenRouter usage ~$0.04316 (model_configs alt ~$0.05011 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0240-gemma-4-26b-a4b-it/`. |
 | AFC Population | Nemotron 3.5 Lightning | `20260912-0310-nemotron-3.5-lightning` | Seventh catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0; Err:507 in J/K; Save dialog flicker. Tokens are second-send (all-from-first higher, not stored). OpenRouter second-send ~$0.04282 (model_configs alt ~$0.06145 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0310-nemotron-3.5-lightning/`. |
 | AFC Population | Mercury 2.5 Preview | `20260912-0330-mercury-2.5-preview` | Eighth catalog cell. First non-gate HAPPY / oracle PASS. Near-full Sample (1518 rows) but S=494 ≥ R=68; husks 2/16680. Attempt1 contaminated; attempt2 wipe. OpenRouter usage ~$0.00468 (model_configs alt ~$0.03144 not stored). First HAPPY USD — lights the cost chart. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0330-mercury-2.5-preview/`. |
+| AFC Population | Grok 4.6 | `20260912-0342-grok-4.6` | Ninth catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. OpenRouter usage ~$0.02375 (model_configs alt ~$0.05831 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0342-grok-4.6/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -173,11 +176,11 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
 `20260912-0240-gemma-4-26b-a4b-it`,
 `20260912-0310-nemotron-3.5-lightning`,
-`20260912-0330-mercury-2.5-preview`) recorded tokens, wall, USD,
-and S/husks. FAIL cells have `failure_count` 1 (or 2 on Nemotron) and
-no `oracle_check_count` / `partial_score`. Mercury is PASS
-(`failure_count=0`) so `partial_score` = 1 and C²/$ is derived from
-the recorded USD.
+`20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`)
+recorded tokens, wall, USD, and S/husks. FAIL cells have
+`failure_count` 1 (or 2 on Nemotron/Grok) and no `oracle_check_count`
+/ `partial_score`. Mercury is PASS (`failure_count=0`) so
+`partial_score` = 1 and C²/$ is derived from the recorded USD.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -38,8 +38,8 @@ cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
 Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, GLM 5.3 Flash,
-and Solar Pro 4). Solar is **BLOCKED** infra (Send never ran) — not
-NOT_HAPPY. The catalog-wide headed
+Solar Pro 4, and Granite 4.2 8B). Solar is **BLOCKED** infra (Send
+never ran) — not NOT_HAPPY. The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -58,7 +58,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0443-qwen3.8-27b`,
 `20260912-0502-qwen3.8-flash`,
 `20260912-0515-glm-5.3-flash`,
-`20260912-0522-solar-pro4`, box-local). Run dirs are typically
+`20260912-0522-solar-pro4`,
+`20260912-0546-granite-4.2-8b`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -67,17 +68,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, blue BLOCKED infra, gray no data." />
 
@@ -98,7 +99,10 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, and GLM 5.3 Flash) are NOT HAPPY except Mercury. Solar Pro 4 is **BLOCKED** infra (`SendButton` / `message_store` sqlite crash; Send never ran) — not a model fail. Most
+   Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, GLM 5.3
+   Flash, and Granite 4.2 8B) are NOT HAPPY except Mercury. Solar Pro
+   4 is **BLOCKED** infra (`SendButton` / `message_store` sqlite
+   crash; Send never ran) — not a model fail. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
    produced parseable R=66 but the Sample sheet is missing
    (`failure_count=1`; truncated mid tool loop). Laguna XS is
@@ -108,8 +112,10 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    round 0 (`finish_reason=length`; no tools; n=1). Qwen3.8 27B stayed on Population
    with `=PY` (~50 tool rounds; PreContract 63). Qwen3.8 Flash is a
    Luna-like incomplete Sample (68 rows, S=68) with SSC
-   Err:508/509/#VALUE! and Scratch Err:513. Grok and Spark are also
-   `failure_count=2` (SSC present, Sample empty, R missing). Glimmer
+   Err:508/509/#VALUE! and Scratch Err:513. Grok, Spark, and Granite
+   4.2 8B are also `failure_count=2` (SSC present, Sample empty, R
+   missing). Granite hung `tool_loop` at round 46 on
+   `read_cell_range` (n=48; all `finish_reason=tool_calls`). Glimmer
    is the same R hole as Luna/20b on an 81-row Sample with S=0; SSC
    B9 looked like 65 but oracle R=None. Luna’s Sample is a better
    incomplete shape (81 rows, S=68) than 120b’s 1516-row dump.
@@ -117,7 +123,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -154,6 +160,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Qwen3.8 Flash | `20260912-0502-qwen3.8-flash` | Fifteenth catalog cell. Sample+SSC present (68 rows; S=68; husks 0/680); same R hole as Luna. SSC Err:508/509/#VALUE!; Scratch Err:513. Tokens n=51. tip `6c6017b7`. UNO/assert/PreContract 0. Recorded wall ~540s (9 min LLM; observer ~12 min). OpenRouter usage ~$0.11382 (model_configs alt ~$0.35238 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0502-qwen3.8-flash/`. |
 | AFC Population | GLM 5.3 Flash | `20260912-0515-glm-5.3-flash` | Sixteenth catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Hung `tool_loop` round 0 — `finish_reason=length`; no tools; truncated reasoning dump. Tokens n=1 (`reasoning_tokens=15160` noted, not stored). tip `6c6017b7`. UNO/assert/PreContract 0. Recorded wall ~155s. OpenRouter usage ~$0.00900 (model_configs alt ~$0.00450 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0515-glm-5.3-flash/`. |
 | AFC Population | Solar Pro 4 | `20260912-0522-solar-pro4` | Seventeenth catalog cell — **BLOCKED** infra, not a model fail. `SendButton` crashed before any LLM call (`sqlite3.OperationalError: no such table: message_store`). Send failed twice. Oracle unscored (missing Sample+SSC only because Send never ran). Tokens 0; cost $0. Headed wait ~1080s. tip `6c6017b7`. Scrolly recreating schema before next trial. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0522-solar-pro4/`. |
+| AFC Population | Granite 4.2 8B | `20260912-0546-granite-4.2-8b` | Eighteenth catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Hung `tool_loop` round 46 on `read_cell_range`; all `finish_reason=tool_calls`. Tokens n=48. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~840s (14 min LLM). OpenRouter usage ~$0.14353 (model_configs alt ~$0.24564 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0546-granite-4.2-8b/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -209,15 +216,18 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0429-laguna-xs-2.1`,
 `20260912-0443-qwen3.8-27b`,
 `20260912-0502-qwen3.8-flash`,
-`20260912-0515-glm-5.3-flash`) recorded tokens, wall,
+`20260912-0515-glm-5.3-flash`,
+`20260912-0546-granite-4.2-8b`) recorded tokens, wall,
 USD, and S/husks. `20260912-0522-solar-pro4` is **BLOCKED** infra
 (tokens/cost 0; oracle omitted). FAIL cells have `failure_count` 1 (or 2 on
-Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash) and no `oracle_check_count` / `partial_score`.
+Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
 renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
 missing Sample+SSC shape at far higher USD. Qwen3.8 Flash is the
 Luna-like S=68 R-missing Sample on 68 rows. GLM 5.3 Flash hung at
 round 0 with no tools and the same missing Sample+SSC shape.
+Granite 4.2 8B matches Grok/Spark’s empty-Sample + SSC-present R
+hole, hung at round 46 on `read_cell_range`.
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -37,7 +37,7 @@ partial and USD.
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
-Glimmer 30B, Muse Spark 1.3, both Lagunas, and Qwen3.8 27B). The catalog-wide headed
+Glimmer 30B, Muse Spark 1.3, both Lagunas, and both Qwen3.8s). The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -53,7 +53,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0409-muse-spark-1.3-contributor`,
 `20260912-0419-laguna-s-2.1`,
 `20260912-0429-laguna-xs-2.1`,
-`20260912-0443-qwen3.8-27b`, box-local). Run dirs are typically
+`20260912-0443-qwen3.8-27b`,
+`20260912-0502-qwen3.8-flash`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -62,17 +63,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -93,14 +94,16 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok, plus Glimmer, Spark, both Lagunas, and Qwen3.8 27B) are NOT HAPPY except Mercury. Most
+   Grok, plus Glimmer, Spark, both Lagunas, and both Qwen3.8s) are NOT HAPPY except Mercury. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
    produced parseable R=66 but the Sample sheet is missing
    (`failure_count=1`; truncated mid tool loop). Laguna XS is
    `failure_count=2` (SSC tab named `Sample_Size_Calculation`; Sample
    empty). Nemotron and Qwen3.8 27B are
-   `failure_count=2` (missing Sample+SSC). Qwen stayed on Population
-   with `=PY` (~50 tool rounds; PreContract 63). Grok and Spark are also
+   `failure_count=2` (missing Sample+SSC). Qwen3.8 27B stayed on Population
+   with `=PY` (~50 tool rounds; PreContract 63). Qwen3.8 Flash is a
+   Luna-like incomplete Sample (68 rows, S=68) with SSC
+   Err:508/509/#VALUE! and Scratch Err:513. Grok and Spark are also
    `failure_count=2` (SSC present, Sample empty, R missing). Glimmer
    is the same R hole as Luna/20b on an 81-row Sample with S=0; SSC
    B9 looked like 65 but oracle R=None. Luna’s Sample is a better
@@ -143,6 +146,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Laguna S 2.1 | `20260912-0419-laguna-s-2.1` | Twelfth catalog cell. SSC present with parseable R=66; Sample sheet missing (`failure_count=1`); S=0 R=66; husks 0/0. `finish_reason=length` — truncated mid tool loop. tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.01480 (model_configs alt ~$0.02142 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0419-laguna-s-2.1/`. |
 | AFC Population | Laguna XS 2.1 | `20260912-0429-laguna-xs-2.1` | Thirteenth catalog cell. SSC tab named `Sample_Size_Calculation` (oracle missing SSC); Sample empty (`failure_count=2`); S=0 R=None; husks 0/0. Raw `tool_call` text in the reply. Recorded wall ~85s (observer ~3m12s). tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.04341 (model_configs alt ~$0.07804 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0429-laguna-xs-2.1/`. |
 | AFC Population | Qwen3.8 27B | `20260912-0443-qwen3.8-27b` | Fourteenth catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Stayed on Population with `=PY`; ~50 tool rounds all `finish_reason=tool_calls`. Tokens n=51. PreContract 63; UNO/assert 0. Recorded wall ~720s (12 min LLM). tip `6c6017b7`. OpenRouter usage ~$1.42823 (model_configs alt ~$1.31711 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0443-qwen3.8-27b/`. |
+| AFC Population | Qwen3.8 Flash | `20260912-0502-qwen3.8-flash` | Fifteenth catalog cell. Sample+SSC present (68 rows; S=68; husks 0/680); same R hole as Luna. SSC Err:508/509/#VALUE!; Scratch Err:513. Tokens n=51. tip `6c6017b7`. UNO/assert/PreContract 0. Recorded wall ~540s (9 min LLM; observer ~12 min). OpenRouter usage ~$0.11382 (model_configs alt ~$0.35238 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0502-qwen3.8-flash/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -196,12 +200,14 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0409-muse-spark-1.3-contributor`,
 `20260912-0419-laguna-s-2.1`,
 `20260912-0429-laguna-xs-2.1`,
-`20260912-0443-qwen3.8-27b`) recorded tokens, wall,
+`20260912-0443-qwen3.8-27b`,
+`20260912-0502-qwen3.8-flash`) recorded tokens, wall,
 USD, and S/husks. FAIL cells have `failure_count` 1 (or 2 on
 Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
 renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
-missing Sample+SSC shape at far higher USD.
+missing Sample+SSC shape at far higher USD. Qwen3.8 Flash is the
+Luna-like S=68 R-missing Sample on 68 rows.
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -38,9 +38,9 @@ cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
 Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, GLM 5.3 Flash,
-Solar Pro 4, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini, and
-MiniMax M3). Solar is **BLOCKED** infra (Send never ran) — not
-NOT_HAPPY. The catalog-wide headed
+Solar Pro 4, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini,
+MiniMax M3, and DeepSeek V4 Flash 0731). Solar is **BLOCKED**
+infra (Send never ran) — not NOT_HAPPY. The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -63,7 +63,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0546-granite-4.2-8b`,
 `20260912-0603-mistral-small-2603`,
 `20260912-0610-seed-2.0-mini`,
-`20260912-0617-minimax-m3`, box-local). Run dirs are typically
+`20260912-0617-minimax-m3`,
+`20260912-0621-deepseek-v4-flash-0731`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -72,17 +73,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini | MiniMax M3 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini | MiniMax M3 | DeepSeek V4 Flash 0731 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, blue BLOCKED infra, gray no data." />
 
@@ -104,8 +105,8 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
    Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, GLM 5.3
-   Flash, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini, and MiniMax
-   M3) are NOT HAPPY except Mercury. Solar Pro
+   Flash, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini, MiniMax M3,
+   and DeepSeek V4 Flash 0731) are NOT HAPPY except Mercury. Solar Pro
    4 is **BLOCKED** infra (`SendButton` / `message_store` sqlite
    crash; Send never ran) — not a model fail. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
@@ -118,9 +119,11 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    round 0 (`finish_reason=length`; no tools; n=1). Qwen3.8 27B stayed on Population
    with `=PY` (~50 tool rounds; PreContract 63). Qwen3.8 Flash is a
    Luna-like incomplete Sample (68 rows, S=68) with SSC
-   Err:508/509/#VALUE! and Scratch Err:513. Grok, Spark, and Granite
-   4.2 8B are also `failure_count=2` (SSC present, Sample empty, R
-   missing). Granite hung `tool_loop` at round 46 on
+   Err:508/509/#VALUE! and Scratch Err:513. Grok, Spark, Granite
+   4.2 8B, and DeepSeek V4 Flash 0731 are also `failure_count=2`
+   (SSC present, Sample empty, R missing). DeepSeek Sample errored
+   `deal.PreContractError expected__deal_wire_dict_ok` (PreContract
+   18); SSC blank; n=51. Granite hung `tool_loop` at round 46 on
    `read_cell_range` (n=48; all `finish_reason=tool_calls`). Glimmer
    and Mistral Small 4 are the same R hole as Luna/20b/Flash Lite on
    an 81-row Sample with S=0 (Mistral husks 0/648, same as Flash
@@ -134,7 +137,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3/DeepSeek V4 Flash 0731) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -175,6 +178,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Mistral Small 4 | `20260912-0603-mistral-small-2603` | Nineteenth catalog cell. Ready with Sample+SSC (81 rows; S=0; husks 0/648); same R hole as Flash Lite (`failure_count=1`). Tokens n=14. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~32s. OpenRouter usage ~$0.00973 (model_configs alt ~$0.02475 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0603-mistral-small-2603/`. |
 | AFC Population | Seed 2.0 Mini | `20260912-0610-seed-2.0-mini` | Twentieth catalog cell. Sample malformed (`=PY("""` in A2; 1 row; S=0; husks 1/1 — first husk-dominated Sample). SSC Err:501 / visual ~65; oracle R=None (`failure_count=2`). Tokens n=2. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~131s. OpenRouter usage ~$0.00814 (model_configs alt matches, not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0610-seed-2.0-mini/`. |
 | AFC Population | MiniMax M3 | `20260912-0617-minimax-m3` | Twenty-first catalog cell. Ready; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Analysis A1=`#NAME?` A2=8. Tokens n=30. tip `71640e30`. UNO/assert/PreContract 0. Recorded wall ~66s. OpenRouter usage ~$0.07965 (model_configs alt ~$0.10003 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0617-minimax-m3/`. |
+| AFC Population | DeepSeek V4 Flash 0731 | `20260912-0621-deepseek-v4-flash-0731` | Twenty-second catalog cell. Ready; Sample empty + SSC blank (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Sample `deal.PreContractError expected__deal_wire_dict_ok`. Tokens n=51. tip `71640e30`. PreContract 18; UNO/assert 0. Recorded wall ~330s. OpenRouter usage ~$0.17007 (model_configs alt ~$0.18897 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0621-deepseek-v4-flash-0731/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -234,10 +238,11 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0546-granite-4.2-8b`,
 `20260912-0603-mistral-small-2603`,
 `20260912-0610-seed-2.0-mini`,
-`20260912-0617-minimax-m3`) recorded tokens, wall,
+`20260912-0617-minimax-m3`,
+`20260912-0621-deepseek-v4-flash-0731`) recorded tokens, wall,
 USD, and S/husks. `20260912-0522-solar-pro4` is **BLOCKED** infra
 (tokens/cost 0; oracle omitted). FAIL cells have `failure_count` 1 (or 2 on
-Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3) and no `oracle_check_count` / `partial_score`.
+Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash/Granite 4.2 8B/Seed 2.0 Mini/MiniMax M3/DeepSeek V4 Flash 0731) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
 renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
 missing Sample+SSC shape at far higher USD. Qwen3.8 Flash is the
@@ -251,6 +256,8 @@ Seed 2.0 Mini is the first husk-dominated Sample (`1/1`) plus R
 missing (`failure_count=2`); visual SSC ~65 is not stored as R.
 MiniMax M3 matches Nemotron/GLM’s missing Sample+SSC with a Ready
 Analysis sheet (`#NAME?` / 8).
+DeepSeek V4 Flash 0731 matches Grok/Spark’s empty-Sample + blank-SSC
+R hole with PreContract 18 on Sample.
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -37,7 +37,7 @@ partial and USD.
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
-Glimmer 30B, Muse Spark 1.3, both Lagunas, and both Qwen3.8s). The catalog-wide headed
+Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, and GLM 5.3 Flash). The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -54,7 +54,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0419-laguna-s-2.1`,
 `20260912-0429-laguna-xs-2.1`,
 `20260912-0443-qwen3.8-27b`,
-`20260912-0502-qwen3.8-flash`, box-local). Run dirs are typically
+`20260912-0502-qwen3.8-flash`,
+`20260912-0515-glm-5.3-flash`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -63,17 +64,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -94,13 +95,14 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok, plus Glimmer, Spark, both Lagunas, and both Qwen3.8s) are NOT HAPPY except Mercury. Most
+   Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, and GLM 5.3 Flash) are NOT HAPPY except Mercury. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
    produced parseable R=66 but the Sample sheet is missing
    (`failure_count=1`; truncated mid tool loop). Laguna XS is
    `failure_count=2` (SSC tab named `Sample_Size_Calculation`; Sample
-   empty). Nemotron and Qwen3.8 27B are
-   `failure_count=2` (missing Sample+SSC). Qwen3.8 27B stayed on Population
+   empty). Nemotron, Qwen3.8 27B, and GLM 5.3 Flash are
+   `failure_count=2` (missing Sample+SSC). GLM hung at `tool_loop`
+   round 0 (`finish_reason=length`; no tools; n=1). Qwen3.8 27B stayed on Population
    with `=PY` (~50 tool rounds; PreContract 63). Qwen3.8 Flash is a
    Luna-like incomplete Sample (68 rows, S=68) with SSC
    Err:508/509/#VALUE! and Scratch Err:513. Grok and Spark are also
@@ -112,7 +114,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -147,6 +149,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Laguna XS 2.1 | `20260912-0429-laguna-xs-2.1` | Thirteenth catalog cell. SSC tab named `Sample_Size_Calculation` (oracle missing SSC); Sample empty (`failure_count=2`); S=0 R=None; husks 0/0. Raw `tool_call` text in the reply. Recorded wall ~85s (observer ~3m12s). tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.04341 (model_configs alt ~$0.07804 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0429-laguna-xs-2.1/`. |
 | AFC Population | Qwen3.8 27B | `20260912-0443-qwen3.8-27b` | Fourteenth catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Stayed on Population with `=PY`; ~50 tool rounds all `finish_reason=tool_calls`. Tokens n=51. PreContract 63; UNO/assert 0. Recorded wall ~720s (12 min LLM). tip `6c6017b7`. OpenRouter usage ~$1.42823 (model_configs alt ~$1.31711 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0443-qwen3.8-27b/`. |
 | AFC Population | Qwen3.8 Flash | `20260912-0502-qwen3.8-flash` | Fifteenth catalog cell. Sample+SSC present (68 rows; S=68; husks 0/680); same R hole as Luna. SSC Err:508/509/#VALUE!; Scratch Err:513. Tokens n=51. tip `6c6017b7`. UNO/assert/PreContract 0. Recorded wall ~540s (9 min LLM; observer ~12 min). OpenRouter usage ~$0.11382 (model_configs alt ~$0.35238 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0502-qwen3.8-flash/`. |
+| AFC Population | GLM 5.3 Flash | `20260912-0515-glm-5.3-flash` | Sixteenth catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Hung `tool_loop` round 0 — `finish_reason=length`; no tools; truncated reasoning dump. Tokens n=1 (`reasoning_tokens=15160` noted, not stored). tip `6c6017b7`. UNO/assert/PreContract 0. Recorded wall ~155s. OpenRouter usage ~$0.00900 (model_configs alt ~$0.00450 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0515-glm-5.3-flash/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -201,13 +204,15 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0419-laguna-s-2.1`,
 `20260912-0429-laguna-xs-2.1`,
 `20260912-0443-qwen3.8-27b`,
-`20260912-0502-qwen3.8-flash`) recorded tokens, wall,
+`20260912-0502-qwen3.8-flash`,
+`20260912-0515-glm-5.3-flash`) recorded tokens, wall,
 USD, and S/husks. FAIL cells have `failure_count` 1 (or 2 on
-Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B) and no `oracle_check_count` / `partial_score`.
+Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
 renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
 missing Sample+SSC shape at far higher USD. Qwen3.8 Flash is the
-Luna-like S=68 R-missing Sample on 68 rows.
+Luna-like S=68 R-missing Sample on 68 rows. GLM 5.3 Flash hung at
+round 0 with no tools and the same missing Sample+SSC shape.
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -37,7 +37,7 @@ partial and USD.
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
-Glimmer 30B and Muse Spark 1.3). The catalog-wide headed
+Glimmer 30B, Muse Spark 1.3, and Laguna S 2.1). The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -50,7 +50,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0310-nemotron-3.5-lightning`,
 `20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
 `20260912-0353-muse-glimmer-30b`,
-`20260912-0409-muse-spark-1.3-contributor`, box-local). Run dirs are typically
+`20260912-0409-muse-spark-1.3-contributor`,
+`20260912-0419-laguna-s-2.1`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -59,17 +60,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -90,8 +91,10 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok, plus Glimmer and Spark) are NOT HAPPY except Mercury. Most
-   miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Nemotron
+   Grok, plus Glimmer, Spark, and Laguna) are NOT HAPPY except Mercury. Most
+   miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna
+   produced parseable R=66 but the Sample sheet is missing
+   (`failure_count=1`; truncated mid tool loop). Nemotron
    is `failure_count=2` (missing Sample+SSC). Grok and Spark are also
    `failure_count=2` (SSC present, Sample empty, R missing). Glimmer
    is the same R hole as Luna/20b on an 81-row Sample with S=0; SSC
@@ -132,6 +135,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Grok 4.6 | `20260912-0342-grok-4.6` | Ninth catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. OpenRouter usage ~$0.02375 (model_configs alt ~$0.05831 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0342-grok-4.6/`. |
 | AFC Population | Muse Glimmer 30B | `20260912-0353-muse-glimmer-30b` | Tenth catalog cell. Sample+SSC present (81 rows; S=0; husks 0/729); same R hole. SSC B9 visually 65; oracle R=None. Hit max 50 tool rounds; recorded wall ~155s (observer ~16 min). tip `e0bb6321`. OpenRouter usage ~$0.15404 (model_configs alt ~$0.66230 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0353-muse-glimmer-30b/`. |
 | AFC Population | Muse Spark 1.3 | `20260912-0409-muse-spark-1.3-contributor` | Eleventh catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Same empty-Sample shape as Grok. tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.00157 (model_configs alt ~$0.00247 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0409-muse-spark-1.3-contributor/`. |
+| AFC Population | Laguna S 2.1 | `20260912-0419-laguna-s-2.1` | Twelfth catalog cell. SSC present with parseable R=66; Sample sheet missing (`failure_count=1`); S=0 R=66; husks 0/0. `finish_reason=length` — truncated mid tool loop. tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.01480 (model_configs alt ~$0.02142 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0419-laguna-s-2.1/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -182,9 +186,11 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0310-nemotron-3.5-lightning`,
 `20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
 `20260912-0353-muse-glimmer-30b`,
-`20260912-0409-muse-spark-1.3-contributor`) recorded tokens, wall,
+`20260912-0409-muse-spark-1.3-contributor`,
+`20260912-0419-laguna-s-2.1`) recorded tokens, wall,
 USD, and S/husks. FAIL cells have `failure_count` 1 (or 2 on
 Nemotron/Grok/Spark) and no `oracle_check_count` / `partial_score`.
+Laguna stored parseable R=66 with a missing Sample sheet.
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -38,8 +38,9 @@ cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Luna, 20B, Flash Lite, Gemma 4 31B, Gemma 4 26B A4B, Nemotron
 3.5 Lightning, Mercury 2.5 Preview, and Grok 4.6 have an AFC stamp
-only. Muse Spark 1.3 is still a placeholder. The catalog-wide headed
-sweep has **not** happened.
+only. Muse Glimmer 30B also has an AFC stamp only. Muse Spark 1.3 is
+still a placeholder. The catalog-wide headed sweep has **not**
+happened.
 
 ## Snapshot ranking (2026-09-12)
 
@@ -50,7 +51,7 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0240-gemma-4-26b-a4b-it`,
 `20260912-0310-nemotron-3.5-lightning`,
 `20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
-box-local). Run dirs are typically
+`20260912-0353-muse-glimmer-30b`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -59,17 +60,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Spark 1.3 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | — |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -90,13 +91,15 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok) are NOT HAPPY except Mercury. Most miss R. Gemma 4 26B A4B
-   produced R=65 then failed S=0 < R. Nemotron is `failure_count=2`
-   (missing Sample+SSC). Grok is also `failure_count=2` (SSC present,
-   Sample empty, R missing). Luna’s Sample is a better incomplete
-   shape (81 rows, S=68) than 120b’s 1516-row dump. Floorstand is NOT
-   HAPPY on both Gemini 3.8 and 120b. Overnight slots 6/8/9/10
-   (gpt-oss only) are all NOT HAPPY.
+   Grok, plus Glimmer) are NOT HAPPY except Mercury. Most miss R.
+   Gemma 4 26B A4B produced R=65 then failed S=0 < R. Nemotron is
+   `failure_count=2` (missing Sample+SSC). Grok is also
+   `failure_count=2` (SSC present, Sample empty, R missing). Glimmer
+   is the same R hole as Luna/20b on an 81-row Sample with S=0; SSC
+   B9 looked like 65 but oracle R=None. Luna’s Sample is a better
+   incomplete shape (81 rows, S=68) than 120b’s 1516-row dump.
+   Floorstand is NOT HAPPY on both Gemini 3.8 and 120b. Overnight
+   slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
    `failure_count` (1, or 2 on Nemotron/Grok) plus S/husks but no
@@ -128,6 +131,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Nemotron 3.5 Lightning | `20260912-0310-nemotron-3.5-lightning` | Seventh catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0; Err:507 in J/K; Save dialog flicker. Tokens are second-send (all-from-first higher, not stored). OpenRouter second-send ~$0.04282 (model_configs alt ~$0.06145 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0310-nemotron-3.5-lightning/`. |
 | AFC Population | Mercury 2.5 Preview | `20260912-0330-mercury-2.5-preview` | Eighth catalog cell. First non-gate HAPPY / oracle PASS. Near-full Sample (1518 rows) but S=494 ≥ R=68; husks 2/16680. Attempt1 contaminated; attempt2 wipe. OpenRouter usage ~$0.00468 (model_configs alt ~$0.03144 not stored). First HAPPY USD — lights the cost chart. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0330-mercury-2.5-preview/`. |
 | AFC Population | Grok 4.6 | `20260912-0342-grok-4.6` | Ninth catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. OpenRouter usage ~$0.02375 (model_configs alt ~$0.05831 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0342-grok-4.6/`. |
+| AFC Population | Muse Glimmer 30B | `20260912-0353-muse-glimmer-30b` | Tenth catalog cell. Sample+SSC present (81 rows; S=0; husks 0/729); same R hole. SSC B9 visually 65; oracle R=None. Hit max 50 tool rounds; recorded wall ~155s (observer ~16 min). tip `e0bb6321`. OpenRouter usage ~$0.15404 (model_configs alt ~$0.66230 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0353-muse-glimmer-30b/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -176,11 +180,12 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
 `20260912-0240-gemma-4-26b-a4b-it`,
 `20260912-0310-nemotron-3.5-lightning`,
-`20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`)
-recorded tokens, wall, USD, and S/husks. FAIL cells have
-`failure_count` 1 (or 2 on Nemotron/Grok) and no `oracle_check_count`
-/ `partial_score`. Mercury is PASS (`failure_count=0`) so
-`partial_score` = 1 and C²/$ is derived from the recorded USD.
+`20260912-0330-mercury-2.5-preview`, `20260912-0342-grok-4.6`,
+`20260912-0353-muse-glimmer-30b`) recorded tokens, wall, USD, and
+S/husks. FAIL cells have `failure_count` 1 (or 2 on Nemotron/Grok)
+and no `oracle_check_count` / `partial_score`. Mercury is PASS
+(`failure_count=0`) so `partial_score` = 1 and C²/$ is derived from
+the recorded USD.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -39,8 +39,8 @@ deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Luna, 20B, Flash Lite, Gemma 4 31B, Gemma 4 26B A4B, Nemotron
 3.5 Lightning, Mercury 2.5 Preview, and Grok 4.6 have an AFC stamp
 only. Muse Glimmer 30B also has an AFC stamp only. Muse Spark 1.3 is
-still a placeholder. The catalog-wide headed sweep has **not**
-happened.
+still a placeholder. The catalog-wide headed
+sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,9 +36,9 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. Luna, 20B, Flash Lite, and Gemma 4 31B have an AFC stamp only.
-Remaining catalog columns (Grok 4.6, Muse Spark 1.3) are placeholders.
-The catalog-wide headed sweep has **not** happened.
+score. Luna, 20B, Flash Lite, Gemma 4 31B, and Gemma 4 26B A4B have an
+AFC stamp only. Remaining catalog columns (Grok 4.6, Muse Spark 1.3)
+are placeholders. The catalog-wide headed sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 
@@ -46,24 +46,25 @@ Seeded from the autopsy, sibling notes, and Scrolly AFC catalog
 stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0202-gpt-oss-20b-nitro`,
 `20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
-box-local). Run dirs are typically untracked —
+`20260912-0240-gemma-4-26b-a4b-it`, box-local). Run dirs are typically
+untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. No HAPPY cell has recorded USD yet.
 
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Grok 4.6 | Muse Spark 1.3 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Grok 4.6 | Muse Spark 1.3 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -77,25 +78,25 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 
 1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
    AFC. gpt-oss-120b is HAPPY only on GMP-0225. Catalog AFC cells
-   (`20260912-0142` 120b, `20260912-0150` Luna, `20260912-0202` 20b,
-   `20260912-0216` Flash Lite, `20260912-0224` Gemma) are all NOT
-   HAPPY (missing R). Luna’s Sample is a better shape (81 rows, S=68)
-   than 120b’s 1516-row dump; 20b / Flash Lite / Gemma are similar size
-   (80–81 rows) but S=0. Gemma is husk-heavy (81/810) with SSC
-   Err:508/#NAME?. Floorstand is NOT HAPPY on both Gemini 3.8 and 120b.
-   Overnight slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
+   (`20260912-0142` 120b through `20260912-0240` 26B A4B) are all NOT
+   HAPPY. Most miss R. Gemma 4 26B A4B is the first catalog model
+   besides the Gemini 3.8 gate to produce R=65, then fails S=0 < R on
+   a 10-row Sample. Luna’s Sample is a better shape (81 rows, S=68)
+   than 120b’s 1516-row dump. Floorstand is NOT HAPPY on both Gemini
+   3.8 and 120b. Overnight slots 6/8/9/10 (gpt-oss only) are all NOT
+   HAPPY.
 2. **Partial:** AFC Gemini 3.8 is oracle PASS (`partial_score` = 1).
-   Catalog AFC cells each recorded `failure_count=1` (R missing) plus
-   S/husks but no `oracle_check_count`, so no FAIL ratio. Tenant /
-   Cadaver / GMP HAPPY cells are still oracle FAIL without a recorded
-   check count. Do not invent one from autopsy prose.
+   Catalog AFC cells each recorded `failure_count=1` plus S/husks but
+   no `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
+   HAPPY cells are still oracle FAIL without a recorded check count.
+   Do not invent one from autopsy prose.
 3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
    chart stays empty (AFC catalog USD is on NOT_HAPPY cells). Then
    Value is `partial_score`² ÷ that USD among HAPPY.
-4. **Coverage:** Grok 4.6 and Muse Spark are entirely no data. Luna,
-   20b, Flash Lite, and Gemma have AFC only. Gemini 3.8 has no stamp
-   yet for GMP, Calc-primary, Draw-primary, Reverse Tenant, or Long
-   Writer. gpt-oss-120b has no stamp for Tenant or Cadaver.
+4. **Coverage:** Grok 4.6 and Muse Spark are entirely no data. The
+   new catalog columns have AFC only. Gemini 3.8 has no stamp yet for
+   GMP, Calc-primary, Draw-primary, Reverse Tenant, or Long Writer.
+   gpt-oss-120b has no stamp for Tenant or Cadaver.
 
 ### Cell notes (only scored pairs)
 
@@ -109,6 +110,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | GPT-OSS 20B | `20260912-0202-gpt-oss-20b-nitro` | Third catalog cell. Ran as `:nitro` (resolved to bare 20b). Sample/SSC present but incomplete (80 rows; S=0; husks 0/800); same R hole, weaker than Luna. OpenRouter usage ~$0.00122 (model_configs alt ~$0.00049 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0202-gpt-oss-20b-nitro/`. |
 | AFC Population | Gemini 3.5 Flash Lite | `20260912-0216-gemini-3.5-flash-lite` | Fourth catalog cell. Attempt1 aborted (nitro contamination); attempt2 clean history. Sample/SSC present (81 rows; S=0; husks 0/648). Shot SSC label truncated “Required Sar”=73; oracle R=None. OpenRouter usage ~$0.00629 (model_configs alt ~$0.00821 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0216-gemini-3.5-flash-lite/`. |
 | AFC Population | Gemma 4 31B | `20260912-0224-gemma-4-31b-it` | Fifth catalog cell. Sample+SSC present (81 rows; S=0; husks 81/810). SSC R is Err:508/#NAME?; oracle R=None. OpenRouter usage ~$0.10841 (model_configs alt ~$0.01404 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0224-gemma-4-31b-it/`. |
+| AFC Population | Gemma 4 26B A4B | `20260912-0240-gemma-4-26b-a4b-it` | Sixth catalog cell. First catalog R=65 besides the Gemini gate; Sample undersized (10 rows, S=0 < R). Attempt1 contaminated; attempt2 wipe. OpenRouter usage ~$0.04316 (model_configs alt ~$0.05011 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0240-gemma-4-26b-a4b-it/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -154,9 +156,10 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `partial_score` = 1 on AFC Gemini. Catalog AFC stamps
 (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0202-gpt-oss-20b-nitro`,
-`20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`)
-recorded tokens, wall, USD, `failure_count=1`, S/husks — not
-`oracle_check_count` or `partial_score`.
+`20260912-0216-gemini-3.5-flash-lite`, `20260912-0224-gemma-4-31b-it`,
+`20260912-0240-gemma-4-26b-a4b-it`) recorded tokens, wall, USD,
+`failure_count=1`, S/husks — not `oracle_check_count` or
+`partial_score`.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,32 +36,33 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. GPT-5.6 Luna and GPT-OSS 20B have an AFC stamp only. Remaining
-catalog columns (Grok 4.6, Muse Spark 1.3) are placeholders. The
-catalog-wide headed sweep has **not** happened.
+score. Luna, 20B, and Gemini 3.5 Flash Lite have an AFC stamp only.
+Remaining catalog columns (Grok 4.6, Muse Spark 1.3) are placeholders.
+The catalog-wide headed sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 
 Seeded from the autopsy, sibling notes, and Scrolly AFC catalog
 stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
-`20260912-0202-gpt-oss-20b-nitro`, box-local). Run dirs are typically
-untracked — `run_artifacts_committed` is false for every cell. No
-OpenRouter eval-2 CI job. No HAPPY cell has recorded USD yet.
+`20260912-0202-gpt-oss-20b-nitro`,
+`20260912-0216-gemini-3.5-flash-lite`, box-local). Run dirs are
+typically untracked — `run_artifacts_committed` is false for every
+cell. No OpenRouter eval-2 CI job. No HAPPY cell has recorded USD yet.
 
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Grok 4.6 | Muse Spark 1.3 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Grok 4.6 | Muse Spark 1.3 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -75,24 +76,26 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 
 1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
    AFC. gpt-oss-120b is HAPPY only on GMP-0225. Catalog AFC cells
-   (`20260912-0142` 120b, `20260912-0150` Luna, `20260912-0202` 20b)
-   are all NOT HAPPY (missing R). Luna’s Sample is a better shape (81
-   rows, S=68) than 120b’s 1516-row dump; 20b is similar size (80 rows)
-   but S=0. Floorstand is NOT HAPPY on both Gemini and 120b. Overnight
-   slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
-2. **Partial:** AFC Gemini is oracle PASS (`partial_score` = 1). AFC
-   120b / Luna / 20b each recorded `failure_count=1` (R missing) plus
-   S/husks (585 / 0 of 15159; 68 / 0 of 810; 0 / 0 of 800) but no
-   `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP HAPPY
-   cells are still oracle FAIL without a recorded check count. Do not
-   invent one from autopsy prose.
+   (`20260912-0142` 120b, `20260912-0150` Luna, `20260912-0202` 20b,
+   `20260912-0216` Flash Lite) are all NOT HAPPY (missing R). Luna’s
+   Sample is a better shape (81 rows, S=68) than 120b’s 1516-row dump;
+   20b and Flash Lite are similar size (80–81 rows) but S=0. Floorstand
+   is NOT HAPPY on both Gemini 3.8 and 120b. Overnight slots 6/8/9/10
+   (gpt-oss only) are all NOT HAPPY.
+2. **Partial:** AFC Gemini 3.8 is oracle PASS (`partial_score` = 1).
+   Catalog AFC cells each recorded `failure_count=1` (R missing) plus
+   S/husks but no `oracle_check_count`, so no FAIL ratio. Flash Lite’s
+   shot showed a truncated SSC label “Required Sar”=73; oracle still
+   parsed R=None. Tenant / Cadaver / GMP HAPPY cells are still oracle
+   FAIL without a recorded check count. Do not invent one from autopsy
+   prose.
 3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
    chart stays empty (AFC catalog USD is on NOT_HAPPY cells). Then
    Value is `partial_score`² ÷ that USD among HAPPY.
-4. **Coverage:** Grok 4.6 and Muse Spark are entirely no data. Luna
-   and 20b have AFC only. Gemini has no stamp yet for GMP, Calc-primary,
-   Draw-primary, Reverse Tenant, or Long Writer. gpt-oss-120b has no
-   stamp for Tenant or Cadaver.
+4. **Coverage:** Grok 4.6 and Muse Spark are entirely no data. Luna,
+   20b, and Flash Lite have AFC only. Gemini 3.8 has no stamp yet for
+   GMP, Calc-primary, Draw-primary, Reverse Tenant, or Long Writer.
+   gpt-oss-120b has no stamp for Tenant or Cadaver.
 
 ### Cell notes (only scored pairs)
 
@@ -104,6 +107,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | GPT-OSS 120B | `20260912-0142-gpt-oss-120b` | First catalog cell. Sample+SSC nonempty but wrong shape (1516 rows); R missing; S=585; husks 0/15159; Ready then kept iterating. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0142-gpt-oss-120b/`. |
 | AFC Population | GPT-5.6 Luna | `20260912-0150-gpt-5.6-luna` | Second catalog cell. Sample+SSC present but incomplete (81 rows; S=68; husks 0/810); same R hole as 120b. OpenRouter usage ~$0.0419 (model_configs alt ~$0.1252 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0150-gpt-5.6-luna/`. |
 | AFC Population | GPT-OSS 20B | `20260912-0202-gpt-oss-20b-nitro` | Third catalog cell. Ran as `:nitro` (resolved to bare 20b). Sample/SSC present but incomplete (80 rows; S=0; husks 0/800); same R hole, weaker than Luna. OpenRouter usage ~$0.00122 (model_configs alt ~$0.00049 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0202-gpt-oss-20b-nitro/`. |
+| AFC Population | Gemini 3.5 Flash Lite | `20260912-0216-gemini-3.5-flash-lite` | Fourth catalog cell. Attempt1 aborted (nitro contamination); attempt2 clean history. Sample/SSC present (81 rows; S=0; husks 0/648). Shot SSC label truncated “Required Sar”=73; oracle R=None. OpenRouter usage ~$0.00629 (model_configs alt ~$0.00821 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0216-gemini-3.5-flash-lite/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -148,7 +152,8 @@ Optional result fields (`oracle_passed`, `oracle_failure_count`,
 recorded them. The 2026-09-12 seed still has derived PASS →
 `partial_score` = 1 on AFC Gemini. Catalog AFC stamps
 (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
-`20260912-0202-gpt-oss-20b-nitro`) recorded tokens, wall, USD,
+`20260912-0202-gpt-oss-20b-nitro`,
+`20260912-0216-gemini-3.5-flash-lite`) recorded tokens, wall, USD,
 `failure_count=1`, S/husks — not `oracle_check_count` or
 `partial_score`.
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,30 +36,32 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. Catalog columns (GPT-OSS 20B, Grok 4.6, Muse Spark 1.3) are
-placeholders. The catalog-wide headed sweep has **not** happened.
+score. GPT-5.6 Luna has an AFC stamp only. Remaining catalog columns
+(GPT-OSS 20B, Grok 4.6, Muse Spark 1.3) are placeholders. The
+catalog-wide headed sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
 
-Seeded from the autopsy, sibling notes, and the first Scrolly AFC
-catalog stamp (`20260912-0142-gpt-oss-120b`, box-local). Run dirs are
-typically untracked — `run_artifacts_committed` is false for every
-cell. No OpenRouter eval-2 CI job. No HAPPY cell has recorded USD yet.
+Seeded from the autopsy, sibling notes, and Scrolly AFC catalog
+stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
+box-local). Run dirs are typically untracked —
+`run_artifacts_committed` is false for every cell. No OpenRouter
+eval-2 CI job. No HAPPY cell has recorded USD yet.
 
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-OSS 20B | Grok 4.6 | Muse Spark 1.3 |
-| --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | — | — | — |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Grok 4.6 | Muse Spark 1.3 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -72,22 +74,24 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 ## Key insights
 
 1. **Hard (HAPPY):** Gemini 3.8 Flash is HAPPY on Tenant, Cadaver, and
-   AFC. gpt-oss-120b is HAPPY only on GMP-0225. First catalog AFC cell
-   (`20260912-0142`) is NOT HAPPY (near-full dump, missing R). Floorstand
-   is NOT HAPPY on both. Overnight slots 6/8/9/10 (gpt-oss only) are
-   all NOT HAPPY.
+   AFC. gpt-oss-120b is HAPPY only on GMP-0225. Catalog AFC cells
+   (`20260912-0142` 120b, `20260912-0150` Luna) are both NOT HAPPY
+   (missing R). Luna’s Sample is a better shape (81 rows vs 120b’s
+   1516-row dump) but the same R hole. Floorstand is NOT HAPPY on both
+   Gemini and 120b. Overnight slots 6/8/9/10 (gpt-oss only) are all
+   NOT HAPPY.
 2. **Partial:** AFC Gemini is oracle PASS (`partial_score` = 1). AFC
-   gpt-oss-120b recorded `failure_count=1` (R missing) plus S=585 /
-   husks 0/15159, but no `oracle_check_count`, so no FAIL ratio. Tenant /
-   Cadaver / GMP HAPPY cells are still oracle FAIL without a recorded
-   check count. Do not invent one from autopsy prose.
+   120b and Luna each recorded `failure_count=1` (R missing) plus S/husks
+   (585 / 0 of 15159; 68 / 0 of 810) but no `oracle_check_count`, so no
+   FAIL ratio. Tenant / Cadaver / GMP HAPPY cells are still oracle FAIL
+   without a recorded check count. Do not invent one from autopsy prose.
 3. **C²/$:** no HAPPY cell has recorded `total_cost_usd`. The cost
-   chart stays empty (the AFC 120b USD is on a NOT_HAPPY cell). Then
+   chart stays empty (AFC 120b / Luna USD are on NOT_HAPPY cells). Then
    Value is `partial_score`² ÷ that USD among HAPPY.
-4. **Coverage:** catalog peers (20B, Grok 4.6, Muse Spark) are entirely
-   no data. Gemini has no stamp yet for GMP, Calc-primary, Draw-primary,
-   Reverse Tenant, or Long Writer. gpt-oss has no stamp for Tenant or
-   Cadaver.
+4. **Coverage:** 20B, Grok 4.6, and Muse Spark are entirely no data.
+   Luna has AFC only. Gemini has no stamp yet for GMP, Calc-primary,
+   Draw-primary, Reverse Tenant, or Long Writer. gpt-oss has no stamp
+   for Tenant or Cadaver.
 
 ### Cell notes (only scored pairs)
 
@@ -97,6 +101,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | Cadaver Proposal | Gemini 3.8 Flash | `20260908-2246-gemini-3.8-flash-r200` | Oracle false-red (aliases, Figure/`draw:frame`, length). |
 | AFC Population | Gemini 3.8 Flash | `20260908-0030-retry2` | Oracle PASS after smoother (S=65 R=2). Autopsy abbreviates the stamp with `…`. |
 | AFC Population | GPT-OSS 120B | `20260912-0142-gpt-oss-120b` | First catalog cell. Sample+SSC nonempty but wrong shape (1516 rows); R missing; S=585; husks 0/15159; Ready then kept iterating. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0142-gpt-oss-120b/`. |
+| AFC Population | GPT-5.6 Luna | `20260912-0150-gpt-5.6-luna` | Second catalog cell. Sample+SSC present but incomplete (81 rows; S=68; husks 0/810); same R hole as 120b. OpenRouter usage ~$0.0419 (model_configs alt ~$0.1252 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0150-gpt-5.6-luna/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -139,10 +144,10 @@ Optional result fields (`oracle_passed`, `oracle_failure_count`,
 `total_tokens`, `input_tokens`, `output_tokens`, `total_cost_usd`,
 `wall_time_s`, `intelligence_per_dollar`) stay empty unless a stamp
 recorded them. The 2026-09-12 seed still has derived PASS →
-`partial_score` = 1 on AFC Gemini. The first catalog AFC stamp
-(`20260912-0142-gpt-oss-120b`) recorded tokens, wall, est. USD,
-`failure_count=1`, S/husks — not `oracle_check_count` or
-`partial_score`.
+`partial_score` = 1 on AFC Gemini. Catalog AFC stamps
+(`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`) recorded
+tokens, wall, USD, `failure_count=1`, S/husks — not
+`oracle_check_count` or `partial_score`.
 
 ## How to refresh
 

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -37,7 +37,9 @@ partial and USD.
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
-Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, and GLM 5.3 Flash). The catalog-wide headed
+Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, GLM 5.3 Flash,
+and Solar Pro 4). Solar is **BLOCKED** infra (Send never ran) — not
+NOT_HAPPY. The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -55,7 +57,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0429-laguna-xs-2.1`,
 `20260912-0443-qwen3.8-27b`,
 `20260912-0502-qwen3.8-flash`,
-`20260912-0515-glm-5.3-flash`, box-local). Run dirs are typically
+`20260912-0515-glm-5.3-flash`,
+`20260912-0522-solar-pro4`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -64,19 +67,19 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
-<img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
+<img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, blue BLOCKED infra, gray no data." />
 
 <img src="eval2-coverage.svg" alt="Eval-2 headed coverage bars per model. Catalog peers have AFC only." />
 
@@ -95,7 +98,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, and GLM 5.3 Flash) are NOT HAPPY except Mercury. Most
+   Grok, plus Glimmer, Spark, both Lagunas, both Qwen3.8s, and GLM 5.3 Flash) are NOT HAPPY except Mercury. Solar Pro 4 is **BLOCKED** infra (`SendButton` / `message_store` sqlite crash; Send never ran) — not a model fail. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
    produced parseable R=66 but the Sample sheet is missing
    (`failure_count=1`; truncated mid tool loop). Laguna XS is
@@ -150,6 +153,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Qwen3.8 27B | `20260912-0443-qwen3.8-27b` | Fourteenth catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Stayed on Population with `=PY`; ~50 tool rounds all `finish_reason=tool_calls`. Tokens n=51. PreContract 63; UNO/assert 0. Recorded wall ~720s (12 min LLM). tip `6c6017b7`. OpenRouter usage ~$1.42823 (model_configs alt ~$1.31711 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0443-qwen3.8-27b/`. |
 | AFC Population | Qwen3.8 Flash | `20260912-0502-qwen3.8-flash` | Fifteenth catalog cell. Sample+SSC present (68 rows; S=68; husks 0/680); same R hole as Luna. SSC Err:508/509/#VALUE!; Scratch Err:513. Tokens n=51. tip `6c6017b7`. UNO/assert/PreContract 0. Recorded wall ~540s (9 min LLM; observer ~12 min). OpenRouter usage ~$0.11382 (model_configs alt ~$0.35238 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0502-qwen3.8-flash/`. |
 | AFC Population | GLM 5.3 Flash | `20260912-0515-glm-5.3-flash` | Sixteenth catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Hung `tool_loop` round 0 — `finish_reason=length`; no tools; truncated reasoning dump. Tokens n=1 (`reasoning_tokens=15160` noted, not stored). tip `6c6017b7`. UNO/assert/PreContract 0. Recorded wall ~155s. OpenRouter usage ~$0.00900 (model_configs alt ~$0.00450 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0515-glm-5.3-flash/`. |
+| AFC Population | Solar Pro 4 | `20260912-0522-solar-pro4` | Seventeenth catalog cell — **BLOCKED** infra, not a model fail. `SendButton` crashed before any LLM call (`sqlite3.OperationalError: no such table: message_store`). Send failed twice. Oracle unscored (missing Sample+SSC only because Send never ran). Tokens 0; cost $0. Headed wait ~1080s. tip `6c6017b7`. Scrolly recreating schema before next trial. Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0522-solar-pro4/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -206,7 +210,8 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0443-qwen3.8-27b`,
 `20260912-0502-qwen3.8-flash`,
 `20260912-0515-glm-5.3-flash`) recorded tokens, wall,
-USD, and S/husks. FAIL cells have `failure_count` 1 (or 2 on
+USD, and S/husks. `20260912-0522-solar-pro4` is **BLOCKED** infra
+(tokens/cost 0; oracle omitted). FAIL cells have `failure_count` 1 (or 2 on
 Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B/GLM 5.3 Flash) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
 renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
@@ -221,8 +226,8 @@ is derived from the recorded USD.
 1. After a headed `--launch` / `--score`, add or replace **one** object
    in [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`task_id` × `model`). Leave unknown pairs **out** of `results`.
-2. Fields: `product_bar` (`HAPPY` \| `NOT_HAPPY`), `oracle`
-   (`PASS` \| `FAIL`), optional `oracle_note` / `stamp` / `source` /
+2. Fields: `product_bar` (`HAPPY` \| `NOT_HAPPY` \| `BLOCKED`), `oracle`
+   (`PASS` \| `FAIL`; omit/null when BLOCKED / unscored), optional `oracle_note` / `stamp` / `source` /
    `patches`. Optional hard/partial/cost extras (omit when unknown):
    `oracle_passed`, `oracle_failure_count`, `oracle_check_count`,
    `oracle_failures`, `afc_s_flags` / `afc_r_required`, `husk_cells` /

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -37,7 +37,7 @@ partial and USD.
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
 score. Every catalog column now has an AFC stamp only (including Muse
-Glimmer 30B, Muse Spark 1.3, Laguna S 2.1, and Laguna XS 2.1). The catalog-wide headed
+Glimmer 30B, Muse Spark 1.3, both Lagunas, and Qwen3.8 27B). The catalog-wide headed
 sweep has **not** happened.
 
 ## Snapshot ranking (2026-09-12)
@@ -52,7 +52,8 @@ stamps (`20260912-0142-gpt-oss-120b`, `20260912-0150-gpt-5.6-luna`,
 `20260912-0353-muse-glimmer-30b`,
 `20260912-0409-muse-spark-1.3-contributor`,
 `20260912-0419-laguna-s-2.1`,
-`20260912-0429-laguna-xs-2.1`, box-local). Run dirs are typically
+`20260912-0429-laguna-xs-2.1`,
+`20260912-0443-qwen3.8-27b`, box-local). Run dirs are typically
 untracked —
 `run_artifacts_committed` is false for every cell. No OpenRouter
 eval-2 CI job. Mercury 2.5 Preview is the first HAPPY cell with
@@ -61,17 +62,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, gray no data." />
 
@@ -92,13 +93,14 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    (`20260912-0330`) is the first non-gate catalog **HAPPY / oracle
    PASS** (S=494 ≥ R=68 on a 1518-row near-full Sample). Earlier
    catalog AFC cells (`20260912-0142` 120b through `20260912-0342`
-   Grok, plus Glimmer, Spark, and both Lagunas) are NOT HAPPY except Mercury. Most
+   Grok, plus Glimmer, Spark, both Lagunas, and Qwen3.8 27B) are NOT HAPPY except Mercury. Most
    miss R. Gemma 4 26B A4B produced R=65 then failed S=0 < R. Laguna S
    produced parseable R=66 but the Sample sheet is missing
    (`failure_count=1`; truncated mid tool loop). Laguna XS is
    `failure_count=2` (SSC tab named `Sample_Size_Calculation`; Sample
-   empty). Nemotron
-   is `failure_count=2` (missing Sample+SSC). Grok and Spark are also
+   empty). Nemotron and Qwen3.8 27B are
+   `failure_count=2` (missing Sample+SSC). Qwen stayed on Population
+   with `=PY` (~50 tool rounds; PreContract 63). Grok and Spark are also
    `failure_count=2` (SSC present, Sample empty, R missing). Glimmer
    is the same R hole as Luna/20b on an 81-row Sample with S=0; SSC
    B9 looked like 65 but oracle R=None. Luna’s Sample is a better
@@ -107,7 +109,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    slots 6/8/9/10 (gpt-oss only) are all NOT HAPPY.
 2. **Partial:** AFC Gemini 3.8 and Mercury are oracle PASS
    (`partial_score` = 1). Other catalog AFC cells recorded
-   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS) plus S/husks but no
+   `failure_count` (1, or 2 on Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B) plus S/husks but no
    `oracle_check_count`, so no FAIL ratio. Tenant / Cadaver / GMP
    HAPPY cells are still oracle FAIL without a recorded check count.
    Do not invent one from autopsy prose.
@@ -140,6 +142,7 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 | AFC Population | Muse Spark 1.3 | `20260912-0409-muse-spark-1.3-contributor` | Eleventh catalog cell. SSC present; Sample empty (`failure_count=2`: no data rows + R missing); S=0 R=None; husks 0/0. Same empty-Sample shape as Grok. tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.00157 (model_configs alt ~$0.00247 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0409-muse-spark-1.3-contributor/`. |
 | AFC Population | Laguna S 2.1 | `20260912-0419-laguna-s-2.1` | Twelfth catalog cell. SSC present with parseable R=66; Sample sheet missing (`failure_count=1`); S=0 R=66; husks 0/0. `finish_reason=length` — truncated mid tool loop. tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.01480 (model_configs alt ~$0.02142 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0419-laguna-s-2.1/`. |
 | AFC Population | Laguna XS 2.1 | `20260912-0429-laguna-xs-2.1` | Thirteenth catalog cell. SSC tab named `Sample_Size_Calculation` (oracle missing SSC); Sample empty (`failure_count=2`); S=0 R=None; husks 0/0. Raw `tool_call` text in the reply. Recorded wall ~85s (observer ~3m12s). tip `6c6017b7`. UNO/assert/PreContract 0. OpenRouter usage ~$0.04341 (model_configs alt ~$0.07804 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0429-laguna-xs-2.1/`. |
+| AFC Population | Qwen3.8 27B | `20260912-0443-qwen3.8-27b` | Fourteenth catalog cell. Population only; missing Sample+SSC (`failure_count=2`); S=0 R=None; husks 0/0. Stayed on Population with `=PY`; ~50 tool rounds all `finish_reason=tool_calls`. Tokens n=51. PreContract 63; UNO/assert 0. Recorded wall ~720s (12 min LLM). tip `6c6017b7`. OpenRouter usage ~$1.42823 (model_configs alt ~$1.31711 not stored). Box-local `docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0443-qwen3.8-27b/`. |
 | Floorstand | Gemini 3.8 Flash | `20260909-1748-gemini-3.8-flash-private-patch` | Polarity HIT; still empty + stall. Private patches, not PR’d. |
 | GMP Change Control | GPT-OSS 120B | `20260909-0225-gpt-oss-120b` | Cite-only oracle fail. Prior `0103` was NOT HAPPY (dump polarity). |
 | Floorstand | GPT-OSS 120B | `20260909-0323-gpt-oss-120b` | Extract/JSON polarity MISS; empty + LO crash. Private `1733` still MISS. |
@@ -192,11 +195,13 @@ recorded them. The 2026-09-12 seed still has derived PASS →
 `20260912-0353-muse-glimmer-30b`,
 `20260912-0409-muse-spark-1.3-contributor`,
 `20260912-0419-laguna-s-2.1`,
-`20260912-0429-laguna-xs-2.1`) recorded tokens, wall,
+`20260912-0429-laguna-xs-2.1`,
+`20260912-0443-qwen3.8-27b`) recorded tokens, wall,
 USD, and S/husks. FAIL cells have `failure_count` 1 (or 2 on
-Nemotron/Grok/Spark/Laguna XS) and no `oracle_check_count` / `partial_score`.
+Nemotron/Grok/Spark/Laguna XS/Qwen3.8 27B) and no `oracle_check_count` / `partial_score`.
 Laguna S stored parseable R=66 with a missing Sample sheet. Laguna XS
-renamed the SSC tab so R is missing.
+renamed the SSC tab so R is missing. Qwen3.8 27B matches Nemotron’s
+missing Sample+SSC shape at far higher USD.
 Mercury is PASS (`failure_count=0`) so `partial_score` = 1 and C²/$
 is derived from the recorded USD.
 

--- a/docs/eval/eval-2/eval2-cost.svg
+++ b/docs/eval/eval-2/eval2-cost.svg
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="140" viewBox="0 0 820 140" role="img">
-  <title>Eval-2 headed cost for results (empty — no recorded USD)</title>
-  <rect width="820" height="140" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="166" viewBox="0 0 820 166" role="img">
+  <title>Eval-2 headed cost for results (HAPPY cells with recorded USD)</title>
+  <rect width="820" height="166" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed cost for results (HAPPY cells)</text>
-  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first. C²/$ = partial² / USD among successes (same shape as the string pack).</text>
-  <rect x="24" y="64" width="772" height="40" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="410.0" y="89" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#5f6368">No HAPPY cell has recorded total_cost_usd yet</text>
+  <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among HAPPY, higher partial then lower USD. C²/$ = partial² / USD. NOT_HAPPY and missing cost omitted.</text>
+  <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
+  <text x="296.0" y="94.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Mercury 2.5 Preview</text>
+  <rect x="304.0" y="82.0" width="360.0" height="16" rx="3" fill="#009E73" stroke="#dadce0" data-cost-usd="0.004680"/>
+  <text x="672.0" y="94.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">$0.0047 · 213.68 C²/$</text>
+  <text x="24" y="150" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Recorded USD only. Empty cost stays empty — do not invent run costs.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="716" height="414" viewBox="0 0 716 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="414" viewBox="0 0 840 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="716" height="414" fill="#ffffff"/>
+  <rect width="840" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -14,15 +14,19 @@
   <rect x="180.0" y="64.0" width="88" height="28.9" fill="#009E73" stroke="#dadce0" data-segment="HAPPY"/>
   <text x="224.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 120B</text>
   <text x="224.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1 HAPPY / 7 scored</text>
-  <rect x="304.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="348.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
-  <text x="348.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="304.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="304.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="348.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-5.6 Luna</text>
+  <text x="348.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="428.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="472.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="472.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
   <text x="472.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="552.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="596.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="596.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="596.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="676.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="720.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="720.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2328" height="414" viewBox="0 0 2328 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2452" height="414" viewBox="0 0 2452 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="2328" height="414" fill="#ffffff"/>
+  <rect width="2452" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -78,6 +78,10 @@
   <rect x="2164.0" y="64.0" width="88" height="28.9" fill="#0072B2" stroke="#dadce0" data-segment="BLOCKED"/>
   <text x="2208.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Solar Pro 4</text>
   <text x="2208.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="2288.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="2288.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="2332.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Granite 4.2 8B</text>
+  <text x="2332.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1212" height="414" viewBox="0 0 1212 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1336" height="414" viewBox="0 0 1336 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="1212" height="414" fill="#ffffff"/>
+  <rect width="1336" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -34,12 +34,16 @@
   <rect x="800.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="844.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemma 4 26B A4B</text>
   <text x="844.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
-  <rect x="924.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="968.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="968.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="924.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="924.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="968.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="968.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="1048.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="1092.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1092.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="1092.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="1172.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="1216.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1216.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2824" height="414" viewBox="0 0 2824 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2948" height="414" viewBox="0 0 2948 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="2824" height="414" fill="#ffffff"/>
+  <rect width="2948" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -94,6 +94,10 @@
   <rect x="2660.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="2704.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">MiniMax M3</text>
   <text x="2704.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="2784.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="2784.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="2828.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">DeepSeek V4 Flash 0731</text>
+  <text x="2828.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1336" height="414" viewBox="0 0 1336 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1460" height="414" viewBox="0 0 1460 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="1336" height="414" fill="#ffffff"/>
+  <rect width="1460" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -38,12 +38,16 @@
   <rect x="924.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="968.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Nemotron 3.5 Lightning</text>
   <text x="968.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
-  <rect x="1048.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="1092.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="1092.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="1048.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1048.0" y="64.0" width="88" height="28.9" fill="#009E73" stroke="#dadce0" data-segment="HAPPY"/>
+  <text x="1092.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Mercury 2.5 Preview</text>
+  <text x="1092.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1 HAPPY / 1 scored</text>
   <rect x="1172.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="1216.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1216.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="1216.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="1296.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="1340.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1340.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -50,9 +50,10 @@
   <rect x="1296.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1340.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Glimmer 30B</text>
   <text x="1340.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
-  <rect x="1420.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1420.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1420.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1464.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="1464.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <text x="1464.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2204" height="414" viewBox="0 0 2204 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2328" height="414" viewBox="0 0 2328 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="2204" height="414" fill="#ffffff"/>
+  <rect width="2328" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -74,10 +74,16 @@
   <rect x="2040.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="2084.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GLM 5.3 Flash</text>
   <text x="2084.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="2164.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="2164.0" y="64.0" width="88" height="28.9" fill="#0072B2" stroke="#dadce0" data-segment="BLOCKED"/>
+  <text x="2208.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Solar Pro 4</text>
+  <text x="2208.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>
   <text x="152" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">NOT_HAPPY</text>
-  <rect x="244" y="376" width="12" height="12" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="262" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">no data</text>
+  <rect x="244" y="376" width="12" height="12" fill="#0072B2" stroke="#dadce0"/>
+  <text x="262" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">BLOCKED</text>
+  <rect x="354" y="376" width="12" height="12" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="372" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">no data</text>
 </svg>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -18,9 +18,10 @@
   <rect x="304.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="348.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-5.6 Luna</text>
   <text x="348.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
-  <rect x="428.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="428.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="428.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="472.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
-  <text x="472.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <text x="472.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="552.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
   <text x="596.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="596.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -42,9 +42,10 @@
   <rect x="1048.0" y="64.0" width="88" height="28.9" fill="#009E73" stroke="#dadce0" data-segment="HAPPY"/>
   <text x="1092.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Mercury 2.5 Preview</text>
   <text x="1092.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1 HAPPY / 1 scored</text>
-  <rect x="1172.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1172.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1172.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1216.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="1216.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <text x="1216.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="1296.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
   <text x="1340.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
   <text x="1340.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2452" height="414" viewBox="0 0 2452 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2576" height="414" viewBox="0 0 2576 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="2452" height="414" fill="#ffffff"/>
+  <rect width="2576" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -82,6 +82,10 @@
   <rect x="2288.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="2332.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Granite 4.2 8B</text>
   <text x="2332.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="2412.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="2412.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="2456.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Mistral Small 4</text>
+  <text x="2456.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1584" height="414" viewBox="0 0 1584 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1708" height="414" viewBox="0 0 1708 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="1584" height="414" fill="#ffffff"/>
+  <rect width="1708" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -54,6 +54,10 @@
   <rect x="1420.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1464.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
   <text x="1464.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="1544.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1544.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="1588.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Laguna S 2.1</text>
+  <text x="1588.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2080" height="414" viewBox="0 0 2080 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2204" height="414" viewBox="0 0 2204 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="2080" height="414" fill="#ffffff"/>
+  <rect width="2204" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -70,6 +70,10 @@
   <rect x="1916.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1960.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Qwen3.8 Flash</text>
   <text x="1960.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="2040.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="2040.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="2084.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GLM 5.3 Flash</text>
+  <text x="2084.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1708" height="414" viewBox="0 0 1708 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1832" height="414" viewBox="0 0 1832 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="1708" height="414" fill="#ffffff"/>
+  <rect width="1832" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -58,6 +58,10 @@
   <rect x="1544.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1588.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Laguna S 2.1</text>
   <text x="1588.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="1668.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1668.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="1712.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Laguna XS 2.1</text>
+  <text x="1712.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2576" height="414" viewBox="0 0 2576 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2700" height="414" viewBox="0 0 2700 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="2576" height="414" fill="#ffffff"/>
+  <rect width="2700" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -86,6 +86,10 @@
   <rect x="2412.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="2456.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Mistral Small 4</text>
   <text x="2456.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="2536.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="2536.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="2580.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Seed 2.0 Mini</text>
+  <text x="2580.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -9,11 +9,11 @@
   <rect x="56.0" y="64.0" width="88" height="86.7" fill="#009E73" stroke="#dadce0" data-segment="HAPPY"/>
   <text x="100.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash</text>
   <text x="100.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">3 HAPPY / 4 scored</text>
-  <rect x="180.0" y="237.3" width="88" height="86.7" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <rect x="180.0" y="92.9" width="88" height="144.4" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <rect x="180.0" y="266.2" width="88" height="57.8" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="180.0" y="92.9" width="88" height="173.3" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <rect x="180.0" y="64.0" width="88" height="28.9" fill="#009E73" stroke="#dadce0" data-segment="HAPPY"/>
   <text x="224.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 120B</text>
-  <text x="224.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1 HAPPY / 6 scored</text>
+  <text x="224.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1 HAPPY / 7 scored</text>
   <rect x="304.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
   <text x="348.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
   <text x="348.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1832" height="414" viewBox="0 0 1832 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1956" height="414" viewBox="0 0 1956 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="1832" height="414" fill="#ffffff"/>
+  <rect width="1956" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -62,6 +62,10 @@
   <rect x="1668.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1712.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Laguna XS 2.1</text>
   <text x="1712.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="1792.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1792.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="1836.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Qwen3.8 27B</text>
+  <text x="1836.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1088" height="414" viewBox="0 0 1088 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1212" height="414" viewBox="0 0 1212 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="1088" height="414" fill="#ffffff"/>
+  <rect width="1212" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -30,12 +30,16 @@
   <rect x="676.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="720.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemma 4 31B</text>
   <text x="720.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
-  <rect x="800.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="844.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="844.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="800.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="800.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="844.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="844.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="924.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="968.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="968.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="968.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="1048.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="1092.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1092.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2700" height="414" viewBox="0 0 2700 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2824" height="414" viewBox="0 0 2824 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="2700" height="414" fill="#ffffff"/>
+  <rect width="2824" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -90,6 +90,10 @@
   <rect x="2536.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="2580.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Seed 2.0 Mini</text>
   <text x="2580.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="2660.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="2660.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="2704.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">MiniMax M3</text>
+  <text x="2704.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="840" height="414" viewBox="0 0 840 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="964" height="414" viewBox="0 0 964 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="840" height="414" fill="#ffffff"/>
+  <rect width="964" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -22,12 +22,16 @@
   <rect x="428.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="472.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
   <text x="472.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
-  <rect x="552.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="596.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="596.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="552.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="552.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="596.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.5 Flash Lite</text>
+  <text x="596.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="676.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="720.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="720.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="720.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="800.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="844.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="844.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1956" height="414" viewBox="0 0 1956 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2080" height="414" viewBox="0 0 2080 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="1956" height="414" fill="#ffffff"/>
+  <rect width="2080" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -66,6 +66,10 @@
   <rect x="1792.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1836.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Qwen3.8 27B</text>
   <text x="1836.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="1916.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1916.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="1960.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Qwen3.8 Flash</text>
+  <text x="1960.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="964" height="414" viewBox="0 0 964 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1088" height="414" viewBox="0 0 1088 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="964" height="414" fill="#ffffff"/>
+  <rect width="1088" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -26,12 +26,16 @@
   <rect x="552.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="596.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.5 Flash Lite</text>
   <text x="596.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
-  <rect x="676.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="720.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="720.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="676.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="676.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="720.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemma 4 31B</text>
+  <text x="720.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="800.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="844.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="844.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="844.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="924.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="968.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="968.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2948" height="414" viewBox="0 0 2948 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="3072" height="414" viewBox="0 0 3072 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="2948" height="414" fill="#ffffff"/>
+  <rect width="3072" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -98,6 +98,10 @@
   <rect x="2784.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="2828.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">DeepSeek V4 Flash 0731</text>
   <text x="2828.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="2908.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="2908.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="2952.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">DeepSeek V4.1 Flash</text>
+  <text x="2952.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1460" height="414" viewBox="0 0 1460 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1584" height="414" viewBox="0 0 1584 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="1460" height="414" fill="#ffffff"/>
+  <rect width="1584" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -46,9 +46,13 @@
   <rect x="1172.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="1216.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="1216.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
-  <rect x="1296.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
-  <text x="1340.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="1340.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="1296.0" y="92.9" width="88" height="231.1" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <rect x="1296.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
+  <text x="1340.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Glimmer 30B</text>
+  <text x="1340.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="1420.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="1464.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1464.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2208" height="714" viewBox="0 0 2208 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2358" height="714" viewBox="0 0 2358 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="2208" height="714" fill="#ffffff"/>
+  <rect width="2358" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -30,6 +30,8 @@
   <text x="1959.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
   <text x="2109.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Laguna S 2.1</text>
   <text x="2109.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">poolside/laguna-s-2.1</text>
+  <text x="2259.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Laguna XS 2.1</text>
+  <text x="2259.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">poolside/laguna-xs-2.1</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -71,6 +73,9 @@
   <rect x="2038.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2109.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2109.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2188.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2259.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2259.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -112,6 +117,9 @@
   <rect x="2038.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2109.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2109.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2188.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2259.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2259.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -153,6 +161,9 @@
   <rect x="2038.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="2109.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="2109.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="2188.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="2259.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="2259.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -194,6 +205,9 @@
   <rect x="2038.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2109.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2109.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2188.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2259.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2259.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -235,6 +249,9 @@
   <rect x="2038.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2109.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2109.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2188.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2259.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2259.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -276,6 +293,9 @@
   <rect x="2038.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2109.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2109.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2188.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2259.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2259.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -317,6 +337,9 @@
   <rect x="2038.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2109.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2109.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2188.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2259.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2259.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -358,6 +381,9 @@
   <rect x="2038.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2109.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2109.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2188.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2259.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2259.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -399,5 +425,8 @@
   <rect x="2038.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2109.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2109.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2188.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2259.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2259.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -125,9 +125,9 @@
   <rect x="1438.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
   <text x="1509.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">HAPPY</text>
   <text x="1509.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle PASS</text>
-  <rect x="1588.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="1659.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="1659.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="1659.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="1659.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <rect x="1738.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1758" height="714" viewBox="0 0 1758 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1908" height="714" viewBox="0 0 1908 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="1758" height="714" fill="#ffffff"/>
+  <rect width="1908" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -20,10 +20,12 @@
   <text x="1209.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemma-4-26b-a4b-it</text>
   <text x="1359.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Nemotron 3.5 Lightning</text>
   <text x="1359.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">nvidia/nemotron-3.5-lightning</text>
-  <text x="1509.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="1509.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
-  <text x="1659.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="1659.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="1509.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Mercury 2.5 Preview</text>
+  <text x="1509.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">inception/mercury-2.5-preview</text>
+  <text x="1659.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="1659.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
+  <text x="1809.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1809.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -56,6 +58,9 @@
   <rect x="1588.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -88,6 +93,9 @@
   <rect x="1588.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -114,12 +122,15 @@
   <rect x="1288.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="1359.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="1359.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="1438.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="1509.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="1509.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
+  <text x="1509.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">HAPPY</text>
+  <text x="1509.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle PASS</text>
   <rect x="1588.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -152,6 +163,9 @@
   <rect x="1588.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -184,6 +198,9 @@
   <rect x="1588.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -216,6 +233,9 @@
   <rect x="1588.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -248,6 +268,9 @@
   <rect x="1588.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -280,6 +303,9 @@
   <rect x="1588.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -312,5 +338,8 @@
   <rect x="1588.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1659.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1659.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1809.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1809.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2508" height="714" viewBox="0 0 2508 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2658" height="714" viewBox="0 0 2658 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="2508" height="714" fill="#ffffff"/>
+  <rect width="2658" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -34,6 +34,8 @@
   <text x="2259.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">poolside/laguna-xs-2.1</text>
   <text x="2409.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Qwen3.8 27B</text>
   <text x="2409.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">qwen/qwen3.8-27b</text>
+  <text x="2559.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Qwen3.8 Flash</text>
+  <text x="2559.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">qwen/qwen3.8-flash</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -81,6 +83,9 @@
   <rect x="2338.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2409.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2409.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2488.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2559.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2559.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -128,6 +133,9 @@
   <rect x="2338.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2409.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2409.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2488.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2559.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2559.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -175,6 +183,9 @@
   <rect x="2338.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="2409.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="2409.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="2488.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="2559.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="2559.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -222,6 +233,9 @@
   <rect x="2338.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2409.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2409.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2488.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2559.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2559.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -269,6 +283,9 @@
   <rect x="2338.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2409.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2409.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2488.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2559.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2559.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -316,6 +333,9 @@
   <rect x="2338.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2409.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2409.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2488.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2559.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2559.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -363,6 +383,9 @@
   <rect x="2338.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2409.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2409.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2488.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2559.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2559.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -410,6 +433,9 @@
   <rect x="2338.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2409.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2409.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2488.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2559.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2559.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -457,5 +483,8 @@
   <rect x="2338.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2409.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2409.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2488.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2559.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2559.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="3708" height="714" viewBox="0 0 3708 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="3858" height="714" viewBox="0 0 3858 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="3708" height="714" fill="#ffffff"/>
+  <rect width="3858" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -50,6 +50,8 @@
   <text x="3459.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">minimax/minimax-m3</text>
   <text x="3609.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">DeepSeek V4 Flash 0731</text>
   <text x="3609.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">deepseek/deepseek-v4-flash-0731</text>
+  <text x="3759.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">DeepSeek V4.1 Flash</text>
+  <text x="3759.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">deepseek/deepseek-v4.1-flash</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -121,6 +123,9 @@
   <rect x="3538.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3609.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3609.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3688.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3759.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3759.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -192,6 +197,9 @@
   <rect x="3538.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3609.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3609.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3688.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3759.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3759.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -263,6 +271,9 @@
   <rect x="3538.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="3609.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="3609.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="3688.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="3759.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="3759.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -334,6 +345,9 @@
   <rect x="3538.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3609.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3609.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3688.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3759.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3759.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -405,6 +419,9 @@
   <rect x="3538.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3609.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3609.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3688.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3759.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3759.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -476,6 +493,9 @@
   <rect x="3538.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3609.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3609.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3688.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3759.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3759.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -547,6 +567,9 @@
   <rect x="3538.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3609.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3609.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3688.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3759.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3759.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -618,6 +641,9 @@
   <rect x="3538.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3609.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3609.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3688.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3759.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3759.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -689,5 +715,8 @@
   <rect x="3538.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3609.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3609.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3688.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3759.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3759.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1008" height="714" viewBox="0 0 1008 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1158" height="714" viewBox="0 0 1158 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="1008" height="714" fill="#ffffff"/>
+  <rect width="1158" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
   <text x="309.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemini-3.8-flash</text>
   <text x="459.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 120B</text>
   <text x="459.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-oss-120b</text>
-  <text x="609.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
-  <text x="609.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-oss-20b</text>
-  <text x="759.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="759.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
-  <text x="909.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="909.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="609.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-5.6 Luna</text>
+  <text x="609.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-5.6-luna</text>
+  <text x="759.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
+  <text x="759.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-oss-20b</text>
+  <text x="909.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="909.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
+  <text x="1059.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1059.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -31,6 +33,9 @@
   <rect x="838.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -48,6 +53,9 @@
   <rect x="838.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -56,15 +64,18 @@
   <rect x="388.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="459.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="459.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="538.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="609.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="609.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="538.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="609.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="609.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <rect x="688.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="759.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="759.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <rect x="838.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -82,6 +93,9 @@
   <rect x="838.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -99,6 +113,9 @@
   <rect x="838.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -116,6 +133,9 @@
   <rect x="838.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -133,6 +153,9 @@
   <rect x="838.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -150,6 +173,9 @@
   <rect x="838.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -167,5 +193,8 @@
   <rect x="838.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1059.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1059.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2358" height="714" viewBox="0 0 2358 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2508" height="714" viewBox="0 0 2508 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="2358" height="714" fill="#ffffff"/>
+  <rect width="2508" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -32,6 +32,8 @@
   <text x="2109.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">poolside/laguna-s-2.1</text>
   <text x="2259.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Laguna XS 2.1</text>
   <text x="2259.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">poolside/laguna-xs-2.1</text>
+  <text x="2409.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Qwen3.8 27B</text>
+  <text x="2409.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">qwen/qwen3.8-27b</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -76,6 +78,9 @@
   <rect x="2188.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2259.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2259.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2338.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2409.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2409.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -120,6 +125,9 @@
   <rect x="2188.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2259.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2259.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2338.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2409.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2409.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -164,6 +172,9 @@
   <rect x="2188.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="2259.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="2259.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="2338.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="2409.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="2409.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -208,6 +219,9 @@
   <rect x="2188.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2259.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2259.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2338.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2409.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2409.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -252,6 +266,9 @@
   <rect x="2188.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2259.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2259.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2338.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2409.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2409.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -296,6 +313,9 @@
   <rect x="2188.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2259.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2259.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2338.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2409.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2409.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -340,6 +360,9 @@
   <rect x="2188.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2259.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2259.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2338.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2409.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2409.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -384,6 +407,9 @@
   <rect x="2188.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2259.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2259.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2338.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2409.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2409.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -428,5 +454,8 @@
   <rect x="2188.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2259.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2259.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2338.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2409.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2409.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="3558" height="714" viewBox="0 0 3558 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="3708" height="714" viewBox="0 0 3708 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="3558" height="714" fill="#ffffff"/>
+  <rect width="3708" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -48,6 +48,8 @@
   <text x="3309.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">bytedance-seed/seed-2.0-mini</text>
   <text x="3459.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">MiniMax M3</text>
   <text x="3459.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">minimax/minimax-m3</text>
+  <text x="3609.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">DeepSeek V4 Flash 0731</text>
+  <text x="3609.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">deepseek/deepseek-v4-flash-0731</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -116,6 +118,9 @@
   <rect x="3388.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3459.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3459.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3538.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3609.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3609.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -184,6 +189,9 @@
   <rect x="3388.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3459.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3459.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3538.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3609.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3609.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -252,6 +260,9 @@
   <rect x="3388.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="3459.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="3459.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="3538.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="3609.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="3609.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -320,6 +331,9 @@
   <rect x="3388.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3459.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3459.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3538.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3609.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3609.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -388,6 +402,9 @@
   <rect x="3388.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3459.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3459.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3538.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3609.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3609.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -456,6 +473,9 @@
   <rect x="3388.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3459.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3459.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3538.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3609.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3609.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -524,6 +544,9 @@
   <rect x="3388.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3459.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3459.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3538.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3609.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3609.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -592,6 +615,9 @@
   <rect x="3388.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3459.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3459.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3538.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3609.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3609.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -660,5 +686,8 @@
   <rect x="3388.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3459.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3459.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3538.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3609.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3609.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1458" height="714" viewBox="0 0 1458 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1608" height="714" viewBox="0 0 1608 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="1458" height="714" fill="#ffffff"/>
+  <rect width="1608" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -16,10 +16,12 @@
   <text x="909.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemini-3.5-flash-lite</text>
   <text x="1059.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemma 4 31B</text>
   <text x="1059.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemma-4-31b-it</text>
-  <text x="1209.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="1209.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
-  <text x="1359.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="1359.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="1209.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="1209.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemma-4-26b-a4b-it</text>
+  <text x="1359.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="1359.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
+  <text x="1509.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1509.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -46,6 +48,9 @@
   <rect x="1288.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -72,6 +77,9 @@
   <rect x="1288.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -92,12 +100,15 @@
   <rect x="988.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="1059.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="1059.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="1138.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="1209.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="1209.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="1209.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="1209.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <rect x="1288.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -124,6 +135,9 @@
   <rect x="1288.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -150,6 +164,9 @@
   <rect x="1288.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -176,6 +193,9 @@
   <rect x="1288.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -202,6 +222,9 @@
   <rect x="1288.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -228,6 +251,9 @@
   <rect x="1288.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -254,5 +280,8 @@
   <rect x="1288.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1359.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1359.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1438.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1509.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1509.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1158" height="714" viewBox="0 0 1158 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1308" height="714" viewBox="0 0 1308 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="1158" height="714" fill="#ffffff"/>
+  <rect width="1308" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -12,10 +12,12 @@
   <text x="609.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-5.6-luna</text>
   <text x="759.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GPT-OSS 20B</text>
   <text x="759.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-oss-20b</text>
-  <text x="909.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="909.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
-  <text x="1059.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="1059.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="909.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.5 Flash Lite</text>
+  <text x="909.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemini-3.5-flash-lite</text>
+  <text x="1059.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="1059.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
+  <text x="1209.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1209.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -36,6 +38,9 @@
   <rect x="988.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -56,6 +61,9 @@
   <rect x="988.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -70,12 +78,15 @@
   <rect x="688.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="759.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="759.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="838.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="909.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="909.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="838.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="909.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="909.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <rect x="988.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -96,6 +107,9 @@
   <rect x="988.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -116,6 +130,9 @@
   <rect x="988.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -136,6 +153,9 @@
   <rect x="988.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -156,6 +176,9 @@
   <rect x="988.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -176,6 +199,9 @@
   <rect x="988.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -196,5 +222,8 @@
   <rect x="988.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1059.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1059.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1138.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1209.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1209.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="3108" height="714" viewBox="0 0 3108 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="3258" height="714" viewBox="0 0 3258 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="3108" height="714" fill="#ffffff"/>
+  <rect width="3258" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -42,6 +42,8 @@
   <text x="2859.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">upstage/solar-pro4</text>
   <text x="3009.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Granite 4.2 8B</text>
   <text x="3009.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">ibm-granite/granite-4.2-8b</text>
+  <text x="3159.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Mistral Small 4</text>
+  <text x="3159.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">mistralai/mistral-small-2603</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -101,6 +103,9 @@
   <rect x="2938.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3009.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3009.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3088.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3159.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3159.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -160,6 +165,9 @@
   <rect x="2938.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3009.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3009.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3088.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3159.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3159.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -219,6 +227,9 @@
   <rect x="2938.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="3009.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="3009.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="3088.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="3159.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="3159.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -278,6 +289,9 @@
   <rect x="2938.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3009.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3009.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3088.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3159.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3159.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -337,6 +351,9 @@
   <rect x="2938.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3009.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3009.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3088.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3159.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3159.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -396,6 +413,9 @@
   <rect x="2938.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3009.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3009.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3088.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3159.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3159.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -455,6 +475,9 @@
   <rect x="2938.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3009.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3009.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3088.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3159.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3159.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -514,6 +537,9 @@
   <rect x="2938.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3009.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3009.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3088.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3159.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3159.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -573,5 +599,8 @@
   <rect x="2938.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3009.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3009.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3088.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3159.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3159.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1308" height="714" viewBox="0 0 1308 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1458" height="714" viewBox="0 0 1458 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="1308" height="714" fill="#ffffff"/>
+  <rect width="1458" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -14,10 +14,12 @@
   <text x="759.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">openai/gpt-oss-20b</text>
   <text x="909.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.5 Flash Lite</text>
   <text x="909.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemini-3.5-flash-lite</text>
-  <text x="1059.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="1059.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
-  <text x="1209.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="1209.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="1059.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemma 4 31B</text>
+  <text x="1059.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemma-4-31b-it</text>
+  <text x="1209.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="1209.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
+  <text x="1359.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1359.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -41,6 +43,9 @@
   <rect x="1138.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -64,6 +69,9 @@
   <rect x="1138.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -81,12 +89,15 @@
   <rect x="838.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="909.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="909.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="988.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="1059.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="1059.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="988.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="1059.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="1059.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <rect x="1138.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -110,6 +121,9 @@
   <rect x="1138.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -133,6 +147,9 @@
   <rect x="1138.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -156,6 +173,9 @@
   <rect x="1138.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -179,6 +199,9 @@
   <rect x="1138.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -202,6 +225,9 @@
   <rect x="1138.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -225,5 +251,8 @@
   <rect x="1138.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1209.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1209.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1359.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1359.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2808" height="714" viewBox="0 0 2808 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2958" height="714" viewBox="0 0 2958 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="2808" height="714" fill="#ffffff"/>
+  <rect width="2958" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -38,6 +38,8 @@
   <text x="2559.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">qwen/qwen3.8-flash</text>
   <text x="2709.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GLM 5.3 Flash</text>
   <text x="2709.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">z-ai/glm-5.3-flash</text>
+  <text x="2859.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Solar Pro 4</text>
+  <text x="2859.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">upstage/solar-pro4</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -91,6 +93,9 @@
   <rect x="2638.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2709.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2709.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2788.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2859.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2859.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -144,6 +149,9 @@
   <rect x="2638.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2709.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2709.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2788.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2859.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2859.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -197,6 +205,9 @@
   <rect x="2638.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="2709.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="2709.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="2788.0" y="250.0" width="142" height="46" rx="6" fill="#0072B2" stroke="#dadce0"/>
+  <text x="2859.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">BLOCKED</text>
+  <text x="2859.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">unscored</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -250,6 +261,9 @@
   <rect x="2638.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2709.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2709.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2788.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2859.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2859.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -303,6 +317,9 @@
   <rect x="2638.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2709.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2709.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2788.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2859.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2859.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -356,6 +373,9 @@
   <rect x="2638.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2709.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2709.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2788.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2859.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2859.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -409,6 +429,9 @@
   <rect x="2638.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2709.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2709.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2788.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2859.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2859.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -462,6 +485,9 @@
   <rect x="2638.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2709.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2709.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2788.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2859.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2859.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -515,5 +541,8 @@
   <rect x="2638.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2709.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2709.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2788.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2859.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2859.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="3408" height="714" viewBox="0 0 3408 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="3558" height="714" viewBox="0 0 3558 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="3408" height="714" fill="#ffffff"/>
+  <rect width="3558" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -46,6 +46,8 @@
   <text x="3159.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">mistralai/mistral-small-2603</text>
   <text x="3309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Seed 2.0 Mini</text>
   <text x="3309.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">bytedance-seed/seed-2.0-mini</text>
+  <text x="3459.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">MiniMax M3</text>
+  <text x="3459.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">minimax/minimax-m3</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -111,6 +113,9 @@
   <rect x="3238.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3309.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3309.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3388.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3459.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3459.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -176,6 +181,9 @@
   <rect x="3238.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3309.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3309.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3388.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3459.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3459.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -241,6 +249,9 @@
   <rect x="3238.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="3309.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="3309.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="3388.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="3459.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="3459.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -306,6 +317,9 @@
   <rect x="3238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3309.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3309.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3388.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3459.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3459.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -371,6 +385,9 @@
   <rect x="3238.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3309.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3309.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3388.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3459.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3459.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -436,6 +453,9 @@
   <rect x="3238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3309.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3309.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3388.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3459.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3459.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -501,6 +521,9 @@
   <rect x="3238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3309.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3309.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3388.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3459.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3459.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -566,6 +589,9 @@
   <rect x="3238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3309.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3309.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3388.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3459.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3459.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -631,5 +657,8 @@
   <rect x="3238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3309.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3309.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3388.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3459.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3459.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -139,9 +139,9 @@
   <rect x="1738.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="1809.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="1809.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="1888.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="1959.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="1959.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="1959.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="1959.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2058" height="714" viewBox="0 0 2058 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2208" height="714" viewBox="0 0 2208 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="2058" height="714" fill="#ffffff"/>
+  <rect width="2208" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -28,6 +28,8 @@
   <text x="1809.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-glimmer-30b</text>
   <text x="1959.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
   <text x="1959.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="2109.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Laguna S 2.1</text>
+  <text x="2109.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">poolside/laguna-s-2.1</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -66,6 +68,9 @@
   <rect x="1888.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1959.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1959.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2038.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2109.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2109.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -104,6 +109,9 @@
   <rect x="1888.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1959.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1959.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2038.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2109.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2109.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -142,6 +150,9 @@
   <rect x="1888.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="1959.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="1959.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="2038.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="2109.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="2109.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -180,6 +191,9 @@
   <rect x="1888.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1959.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1959.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2038.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2109.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2109.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -218,6 +232,9 @@
   <rect x="1888.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1959.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1959.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2038.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2109.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2109.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -256,6 +273,9 @@
   <rect x="1888.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1959.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1959.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2038.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2109.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2109.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -294,6 +314,9 @@
   <rect x="1888.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1959.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1959.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2038.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2109.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2109.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -332,6 +355,9 @@
   <rect x="1888.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1959.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1959.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2038.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2109.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2109.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -370,5 +396,8 @@
   <rect x="1888.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1959.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1959.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2038.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2109.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2109.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2658" height="714" viewBox="0 0 2658 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2808" height="714" viewBox="0 0 2808 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="2658" height="714" fill="#ffffff"/>
+  <rect width="2808" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -36,6 +36,8 @@
   <text x="2409.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">qwen/qwen3.8-27b</text>
   <text x="2559.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Qwen3.8 Flash</text>
   <text x="2559.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">qwen/qwen3.8-flash</text>
+  <text x="2709.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">GLM 5.3 Flash</text>
+  <text x="2709.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">z-ai/glm-5.3-flash</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -86,6 +88,9 @@
   <rect x="2488.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2559.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2559.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2638.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2709.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2709.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -136,6 +141,9 @@
   <rect x="2488.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2559.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2559.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2638.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2709.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2709.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -186,6 +194,9 @@
   <rect x="2488.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="2559.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="2559.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="2638.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="2709.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="2709.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -236,6 +247,9 @@
   <rect x="2488.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2559.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2559.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2638.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2709.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2709.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -286,6 +300,9 @@
   <rect x="2488.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2559.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2559.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2638.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2709.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2709.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -336,6 +353,9 @@
   <rect x="2488.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2559.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2559.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2638.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2709.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2709.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -386,6 +406,9 @@
   <rect x="2488.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2559.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2559.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2638.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2709.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2709.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -436,6 +459,9 @@
   <rect x="2488.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2559.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2559.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2638.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2709.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2709.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -486,5 +512,8 @@
   <rect x="2488.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2559.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2559.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2638.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="2709.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="2709.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="3258" height="714" viewBox="0 0 3258 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="3408" height="714" viewBox="0 0 3408 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="3258" height="714" fill="#ffffff"/>
+  <rect width="3408" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -44,6 +44,8 @@
   <text x="3009.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">ibm-granite/granite-4.2-8b</text>
   <text x="3159.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Mistral Small 4</text>
   <text x="3159.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">mistralai/mistral-small-2603</text>
+  <text x="3309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Seed 2.0 Mini</text>
+  <text x="3309.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">bytedance-seed/seed-2.0-mini</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -106,6 +108,9 @@
   <rect x="3088.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3159.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3159.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3238.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3309.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3309.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -168,6 +173,9 @@
   <rect x="3088.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3159.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3159.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3238.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3309.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3309.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -230,6 +238,9 @@
   <rect x="3088.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="3159.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="3159.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="3238.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="3309.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="3309.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -292,6 +303,9 @@
   <rect x="3088.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3159.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3159.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3309.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3309.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -354,6 +368,9 @@
   <rect x="3088.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3159.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3159.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3238.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3309.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3309.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -416,6 +433,9 @@
   <rect x="3088.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3159.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3159.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3309.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3309.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -478,6 +498,9 @@
   <rect x="3088.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3159.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3159.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3309.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3309.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -540,6 +563,9 @@
   <rect x="3088.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3159.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3159.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3309.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3309.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -602,5 +628,8 @@
   <rect x="3088.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3159.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3159.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3309.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3309.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -67,9 +67,9 @@
   <rect x="538.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="609.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="609.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="688.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="759.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="759.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="688.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="759.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="759.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <rect x="838.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="909.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="909.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2958" height="714" viewBox="0 0 2958 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="3108" height="714" viewBox="0 0 3108 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="2958" height="714" fill="#ffffff"/>
+  <rect width="3108" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -40,6 +40,8 @@
   <text x="2709.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">z-ai/glm-5.3-flash</text>
   <text x="2859.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Solar Pro 4</text>
   <text x="2859.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">upstage/solar-pro4</text>
+  <text x="3009.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Granite 4.2 8B</text>
+  <text x="3009.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">ibm-granite/granite-4.2-8b</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -96,6 +98,9 @@
   <rect x="2788.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2859.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2859.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2938.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3009.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3009.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -152,6 +157,9 @@
   <rect x="2788.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2859.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2859.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2938.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3009.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3009.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -208,6 +216,9 @@
   <rect x="2788.0" y="250.0" width="142" height="46" rx="6" fill="#0072B2" stroke="#dadce0"/>
   <text x="2859.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">BLOCKED</text>
   <text x="2859.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">unscored</text>
+  <rect x="2938.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="3009.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="3009.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -264,6 +275,9 @@
   <rect x="2788.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2859.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2859.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2938.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3009.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3009.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -320,6 +334,9 @@
   <rect x="2788.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2859.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2859.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2938.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3009.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3009.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -376,6 +393,9 @@
   <rect x="2788.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2859.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2859.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2938.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3009.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3009.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -432,6 +452,9 @@
   <rect x="2788.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2859.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2859.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2938.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3009.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3009.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -488,6 +511,9 @@
   <rect x="2788.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2859.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2859.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2938.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3009.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3009.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -544,5 +570,8 @@
   <rect x="2788.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="2859.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="2859.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="2938.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3009.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3009.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1908" height="714" viewBox="0 0 1908 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="2058" height="714" viewBox="0 0 2058 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="1908" height="714" fill="#ffffff"/>
+  <rect width="2058" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -24,8 +24,10 @@
   <text x="1509.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">inception/mercury-2.5-preview</text>
   <text x="1659.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
   <text x="1659.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
-  <text x="1809.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="1809.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="1809.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Glimmer 30B</text>
+  <text x="1809.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-glimmer-30b</text>
+  <text x="1959.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1959.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -61,6 +63,9 @@
   <rect x="1738.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -96,6 +101,9 @@
   <rect x="1738.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -128,9 +136,12 @@
   <rect x="1588.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="1659.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="1659.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="1738.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="1809.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="1809.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1738.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="1809.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="1809.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="1888.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -166,6 +177,9 @@
   <rect x="1738.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -201,6 +215,9 @@
   <rect x="1738.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -236,6 +253,9 @@
   <rect x="1738.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -271,6 +291,9 @@
   <rect x="1738.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -306,6 +329,9 @@
   <rect x="1738.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -341,5 +367,8 @@
   <rect x="1738.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1809.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1809.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1888.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1959.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1959.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -53,9 +53,9 @@
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
   <text x="309.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">HAPPY</text>
   <text x="309.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle PASS</text>
-  <rect x="388.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="459.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="459.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="388.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="459.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="459.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <rect x="538.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="609.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="609.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1608" height="714" viewBox="0 0 1608 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="1758" height="714" viewBox="0 0 1758 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="1608" height="714" fill="#ffffff"/>
+  <rect width="1758" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -18,10 +18,12 @@
   <text x="1059.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemma-4-31b-it</text>
   <text x="1209.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemma 4 26B A4B</text>
   <text x="1209.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">google/gemma-4-26b-a4b-it</text>
-  <text x="1359.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
-  <text x="1359.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
-  <text x="1509.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
-  <text x="1509.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
+  <text x="1359.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="1359.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">nvidia/nemotron-3.5-lightning</text>
+  <text x="1509.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Grok 4.6</text>
+  <text x="1509.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">x-ai/grok-4.6</text>
+  <text x="1659.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Muse Spark 1.3</text>
+  <text x="1659.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">meta/muse-spark-1.3-contributor</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -51,6 +53,9 @@
   <rect x="1438.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -80,6 +85,9 @@
   <rect x="1438.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -103,12 +111,15 @@
   <rect x="1138.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="1209.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="1209.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
-  <rect x="1288.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
-  <text x="1359.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
-  <text x="1359.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1288.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
+  <text x="1359.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
+  <text x="1359.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
   <rect x="1438.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -138,6 +149,9 @@
   <rect x="1438.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -167,6 +181,9 @@
   <rect x="1438.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -196,6 +213,9 @@
   <rect x="1438.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -225,6 +245,9 @@
   <rect x="1438.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -254,6 +277,9 @@
   <rect x="1438.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -283,5 +309,8 @@
   <rect x="1438.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="1509.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="1509.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="1588.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="1659.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="1659.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="222" viewBox="0 0 860 222" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="250" viewBox="0 0 860 250" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="222" fill="#ffffff"/>
+  <rect width="860" height="250" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
   <text x="296.0" y="94.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.8 Flash</text>
   <rect x="304.0" y="82.0" width="280.0" height="16" rx="3" fill="#009E73" stroke="#dadce0" data-partial-score="1.00"/>
   <text x="592.0" y="94.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1.00</text>
-  <text x="296.0" y="122.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
-  <text x="312.0" y="122.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
-  <text x="296.0" y="150.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="150.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="24" y="206" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="122.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 20B</text>
+  <text x="312.0" y="122.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0012</text>
+  <text x="296.0" y="150.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
+  <text x="312.0" y="150.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
+  <text x="296.0" y="178.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="24" y="234" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="390" viewBox="0 0 860 390" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="418" viewBox="0 0 860 418" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="390" fill="#ffffff"/>
+  <rect width="860" height="418" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -17,13 +17,15 @@
   <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
   <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
   <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
-  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
-  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
-  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="24" y="374" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
+  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
+  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="24" y="402" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="250" viewBox="0 0 860 250" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="278" viewBox="0 0 860 278" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="250" fill="#ffffff"/>
+  <rect width="860" height="278" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -12,7 +12,9 @@
   <text x="312.0" y="122.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0012</text>
   <text x="296.0" y="150.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
   <text x="312.0" y="150.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
-  <text x="296.0" y="178.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="24" y="234" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="178.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
+  <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
+  <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="24" y="262" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="306" viewBox="0 0 860 306" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="334" viewBox="0 0 860 334" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="306" fill="#ffffff"/>
+  <rect width="860" height="334" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -16,7 +16,9 @@
   <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
   <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
   <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="24" y="290" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="24" y="318" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="418" viewBox="0 0 860 418" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="446" viewBox="0 0 860 446" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="418" fill="#ffffff"/>
+  <rect width="860" height="446" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -27,5 +27,7 @@
   <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
   <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
   <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="24" y="402" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="24" y="430" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="754" viewBox="0 0 860 754" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="782" viewBox="0 0 860 782" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="754" fill="#ffffff"/>
+  <rect width="860" height="782" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -27,29 +27,31 @@
   <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0097</text>
   <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna S 2.1</text>
   <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=66 · $0.0148</text>
-  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
-  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
-  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
-  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
-  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
-  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
-  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">MiniMax M3</text>
-  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0796</text>
-  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
-  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
-  <text x="296.0" y="598.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
-  <text x="312.0" y="598.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
-  <text x="296.0" y="626.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="626.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="296.0" y="654.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">DeepSeek V4 Flash 0731</text>
-  <text x="312.0" y="654.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1701</text>
-  <text x="296.0" y="682.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
-  <text x="312.0" y="682.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
-  <text x="24" y="738" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">DeepSeek V4.1 Flash</text>
+  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0183</text>
+  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
+  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
+  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
+  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
+  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">MiniMax M3</text>
+  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0796</text>
+  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="296.0" y="598.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
+  <text x="312.0" y="598.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
+  <text x="296.0" y="626.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
+  <text x="312.0" y="626.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
+  <text x="296.0" y="654.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="654.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="296.0" y="682.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">DeepSeek V4 Flash 0731</text>
+  <text x="312.0" y="682.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1701</text>
+  <text x="296.0" y="710.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="710.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="766" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="586" viewBox="0 0 860 586" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="614" viewBox="0 0 860 614" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="586" fill="#ffffff"/>
+  <rect width="860" height="614" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -19,25 +19,27 @@
   <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
   <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
   <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
-  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna S 2.1</text>
-  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=66 · $0.0148</text>
-  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
-  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
-  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
-  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
-  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
-  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
-  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
-  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
-  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
-  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
-  <text x="24" y="570" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GLM 5.3 Flash</text>
+  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0090</text>
+  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna S 2.1</text>
+  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=66 · $0.0148</text>
+  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
+  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
+  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
+  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
+  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
+  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
+  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="598" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="194" viewBox="0 0 860 194" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="222" viewBox="0 0 860 222" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="194" fill="#ffffff"/>
+  <rect width="860" height="222" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -10,5 +10,7 @@
   <text x="592.0" y="94.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1.00</text>
   <text x="296.0" y="122.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
   <text x="312.0" y="122.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
-  <text x="24" y="178" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="150.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="150.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="24" y="206" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="614" viewBox="0 0 860 614" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="642" viewBox="0 0 860 642" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="614" fill="#ffffff"/>
+  <rect width="860" height="642" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -37,9 +37,11 @@
   <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
   <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
   <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
-  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
-  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
-  <text x="24" y="598" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
+  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
+  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="626" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="726" viewBox="0 0 860 726" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="754" viewBox="0 0 860 754" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="726" fill="#ffffff"/>
+  <rect width="860" height="754" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -47,7 +47,9 @@
   <text x="312.0" y="598.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
   <text x="296.0" y="626.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
   <text x="312.0" y="626.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="296.0" y="654.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
-  <text x="312.0" y="654.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
-  <text x="24" y="710" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="654.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">DeepSeek V4 Flash 0731</text>
+  <text x="312.0" y="654.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1701</text>
+  <text x="296.0" y="682.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="682.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="738" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="502" viewBox="0 0 860 502" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="530" viewBox="0 0 860 530" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="502" fill="#ffffff"/>
+  <rect width="860" height="530" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -29,9 +29,11 @@
   <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
   <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
   <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="24" y="486" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
+  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
+  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="24" y="514" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="558" viewBox="0 0 860 558" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="586" viewBox="0 0 860 586" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="558" fill="#ffffff"/>
+  <rect width="860" height="586" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -33,9 +33,11 @@
   <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
   <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
   <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
-  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
-  <text x="24" y="542" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
+  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
+  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="570" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="474" viewBox="0 0 860 474" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="502" viewBox="0 0 860 502" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="474" fill="#ffffff"/>
+  <rect width="860" height="502" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -19,17 +19,19 @@
   <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
   <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
   <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
-  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
-  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
-  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
-  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
-  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="24" y="458" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna S 2.1</text>
+  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=66 · $0.0148</text>
+  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
+  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
+  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="24" y="486" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,26 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="362" viewBox="0 0 860 362" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="390" viewBox="0 0 860 390" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="362" fill="#ffffff"/>
+  <rect width="860" height="390" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
-  <text x="296.0" y="94.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.8 Flash</text>
+  <text x="296.0" y="94.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Mercury 2.5 Preview</text>
   <rect x="304.0" y="82.0" width="280.0" height="16" rx="3" fill="#009E73" stroke="#dadce0" data-partial-score="1.00"/>
-  <text x="592.0" y="94.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1.00</text>
-  <text x="296.0" y="122.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 20B</text>
-  <text x="312.0" y="122.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0012</text>
-  <text x="296.0" y="150.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
-  <text x="312.0" y="150.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
-  <text x="296.0" y="178.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
-  <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
-  <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
-  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
-  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="24" y="346" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="592.0" y="94.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1.00 · 0/— · S=494 R=68 · $0.0047</text>
+  <text x="296.0" y="122.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.8 Flash</text>
+  <rect x="304.0" y="110.0" width="280.0" height="16" rx="3" fill="#009E73" stroke="#dadce0" data-partial-score="1.00"/>
+  <text x="592.0" y="122.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1.00</text>
+  <text x="296.0" y="150.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 20B</text>
+  <text x="312.0" y="150.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0012</text>
+  <text x="296.0" y="178.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
+  <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
+  <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
+  <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
+  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="24" y="374" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="446" viewBox="0 0 860 446" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="474" viewBox="0 0 860 474" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="446" fill="#ffffff"/>
+  <rect width="860" height="474" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -13,21 +13,23 @@
   <text x="592.0" y="122.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1.00</text>
   <text x="296.0" y="150.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 20B</text>
   <text x="312.0" y="150.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0012</text>
-  <text x="296.0" y="178.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
-  <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
-  <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
-  <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
-  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
-  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
-  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
-  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
-  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="24" y="430" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="178.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Spark 1.3</text>
+  <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0016</text>
+  <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
+  <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
+  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
+  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
+  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
+  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
+  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="24" y="458" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="698" viewBox="0 0 860 698" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="726" viewBox="0 0 860 726" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="698" fill="#ffffff"/>
+  <rect width="860" height="726" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -37,15 +37,17 @@
   <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
   <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
   <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
-  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
-  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
-  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
-  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
-  <text x="296.0" y="598.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="598.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="296.0" y="626.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
-  <text x="312.0" y="626.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
-  <text x="24" y="682" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">MiniMax M3</text>
+  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0796</text>
+  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
+  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
+  <text x="296.0" y="598.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
+  <text x="312.0" y="598.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
+  <text x="296.0" y="626.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="626.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="296.0" y="654.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="654.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="710" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="278" viewBox="0 0 860 278" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="306" viewBox="0 0 860 306" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="278" fill="#ffffff"/>
+  <rect width="860" height="306" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -16,5 +16,7 @@
   <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
   <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
   <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="24" y="262" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="24" y="290" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="670" viewBox="0 0 860 670" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="698" viewBox="0 0 860 698" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="670" fill="#ffffff"/>
+  <rect width="860" height="698" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -19,31 +19,33 @@
   <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
   <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.5 Flash Lite</text>
   <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
-  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GLM 5.3 Flash</text>
-  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0090</text>
-  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Mistral Small 4</text>
-  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0097</text>
-  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna S 2.1</text>
-  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=66 · $0.0148</text>
-  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
-  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
-  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
-  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
-  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
-  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
-  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
-  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
-  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
-  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
-  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="296.0" y="598.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
-  <text x="312.0" y="598.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
-  <text x="24" y="654" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Seed 2.0 Mini</text>
+  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0081</text>
+  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GLM 5.3 Flash</text>
+  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0090</text>
+  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Mistral Small 4</text>
+  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0097</text>
+  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna S 2.1</text>
+  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=66 · $0.0148</text>
+  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
+  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
+  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
+  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
+  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
+  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
+  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
+  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
+  <text x="296.0" y="598.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="598.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="296.0" y="626.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="626.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="682" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="530" viewBox="0 0 860 530" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="558" viewBox="0 0 860 558" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="530" fill="#ffffff"/>
+  <rect width="860" height="558" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -35,5 +35,7 @@
   <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
   <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
   <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="24" y="514" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="542" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="334" viewBox="0 0 860 334" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="362" viewBox="0 0 860 362" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="334" fill="#ffffff"/>
+  <rect width="860" height="362" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -16,9 +16,11 @@
   <text x="312.0" y="178.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
   <text x="296.0" y="206.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
   <text x="312.0" y="206.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="24" y="318" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="234.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="24" y="346" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="166" viewBox="0 0 860 166" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="194" viewBox="0 0 860 194" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="166" fill="#ffffff"/>
+  <rect width="860" height="194" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
   <text x="296.0" y="94.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemini 3.8 Flash</text>
   <rect x="304.0" y="82.0" width="280.0" height="16" rx="3" fill="#009E73" stroke="#dadce0" data-partial-score="1.00"/>
   <text x="592.0" y="94.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">1.00</text>
-  <text x="24" y="150" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="122.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-OSS 120B</text>
+  <text x="312.0" y="122.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=585 R=— · $0.0052</text>
+  <text x="24" y="178" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2-partial.svg
+++ b/docs/eval/eval-2/eval2-partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="642" viewBox="0 0 860 642" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="670" viewBox="0 0 860 670" role="img">
   <title>Eval-2 headed partial / cost (recorded oracle quality)</title>
-  <rect width="860" height="642" fill="#ffffff"/>
+  <rect width="860" height="670" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed partial / cost (recorded oracle quality)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Hard (HAPPY) first; among comparable, higher partial then lower USD. Bars only when PASS or fails/checks recorded. Coarse C²/$ sibling.</text>
   <text x="24" y="64" font-family="DejaVu Sans, sans-serif" font-size="12" font-weight="700" fill="#202124">3. AFC Population</text>
@@ -21,27 +21,29 @@
   <text x="312.0" y="234.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0063</text>
   <text x="296.0" y="262.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GLM 5.3 Flash</text>
   <text x="312.0" y="262.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0090</text>
-  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna S 2.1</text>
-  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=66 · $0.0148</text>
-  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
-  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
-  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
-  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
-  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
-  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
-  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
-  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
-  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
-  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
-  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
-  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
-  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
-  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
-  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
-  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
-  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
-  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
-  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
-  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
-  <text x="24" y="626" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
+  <text x="296.0" y="290.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Mistral Small 4</text>
+  <text x="312.0" y="290.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.0097</text>
+  <text x="296.0" y="318.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna S 2.1</text>
+  <text x="312.0" y="318.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=66 · $0.0148</text>
+  <text x="296.0" y="346.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Grok 4.6</text>
+  <text x="312.0" y="346.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0238</text>
+  <text x="296.0" y="374.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">GPT-5.6 Luna</text>
+  <text x="312.0" y="374.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.0419</text>
+  <text x="296.0" y="402.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Nemotron 3.5 Lightning</text>
+  <text x="312.0" y="402.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0428</text>
+  <text x="296.0" y="430.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 26B A4B</text>
+  <text x="312.0" y="430.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=65 · $0.0432</text>
+  <text x="296.0" y="458.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Laguna XS 2.1</text>
+  <text x="312.0" y="458.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.0434</text>
+  <text x="296.0" y="486.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Gemma 4 31B</text>
+  <text x="312.0" y="486.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1084</text>
+  <text x="296.0" y="514.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 Flash</text>
+  <text x="312.0" y="514.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=68 R=— · $0.1138</text>
+  <text x="296.0" y="542.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Granite 4.2 8B</text>
+  <text x="312.0" y="542.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $0.1435</text>
+  <text x="296.0" y="570.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Muse Glimmer 30B</text>
+  <text x="312.0" y="570.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 1/— · S=0 R=— · $0.1540</text>
+  <text x="296.0" y="598.0" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">Qwen3.8 27B</text>
+  <text x="312.0" y="598.0" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">no ratio · 2/— · S=0 R=— · $1.4282</text>
+  <text x="24" y="654" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">partial = 1 when oracle PASS; else 1 − fails/checks. Do not invent check counts.</text>
 </svg>

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -184,6 +184,31 @@
       "total_tokens": 573376,
       "wall_time_s": 406,
       "total_cost_usd": 0.0419
+    },
+    {
+      "task_id": "afc",
+      "model": "openai/gpt-oss-20b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Third catalog AFC cell. Ran as openai/gpt-oss-20b:nitro (resolved to bare 20b; no batch 404). Sample/SSC present but incomplete (sample_data_rows=80). Same R hole as 120b/Luna; S=0 is weaker than Luna’s S=68. Oracle failure_count=1: R from Sample Size Calculation is missing or < 1. S=0 R=None, husks 0/800. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.00122); model_configs estimate ~0.00049 is an alternate, not stored. Nitro routing OK. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0202-gpt-oss-20b-nitro/",
+      "stamp": "20260912-0202-gpt-oss-20b-nitro",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 800,
+      "input_tokens": 15316,
+      "output_tokens": 236,
+      "total_tokens": 15552,
+      "wall_time_s": 309,
+      "total_cost_usd": 0.00122
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded only from in-repo autopsy / sibling notes. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus the first Scrolly AFC catalog stamp (gpt-oss-120b). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -129,6 +129,31 @@
       "source": "docs/eval/eval-2/headed-failure-autopsy.md §1; docs/eval/eval-2/afc-sample-83d10b06/SMOOTHER_CHANGES.md",
       "run_artifacts_committed": false,
       "patches": null
+    },
+    {
+      "task_id": "afc",
+      "model": "openai/gpt-oss-120b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "First catalog AFC cell. Ran as openai/gpt-oss-120b:nitro. Sample+SSC nonempty but wrong shape (sample_data_rows=1516, near-full dump, not sample-sized). #DIV/0! on Sample. Agent Ready then kept iterating. Oracle failure_count=1: R from Sample Size Calculation is missing or < 1. S=585 R=None, husks 0/15159. No oracle_check_count on the stamp — omit partial_score (do not invent a 4-check denominator). Est. USD from the headed run, not a later list-price backfill. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0142-gpt-oss-120b/",
+      "stamp": "20260912-0142-gpt-oss-120b",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 585,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 15159,
+      "input_tokens": 108266,
+      "output_tokens": 6994,
+      "total_tokens": 115260,
+      "wall_time_s": 1290,
+      "total_cost_usd": 0.0052
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus the first Scrolly AFC catalog stamp (gpt-oss-120b). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -81,6 +81,11 @@
       "role": "headed"
     },
     {
+      "openrouter_id": "openai/gpt-5.6-luna",
+      "display_name": "GPT-5.6 Luna",
+      "role": "catalog"
+    },
+    {
       "openrouter_id": "openai/gpt-oss-20b",
       "display_name": "GPT-OSS 20B",
       "role": "catalog"
@@ -154,6 +159,31 @@
       "total_tokens": 115260,
       "wall_time_s": 1290,
       "total_cost_usd": 0.0052
+    },
+    {
+      "task_id": "afc",
+      "model": "openai/gpt-5.6-luna",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Second catalog AFC cell. Sample+SSC present (Population / Sample / Sample Size Calculation) but incomplete — better shape than the gpt-oss-120b near-full dump (sample_data_rows=81 vs 1516) but the same R hole. Oracle failure_count=1: R from Sample Size Calculation is missing or < 1. S=68 R=None, husks 0/810. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.0419); model_configs estimate ~0.1252 is an alternate, not stored. Wall 406s incl setup (tool loop ~304s). Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0150-gpt-5.6-luna/",
+      "stamp": "20260912-0150-gpt-5.6-luna",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 68,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 810,
+      "input_tokens": 562909,
+      "output_tokens": 10467,
+      "total_tokens": 573376,
+      "wall_time_s": 406,
+      "total_cost_usd": 0.0419
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -163,6 +163,11 @@
     {
       "openrouter_id": "ibm-granite/granite-4.2-8b",
       "display_name": "Granite 4.2 8B",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "mistralai/mistral-small-2603",
+      "display_name": "Mistral Small 4",
       "role": "catalog"
     }
   ],
@@ -645,6 +650,31 @@
       "total_tokens": 2424278,
       "wall_time_s": 840,
       "total_cost_usd": 0.14353
+    },
+    {
+      "task_id": "afc",
+      "model": "mistralai/mistral-small-2603",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Nineteenth catalog AFC cell. Ready with Sample+SSC present (sample_data_rows=81) but incomplete. Same R hole as Flash Lite/Glimmer; S=0 despite 81 Sample rows. Oracle failure_count=1: R from Sample Size Calculation is missing or < 1 (unparseable). S=0 R=None; husks 0/648. Tokens are OpenRouter usage sum across n=14 generations (in=149439 out=3893). wall_time_s is the recorded ~32s loop. tip_at_run 71640e30. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.00973); model_configs estimate ~0.02475 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0603-mistral-small-2603/",
+      "stamp": "20260912-0603-mistral-small-2603",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 648,
+      "input_tokens": 149439,
+      "output_tokens": 3893,
+      "total_tokens": 153332,
+      "wall_time_s": 32,
+      "total_cost_usd": 0.00973
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -414,6 +414,32 @@
       "total_tokens": 2159501,
       "wall_time_s": 155,
       "total_cost_usd": 0.15404
+    },
+    {
+      "task_id": "afc",
+      "model": "meta/muse-spark-1.3-contributor",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Eleventh catalog AFC cell. SSC present; Sample sheet present but empty (sample_data_rows=0). Oracle failure_count=2: Sample has no data rows; R from Sample Size Calculation is missing or < 1. S=0 R=None; husks 0/0. Same empty-Sample shape as Grok. tip_at_run 6c6017b7. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.00157); model_configs estimate ~0.00247 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0409-muse-spark-1.3-contributor/",
+      "stamp": "20260912-0409-muse-spark-1.3-contributor",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "Sample has no data rows",
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 23560,
+      "output_tokens": 550,
+      "total_tokens": 24110,
+      "wall_time_s": 241,
+      "total_cost_usd": 0.00157
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini, minimax-m3). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -173,6 +173,11 @@
     {
       "openrouter_id": "bytedance-seed/seed-2.0-mini",
       "display_name": "Seed 2.0 Mini",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "minimax/minimax-m3",
+      "display_name": "MiniMax M3",
       "role": "catalog"
     }
   ],
@@ -706,6 +711,32 @@
       "total_tokens": 38401,
       "wall_time_s": 131,
       "total_cost_usd": 0.00814
+    },
+    {
+      "task_id": "afc",
+      "model": "minimax/minimax-m3",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Twenty-first catalog AFC cell. Ready but Population/Analysis only — no Sample or Sample Size Calculation sheets (oracle failure_count=2: missing sheet 'Sample'; missing sheet 'Sample Size Calculation'). sample_data_rows=0; S=0 R=None; husks 0/0. Analysis sheet A1=#NAME? A2=8. Tokens are OpenRouter usage sum across n=30 generations (in=318690 out=3685). wall_time_s is the recorded ~66s loop. tip_at_run 71640e30. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.07965); model_configs estimate ~0.10003 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0617-minimax-m3/",
+      "stamp": "20260912-0617-minimax-m3",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 318690,
+      "output_tokens": 3685,
+      "total_tokens": 322375,
+      "wall_time_s": 66,
+      "total_cost_usd": 0.07965
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -93,6 +93,11 @@
     {
       "openrouter_id": "google/gemini-3.5-flash-lite",
       "display_name": "Gemini 3.5 Flash Lite",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "google/gemma-4-31b-it",
+      "display_name": "Gemma 4 31B",
       "role": "catalog"
     },
     {
@@ -239,6 +244,31 @@
       "total_tokens": 26261,
       "wall_time_s": 338,
       "total_cost_usd": 0.00629
+    },
+    {
+      "task_id": "afc",
+      "model": "google/gemma-4-31b-it",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Fifth catalog AFC cell. Sample+SSC present (sample_data_rows=81) but incomplete. Same R hole; SSC R is Err:508/#NAME? so oracle R=None. S=0; husk-heavy Sample flags (81/810 scored cells) — below the 50% husk-dominate fail, so failure_count stays 1. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.10841); model_configs estimate ~0.01404 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0224-gemma-4-31b-it/",
+      "stamp": "20260912-0224-gemma-4-31b-it",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 81,
+      "scored_cells": 810,
+      "input_tokens": 146941,
+      "output_tokens": 2394,
+      "total_tokens": 149335,
+      "wall_time_s": 392,
+      "total_cost_usd": 0.10841
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -148,6 +148,11 @@
     {
       "openrouter_id": "qwen/qwen3.8-flash",
       "display_name": "Qwen3.8 Flash",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "z-ai/glm-5.3-flash",
+      "display_name": "GLM 5.3 Flash",
       "role": "catalog"
     }
   ],
@@ -562,6 +567,32 @@
       "total_tokens": 2244139,
       "wall_time_s": 540,
       "total_cost_usd": 0.11382
+    },
+    {
+      "task_id": "afc",
+      "model": "z-ai/glm-5.3-flash",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Sixteenth catalog AFC cell. Population only — no Sample or Sample Size Calculation sheets (oracle failure_count=2: missing sheet 'Sample'; missing sheet 'Sample Size Calculation'). sample_data_rows=0; S=0 R=None; husks 0/0. Hung tool_loop at round 0 — finish_reason=length; no tools fired; truncated reasoning dump. Tokens are a single OpenRouter generation (n=1; in=5404 out=16384; reasoning_tokens=15160 noted, not stored). wall_time_s is the recorded ~155s hang. tip_at_run 6c6017b7. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.00900); model_configs estimate ~0.00450 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0515-glm-5.3-flash/",
+      "stamp": "20260912-0515-glm-5.3-flash",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 5404,
+      "output_tokens": 16384,
+      "total_tokens": 21788,
+      "wall_time_s": 155,
+      "total_cost_usd": 0.00900
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini, minimax-m3). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini, minimax-m3, deepseek-v4-flash-0731). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -178,6 +178,11 @@
     {
       "openrouter_id": "minimax/minimax-m3",
       "display_name": "MiniMax M3",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "deepseek/deepseek-v4-flash-0731",
+      "display_name": "DeepSeek V4 Flash 0731",
       "role": "catalog"
     }
   ],
@@ -737,6 +742,32 @@
       "total_tokens": 322375,
       "wall_time_s": 66,
       "total_cost_usd": 0.07965
+    },
+    {
+      "task_id": "afc",
+      "model": "deepseek/deepseek-v4-flash-0731",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Twenty-second catalog AFC cell. Ready; Sample+SSC present but empty (sample_data_rows=0). Sample errored deal.PreContractError expected__deal_wire_dict_ok; SSC blank. Oracle failure_count=2: Sample has no data rows; R from Sample Size Calculation is missing or < 1. S=0 R=None; husks 0/0. Tokens are OpenRouter usage sum across n=51 generations (in=2733344 out=62813). wall_time_s is the recorded ~330s loop. tip_at_run 71640e30. PreContract=18; UNO/assert=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.17007); model_configs estimate ~0.18897 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0621-deepseek-v4-flash-0731/",
+      "stamp": "20260912-0621-deepseek-v4-flash-0731",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "Sample has no data rows",
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 2733344,
+      "output_tokens": 62813,
+      "total_tokens": 2796157,
+      "wall_time_s": 330,
+      "total_cost_usd": 0.17007
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -118,6 +118,11 @@
     {
       "openrouter_id": "x-ai/grok-4.6",
       "display_name": "Grok 4.6",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "meta/muse-glimmer-30b",
+      "display_name": "Muse Glimmer 30B",
       "role": "catalog"
     },
     {
@@ -384,6 +389,31 @@
       "total_tokens": 28507,
       "wall_time_s": 416,
       "total_cost_usd": 0.02375
+    },
+    {
+      "task_id": "afc",
+      "model": "meta/muse-glimmer-30b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Tenth catalog AFC cell. Sample+SSC present (sample_data_rows=81) but incomplete. Same R hole as 120b/Luna/20b/Flash Lite/31B; S=0. SSC B9 visually 65, but the oracle parsed R=None — do not store 65 as afc_r_required. Oracle failure_count=1: R from Sample Size Calculation is missing or < 1. S=0 R=None, husks 0/729. Hit max 50 tool rounds. wall_time_s is the recorded ~155s loop (observer ~16 min). tip_at_run e0bb6321. PreContract lines=2 (PY deal); UNO/assert_main_thread=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.15404); model_configs estimate ~0.66230 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0353-muse-glimmer-30b/",
+      "stamp": "20260912-0353-muse-glimmer-30b",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 729,
+      "input_tokens": 2143441,
+      "output_tokens": 16060,
+      "total_tokens": 2159501,
+      "wall_time_s": 155,
+      "total_cost_usd": 0.15404
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -143,6 +143,11 @@
     {
       "openrouter_id": "qwen/qwen3.8-27b",
       "display_name": "Qwen3.8 27B",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "qwen/qwen3.8-flash",
+      "display_name": "Qwen3.8 Flash",
       "role": "catalog"
     }
   ],
@@ -532,6 +537,31 @@
       "total_tokens": 2762664,
       "wall_time_s": 720,
       "total_cost_usd": 1.42823
+    },
+    {
+      "task_id": "afc",
+      "model": "qwen/qwen3.8-flash",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Fifteenth catalog AFC cell. Sample+SSC present but incomplete (sample_data_rows=68). Same R hole as Luna; S=68 matches Luna’s flag count on a slightly smaller Sample. SSC Err:508/509/#VALUE!; Scratch Err:513. Oracle failure_count=1: R from Sample Size Calculation is missing or < 1. S=68 R=None; husks 0/680. Tokens are OpenRouter usage sum across n=51 generations (in=2194886 out=49253). wall_time_s is the recorded ~540s LLM loop (9 min; observer ~12 min). tip_at_run 6c6017b7. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.11382); model_configs estimate ~0.35238 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0502-qwen3.8-flash/",
+      "stamp": "20260912-0502-qwen3.8-flash",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 68,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 680,
+      "input_tokens": 2194886,
+      "output_tokens": 49253,
+      "total_tokens": 2244139,
+      "wall_time_s": 540,
+      "total_cost_usd": 0.11382
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -108,6 +108,11 @@
     {
       "openrouter_id": "nvidia/nemotron-3.5-lightning",
       "display_name": "Nemotron 3.5 Lightning",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "inception/mercury-2.5-preview",
+      "display_name": "Mercury 2.5 Preview",
       "role": "catalog"
     },
     {
@@ -330,6 +335,29 @@
       "total_tokens": 763360,
       "wall_time_s": 540,
       "total_cost_usd": 0.04282
+    },
+    {
+      "task_id": "afc",
+      "model": "inception/mercury-2.5-preview",
+      "product_bar": "HAPPY",
+      "oracle": "PASS",
+      "oracle_note": "Eighth catalog AFC cell. First non-gate catalog HAPPY / oracle PASS (failure_count=0). Sample is a near-full Population copy (sample_data_rows=1518) but S=494 ≥ R=68 so the oracle passes. Husks 2/16680. Attempt1 contaminated; attempt2 wipe. No oracle_check_count stored — PASS still yields partial_score=1. total_cost_usd is the OpenRouter usage sum (~0.00468); model_configs estimate ~0.03144 is an alternate, not stored. First HAPPY cell with recorded USD, so C²/$ is computed (partial² / USD). Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0330-mercury-2.5-preview/",
+      "stamp": "20260912-0330-mercury-2.5-preview",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": true,
+      "oracle_failure_count": 0,
+      "oracle_failures": [],
+      "afc_s_flags": 494,
+      "afc_r_required": 68,
+      "husk_cells": 2,
+      "scored_cells": 16680,
+      "input_tokens": 115096,
+      "output_tokens": 3554,
+      "total_tokens": 118650,
+      "wall_time_s": 479,
+      "total_cost_usd": 0.00468
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -138,6 +138,11 @@
     {
       "openrouter_id": "poolside/laguna-xs-2.1",
       "display_name": "Laguna XS 2.1",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "qwen/qwen3.8-27b",
+      "display_name": "Qwen3.8 27B",
       "role": "catalog"
     }
   ],
@@ -501,6 +506,32 @@
       "total_tokens": 1290524,
       "wall_time_s": 85,
       "total_cost_usd": 0.04341
+    },
+    {
+      "task_id": "afc",
+      "model": "qwen/qwen3.8-27b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Fourteenth catalog AFC cell. Population only — no Sample or Sample Size Calculation sheets (oracle failure_count=2: missing sheet 'Sample'; missing sheet 'Sample Size Calculation'). sample_data_rows=0; S=0 R=None; husks 0/0. Stayed on Population with =PY attempts. ~50 tool rounds, all finish_reason=tool_calls. Tokens are OpenRouter usage sum across n=51 generations (in=2695380 out=67284). PreContract=63; UNO/assert=0. wall_time_s is the recorded ~720s LLM loop (12 min). tip_at_run 6c6017b7. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~1.42823); model_configs estimate ~1.31711 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0443-qwen3.8-27b/",
+      "stamp": "20260912-0443-qwen3.8-27b",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 2695380,
+      "output_tokens": 67284,
+      "total_tokens": 2762664,
+      "wall_time_s": 720,
+      "total_cost_usd": 1.42823
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini, minimax-m3, deepseek-v4-flash-0731). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini, minimax-m3, deepseek-v4-flash-0731, deepseek-v4.1-flash). AFC catalog FIFO is complete. solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. The 9-task headed sweep has not happened. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -183,6 +183,11 @@
     {
       "openrouter_id": "deepseek/deepseek-v4-flash-0731",
       "display_name": "DeepSeek V4 Flash 0731",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "deepseek/deepseek-v4.1-flash",
+      "display_name": "DeepSeek V4.1 Flash",
       "role": "catalog"
     }
   ],
@@ -768,6 +773,32 @@
       "total_tokens": 2796157,
       "wall_time_s": 330,
       "total_cost_usd": 0.17007
+    },
+    {
+      "task_id": "afc",
+      "model": "deepseek/deepseek-v4.1-flash",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Twenty-third catalog AFC cell — catalog FIFO tail. API Request Timed Out mid tool_loop at round 5 on read_cell_range (NetworkError); model never finished. NOT_HAPPY (not BLOCKED): Send ran and the leftover workbook is scored. Population only — no Sample or Sample Size Calculation sheets (oracle failure_count=2: missing sheet 'Sample'; missing sheet 'Sample Size Calculation'). sample_data_rows=0; S=0 R=None; husks 0/0. Tokens are OpenRouter usage sum across n=5 generations before the timeout (in=55652 out=3474). wall_time_s is the recorded ~270s loop. tip_at_run 71640e30. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.01832); model_configs estimate ~0.01043 is an alternate, not stored. CATALOG FIFO COMPLETE. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0630-deepseek-v4.1-flash/",
+      "stamp": "20260912-0630-deepseek-v4.1-flash",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 55652,
+      "output_tokens": 3474,
+      "total_tokens": 59126,
+      "wall_time_s": 270,
+      "total_cost_usd": 0.01832
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -133,6 +133,11 @@
     {
       "openrouter_id": "poolside/laguna-s-2.1",
       "display_name": "Laguna S 2.1",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "poolside/laguna-xs-2.1",
+      "display_name": "Laguna XS 2.1",
       "role": "catalog"
     }
   ],
@@ -470,6 +475,32 @@
       "total_tokens": 202196,
       "wall_time_s": 384,
       "total_cost_usd": 0.01480
+    },
+    {
+      "task_id": "afc",
+      "model": "poolside/laguna-xs-2.1",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Thirteenth catalog AFC cell. Sample sheet present but empty (sample_data_rows=0). SSC tab named Sample_Size_Calculation, not 'Sample Size Calculation', so the oracle treats SSC as missing. Oracle failure_count=2: missing sheet 'Sample Size Calculation'; Sample has no data rows. S=0 R=None; husks 0/0. Raw tool_call text in the reply. wall_time_s is the recorded ~85s loop (observer ~3m12s). tip_at_run 6c6017b7. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.04341); model_configs estimate ~0.07804 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0429-laguna-xs-2.1/",
+      "stamp": "20260912-0429-laguna-xs-2.1",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "missing sheet 'Sample Size Calculation'",
+        "Sample has no data rows"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 1280356,
+      "output_tokens": 10168,
+      "total_tokens": 1290524,
+      "wall_time_s": 85,
+      "total_cost_usd": 0.04341
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -158,6 +158,11 @@
     {
       "openrouter_id": "upstage/solar-pro4",
       "display_name": "Solar Pro 4",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "ibm-granite/granite-4.2-8b",
+      "display_name": "Granite 4.2 8B",
       "role": "catalog"
     }
   ],
@@ -614,6 +619,32 @@
       "total_tokens": 0,
       "wall_time_s": 1080,
       "total_cost_usd": 0
+    },
+    {
+      "task_id": "afc",
+      "model": "ibm-granite/granite-4.2-8b",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Eighteenth catalog AFC cell. SSC present; Sample sheet present but empty (sample_data_rows=0). Oracle failure_count=2: Sample has no data rows; R from Sample Size Calculation is missing or < 1. S=0 R=None; husks 0/0. Hung tool_loop at round 46 on read_cell_range; all finish_reason=tool_calls. Tokens are OpenRouter usage sum across n=48 generations (in=2359996 out=64282). wall_time_s is the recorded ~840s LLM loop (14 min). tip_at_run 71640e30. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.14353); model_configs estimate ~0.24564 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0546-granite-4.2-8b/",
+      "stamp": "20260912-0546-granite-4.2-8b",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "Sample has no data rows",
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 2359996,
+      "output_tokens": 64282,
+      "total_tokens": 2424278,
+      "wall_time_s": 840,
+      "total_cost_usd": 0.14353
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -103,6 +103,11 @@
     {
       "openrouter_id": "google/gemma-4-26b-a4b-it",
       "display_name": "Gemma 4 26B A4B",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "nvidia/nemotron-3.5-lightning",
+      "display_name": "Nemotron 3.5 Lightning",
       "role": "catalog"
     },
     {
@@ -299,6 +304,32 @@
       "total_tokens": 694247,
       "wall_time_s": 886,
       "total_cost_usd": 0.04316
+    },
+    {
+      "task_id": "afc",
+      "model": "nvidia/nemotron-3.5-lightning",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Seventh catalog AFC cell. Population only — missing Sample and Sample Size Calculation sheets (oracle failure_count=2). sample_data_rows=0; S=0 R=None; husks 0/0. Err:507 in Population J/K. Save dialog flicker mid-flight. Tokens stored are the second-send OpenRouter usage (in=760171 out=3189); all-from-first totals were higher (no separate field — not stored). No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter second-send usage sum (~0.04282); model_configs estimate ~0.06145 is an alternate, not stored. Wall ~540–600s (stored 540). Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0310-nemotron-3.5-lightning/",
+      "stamp": "20260912-0310-nemotron-3.5-lightning",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 760171,
+      "output_tokens": 3189,
+      "total_tokens": 763360,
+      "wall_time_s": 540,
+      "total_cost_usd": 0.04282
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -98,6 +98,11 @@
     {
       "openrouter_id": "google/gemma-4-31b-it",
       "display_name": "Gemma 4 31B",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "google/gemma-4-26b-a4b-it",
+      "display_name": "Gemma 4 26B A4B",
       "role": "catalog"
     },
     {
@@ -269,6 +274,31 @@
       "total_tokens": 149335,
       "wall_time_s": 392,
       "total_cost_usd": 0.10841
+    },
+    {
+      "task_id": "afc",
+      "model": "google/gemma-4-26b-a4b-it",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Sixth catalog AFC cell. First catalog model besides the Gemini 3.8 gate to produce a parseable R (R=65). Sample undersized (sample_data_rows=10 << 65) with S=0, so oracle FAIL is S < R, not the missing-R hole. Attempt1 contaminated; attempt2 wipe. Husks 0/70. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.04316); model_configs estimate ~0.05011 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0240-gemma-4-26b-a4b-it/",
+      "stamp": "20260912-0240-gemma-4-26b-a4b-it",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "S=0 flag=1 in column K is < R=65"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": 65,
+      "husk_cells": 0,
+      "scored_cells": 70,
+      "input_tokens": 688661,
+      "output_tokens": 5586,
+      "total_tokens": 694247,
+      "wall_time_s": 886,
+      "total_cost_usd": 0.04316
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -153,6 +153,11 @@
     {
       "openrouter_id": "z-ai/glm-5.3-flash",
       "display_name": "GLM 5.3 Flash",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "upstage/solar-pro4",
+      "display_name": "Solar Pro 4",
       "role": "catalog"
     }
   ],
@@ -593,6 +598,22 @@
       "total_tokens": 21788,
       "wall_time_s": 155,
       "total_cost_usd": 0.00900
+    },
+    {
+      "task_id": "afc",
+      "model": "upstage/solar-pro4",
+      "product_bar": "BLOCKED",
+      "oracle": null,
+      "oracle_note": "Seventeenth catalog AFC cell — infra/blocked, not a model judgment. SendButton crashed before any LLM call (sqlite3.OperationalError: no such table: message_store; writeragent_history.db wiped empty/broken between trials). Send failed twice. No tools. Missing Sample+SSC only because Send never ran — do not store as oracle FAIL. sample_data_rows=0; S=0 R=None; husks 0/0 noted here, not stored as scored oracle fields. Tokens 0; total_cost_usd 0 (no LLM). wall_time_s is the headed wait (~1080s). tip_at_run 6c6017b7. Scrolly recreating schema before next trial. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0522-solar-pro4/",
+      "stamp": "20260912-0522-solar-pro4",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "total_tokens": 0,
+      "wall_time_s": 1080,
+      "total_cost_usd": 0
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -128,6 +128,11 @@
     {
       "openrouter_id": "meta/muse-spark-1.3-contributor",
       "display_name": "Muse Spark 1.3",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "poolside/laguna-s-2.1",
+      "display_name": "Laguna S 2.1",
       "role": "catalog"
     }
   ],
@@ -440,6 +445,31 @@
       "total_tokens": 24110,
       "wall_time_s": 241,
       "total_cost_usd": 0.00157
+    },
+    {
+      "task_id": "afc",
+      "model": "poolside/laguna-s-2.1",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Twelfth catalog AFC cell. SSC present with parseable R=66; Sample sheet missing (oracle failure_count=1: missing sheet 'Sample'). sample_data_rows=0; S=0 R=66; husks 0/0. finish_reason=length — response truncated mid tool loop. tip_at_run 6c6017b7. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.01480); model_configs estimate ~0.02142 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0419-laguna-s-2.1/",
+      "stamp": "20260912-0419-laguna-s-2.1",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "missing sheet 'Sample'"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": 66,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 166351,
+      "output_tokens": 35845,
+      "total_tokens": 202196,
+      "wall_time_s": 384,
+      "total_cost_usd": 0.01480
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -358,6 +358,32 @@
       "total_tokens": 118650,
       "wall_time_s": 479,
       "total_cost_usd": 0.00468
+    },
+    {
+      "task_id": "afc",
+      "model": "x-ai/grok-4.6",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Ninth catalog AFC cell. SSC present; Sample sheet present but empty (sample_data_rows=0). Oracle failure_count=2: Sample has no data rows; R from Sample Size Calculation is missing or < 1. S=0 R=None; husks 0/0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.02375); model_configs estimate ~0.05831 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0342-grok-4.6/",
+      "stamp": "20260912-0342-grok-4.6",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "Sample has no data rows",
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 0,
+      "input_tokens": 28184,
+      "output_tokens": 323,
+      "total_tokens": 28507,
+      "wall_time_s": 416,
+      "total_cost_usd": 0.02375
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini). solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -168,6 +168,11 @@
     {
       "openrouter_id": "mistralai/mistral-small-2603",
       "display_name": "Mistral Small 4",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "bytedance-seed/seed-2.0-mini",
+      "display_name": "Seed 2.0 Mini",
       "role": "catalog"
     }
   ],
@@ -675,6 +680,32 @@
       "total_tokens": 153332,
       "wall_time_s": 32,
       "total_cost_usd": 0.00973
+    },
+    {
+      "task_id": "afc",
+      "model": "bytedance-seed/seed-2.0-mini",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Twentieth catalog AFC cell. Sample+SSC present but malformed (sample_data_rows=1). Sample A2 is =PY(\"\"\"; SSC Err:501 with a visual ~65 — oracle parsed R=None, do not store 65 as afc_r_required. Oracle failure_count=2: R from Sample Size Calculation is missing or < 1; husk-dominated Sample (1/1 scored cells). S=0 R=None; husks 1/1. Tokens are OpenRouter usage sum across n=2 generations (in=24059 out=14342). wall_time_s is the recorded ~131s loop. tip_at_run 71640e30. UNO/assert/PreContract=0. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.00814); model_configs estimate ~0.00814 matches and is not stored separately. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0610-seed-2.0-mini/",
+      "stamp": "20260912-0610-seed-2.0-mini",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 2,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1",
+        "husk-dominated Sample (1/1 scored cells)"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 1,
+      "scored_cells": 1,
+      "input_tokens": 24059,
+      "output_tokens": 14342,
+      "total_tokens": 38401,
+      "wall_time_s": 131,
+      "total_cost_usd": 0.00814
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite). No catalog-wide eval-2 sweep. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -88,6 +88,11 @@
     {
       "openrouter_id": "openai/gpt-oss-20b",
       "display_name": "GPT-OSS 20B",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "google/gemini-3.5-flash-lite",
+      "display_name": "Gemini 3.5 Flash Lite",
       "role": "catalog"
     },
     {
@@ -209,6 +214,31 @@
       "total_tokens": 15552,
       "wall_time_s": 309,
       "total_cost_usd": 0.00122
+    },
+    {
+      "task_id": "afc",
+      "model": "google/gemini-3.5-flash-lite",
+      "product_bar": "NOT_HAPPY",
+      "oracle": "FAIL",
+      "oracle_note": "Fourth catalog AFC cell. Attempt1 aborted (nitro contamination); attempt2 used a clean history. Sample/SSC present (sample_data_rows=81) but incomplete. Same R hole as 120b/Luna/20b; S=0. Shot shows SSC label truncated “Required Sar”=73, but the oracle parsed R=None — do not store 73 as afc_r_required. Oracle failure_count=1: R from Sample Size Calculation is missing or < 1. S=0 R=None, husks 0/648. No oracle_check_count — omit partial_score. total_cost_usd is the OpenRouter usage sum (~0.00629); model_configs estimate ~0.00821 is an alternate, not stored. Box-local run_dir: docs/eval/eval-2/afc-sample-83d10b06/runs/20260912-0216-gemini-3.5-flash-lite/",
+      "stamp": "20260912-0216-gemini-3.5-flash-lite",
+      "source": "docs/eval/eval-2/afc-sample-83d10b06/notes.md; Scrolly headed catalog run (box-local stamp)",
+      "run_artifacts_committed": false,
+      "patches": null,
+      "oracle_passed": false,
+      "oracle_failure_count": 1,
+      "oracle_failures": [
+        "R from Sample Size Calculation is missing or < 1"
+      ],
+      "afc_s_flags": 0,
+      "afc_r_required": null,
+      "husk_cells": 0,
+      "scored_cells": 648,
+      "input_tokens": 26111,
+      "output_tokens": 150,
+      "total_tokens": 26261,
+      "wall_time_s": 338,
+      "total_cost_usd": 0.00629
     },
     {
       "task_id": "writer-calc-peer-write",

--- a/docs/eval/eval-2/eval2_benchmark_results.schema.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.schema.json
@@ -89,9 +89,9 @@
       }
     },
     "product_bar": {
-      "description": "Headed product/task success. HAPPY means the deliverable did the job even if a soft oracle is red.",
+      "description": "Headed product/task success. HAPPY means the deliverable did the job even if a soft oracle is red. BLOCKED is infra (Send/harness never ran) — not a model NOT_HAPPY.",
       "type": ["string", "null"],
-      "enum": ["HAPPY", "NOT_HAPPY", null]
+      "enum": ["HAPPY", "NOT_HAPPY", "BLOCKED", null]
     },
     "oracle": {
       "description": "CLI oracle PASS/FAIL for the saved deliverable. Fail-closed. Soft notes go in oracle_note.",

--- a/scripts/plot_eval2_leaderboard.py
+++ b/scripts/plot_eval2_leaderboard.py
@@ -26,7 +26,7 @@ DEFAULT_RESULTS = REPO_ROOT / "docs" / "eval" / "eval-2" / "eval2_benchmark_resu
 DEFAULT_OUT_DIR = REPO_ROOT / "docs" / "eval" / "eval-2"
 
 SCHEMA_VERSION = 1
-PRODUCT_BARS = frozenset({"HAPPY", "NOT_HAPPY"})
+PRODUCT_BARS = frozenset({"HAPPY", "NOT_HAPPY", "BLOCKED"})
 ORACLES = frozenset({"PASS", "FAIL"})
 TASK_STATUSES = frozenset({"Ready", "Headed-ready"})
 MODEL_ROLES = frozenset({"gate", "headed", "catalog"})
@@ -35,6 +35,7 @@ PARKED_SLOT = 7
 # Okabe–Ito (same family as plot_pareto.py) plus an honest empty fill.
 COLOR_HAPPY = "#009E73"
 COLOR_NOT_HAPPY = "#D55E00"
+COLOR_BLOCKED = "#0072B2"
 COLOR_EMPTY = "#F1F3F4"
 COLOR_INK = "#202124"
 COLOR_MUTED = "#5f6368"
@@ -139,13 +140,21 @@ class Eval2Board:
         return None
 
     def scored_count(self, model: str) -> int:
-        return sum(1 for row in self.results if row.model == model and row.product_bar)
+        # BLOCKED is infra, not a headed score.
+        return sum(
+            1
+            for row in self.results
+            if row.model == model and row.product_bar in {"HAPPY", "NOT_HAPPY"}
+        )
 
     def happy_count(self, model: str) -> int:
         return sum(1 for row in self.results if row.model == model and row.product_bar == "HAPPY")
 
     def not_happy_count(self, model: str) -> int:
         return sum(1 for row in self.results if row.model == model and row.product_bar == "NOT_HAPPY")
+
+    def blocked_count(self, model: str) -> int:
+        return sum(1 for row in self.results if row.model == model and row.product_bar == "BLOCKED")
 
 
 def _require_str(row: Mapping[str, Any], key: str, *, ctx: str) -> str:
@@ -440,6 +449,8 @@ def cell_label(row: Eval2Result | None) -> str:
     """Short matrix token: HAPPY / oracle FAIL, or an em dash when unscored."""
     if row is None or (row.product_bar is None and row.oracle is None):
         return "—"
+    if row.product_bar == "BLOCKED":
+        return "BLOCKED / unscored"
     bits: list[str] = []
     if row.product_bar:
         bits.append(row.product_bar)
@@ -579,6 +590,7 @@ def ranked_rows(board: Eval2Board) -> tuple[RankedRow, ...]:
             cost_usd=result.total_cost_usd if result.total_cost_usd else None,
         )
         for result in board.results
+        if result.product_bar in {"HAPPY", "NOT_HAPPY"}
     ]
     rows.sort(key=rank_sort_key)
     return tuple(rows)
@@ -709,6 +721,11 @@ def write_heatmap_svg(board: Eval2Board, out_path: Path) -> Path:
                 bar_text = "no data"
                 oracle_text = "—"
                 ink = COLOR_MUTED
+            elif row.product_bar == "BLOCKED":
+                fill = COLOR_BLOCKED
+                bar_text = "BLOCKED"
+                oracle_text = "unscored"
+                ink = "#ffffff"
             else:
                 fill = COLOR_HAPPY if row.product_bar == "HAPPY" else COLOR_NOT_HAPPY
                 bar_text = row.product_bar
@@ -771,12 +788,14 @@ def write_coverage_svg(board: Eval2Board, out_path: Path) -> Path:
         x = left + col * (bar_w + gap)
         happy = board.happy_count(model.openrouter_id)
         not_happy = board.not_happy_count(model.openrouter_id)
-        empty = n_tasks - happy - not_happy
-        # Stack from the axis: empty, then NOT_HAPPY, then HAPPY on top.
+        blocked = board.blocked_count(model.openrouter_id)
+        empty = n_tasks - happy - not_happy - blocked
+        # Stack from the axis: empty, then BLOCKED, then NOT_HAPPY, then HAPPY.
         scale = plot_h / n_tasks
         y = top + plot_h
         for count, fill, label in (
             (empty, COLOR_EMPTY, "no data"),
+            (blocked, COLOR_BLOCKED, "BLOCKED"),
             (not_happy, COLOR_NOT_HAPPY, "NOT_HAPPY"),
             (happy, COLOR_HAPPY, "HAPPY"),
         ):
@@ -802,7 +821,12 @@ def write_coverage_svg(board: Eval2Board, out_path: Path) -> Path:
     # Legend
     legend_y = height - 28
     for i, (fill, label) in enumerate(
-        ((COLOR_HAPPY, "HAPPY"), (COLOR_NOT_HAPPY, "NOT_HAPPY"), (COLOR_EMPTY, "no data"))
+        (
+            (COLOR_HAPPY, "HAPPY"),
+            (COLOR_NOT_HAPPY, "NOT_HAPPY"),
+            (COLOR_BLOCKED, "BLOCKED"),
+            (COLOR_EMPTY, "no data"),
+        )
     ):
         lx = 24 + i * 110
         parts.append(
@@ -1099,7 +1123,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stdout.write("\n")
         sys.stdout.write(render_partial_markdown(board))
     if args.check:
-        print(f"OK {args.in_path} ({len(board.results)} scored cells, gate={board.gate_model})")
+        scored = sum(1 for row in board.results if row.product_bar in {"HAPPY", "NOT_HAPPY"})
+        blocked = sum(1 for row in board.results if row.product_bar == "BLOCKED")
+        extra = f", {blocked} blocked" if blocked else ""
+        print(f"OK {args.in_path} ({scored} scored cells{extra}, gate={board.gate_model})")
         return 0
     for path in write_eval2_svgs(board, args.out_dir):
         print(f"Wrote {path}")

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -113,6 +113,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "poolside/laguna-xs-2.1",
         "qwen/qwen3.8-27b",
         "qwen/qwen3.8-flash",
+        "z-ai/glm-5.3-flash",
     }
 
 
@@ -134,6 +135,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     laguna_xs = "poolside/laguna-xs-2.1"
     qwen27 = "qwen/qwen3.8-27b"
     qwen_flash = "qwen/qwen3.8-flash"
+    glm_flash = "z-ai/glm-5.3-flash"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -602,6 +604,37 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "Err:508" in afc_qwen_flash.oracle_note
     assert "n=51" in afc_qwen_flash.oracle_note
 
+    # Sixteenth catalog AFC stamp (Scrolly headed 20260912-0515).
+    afc_glm_flash = board.result_for("afc", glm_flash)
+    assert afc_glm_flash is not None
+    assert afc_glm_flash.product_bar == "NOT_HAPPY"
+    assert afc_glm_flash.oracle == "FAIL"
+    assert afc_glm_flash.stamp == "20260912-0515-glm-5.3-flash"
+    assert afc_glm_flash.oracle_passed is False
+    assert afc_glm_flash.oracle_failure_count == 2
+    assert afc_glm_flash.oracle_failures == (
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'",
+    )
+    assert afc_glm_flash.oracle_check_count is None
+    assert afc_glm_flash.partial_score is None
+    assert afc_glm_flash.afc_s_flags == 0
+    assert afc_glm_flash.afc_r_required is None
+    assert afc_glm_flash.husk_cells == 0
+    assert afc_glm_flash.scored_cells == 0
+    assert afc_glm_flash.input_tokens == 5404
+    assert afc_glm_flash.output_tokens == 16384
+    assert afc_glm_flash.total_tokens == 21788
+    assert afc_glm_flash.wall_time_s == 155
+    assert afc_glm_flash.total_cost_usd == pytest.approx(0.00900)
+    assert afc_glm_flash.intelligence_per_dollar is None
+    assert "20260912-0515-glm-5.3-flash" in afc_glm_flash.oracle_note
+    assert "0.00450" in afc_glm_flash.oracle_note
+    assert "6c6017b7" in afc_glm_flash.oracle_note
+    assert "finish_reason=length" in afc_glm_flash.oracle_note
+    assert "n=1" in afc_glm_flash.oracle_note
+    assert "15160" in afc_glm_flash.oracle_note
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -627,6 +660,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, laguna_xs) is None
         assert board.result_for(task_id, qwen27) is None
         assert board.result_for(task_id, qwen_flash) is None
+        assert board.result_for(task_id, glm_flash) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -645,6 +679,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", laguna_xs),
         ("afc", qwen27),
         ("afc", qwen_flash),
+        ("afc", glm_flash),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -691,6 +726,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_laguna_xs)
     assert pel.has_recorded_partial(afc_qwen27)
     assert pel.has_recorded_partial(afc_qwen_flash)
+    assert pel.has_recorded_partial(afc_glm_flash)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -709,6 +745,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "poolside/laguna-xs-2.1"),
     ("afc", "qwen/qwen3.8-27b"),
     ("afc", "qwen/qwen3.8-flash"),
+    ("afc", "z-ai/glm-5.3-flash"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -803,6 +840,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Laguna XS 2.1" in partial
     assert "Qwen3.8 27B" in partial
     assert "Qwen3.8 Flash" in partial
+    assert "GLM 5.3 Flash" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -869,6 +907,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Laguna XS 2.1" in partial_text
     assert "Qwen3.8 27B" in partial_text
     assert "Qwen3.8 Flash" in partial_text
+    assert "GLM 5.3 Flash" in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -105,6 +105,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "google/gemma-4-31b-it",
         "google/gemma-4-26b-a4b-it",
         "nvidia/nemotron-3.5-lightning",
+        "inception/mercury-2.5-preview",
         "x-ai/grok-4.6",
         "meta/muse-spark-1.3-contributor",
     }
@@ -120,6 +121,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     gemma = "google/gemma-4-31b-it"
     gemma26 = "google/gemma-4-26b-a4b-it"
     nemo = "nvidia/nemotron-3.5-lightning"
+    mercury = "inception/mercury-2.5-preview"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -365,7 +367,32 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "second-send" in afc_nemo.oracle_note
     assert "Err:507" in afc_nemo.oracle_note
 
-    # No invented Luna / 20b / Flash Lite / Gemma / Nemotron scores outside AFC.
+    # Eighth catalog AFC stamp (Scrolly headed 20260912-0330).
+    afc_mercury = board.result_for("afc", mercury)
+    assert afc_mercury is not None
+    assert afc_mercury.product_bar == "HAPPY"
+    assert afc_mercury.oracle == "PASS"
+    assert afc_mercury.stamp == "20260912-0330-mercury-2.5-preview"
+    assert afc_mercury.oracle_passed is True
+    assert afc_mercury.oracle_failure_count == 0
+    assert afc_mercury.oracle_failures == ()
+    assert afc_mercury.oracle_check_count is None
+    assert afc_mercury.partial_score == 1.0
+    assert afc_mercury.afc_s_flags == 494
+    assert afc_mercury.afc_r_required == 68
+    assert afc_mercury.husk_cells == 2
+    assert afc_mercury.scored_cells == 16680
+    assert afc_mercury.input_tokens == 115096
+    assert afc_mercury.output_tokens == 3554
+    assert afc_mercury.total_tokens == 118650
+    assert afc_mercury.wall_time_s == 479
+    assert afc_mercury.total_cost_usd == pytest.approx(0.00468)
+    assert afc_mercury.intelligence_per_dollar == pytest.approx(1.0 / 0.00468)
+    assert "20260912-0330-mercury-2.5-preview" in afc_mercury.oracle_note
+    assert "0.03144" in afc_mercury.oracle_note
+    assert "near-full" in afc_mercury.oracle_note
+
+    # No invented Luna / 20b / Flash Lite / Gemma / Nemotron / Mercury scores outside AFC.
     for task_id in (
         "tenant-retention",
         "cadaver-proposal",
@@ -382,6 +409,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, gemma) is None
         assert board.result_for(task_id, gemma26) is None
         assert board.result_for(task_id, nemo) is None
+        assert board.result_for(task_id, mercury) is None
 
     # Remaining catalog peers stay empty until a real stamp lands.
     for mid in (
@@ -400,6 +428,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", gemma),
         ("afc", gemma26),
         ("afc", nemo),
+        ("afc", mercury),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -423,7 +452,11 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         else:
             assert row.oracle_passed is False
             assert row.partial_score is None
-    assert pel.happy_cost_rows(board) == ()
+    happy_costs = pel.happy_cost_rows(board)
+    assert len(happy_costs) == 1
+    assert happy_costs[0].model.openrouter_id == mercury
+    assert happy_costs[0].cost_usd == pytest.approx(0.00468)
+    assert happy_costs[0].intelligence_per_dollar == pytest.approx(1.0 / 0.00468)
     afc = board.result_for("afc", gemini)
     assert afc is not None
     assert pel.has_recorded_partial(afc)
@@ -434,6 +467,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_gemma)
     assert pel.has_recorded_partial(afc_gemma26)
     assert pel.has_recorded_partial(afc_nemo)
+    assert pel.has_recorded_partial(afc_mercury)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -444,6 +478,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "google/gemma-4-31b-it"),
     ("afc", "google/gemma-4-26b-a4b-it"),
     ("afc", "nvidia/nemotron-3.5-lightning"),
+    ("afc", "inception/mercury-2.5-preview"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -517,8 +552,11 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "no data" in heatmap
     assert "HAPPY" in heatmap
     assert "0 HAPPY / 0 scored" in coverage
-    assert "No HAPPY cell has recorded total_cost_usd yet" in cost
-    assert "data-cost-usd=" not in cost
+    assert "1 HAPPY / 1 scored" in coverage
+    assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
+    assert "data-cost-usd=\"0.004680\"" in cost
+    assert "Mercury 2.5 Preview" in cost
+    assert "213.68" in cost
     # Seed has one oracle PASS (AFC Gemini 3.8) → partial 1. Catalog AFC
     # cells recorded S/R + failure_count without a check-count ratio.
     assert "data-partial-score=\"1.00\"" in partial
@@ -527,6 +565,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Gemma 4 31B" in partial
     assert "Gemma 4 26B A4B" in partial
     assert "Nemotron 3.5 Lightning" in partial
+    assert "Mercury 2.5 Preview" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -535,6 +574,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "S=68 R=—" in partial
     assert "S=0 R=—" in partial
     assert "S=0 R=65" in partial
+    assert "S=494 R=68" in partial
     assert "2/—" in partial
     assert "no ratio" in partial
     assert "data-partial-score=\"0." not in partial
@@ -557,15 +597,17 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Tenant Retention" in heat
     assert "no data" in cov
     assert "0 HAPPY / 0 scored" in cov
+    assert "1 HAPPY / 1 scored" in cov
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
     assert pel.COST_NAME != "pareto-fronts.svg"
 
     cost_svg = pel.write_cost_svg(board, tmp_path / "eval2-cost.svg")
     cost_text = cost_svg.read_text(encoding="utf-8")
-    assert "No HAPPY cell has recorded total_cost_usd yet" in cost_text
-    assert "data-cost-usd=" not in cost_text
-    assert "$0." not in cost_text
+    assert "No HAPPY cell has recorded total_cost_usd yet" not in cost_text
+    assert "data-cost-usd=\"0.004680\"" in cost_text
+    assert "Mercury 2.5 Preview" in cost_text
+    assert "213.68" in cost_text
     assert pel.PARTIAL_NAME != "pareto-fronts.svg"
     partial_svg = pel.write_partial_svg(board, tmp_path / "eval2-partial.svg")
     partial_text = partial_svg.read_text(encoding="utf-8")
@@ -581,6 +623,8 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Gemma 4 31B" in partial_text
     assert "Gemma 4 26B A4B" in partial_text
     assert "Nemotron 3.5 Lightning" in partial_text
+    assert "Mercury 2.5 Preview" in partial_text
+    assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text
     assert "no ratio" in partial_text
 
@@ -791,12 +835,21 @@ def test_cost_chart_ranks_happy_by_lower_cost_and_skips_empty(
     assert "Grok 4.6" not in svg
     assert "9999" not in svg
 
-    empty_board = pel.load_eval2_board(_RESULTS)
+    empty_src = tmp_path / "no-happy-cost.json"
+    empty_src.write_text(json.dumps(_minimal_board_payload()), encoding="utf-8")
+    empty_board = pel.load_eval2_board(empty_src)
     empty_svg = pel.write_cost_svg(empty_board, tmp_path / "empty-cost.svg").read_text(
         encoding="utf-8"
     )
     assert "No HAPPY cell has recorded total_cost_usd yet" in empty_svg
     assert "data-cost-usd=" not in empty_svg
+
+    seed_cost = pel.write_cost_svg(pel.load_eval2_board(_RESULTS), tmp_path / "seed-cost.svg")
+    seed_cost_text = seed_cost.read_text(encoding="utf-8")
+    assert "data-cost-usd=\"0.004680\"" in seed_cost_text
+    assert "Mercury 2.5 Preview" in seed_cost_text
+    assert "213.68" in seed_cost_text
+    assert "No HAPPY cell has recorded total_cost_usd yet" not in seed_cost_text
 
 
 def test_partial_score_only_when_pass_or_both_counts() -> None:

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -119,6 +119,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "ibm-granite/granite-4.2-8b",
         "mistralai/mistral-small-2603",
         "bytedance-seed/seed-2.0-mini",
+        "minimax/minimax-m3",
     }
 
 
@@ -145,6 +146,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     granite = "ibm-granite/granite-4.2-8b"
     mistral = "mistralai/mistral-small-2603"
     seed_mini = "bytedance-seed/seed-2.0-mini"
+    minimax = "minimax/minimax-m3"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -778,6 +780,40 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert board.not_happy_count(seed_mini) == 1
     assert board.blocked_count(seed_mini) == 0
 
+    # Twenty-first catalog AFC stamp (Scrolly headed 20260912-0617).
+    afc_minimax = board.result_for("afc", minimax)
+    assert afc_minimax is not None
+    assert afc_minimax.product_bar == "NOT_HAPPY"
+    assert afc_minimax.oracle == "FAIL"
+    assert afc_minimax.stamp == "20260912-0617-minimax-m3"
+    assert afc_minimax.oracle_passed is False
+    assert afc_minimax.oracle_failure_count == 2
+    assert afc_minimax.oracle_failures == (
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'",
+    )
+    assert afc_minimax.oracle_check_count is None
+    assert afc_minimax.partial_score is None
+    assert afc_minimax.afc_s_flags == 0
+    assert afc_minimax.afc_r_required is None
+    assert afc_minimax.husk_cells == 0
+    assert afc_minimax.scored_cells == 0
+    assert afc_minimax.input_tokens == 318690
+    assert afc_minimax.output_tokens == 3685
+    assert afc_minimax.total_tokens == 322375
+    assert afc_minimax.wall_time_s == 66
+    assert afc_minimax.total_cost_usd == pytest.approx(0.07965)
+    assert afc_minimax.intelligence_per_dollar is None
+    assert "20260912-0617-minimax-m3" in afc_minimax.oracle_note
+    assert "0.10003" in afc_minimax.oracle_note
+    assert "71640e30" in afc_minimax.oracle_note
+    assert "n=30" in afc_minimax.oracle_note
+    assert "#NAME?" in afc_minimax.oracle_note
+    assert pel.has_recorded_partial(afc_minimax)
+    assert board.scored_count(minimax) == 1
+    assert board.not_happy_count(minimax) == 1
+    assert board.blocked_count(minimax) == 0
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -808,6 +844,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, granite) is None
         assert board.result_for(task_id, mistral) is None
         assert board.result_for(task_id, seed_mini) is None
+        assert board.result_for(task_id, minimax) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -831,6 +868,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", granite),
         ("afc", mistral),
         ("afc", seed_mini),
+        ("afc", minimax),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -881,6 +919,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_granite)
     assert pel.has_recorded_partial(afc_mistral)
     assert pel.has_recorded_partial(afc_seed)
+    assert pel.has_recorded_partial(afc_minimax)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -904,6 +943,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "ibm-granite/granite-4.2-8b"),
     ("afc", "mistralai/mistral-small-2603"),
     ("afc", "bytedance-seed/seed-2.0-mini"),
+    ("afc", "minimax/minimax-m3"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -984,6 +1024,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Granite 4.2 8B" in heatmap
     assert "Mistral Small 4" in heatmap
     assert "Seed 2.0 Mini" in heatmap
+    assert "MiniMax M3" in heatmap
     assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
     assert "data-cost-usd=\"0.004680\"" in cost
     assert "Mercury 2.5 Preview" in cost
@@ -1008,6 +1049,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Granite 4.2 8B" in partial
     assert "Mistral Small 4" in partial
     assert "Seed 2.0 Mini" in partial
+    assert "MiniMax M3" in partial
     assert "Solar Pro 4" not in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
@@ -1048,6 +1090,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Granite 4.2 8B" in heat
     assert "Mistral Small 4" in heat
     assert "Seed 2.0 Mini" in heat
+    assert "MiniMax M3" in heat
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
     assert pel.COST_NAME != "pareto-fronts.svg"
@@ -1085,6 +1128,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Granite 4.2 8B" in partial_text
     assert "Mistral Small 4" in partial_text
     assert "Seed 2.0 Mini" in partial_text
+    assert "MiniMax M3" in partial_text
     assert "Solar Pro 4" not in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -122,6 +122,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     gemma26 = "google/gemma-4-26b-a4b-it"
     nemo = "nvidia/nemotron-3.5-lightning"
     mercury = "inception/mercury-2.5-preview"
+    grok = "x-ai/grok-4.6"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -392,7 +393,35 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "0.03144" in afc_mercury.oracle_note
     assert "near-full" in afc_mercury.oracle_note
 
-    # No invented Luna / 20b / Flash Lite / Gemma / Nemotron / Mercury scores outside AFC.
+    # Ninth catalog AFC stamp (Scrolly headed 20260912-0342).
+    afc_grok = board.result_for("afc", grok)
+    assert afc_grok is not None
+    assert afc_grok.product_bar == "NOT_HAPPY"
+    assert afc_grok.oracle == "FAIL"
+    assert afc_grok.stamp == "20260912-0342-grok-4.6"
+    assert afc_grok.oracle_passed is False
+    assert afc_grok.oracle_failure_count == 2
+    assert afc_grok.oracle_failures == (
+        "Sample has no data rows",
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_grok.oracle_check_count is None
+    assert afc_grok.partial_score is None
+    assert afc_grok.afc_s_flags == 0
+    assert afc_grok.afc_r_required is None
+    assert afc_grok.husk_cells == 0
+    assert afc_grok.scored_cells == 0
+    assert afc_grok.input_tokens == 28184
+    assert afc_grok.output_tokens == 323
+    assert afc_grok.total_tokens == 28507
+    assert afc_grok.wall_time_s == 416
+    assert afc_grok.total_cost_usd == pytest.approx(0.02375)
+    assert afc_grok.intelligence_per_dollar is None
+    assert "20260912-0342-grok-4.6" in afc_grok.oracle_note
+    assert "0.05831" in afc_grok.oracle_note
+    assert "SSC present" in afc_grok.oracle_note
+
+    # No invented Luna / 20b / Flash Lite / Gemma / Nemotron / Mercury / Grok scores outside AFC.
     for task_id in (
         "tenant-retention",
         "cadaver-proposal",
@@ -410,14 +439,11 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, gemma26) is None
         assert board.result_for(task_id, nemo) is None
         assert board.result_for(task_id, mercury) is None
+        assert board.result_for(task_id, grok) is None
 
     # Remaining catalog peers stay empty until a real stamp lands.
-    for mid in (
-        "x-ai/grok-4.6",
-        "meta/muse-spark-1.3-contributor",
-    ):
-        assert board.scored_count(mid) == 0
-        assert board.happy_count(mid) == 0
+    assert board.scored_count("meta/muse-spark-1.3-contributor") == 0
+    assert board.happy_count("meta/muse-spark-1.3-contributor") == 0
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -429,6 +455,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", gemma26),
         ("afc", nemo),
         ("afc", mercury),
+        ("afc", grok),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -468,6 +495,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_gemma26)
     assert pel.has_recorded_partial(afc_nemo)
     assert pel.has_recorded_partial(afc_mercury)
+    assert pel.has_recorded_partial(afc_grok)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -479,6 +507,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "google/gemma-4-26b-a4b-it"),
     ("afc", "nvidia/nemotron-3.5-lightning"),
     ("afc", "inception/mercury-2.5-preview"),
+    ("afc", "x-ai/grok-4.6"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -566,6 +595,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Gemma 4 26B A4B" in partial
     assert "Nemotron 3.5 Lightning" in partial
     assert "Mercury 2.5 Preview" in partial
+    assert "Grok 4.6" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -624,6 +654,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Gemma 4 26B A4B" in partial_text
     assert "Nemotron 3.5 Lightning" in partial_text
     assert "Mercury 2.5 Preview" in partial_text
+    assert "Grok 4.6" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text
     assert "no ratio" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -125,6 +125,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     mercury = "inception/mercury-2.5-preview"
     grok = "x-ai/grok-4.6"
     glimmer = "meta/muse-glimmer-30b"
+    spark = "meta/muse-spark-1.3-contributor"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -451,7 +452,35 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "e0bb6321" in afc_glimmer.oracle_note
     assert "50 tool" in afc_glimmer.oracle_note
 
-    # No invented Luna / 20b / Flash Lite / Gemma / Nemotron / Mercury / Grok / Glimmer scores outside AFC.
+    # Eleventh catalog AFC stamp (Scrolly headed 20260912-0409).
+    afc_spark = board.result_for("afc", spark)
+    assert afc_spark is not None
+    assert afc_spark.product_bar == "NOT_HAPPY"
+    assert afc_spark.oracle == "FAIL"
+    assert afc_spark.stamp == "20260912-0409-muse-spark-1.3-contributor"
+    assert afc_spark.oracle_passed is False
+    assert afc_spark.oracle_failure_count == 2
+    assert afc_spark.oracle_failures == (
+        "Sample has no data rows",
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_spark.oracle_check_count is None
+    assert afc_spark.partial_score is None
+    assert afc_spark.afc_s_flags == 0
+    assert afc_spark.afc_r_required is None
+    assert afc_spark.husk_cells == 0
+    assert afc_spark.scored_cells == 0
+    assert afc_spark.input_tokens == 23560
+    assert afc_spark.output_tokens == 550
+    assert afc_spark.total_tokens == 24110
+    assert afc_spark.wall_time_s == 241
+    assert afc_spark.total_cost_usd == pytest.approx(0.00157)
+    assert afc_spark.intelligence_per_dollar is None
+    assert "20260912-0409-muse-spark-1.3-contributor" in afc_spark.oracle_note
+    assert "0.00247" in afc_spark.oracle_note
+    assert "6c6017b7" in afc_spark.oracle_note
+
+    # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
         "cadaver-proposal",
@@ -471,10 +500,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, mercury) is None
         assert board.result_for(task_id, grok) is None
         assert board.result_for(task_id, glimmer) is None
-
-    # Remaining catalog peers stay empty until a real stamp lands.
-    assert board.scored_count("meta/muse-spark-1.3-contributor") == 0
-    assert board.happy_count("meta/muse-spark-1.3-contributor") == 0
+        assert board.result_for(task_id, spark) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -488,6 +514,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", mercury),
         ("afc", grok),
         ("afc", glimmer),
+        ("afc", spark),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -529,6 +556,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_mercury)
     assert pel.has_recorded_partial(afc_grok)
     assert pel.has_recorded_partial(afc_glimmer)
+    assert pel.has_recorded_partial(afc_spark)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -542,6 +570,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "inception/mercury-2.5-preview"),
     ("afc", "x-ai/grok-4.6"),
     ("afc", "meta/muse-glimmer-30b"),
+    ("afc", "meta/muse-spark-1.3-contributor"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -614,7 +643,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     partial = (_EVAL2 / pel.PARTIAL_NAME).read_text(encoding="utf-8")
     assert "no data" in heatmap
     assert "HAPPY" in heatmap
-    assert "0 HAPPY / 0 scored" in coverage
+    assert "0 HAPPY / 1 scored" in coverage
     assert "1 HAPPY / 1 scored" in coverage
     assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
     assert "data-cost-usd=\"0.004680\"" in cost
@@ -631,6 +660,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Mercury 2.5 Preview" in partial
     assert "Grok 4.6" in partial
     assert "Muse Glimmer 30B" in partial
+    assert "Muse Spark 1.3" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -661,7 +691,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "google/gemini-3.8-flash" in heat
     assert "Tenant Retention" in heat
     assert "no data" in cov
-    assert "0 HAPPY / 0 scored" in cov
+    assert "0 HAPPY / 1 scored" in cov
     assert "1 HAPPY / 1 scored" in cov
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
@@ -691,6 +721,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Mercury 2.5 Preview" in partial_text
     assert "Grok 4.6" in partial_text
     assert "Muse Glimmer 30B" in partial_text
+    assert "Muse Spark 1.3" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text
     assert "no ratio" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -109,6 +109,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "x-ai/grok-4.6",
         "meta/muse-glimmer-30b",
         "meta/muse-spark-1.3-contributor",
+        "poolside/laguna-s-2.1",
     }
 
 
@@ -126,6 +127,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     grok = "x-ai/grok-4.6"
     glimmer = "meta/muse-glimmer-30b"
     spark = "meta/muse-spark-1.3-contributor"
+    laguna = "poolside/laguna-s-2.1"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -480,6 +482,32 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "0.00247" in afc_spark.oracle_note
     assert "6c6017b7" in afc_spark.oracle_note
 
+    # Twelfth catalog AFC stamp (Scrolly headed 20260912-0419).
+    afc_laguna = board.result_for("afc", laguna)
+    assert afc_laguna is not None
+    assert afc_laguna.product_bar == "NOT_HAPPY"
+    assert afc_laguna.oracle == "FAIL"
+    assert afc_laguna.stamp == "20260912-0419-laguna-s-2.1"
+    assert afc_laguna.oracle_passed is False
+    assert afc_laguna.oracle_failure_count == 1
+    assert afc_laguna.oracle_failures == ("missing sheet 'Sample'",)
+    assert afc_laguna.oracle_check_count is None
+    assert afc_laguna.partial_score is None
+    assert afc_laguna.afc_s_flags == 0
+    assert afc_laguna.afc_r_required == 66
+    assert afc_laguna.husk_cells == 0
+    assert afc_laguna.scored_cells == 0
+    assert afc_laguna.input_tokens == 166351
+    assert afc_laguna.output_tokens == 35845
+    assert afc_laguna.total_tokens == 202196
+    assert afc_laguna.wall_time_s == 384
+    assert afc_laguna.total_cost_usd == pytest.approx(0.01480)
+    assert afc_laguna.intelligence_per_dollar is None
+    assert "20260912-0419-laguna-s-2.1" in afc_laguna.oracle_note
+    assert "0.02142" in afc_laguna.oracle_note
+    assert "6c6017b7" in afc_laguna.oracle_note
+    assert "finish_reason=length" in afc_laguna.oracle_note
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -501,6 +529,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, grok) is None
         assert board.result_for(task_id, glimmer) is None
         assert board.result_for(task_id, spark) is None
+        assert board.result_for(task_id, laguna) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -515,6 +544,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", grok),
         ("afc", glimmer),
         ("afc", spark),
+        ("afc", laguna),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -557,6 +587,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_grok)
     assert pel.has_recorded_partial(afc_glimmer)
     assert pel.has_recorded_partial(afc_spark)
+    assert pel.has_recorded_partial(afc_laguna)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -571,6 +602,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "x-ai/grok-4.6"),
     ("afc", "meta/muse-glimmer-30b"),
     ("afc", "meta/muse-spark-1.3-contributor"),
+    ("afc", "poolside/laguna-s-2.1"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -661,6 +693,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Grok 4.6" in partial
     assert "Muse Glimmer 30B" in partial
     assert "Muse Spark 1.3" in partial
+    assert "Laguna S 2.1" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -669,6 +702,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "S=68 R=—" in partial
     assert "S=0 R=—" in partial
     assert "S=0 R=65" in partial
+    assert "S=0 R=66" in partial
     assert "S=494 R=68" in partial
     assert "2/—" in partial
     assert "no ratio" in partial
@@ -722,6 +756,8 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Grok 4.6" in partial_text
     assert "Muse Glimmer 30B" in partial_text
     assert "Muse Spark 1.3" in partial_text
+    assert "Laguna S 2.1" in partial_text
+    assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text
     assert "no ratio" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -120,6 +120,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "mistralai/mistral-small-2603",
         "bytedance-seed/seed-2.0-mini",
         "minimax/minimax-m3",
+        "deepseek/deepseek-v4-flash-0731",
     }
 
 
@@ -147,6 +148,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     mistral = "mistralai/mistral-small-2603"
     seed_mini = "bytedance-seed/seed-2.0-mini"
     minimax = "minimax/minimax-m3"
+    deepseek = "deepseek/deepseek-v4-flash-0731"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -814,6 +816,41 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert board.not_happy_count(minimax) == 1
     assert board.blocked_count(minimax) == 0
 
+    # Twenty-second catalog AFC stamp (Scrolly headed 20260912-0621).
+    afc_deepseek = board.result_for("afc", deepseek)
+    assert afc_deepseek is not None
+    assert afc_deepseek.product_bar == "NOT_HAPPY"
+    assert afc_deepseek.oracle == "FAIL"
+    assert afc_deepseek.stamp == "20260912-0621-deepseek-v4-flash-0731"
+    assert afc_deepseek.oracle_passed is False
+    assert afc_deepseek.oracle_failure_count == 2
+    assert afc_deepseek.oracle_failures == (
+        "Sample has no data rows",
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_deepseek.oracle_check_count is None
+    assert afc_deepseek.partial_score is None
+    assert afc_deepseek.afc_s_flags == 0
+    assert afc_deepseek.afc_r_required is None
+    assert afc_deepseek.husk_cells == 0
+    assert afc_deepseek.scored_cells == 0
+    assert afc_deepseek.input_tokens == 2733344
+    assert afc_deepseek.output_tokens == 62813
+    assert afc_deepseek.total_tokens == 2796157
+    assert afc_deepseek.wall_time_s == 330
+    assert afc_deepseek.total_cost_usd == pytest.approx(0.17007)
+    assert afc_deepseek.intelligence_per_dollar is None
+    assert "20260912-0621-deepseek-v4-flash-0731" in afc_deepseek.oracle_note
+    assert "0.18897" in afc_deepseek.oracle_note
+    assert "71640e30" in afc_deepseek.oracle_note
+    assert "n=51" in afc_deepseek.oracle_note
+    assert "expected__deal_wire_dict_ok" in afc_deepseek.oracle_note
+    assert "PreContract=18" in afc_deepseek.oracle_note
+    assert pel.has_recorded_partial(afc_deepseek)
+    assert board.scored_count(deepseek) == 1
+    assert board.not_happy_count(deepseek) == 1
+    assert board.blocked_count(deepseek) == 0
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -845,6 +882,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, mistral) is None
         assert board.result_for(task_id, seed_mini) is None
         assert board.result_for(task_id, minimax) is None
+        assert board.result_for(task_id, deepseek) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -869,6 +907,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", mistral),
         ("afc", seed_mini),
         ("afc", minimax),
+        ("afc", deepseek),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -920,6 +959,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_mistral)
     assert pel.has_recorded_partial(afc_seed)
     assert pel.has_recorded_partial(afc_minimax)
+    assert pel.has_recorded_partial(afc_deepseek)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -944,6 +984,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "mistralai/mistral-small-2603"),
     ("afc", "bytedance-seed/seed-2.0-mini"),
     ("afc", "minimax/minimax-m3"),
+    ("afc", "deepseek/deepseek-v4-flash-0731"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -1025,6 +1066,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Mistral Small 4" in heatmap
     assert "Seed 2.0 Mini" in heatmap
     assert "MiniMax M3" in heatmap
+    assert "DeepSeek V4 Flash 0731" in heatmap
     assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
     assert "data-cost-usd=\"0.004680\"" in cost
     assert "Mercury 2.5 Preview" in cost
@@ -1050,6 +1092,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Mistral Small 4" in partial
     assert "Seed 2.0 Mini" in partial
     assert "MiniMax M3" in partial
+    assert "DeepSeek V4 Flash 0731" in partial
     assert "Solar Pro 4" not in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
@@ -1091,6 +1134,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Mistral Small 4" in heat
     assert "Seed 2.0 Mini" in heat
     assert "MiniMax M3" in heat
+    assert "DeepSeek V4 Flash 0731" in heat
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
     assert pel.COST_NAME != "pareto-fronts.svg"
@@ -1129,6 +1173,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Mistral Small 4" in partial_text
     assert "Seed 2.0 Mini" in partial_text
     assert "MiniMax M3" in partial_text
+    assert "DeepSeek V4 Flash 0731" in partial_text
     assert "Solar Pro 4" not in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -117,6 +117,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "z-ai/glm-5.3-flash",
         "upstage/solar-pro4",
         "ibm-granite/granite-4.2-8b",
+        "mistralai/mistral-small-2603",
     }
 
 
@@ -141,6 +142,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     glm_flash = "z-ai/glm-5.3-flash"
     solar = "upstage/solar-pro4"
     granite = "ibm-granite/granite-4.2-8b"
+    mistral = "mistralai/mistral-small-2603"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -706,6 +708,39 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert board.not_happy_count(granite) == 1
     assert board.blocked_count(granite) == 0
 
+    # Nineteenth catalog AFC stamp (Scrolly headed 20260912-0603).
+    afc_mistral = board.result_for("afc", mistral)
+    assert afc_mistral is not None
+    assert afc_mistral.product_bar == "NOT_HAPPY"
+    assert afc_mistral.oracle == "FAIL"
+    assert afc_mistral.stamp == "20260912-0603-mistral-small-2603"
+    assert afc_mistral.oracle_passed is False
+    assert afc_mistral.oracle_failure_count == 1
+    assert afc_mistral.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_mistral.oracle_check_count is None
+    assert afc_mistral.partial_score is None
+    assert afc_mistral.afc_s_flags == 0
+    assert afc_mistral.afc_r_required is None
+    assert afc_mistral.husk_cells == 0
+    assert afc_mistral.scored_cells == 648
+    assert afc_mistral.input_tokens == 149439
+    assert afc_mistral.output_tokens == 3893
+    assert afc_mistral.total_tokens == 153332
+    assert afc_mistral.wall_time_s == 32
+    assert afc_mistral.total_cost_usd == pytest.approx(0.00973)
+    assert afc_mistral.intelligence_per_dollar is None
+    assert "20260912-0603-mistral-small-2603" in afc_mistral.oracle_note
+    assert "0.02475" in afc_mistral.oracle_note
+    assert "71640e30" in afc_mistral.oracle_note
+    assert "n=14" in afc_mistral.oracle_note
+    assert "sample_data_rows=81" in afc_mistral.oracle_note
+    assert pel.has_recorded_partial(afc_mistral)
+    assert board.scored_count(mistral) == 1
+    assert board.not_happy_count(mistral) == 1
+    assert board.blocked_count(mistral) == 0
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -734,6 +769,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, glm_flash) is None
         assert board.result_for(task_id, solar) is None
         assert board.result_for(task_id, granite) is None
+        assert board.result_for(task_id, mistral) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -755,6 +791,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", glm_flash),
         ("afc", solar),
         ("afc", granite),
+        ("afc", mistral),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -803,6 +840,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_qwen_flash)
     assert pel.has_recorded_partial(afc_glm_flash)
     assert pel.has_recorded_partial(afc_granite)
+    assert pel.has_recorded_partial(afc_mistral)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -824,6 +862,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "z-ai/glm-5.3-flash"),
     ("afc", "upstage/solar-pro4"),
     ("afc", "ibm-granite/granite-4.2-8b"),
+    ("afc", "mistralai/mistral-small-2603"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -902,6 +941,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "BLOCKED" in heatmap
     assert "Solar Pro 4" in heatmap
     assert "Granite 4.2 8B" in heatmap
+    assert "Mistral Small 4" in heatmap
     assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
     assert "data-cost-usd=\"0.004680\"" in cost
     assert "Mercury 2.5 Preview" in cost
@@ -924,6 +964,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Qwen3.8 Flash" in partial
     assert "GLM 5.3 Flash" in partial
     assert "Granite 4.2 8B" in partial
+    assert "Mistral Small 4" in partial
     assert "Solar Pro 4" not in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
@@ -962,6 +1003,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "BLOCKED" in heat
     assert "Solar Pro 4" in heat
     assert "Granite 4.2 8B" in heat
+    assert "Mistral Small 4" in heat
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
     assert pel.COST_NAME != "pareto-fronts.svg"
@@ -997,6 +1039,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Qwen3.8 Flash" in partial_text
     assert "GLM 5.3 Flash" in partial_text
     assert "Granite 4.2 8B" in partial_text
+    assert "Mistral Small 4" in partial_text
     assert "Solar Pro 4" not in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -103,6 +103,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "openai/gpt-oss-20b",
         "google/gemini-3.5-flash-lite",
         "google/gemma-4-31b-it",
+        "google/gemma-4-26b-a4b-it",
         "x-ai/grok-4.6",
         "meta/muse-spark-1.3-contributor",
     }
@@ -116,6 +117,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     oss20 = "openai/gpt-oss-20b"
     lite = "google/gemini-3.5-flash-lite"
     gemma = "google/gemma-4-31b-it"
+    gemma26 = "google/gemma-4-26b-a4b-it"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -305,6 +307,33 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "0.01404" in afc_gemma.oracle_note
     assert "Err:508" in afc_gemma.oracle_note
 
+    # Sixth catalog AFC stamp (Scrolly headed 20260912-0240).
+    afc_gemma26 = board.result_for("afc", gemma26)
+    assert afc_gemma26 is not None
+    assert afc_gemma26.product_bar == "NOT_HAPPY"
+    assert afc_gemma26.oracle == "FAIL"
+    assert afc_gemma26.stamp == "20260912-0240-gemma-4-26b-a4b-it"
+    assert afc_gemma26.oracle_passed is False
+    assert afc_gemma26.oracle_failure_count == 1
+    assert afc_gemma26.oracle_failures == (
+        "S=0 flag=1 in column K is < R=65",
+    )
+    assert afc_gemma26.oracle_check_count is None
+    assert afc_gemma26.partial_score is None
+    assert afc_gemma26.afc_s_flags == 0
+    assert afc_gemma26.afc_r_required == 65
+    assert afc_gemma26.husk_cells == 0
+    assert afc_gemma26.scored_cells == 70
+    assert afc_gemma26.input_tokens == 688661
+    assert afc_gemma26.output_tokens == 5586
+    assert afc_gemma26.total_tokens == 694247
+    assert afc_gemma26.wall_time_s == 886
+    assert afc_gemma26.total_cost_usd == pytest.approx(0.04316)
+    assert afc_gemma26.intelligence_per_dollar is None
+    assert "20260912-0240-gemma-4-26b-a4b-it" in afc_gemma26.oracle_note
+    assert "0.05011" in afc_gemma26.oracle_note
+    assert "10 <<" in afc_gemma26.oracle_note or "sample_data_rows=10" in afc_gemma26.oracle_note
+
     # No invented Luna / 20b / Flash Lite / Gemma scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -320,6 +349,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, oss20) is None
         assert board.result_for(task_id, lite) is None
         assert board.result_for(task_id, gemma) is None
+        assert board.result_for(task_id, gemma26) is None
 
     # Remaining catalog peers stay empty until a real stamp lands.
     for mid in (
@@ -336,6 +366,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", oss20),
         ("afc", lite),
         ("afc", gemma),
+        ("afc", gemma26),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -368,6 +399,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_20b)
     assert pel.has_recorded_partial(afc_lite)
     assert pel.has_recorded_partial(afc_gemma)
+    assert pel.has_recorded_partial(afc_gemma26)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -376,6 +408,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "openai/gpt-oss-20b"),
     ("afc", "google/gemini-3.5-flash-lite"),
     ("afc", "google/gemma-4-31b-it"),
+    ("afc", "google/gemma-4-26b-a4b-it"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -457,6 +490,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Gemini 3.8 Flash" in partial
     assert "Gemini 3.5 Flash Lite" in partial
     assert "Gemma 4 31B" in partial
+    assert "Gemma 4 26B A4B" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -464,6 +498,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "S=585 R=—" in partial
     assert "S=68 R=—" in partial
     assert "S=0 R=—" in partial
+    assert "S=0 R=65" in partial
     assert "no ratio" in partial
     assert "data-partial-score=\"0." not in partial
 
@@ -502,10 +537,12 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "S=585 R=—" in partial_text
     assert "S=68 R=—" in partial_text
     assert "S=0 R=—" in partial_text
+    assert "S=0 R=65" in partial_text
     assert "GPT-5.6 Luna" in partial_text
     assert "GPT-OSS 20B" in partial_text
     assert "Gemini 3.5 Flash Lite" in partial_text
     assert "Gemma 4 31B" in partial_text
+    assert "Gemma 4 26B A4B" in partial_text
     assert "no ratio" in partial_text
 
 

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -118,6 +118,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "upstage/solar-pro4",
         "ibm-granite/granite-4.2-8b",
         "mistralai/mistral-small-2603",
+        "bytedance-seed/seed-2.0-mini",
     }
 
 
@@ -143,6 +144,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     solar = "upstage/solar-pro4"
     granite = "ibm-granite/granite-4.2-8b"
     mistral = "mistralai/mistral-small-2603"
+    seed_mini = "bytedance-seed/seed-2.0-mini"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -741,6 +743,41 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert board.not_happy_count(mistral) == 1
     assert board.blocked_count(mistral) == 0
 
+    # Twentieth catalog AFC stamp (Scrolly headed 20260912-0610).
+    afc_seed = board.result_for("afc", seed_mini)
+    assert afc_seed is not None
+    assert afc_seed.product_bar == "NOT_HAPPY"
+    assert afc_seed.oracle == "FAIL"
+    assert afc_seed.stamp == "20260912-0610-seed-2.0-mini"
+    assert afc_seed.oracle_passed is False
+    assert afc_seed.oracle_failure_count == 2
+    assert afc_seed.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+        "husk-dominated Sample (1/1 scored cells)",
+    )
+    assert afc_seed.oracle_check_count is None
+    assert afc_seed.partial_score is None
+    assert afc_seed.afc_s_flags == 0
+    assert afc_seed.afc_r_required is None
+    assert afc_seed.husk_cells == 1
+    assert afc_seed.scored_cells == 1
+    assert afc_seed.input_tokens == 24059
+    assert afc_seed.output_tokens == 14342
+    assert afc_seed.total_tokens == 38401
+    assert afc_seed.wall_time_s == 131
+    assert afc_seed.total_cost_usd == pytest.approx(0.00814)
+    assert afc_seed.intelligence_per_dollar is None
+    assert "20260912-0610-seed-2.0-mini" in afc_seed.oracle_note
+    assert "0.00814" in afc_seed.oracle_note
+    assert "71640e30" in afc_seed.oracle_note
+    assert "n=2" in afc_seed.oracle_note
+    assert "Err:501" in afc_seed.oracle_note
+    assert 'husk-dominated Sample (1/1 scored cells)' in afc_seed.oracle_note
+    assert pel.has_recorded_partial(afc_seed)
+    assert board.scored_count(seed_mini) == 1
+    assert board.not_happy_count(seed_mini) == 1
+    assert board.blocked_count(seed_mini) == 0
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -770,6 +807,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, solar) is None
         assert board.result_for(task_id, granite) is None
         assert board.result_for(task_id, mistral) is None
+        assert board.result_for(task_id, seed_mini) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -792,6 +830,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", solar),
         ("afc", granite),
         ("afc", mistral),
+        ("afc", seed_mini),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -841,6 +880,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_glm_flash)
     assert pel.has_recorded_partial(afc_granite)
     assert pel.has_recorded_partial(afc_mistral)
+    assert pel.has_recorded_partial(afc_seed)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -863,6 +903,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "upstage/solar-pro4"),
     ("afc", "ibm-granite/granite-4.2-8b"),
     ("afc", "mistralai/mistral-small-2603"),
+    ("afc", "bytedance-seed/seed-2.0-mini"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -942,6 +983,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Solar Pro 4" in heatmap
     assert "Granite 4.2 8B" in heatmap
     assert "Mistral Small 4" in heatmap
+    assert "Seed 2.0 Mini" in heatmap
     assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
     assert "data-cost-usd=\"0.004680\"" in cost
     assert "Mercury 2.5 Preview" in cost
@@ -965,6 +1007,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "GLM 5.3 Flash" in partial
     assert "Granite 4.2 8B" in partial
     assert "Mistral Small 4" in partial
+    assert "Seed 2.0 Mini" in partial
     assert "Solar Pro 4" not in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
@@ -1004,6 +1047,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Solar Pro 4" in heat
     assert "Granite 4.2 8B" in heat
     assert "Mistral Small 4" in heat
+    assert "Seed 2.0 Mini" in heat
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
     assert pel.COST_NAME != "pareto-fronts.svg"
@@ -1040,6 +1084,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "GLM 5.3 Flash" in partial_text
     assert "Granite 4.2 8B" in partial_text
     assert "Mistral Small 4" in partial_text
+    assert "Seed 2.0 Mini" in partial_text
     assert "Solar Pro 4" not in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -161,9 +161,34 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     ):
         assert board.result_for(task_id, gemini) is None
 
-    # No invented gpt-oss scores for Gemini-only Writer/AFC stamps.
-    for task_id in ("tenant-retention", "cadaver-proposal", "afc"):
+    # No invented gpt-oss scores for Gemini-only Writer stamps.
+    for task_id in ("tenant-retention", "cadaver-proposal"):
         assert board.result_for(task_id, oss) is None
+
+    # First catalog AFC stamp (Scrolly headed 20260912-0142).
+    afc_oss = board.result_for("afc", oss)
+    assert afc_oss is not None
+    assert afc_oss.product_bar == "NOT_HAPPY"
+    assert afc_oss.oracle == "FAIL"
+    assert afc_oss.stamp == "20260912-0142-gpt-oss-120b"
+    assert afc_oss.oracle_passed is False
+    assert afc_oss.oracle_failure_count == 1
+    assert afc_oss.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_oss.oracle_check_count is None
+    assert afc_oss.partial_score is None
+    assert afc_oss.afc_s_flags == 585
+    assert afc_oss.afc_r_required is None
+    assert afc_oss.husk_cells == 0
+    assert afc_oss.scored_cells == 15159
+    assert afc_oss.input_tokens == 108266
+    assert afc_oss.output_tokens == 6994
+    assert afc_oss.total_tokens == 115260
+    assert afc_oss.wall_time_s == 1290
+    assert afc_oss.total_cost_usd == pytest.approx(0.0052)
+    assert afc_oss.intelligence_per_dollar is None
+    assert "20260912-0142-gpt-oss-120b" in afc_oss.oracle_note
 
     # Catalog peers stay empty until a real stamp lands.
     for mid in (
@@ -174,8 +199,10 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.scored_count(mid) == 0
         assert board.happy_count(mid) == 0
 
-    # Seed must not invent run costs or oracle-partial counts.
+    # Other seed cells must not invent run costs or oracle-partial counts.
     for row in board.results:
+        if row.task_id == "afc" and row.model == oss:
+            continue
         assert row.total_tokens is None
         assert row.input_tokens is None
         assert row.output_tokens is None
@@ -199,6 +226,27 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     afc = board.result_for("afc", gemini)
     assert afc is not None
     assert pel.has_recorded_partial(afc)
+    assert pel.has_recorded_partial(afc_oss)
+
+
+_RECORDED_AFC_OSS = ("afc", "openai/gpt-oss-120b")
+_OPTIONAL_COST_PARTIAL_KEYS = (
+    "total_tokens",
+    "input_tokens",
+    "output_tokens",
+    "total_cost_usd",
+    "wall_time_s",
+    "intelligence_per_dollar",
+    "oracle_passed",
+    "oracle_failure_count",
+    "oracle_check_count",
+    "oracle_failures",
+    "afc_s_flags",
+    "afc_r_required",
+    "husk_cells",
+    "scored_cells",
+    "partial_score",
+)
 
 
 def test_every_seed_source_points_at_an_in_repo_doc() -> None:
@@ -210,23 +258,9 @@ def test_every_seed_source_points_at_an_in_repo_doc() -> None:
         path = _REPO / first
         assert path.is_file(), first
         assert row.get("run_artifacts_committed") is False
-        for key in (
-            "total_tokens",
-            "input_tokens",
-            "output_tokens",
-            "total_cost_usd",
-            "wall_time_s",
-            "intelligence_per_dollar",
-            "oracle_passed",
-            "oracle_failure_count",
-            "oracle_check_count",
-            "oracle_failures",
-            "afc_s_flags",
-            "afc_r_required",
-            "husk_cells",
-            "scored_cells",
-            "partial_score",
-        ):
+        if (row.get("task_id"), row.get("model")) == _RECORDED_AFC_OSS:
+            continue
+        for key in _OPTIONAL_COST_PARTIAL_KEYS:
             assert key not in row or row[key] is None, row
 
 
@@ -270,11 +304,15 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "0 HAPPY / 0 scored" in coverage
     assert "No HAPPY cell has recorded total_cost_usd yet" in cost
     assert "data-cost-usd=" not in cost
-    # Seed has one oracle PASS (AFC) → partial 1; no invented FAIL ratios.
+    # Seed has one oracle PASS (AFC Gemini) → partial 1. Catalog AFC 120b
+    # recorded S/R + failure_count without a check-count ratio.
     assert "data-partial-score=\"1.00\"" in partial
     assert "Gemini 3.8 Flash" in partial
     assert "AFC Population" in partial
-    assert "S=" not in partial
+    assert "GPT-OSS 120B" in partial
+    assert "S=585 R=—" in partial
+    assert "no ratio" in partial
+    assert "data-partial-score=\"0." not in partial
 
 
 def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> None:
@@ -308,6 +346,8 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     partial_text = partial_svg.read_text(encoding="utf-8")
     assert 'data-partial-score="1.00"' in partial_text
     assert "0.50" not in partial_text
+    assert "S=585 R=—" in partial_text
+    assert "no ratio" in partial_text
 
 
 def test_cli_check_and_refuse_string_harness_json(

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -111,6 +111,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "meta/muse-spark-1.3-contributor",
         "poolside/laguna-s-2.1",
         "poolside/laguna-xs-2.1",
+        "qwen/qwen3.8-27b",
     }
 
 
@@ -130,6 +131,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     spark = "meta/muse-spark-1.3-contributor"
     laguna = "poolside/laguna-s-2.1"
     laguna_xs = "poolside/laguna-xs-2.1"
+    qwen27 = "qwen/qwen3.8-27b"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -539,6 +541,36 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "6c6017b7" in afc_laguna_xs.oracle_note
     assert "Sample_Size_Calculation" in afc_laguna_xs.oracle_note
 
+    # Fourteenth catalog AFC stamp (Scrolly headed 20260912-0443).
+    afc_qwen27 = board.result_for("afc", qwen27)
+    assert afc_qwen27 is not None
+    assert afc_qwen27.product_bar == "NOT_HAPPY"
+    assert afc_qwen27.oracle == "FAIL"
+    assert afc_qwen27.stamp == "20260912-0443-qwen3.8-27b"
+    assert afc_qwen27.oracle_passed is False
+    assert afc_qwen27.oracle_failure_count == 2
+    assert afc_qwen27.oracle_failures == (
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'",
+    )
+    assert afc_qwen27.oracle_check_count is None
+    assert afc_qwen27.partial_score is None
+    assert afc_qwen27.afc_s_flags == 0
+    assert afc_qwen27.afc_r_required is None
+    assert afc_qwen27.husk_cells == 0
+    assert afc_qwen27.scored_cells == 0
+    assert afc_qwen27.input_tokens == 2695380
+    assert afc_qwen27.output_tokens == 67284
+    assert afc_qwen27.total_tokens == 2762664
+    assert afc_qwen27.wall_time_s == 720
+    assert afc_qwen27.total_cost_usd == pytest.approx(1.42823)
+    assert afc_qwen27.intelligence_per_dollar is None
+    assert "20260912-0443-qwen3.8-27b" in afc_qwen27.oracle_note
+    assert "1.31711" in afc_qwen27.oracle_note
+    assert "6c6017b7" in afc_qwen27.oracle_note
+    assert "finish_reason=tool_calls" in afc_qwen27.oracle_note
+    assert "n=51" in afc_qwen27.oracle_note
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -562,6 +594,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, spark) is None
         assert board.result_for(task_id, laguna) is None
         assert board.result_for(task_id, laguna_xs) is None
+        assert board.result_for(task_id, qwen27) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -578,6 +611,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", spark),
         ("afc", laguna),
         ("afc", laguna_xs),
+        ("afc", qwen27),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -622,6 +656,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_spark)
     assert pel.has_recorded_partial(afc_laguna)
     assert pel.has_recorded_partial(afc_laguna_xs)
+    assert pel.has_recorded_partial(afc_qwen27)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -638,6 +673,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "meta/muse-spark-1.3-contributor"),
     ("afc", "poolside/laguna-s-2.1"),
     ("afc", "poolside/laguna-xs-2.1"),
+    ("afc", "qwen/qwen3.8-27b"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -730,6 +766,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Muse Spark 1.3" in partial
     assert "Laguna S 2.1" in partial
     assert "Laguna XS 2.1" in partial
+    assert "Qwen3.8 27B" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -794,6 +831,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Muse Spark 1.3" in partial_text
     assert "Laguna S 2.1" in partial_text
     assert "Laguna XS 2.1" in partial_text
+    assert "Qwen3.8 27B" in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -102,6 +102,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "openai/gpt-5.6-luna",
         "openai/gpt-oss-20b",
         "google/gemini-3.5-flash-lite",
+        "google/gemma-4-31b-it",
         "x-ai/grok-4.6",
         "meta/muse-spark-1.3-contributor",
     }
@@ -114,6 +115,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     luna = "openai/gpt-5.6-luna"
     oss20 = "openai/gpt-oss-20b"
     lite = "google/gemini-3.5-flash-lite"
+    gemma = "google/gemma-4-31b-it"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -276,7 +278,34 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "Required Sar" in afc_lite.oracle_note
     assert "73" in afc_lite.oracle_note
 
-    # No invented Luna / 20b / Flash Lite scores outside AFC.
+    # Fifth catalog AFC stamp (Scrolly headed 20260912-0224).
+    afc_gemma = board.result_for("afc", gemma)
+    assert afc_gemma is not None
+    assert afc_gemma.product_bar == "NOT_HAPPY"
+    assert afc_gemma.oracle == "FAIL"
+    assert afc_gemma.stamp == "20260912-0224-gemma-4-31b-it"
+    assert afc_gemma.oracle_passed is False
+    assert afc_gemma.oracle_failure_count == 1
+    assert afc_gemma.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_gemma.oracle_check_count is None
+    assert afc_gemma.partial_score is None
+    assert afc_gemma.afc_s_flags == 0
+    assert afc_gemma.afc_r_required is None
+    assert afc_gemma.husk_cells == 81
+    assert afc_gemma.scored_cells == 810
+    assert afc_gemma.input_tokens == 146941
+    assert afc_gemma.output_tokens == 2394
+    assert afc_gemma.total_tokens == 149335
+    assert afc_gemma.wall_time_s == 392
+    assert afc_gemma.total_cost_usd == pytest.approx(0.10841)
+    assert afc_gemma.intelligence_per_dollar is None
+    assert "20260912-0224-gemma-4-31b-it" in afc_gemma.oracle_note
+    assert "0.01404" in afc_gemma.oracle_note
+    assert "Err:508" in afc_gemma.oracle_note
+
+    # No invented Luna / 20b / Flash Lite / Gemma scores outside AFC.
     for task_id in (
         "tenant-retention",
         "cadaver-proposal",
@@ -290,6 +319,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, luna) is None
         assert board.result_for(task_id, oss20) is None
         assert board.result_for(task_id, lite) is None
+        assert board.result_for(task_id, gemma) is None
 
     # Remaining catalog peers stay empty until a real stamp lands.
     for mid in (
@@ -300,7 +330,13 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.happy_count(mid) == 0
 
     # Other seed cells must not invent run costs or oracle-partial counts.
-    recorded_afc = {("afc", oss), ("afc", luna), ("afc", oss20), ("afc", lite)}
+    recorded_afc = {
+        ("afc", oss),
+        ("afc", luna),
+        ("afc", oss20),
+        ("afc", lite),
+        ("afc", gemma),
+    }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
             continue
@@ -331,6 +367,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_luna)
     assert pel.has_recorded_partial(afc_20b)
     assert pel.has_recorded_partial(afc_lite)
+    assert pel.has_recorded_partial(afc_gemma)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -338,6 +375,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "openai/gpt-5.6-luna"),
     ("afc", "openai/gpt-oss-20b"),
     ("afc", "google/gemini-3.5-flash-lite"),
+    ("afc", "google/gemma-4-31b-it"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -418,6 +456,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "data-partial-score=\"1.00\"" in partial
     assert "Gemini 3.8 Flash" in partial
     assert "Gemini 3.5 Flash Lite" in partial
+    assert "Gemma 4 31B" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -466,6 +505,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "GPT-5.6 Luna" in partial_text
     assert "GPT-OSS 20B" in partial_text
     assert "Gemini 3.5 Flash Lite" in partial_text
+    assert "Gemma 4 31B" in partial_text
     assert "no ratio" in partial_text
 
 

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -121,6 +121,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "bytedance-seed/seed-2.0-mini",
         "minimax/minimax-m3",
         "deepseek/deepseek-v4-flash-0731",
+        "deepseek/deepseek-v4.1-flash",
     }
 
 
@@ -149,6 +150,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     seed_mini = "bytedance-seed/seed-2.0-mini"
     minimax = "minimax/minimax-m3"
     deepseek = "deepseek/deepseek-v4-flash-0731"
+    deepseek41 = "deepseek/deepseek-v4.1-flash"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -851,6 +853,43 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert board.not_happy_count(deepseek) == 1
     assert board.blocked_count(deepseek) == 0
 
+    # Twenty-third catalog AFC stamp — FIFO tail (Scrolly headed 20260912-0630).
+    afc_deepseek41 = board.result_for("afc", deepseek41)
+    assert afc_deepseek41 is not None
+    assert afc_deepseek41.product_bar == "NOT_HAPPY"
+    assert afc_deepseek41.product_bar != "BLOCKED"
+    assert afc_deepseek41.oracle == "FAIL"
+    assert afc_deepseek41.stamp == "20260912-0630-deepseek-v4.1-flash"
+    assert afc_deepseek41.oracle_passed is False
+    assert afc_deepseek41.oracle_failure_count == 2
+    assert afc_deepseek41.oracle_failures == (
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'",
+    )
+    assert afc_deepseek41.oracle_check_count is None
+    assert afc_deepseek41.partial_score is None
+    assert afc_deepseek41.afc_s_flags == 0
+    assert afc_deepseek41.afc_r_required is None
+    assert afc_deepseek41.husk_cells == 0
+    assert afc_deepseek41.scored_cells == 0
+    assert afc_deepseek41.input_tokens == 55652
+    assert afc_deepseek41.output_tokens == 3474
+    assert afc_deepseek41.total_tokens == 59126
+    assert afc_deepseek41.wall_time_s == 270
+    assert afc_deepseek41.total_cost_usd == pytest.approx(0.01832)
+    assert afc_deepseek41.intelligence_per_dollar is None
+    assert "20260912-0630-deepseek-v4.1-flash" in afc_deepseek41.oracle_note
+    assert "0.01043" in afc_deepseek41.oracle_note
+    assert "71640e30" in afc_deepseek41.oracle_note
+    assert "n=5" in afc_deepseek41.oracle_note
+    assert "read_cell_range" in afc_deepseek41.oracle_note
+    assert "NetworkError" in afc_deepseek41.oracle_note
+    assert "CATALOG FIFO COMPLETE" in afc_deepseek41.oracle_note
+    assert pel.has_recorded_partial(afc_deepseek41)
+    assert board.scored_count(deepseek41) == 1
+    assert board.not_happy_count(deepseek41) == 1
+    assert board.blocked_count(deepseek41) == 0
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -883,6 +922,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, seed_mini) is None
         assert board.result_for(task_id, minimax) is None
         assert board.result_for(task_id, deepseek) is None
+        assert board.result_for(task_id, deepseek41) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -908,6 +948,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", seed_mini),
         ("afc", minimax),
         ("afc", deepseek),
+        ("afc", deepseek41),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -960,6 +1001,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_seed)
     assert pel.has_recorded_partial(afc_minimax)
     assert pel.has_recorded_partial(afc_deepseek)
+    assert pel.has_recorded_partial(afc_deepseek41)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -985,6 +1027,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "bytedance-seed/seed-2.0-mini"),
     ("afc", "minimax/minimax-m3"),
     ("afc", "deepseek/deepseek-v4-flash-0731"),
+    ("afc", "deepseek/deepseek-v4.1-flash"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -1067,6 +1110,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Seed 2.0 Mini" in heatmap
     assert "MiniMax M3" in heatmap
     assert "DeepSeek V4 Flash 0731" in heatmap
+    assert "DeepSeek V4.1 Flash" in heatmap
     assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
     assert "data-cost-usd=\"0.004680\"" in cost
     assert "Mercury 2.5 Preview" in cost
@@ -1093,6 +1137,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Seed 2.0 Mini" in partial
     assert "MiniMax M3" in partial
     assert "DeepSeek V4 Flash 0731" in partial
+    assert "DeepSeek V4.1 Flash" in partial
     assert "Solar Pro 4" not in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
@@ -1135,6 +1180,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Seed 2.0 Mini" in heat
     assert "MiniMax M3" in heat
     assert "DeepSeek V4 Flash 0731" in heat
+    assert "DeepSeek V4.1 Flash" in heat
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
     assert pel.COST_NAME != "pareto-fronts.svg"
@@ -1174,6 +1220,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Seed 2.0 Mini" in partial_text
     assert "MiniMax M3" in partial_text
     assert "DeepSeek V4 Flash 0731" in partial_text
+    assert "DeepSeek V4.1 Flash" in partial_text
     assert "Solar Pro 4" not in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -107,6 +107,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "nvidia/nemotron-3.5-lightning",
         "inception/mercury-2.5-preview",
         "x-ai/grok-4.6",
+        "meta/muse-glimmer-30b",
         "meta/muse-spark-1.3-contributor",
     }
 
@@ -123,6 +124,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     nemo = "nvidia/nemotron-3.5-lightning"
     mercury = "inception/mercury-2.5-preview"
     grok = "x-ai/grok-4.6"
+    glimmer = "meta/muse-glimmer-30b"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -421,7 +423,35 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "0.05831" in afc_grok.oracle_note
     assert "SSC present" in afc_grok.oracle_note
 
-    # No invented Luna / 20b / Flash Lite / Gemma / Nemotron / Mercury / Grok scores outside AFC.
+    # Tenth catalog AFC stamp (Scrolly headed 20260912-0353).
+    afc_glimmer = board.result_for("afc", glimmer)
+    assert afc_glimmer is not None
+    assert afc_glimmer.product_bar == "NOT_HAPPY"
+    assert afc_glimmer.oracle == "FAIL"
+    assert afc_glimmer.stamp == "20260912-0353-muse-glimmer-30b"
+    assert afc_glimmer.oracle_passed is False
+    assert afc_glimmer.oracle_failure_count == 1
+    assert afc_glimmer.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_glimmer.oracle_check_count is None
+    assert afc_glimmer.partial_score is None
+    assert afc_glimmer.afc_s_flags == 0
+    assert afc_glimmer.afc_r_required is None
+    assert afc_glimmer.husk_cells == 0
+    assert afc_glimmer.scored_cells == 729
+    assert afc_glimmer.input_tokens == 2143441
+    assert afc_glimmer.output_tokens == 16060
+    assert afc_glimmer.total_tokens == 2159501
+    assert afc_glimmer.wall_time_s == 155
+    assert afc_glimmer.total_cost_usd == pytest.approx(0.15404)
+    assert afc_glimmer.intelligence_per_dollar is None
+    assert "20260912-0353-muse-glimmer-30b" in afc_glimmer.oracle_note
+    assert "0.66230" in afc_glimmer.oracle_note
+    assert "e0bb6321" in afc_glimmer.oracle_note
+    assert "50 tool" in afc_glimmer.oracle_note
+
+    # No invented Luna / 20b / Flash Lite / Gemma / Nemotron / Mercury / Grok / Glimmer scores outside AFC.
     for task_id in (
         "tenant-retention",
         "cadaver-proposal",
@@ -440,6 +470,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, nemo) is None
         assert board.result_for(task_id, mercury) is None
         assert board.result_for(task_id, grok) is None
+        assert board.result_for(task_id, glimmer) is None
 
     # Remaining catalog peers stay empty until a real stamp lands.
     assert board.scored_count("meta/muse-spark-1.3-contributor") == 0
@@ -456,6 +487,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", nemo),
         ("afc", mercury),
         ("afc", grok),
+        ("afc", glimmer),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -496,6 +528,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_nemo)
     assert pel.has_recorded_partial(afc_mercury)
     assert pel.has_recorded_partial(afc_grok)
+    assert pel.has_recorded_partial(afc_glimmer)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -508,6 +541,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "nvidia/nemotron-3.5-lightning"),
     ("afc", "inception/mercury-2.5-preview"),
     ("afc", "x-ai/grok-4.6"),
+    ("afc", "meta/muse-glimmer-30b"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -596,6 +630,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Nemotron 3.5 Lightning" in partial
     assert "Mercury 2.5 Preview" in partial
     assert "Grok 4.6" in partial
+    assert "Muse Glimmer 30B" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -655,6 +690,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Nemotron 3.5 Lightning" in partial_text
     assert "Mercury 2.5 Preview" in partial_text
     assert "Grok 4.6" in partial_text
+    assert "Muse Glimmer 30B" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text
     assert "no ratio" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -101,6 +101,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "openai/gpt-oss-120b",
         "openai/gpt-5.6-luna",
         "openai/gpt-oss-20b",
+        "google/gemini-3.5-flash-lite",
         "x-ai/grok-4.6",
         "meta/muse-spark-1.3-contributor",
     }
@@ -112,6 +113,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     oss = "openai/gpt-oss-120b"
     luna = "openai/gpt-5.6-luna"
     oss20 = "openai/gpt-oss-20b"
+    lite = "google/gemini-3.5-flash-lite"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -246,7 +248,35 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "0.00049" in afc_20b.oracle_note
     assert "nitro" in afc_20b.oracle_note.lower()
 
-    # No invented Luna / 20b scores outside AFC.
+    # Fourth catalog AFC stamp (Scrolly headed 20260912-0216).
+    afc_lite = board.result_for("afc", lite)
+    assert afc_lite is not None
+    assert afc_lite.product_bar == "NOT_HAPPY"
+    assert afc_lite.oracle == "FAIL"
+    assert afc_lite.stamp == "20260912-0216-gemini-3.5-flash-lite"
+    assert afc_lite.oracle_passed is False
+    assert afc_lite.oracle_failure_count == 1
+    assert afc_lite.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_lite.oracle_check_count is None
+    assert afc_lite.partial_score is None
+    assert afc_lite.afc_s_flags == 0
+    assert afc_lite.afc_r_required is None
+    assert afc_lite.husk_cells == 0
+    assert afc_lite.scored_cells == 648
+    assert afc_lite.input_tokens == 26111
+    assert afc_lite.output_tokens == 150
+    assert afc_lite.total_tokens == 26261
+    assert afc_lite.wall_time_s == 338
+    assert afc_lite.total_cost_usd == pytest.approx(0.00629)
+    assert afc_lite.intelligence_per_dollar is None
+    assert "20260912-0216-gemini-3.5-flash-lite" in afc_lite.oracle_note
+    assert "0.00821" in afc_lite.oracle_note
+    assert "Required Sar" in afc_lite.oracle_note
+    assert "73" in afc_lite.oracle_note
+
+    # No invented Luna / 20b / Flash Lite scores outside AFC.
     for task_id in (
         "tenant-retention",
         "cadaver-proposal",
@@ -259,6 +289,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     ):
         assert board.result_for(task_id, luna) is None
         assert board.result_for(task_id, oss20) is None
+        assert board.result_for(task_id, lite) is None
 
     # Remaining catalog peers stay empty until a real stamp lands.
     for mid in (
@@ -269,7 +300,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.happy_count(mid) == 0
 
     # Other seed cells must not invent run costs or oracle-partial counts.
-    recorded_afc = {("afc", oss), ("afc", luna), ("afc", oss20)}
+    recorded_afc = {("afc", oss), ("afc", luna), ("afc", oss20), ("afc", lite)}
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
             continue
@@ -299,12 +330,14 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_oss)
     assert pel.has_recorded_partial(afc_luna)
     assert pel.has_recorded_partial(afc_20b)
+    assert pel.has_recorded_partial(afc_lite)
 
 
 _RECORDED_AFC_CATALOG = {
     ("afc", "openai/gpt-oss-120b"),
     ("afc", "openai/gpt-5.6-luna"),
     ("afc", "openai/gpt-oss-20b"),
+    ("afc", "google/gemini-3.5-flash-lite"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -380,10 +413,11 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "0 HAPPY / 0 scored" in coverage
     assert "No HAPPY cell has recorded total_cost_usd yet" in cost
     assert "data-cost-usd=" not in cost
-    # Seed has one oracle PASS (AFC Gemini) → partial 1. Catalog AFC
-    # 120b / Luna / 20b recorded S/R + failure_count without a check-count ratio.
+    # Seed has one oracle PASS (AFC Gemini 3.8) → partial 1. Catalog AFC
+    # cells recorded S/R + failure_count without a check-count ratio.
     assert "data-partial-score=\"1.00\"" in partial
     assert "Gemini 3.8 Flash" in partial
+    assert "Gemini 3.5 Flash Lite" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -431,6 +465,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "S=0 R=—" in partial_text
     assert "GPT-5.6 Luna" in partial_text
     assert "GPT-OSS 20B" in partial_text
+    assert "Gemini 3.5 Flash Lite" in partial_text
     assert "no ratio" in partial_text
 
 

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -111,6 +111,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     gemini = "google/gemini-3.8-flash"
     oss = "openai/gpt-oss-120b"
     luna = "openai/gpt-5.6-luna"
+    oss20 = "openai/gpt-oss-20b"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -218,7 +219,34 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "20260912-0150-gpt-5.6-luna" in afc_luna.oracle_note
     assert "0.1252" in afc_luna.oracle_note
 
-    # No invented Luna scores outside AFC.
+    # Third catalog AFC stamp (Scrolly headed 20260912-0202, :nitro).
+    afc_20b = board.result_for("afc", oss20)
+    assert afc_20b is not None
+    assert afc_20b.product_bar == "NOT_HAPPY"
+    assert afc_20b.oracle == "FAIL"
+    assert afc_20b.stamp == "20260912-0202-gpt-oss-20b-nitro"
+    assert afc_20b.oracle_passed is False
+    assert afc_20b.oracle_failure_count == 1
+    assert afc_20b.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_20b.oracle_check_count is None
+    assert afc_20b.partial_score is None
+    assert afc_20b.afc_s_flags == 0
+    assert afc_20b.afc_r_required is None
+    assert afc_20b.husk_cells == 0
+    assert afc_20b.scored_cells == 800
+    assert afc_20b.input_tokens == 15316
+    assert afc_20b.output_tokens == 236
+    assert afc_20b.total_tokens == 15552
+    assert afc_20b.wall_time_s == 309
+    assert afc_20b.total_cost_usd == pytest.approx(0.00122)
+    assert afc_20b.intelligence_per_dollar is None
+    assert "20260912-0202-gpt-oss-20b-nitro" in afc_20b.oracle_note
+    assert "0.00049" in afc_20b.oracle_note
+    assert "nitro" in afc_20b.oracle_note.lower()
+
+    # No invented Luna / 20b scores outside AFC.
     for task_id in (
         "tenant-retention",
         "cadaver-proposal",
@@ -230,10 +258,10 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         "long-writer-pack",
     ):
         assert board.result_for(task_id, luna) is None
+        assert board.result_for(task_id, oss20) is None
 
-    # Catalog peers stay empty until a real stamp lands.
+    # Remaining catalog peers stay empty until a real stamp lands.
     for mid in (
-        "openai/gpt-oss-20b",
         "x-ai/grok-4.6",
         "meta/muse-spark-1.3-contributor",
     ):
@@ -241,7 +269,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.happy_count(mid) == 0
 
     # Other seed cells must not invent run costs or oracle-partial counts.
-    recorded_afc = {( "afc", oss), ("afc", luna)}
+    recorded_afc = {("afc", oss), ("afc", luna), ("afc", oss20)}
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
             continue
@@ -270,11 +298,13 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc)
     assert pel.has_recorded_partial(afc_oss)
     assert pel.has_recorded_partial(afc_luna)
+    assert pel.has_recorded_partial(afc_20b)
 
 
 _RECORDED_AFC_CATALOG = {
     ("afc", "openai/gpt-oss-120b"),
     ("afc", "openai/gpt-5.6-luna"),
+    ("afc", "openai/gpt-oss-20b"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -351,14 +381,16 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "No HAPPY cell has recorded total_cost_usd yet" in cost
     assert "data-cost-usd=" not in cost
     # Seed has one oracle PASS (AFC Gemini) → partial 1. Catalog AFC
-    # 120b / Luna recorded S/R + failure_count without a check-count ratio.
+    # 120b / Luna / 20b recorded S/R + failure_count without a check-count ratio.
     assert "data-partial-score=\"1.00\"" in partial
     assert "Gemini 3.8 Flash" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
+    assert "GPT-OSS 20B" in partial
     assert "S=585 R=—" in partial
     assert "S=68 R=—" in partial
+    assert "S=0 R=—" in partial
     assert "no ratio" in partial
     assert "data-partial-score=\"0." not in partial
 
@@ -396,7 +428,9 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "0.50" not in partial_text
     assert "S=585 R=—" in partial_text
     assert "S=68 R=—" in partial_text
+    assert "S=0 R=—" in partial_text
     assert "GPT-5.6 Luna" in partial_text
+    assert "GPT-OSS 20B" in partial_text
     assert "no ratio" in partial_text
 
 

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -110,6 +110,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "meta/muse-glimmer-30b",
         "meta/muse-spark-1.3-contributor",
         "poolside/laguna-s-2.1",
+        "poolside/laguna-xs-2.1",
     }
 
 
@@ -128,6 +129,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     glimmer = "meta/muse-glimmer-30b"
     spark = "meta/muse-spark-1.3-contributor"
     laguna = "poolside/laguna-s-2.1"
+    laguna_xs = "poolside/laguna-xs-2.1"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -508,6 +510,35 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "6c6017b7" in afc_laguna.oracle_note
     assert "finish_reason=length" in afc_laguna.oracle_note
 
+    # Thirteenth catalog AFC stamp (Scrolly headed 20260912-0429).
+    afc_laguna_xs = board.result_for("afc", laguna_xs)
+    assert afc_laguna_xs is not None
+    assert afc_laguna_xs.product_bar == "NOT_HAPPY"
+    assert afc_laguna_xs.oracle == "FAIL"
+    assert afc_laguna_xs.stamp == "20260912-0429-laguna-xs-2.1"
+    assert afc_laguna_xs.oracle_passed is False
+    assert afc_laguna_xs.oracle_failure_count == 2
+    assert afc_laguna_xs.oracle_failures == (
+        "missing sheet 'Sample Size Calculation'",
+        "Sample has no data rows",
+    )
+    assert afc_laguna_xs.oracle_check_count is None
+    assert afc_laguna_xs.partial_score is None
+    assert afc_laguna_xs.afc_s_flags == 0
+    assert afc_laguna_xs.afc_r_required is None
+    assert afc_laguna_xs.husk_cells == 0
+    assert afc_laguna_xs.scored_cells == 0
+    assert afc_laguna_xs.input_tokens == 1280356
+    assert afc_laguna_xs.output_tokens == 10168
+    assert afc_laguna_xs.total_tokens == 1290524
+    assert afc_laguna_xs.wall_time_s == 85
+    assert afc_laguna_xs.total_cost_usd == pytest.approx(0.04341)
+    assert afc_laguna_xs.intelligence_per_dollar is None
+    assert "20260912-0429-laguna-xs-2.1" in afc_laguna_xs.oracle_note
+    assert "0.07804" in afc_laguna_xs.oracle_note
+    assert "6c6017b7" in afc_laguna_xs.oracle_note
+    assert "Sample_Size_Calculation" in afc_laguna_xs.oracle_note
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -530,6 +561,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, glimmer) is None
         assert board.result_for(task_id, spark) is None
         assert board.result_for(task_id, laguna) is None
+        assert board.result_for(task_id, laguna_xs) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -545,6 +577,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", glimmer),
         ("afc", spark),
         ("afc", laguna),
+        ("afc", laguna_xs),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -588,6 +621,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_glimmer)
     assert pel.has_recorded_partial(afc_spark)
     assert pel.has_recorded_partial(afc_laguna)
+    assert pel.has_recorded_partial(afc_laguna_xs)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -603,6 +637,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "meta/muse-glimmer-30b"),
     ("afc", "meta/muse-spark-1.3-contributor"),
     ("afc", "poolside/laguna-s-2.1"),
+    ("afc", "poolside/laguna-xs-2.1"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -694,6 +729,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Muse Glimmer 30B" in partial
     assert "Muse Spark 1.3" in partial
     assert "Laguna S 2.1" in partial
+    assert "Laguna XS 2.1" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -757,6 +793,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Muse Glimmer 30B" in partial_text
     assert "Muse Spark 1.3" in partial_text
     assert "Laguna S 2.1" in partial_text
+    assert "Laguna XS 2.1" in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -112,6 +112,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "poolside/laguna-s-2.1",
         "poolside/laguna-xs-2.1",
         "qwen/qwen3.8-27b",
+        "qwen/qwen3.8-flash",
     }
 
 
@@ -132,6 +133,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     laguna = "poolside/laguna-s-2.1"
     laguna_xs = "poolside/laguna-xs-2.1"
     qwen27 = "qwen/qwen3.8-27b"
+    qwen_flash = "qwen/qwen3.8-flash"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -571,6 +573,35 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "finish_reason=tool_calls" in afc_qwen27.oracle_note
     assert "n=51" in afc_qwen27.oracle_note
 
+    # Fifteenth catalog AFC stamp (Scrolly headed 20260912-0502).
+    afc_qwen_flash = board.result_for("afc", qwen_flash)
+    assert afc_qwen_flash is not None
+    assert afc_qwen_flash.product_bar == "NOT_HAPPY"
+    assert afc_qwen_flash.oracle == "FAIL"
+    assert afc_qwen_flash.stamp == "20260912-0502-qwen3.8-flash"
+    assert afc_qwen_flash.oracle_passed is False
+    assert afc_qwen_flash.oracle_failure_count == 1
+    assert afc_qwen_flash.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_qwen_flash.oracle_check_count is None
+    assert afc_qwen_flash.partial_score is None
+    assert afc_qwen_flash.afc_s_flags == 68
+    assert afc_qwen_flash.afc_r_required is None
+    assert afc_qwen_flash.husk_cells == 0
+    assert afc_qwen_flash.scored_cells == 680
+    assert afc_qwen_flash.input_tokens == 2194886
+    assert afc_qwen_flash.output_tokens == 49253
+    assert afc_qwen_flash.total_tokens == 2244139
+    assert afc_qwen_flash.wall_time_s == 540
+    assert afc_qwen_flash.total_cost_usd == pytest.approx(0.11382)
+    assert afc_qwen_flash.intelligence_per_dollar is None
+    assert "20260912-0502-qwen3.8-flash" in afc_qwen_flash.oracle_note
+    assert "0.35238" in afc_qwen_flash.oracle_note
+    assert "6c6017b7" in afc_qwen_flash.oracle_note
+    assert "Err:508" in afc_qwen_flash.oracle_note
+    assert "n=51" in afc_qwen_flash.oracle_note
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -595,6 +626,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, laguna) is None
         assert board.result_for(task_id, laguna_xs) is None
         assert board.result_for(task_id, qwen27) is None
+        assert board.result_for(task_id, qwen_flash) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -612,6 +644,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", laguna),
         ("afc", laguna_xs),
         ("afc", qwen27),
+        ("afc", qwen_flash),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -657,6 +690,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_laguna)
     assert pel.has_recorded_partial(afc_laguna_xs)
     assert pel.has_recorded_partial(afc_qwen27)
+    assert pel.has_recorded_partial(afc_qwen_flash)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -674,6 +708,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "poolside/laguna-s-2.1"),
     ("afc", "poolside/laguna-xs-2.1"),
     ("afc", "qwen/qwen3.8-27b"),
+    ("afc", "qwen/qwen3.8-flash"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -767,6 +802,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Laguna S 2.1" in partial
     assert "Laguna XS 2.1" in partial
     assert "Qwen3.8 27B" in partial
+    assert "Qwen3.8 Flash" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -832,6 +868,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Laguna S 2.1" in partial_text
     assert "Laguna XS 2.1" in partial_text
     assert "Qwen3.8 27B" in partial_text
+    assert "Qwen3.8 Flash" in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -99,6 +99,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
     assert {model.openrouter_id for model in board.models} >= {
         "google/gemini-3.8-flash",
         "openai/gpt-oss-120b",
+        "openai/gpt-5.6-luna",
         "openai/gpt-oss-20b",
         "x-ai/grok-4.6",
         "meta/muse-spark-1.3-contributor",
@@ -109,6 +110,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     board = pel.load_eval2_board(_RESULTS)
     gemini = "google/gemini-3.8-flash"
     oss = "openai/gpt-oss-120b"
+    luna = "openai/gpt-5.6-luna"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -190,6 +192,45 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert afc_oss.intelligence_per_dollar is None
     assert "20260912-0142-gpt-oss-120b" in afc_oss.oracle_note
 
+    # Second catalog AFC stamp (Scrolly headed 20260912-0150).
+    afc_luna = board.result_for("afc", luna)
+    assert afc_luna is not None
+    assert afc_luna.product_bar == "NOT_HAPPY"
+    assert afc_luna.oracle == "FAIL"
+    assert afc_luna.stamp == "20260912-0150-gpt-5.6-luna"
+    assert afc_luna.oracle_passed is False
+    assert afc_luna.oracle_failure_count == 1
+    assert afc_luna.oracle_failures == (
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_luna.oracle_check_count is None
+    assert afc_luna.partial_score is None
+    assert afc_luna.afc_s_flags == 68
+    assert afc_luna.afc_r_required is None
+    assert afc_luna.husk_cells == 0
+    assert afc_luna.scored_cells == 810
+    assert afc_luna.input_tokens == 562909
+    assert afc_luna.output_tokens == 10467
+    assert afc_luna.total_tokens == 573376
+    assert afc_luna.wall_time_s == 406
+    assert afc_luna.total_cost_usd == pytest.approx(0.0419)
+    assert afc_luna.intelligence_per_dollar is None
+    assert "20260912-0150-gpt-5.6-luna" in afc_luna.oracle_note
+    assert "0.1252" in afc_luna.oracle_note
+
+    # No invented Luna scores outside AFC.
+    for task_id in (
+        "tenant-retention",
+        "cadaver-proposal",
+        "gmp-change-control",
+        "writer-calc-peer-write",
+        "calc-primary-model",
+        "draw-primary",
+        "reverse-tenant",
+        "long-writer-pack",
+    ):
+        assert board.result_for(task_id, luna) is None
+
     # Catalog peers stay empty until a real stamp lands.
     for mid in (
         "openai/gpt-oss-20b",
@@ -200,8 +241,9 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.happy_count(mid) == 0
 
     # Other seed cells must not invent run costs or oracle-partial counts.
+    recorded_afc = {( "afc", oss), ("afc", luna)}
     for row in board.results:
-        if row.task_id == "afc" and row.model == oss:
+        if (row.task_id, row.model) in recorded_afc:
             continue
         assert row.total_tokens is None
         assert row.input_tokens is None
@@ -227,9 +269,13 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert afc is not None
     assert pel.has_recorded_partial(afc)
     assert pel.has_recorded_partial(afc_oss)
+    assert pel.has_recorded_partial(afc_luna)
 
 
-_RECORDED_AFC_OSS = ("afc", "openai/gpt-oss-120b")
+_RECORDED_AFC_CATALOG = {
+    ("afc", "openai/gpt-oss-120b"),
+    ("afc", "openai/gpt-5.6-luna"),
+}
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
     "input_tokens",
@@ -258,7 +304,7 @@ def test_every_seed_source_points_at_an_in_repo_doc() -> None:
         path = _REPO / first
         assert path.is_file(), first
         assert row.get("run_artifacts_committed") is False
-        if (row.get("task_id"), row.get("model")) == _RECORDED_AFC_OSS:
+        if (row.get("task_id"), row.get("model")) in _RECORDED_AFC_CATALOG:
             continue
         for key in _OPTIONAL_COST_PARTIAL_KEYS:
             assert key not in row or row[key] is None, row
@@ -304,13 +350,15 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "0 HAPPY / 0 scored" in coverage
     assert "No HAPPY cell has recorded total_cost_usd yet" in cost
     assert "data-cost-usd=" not in cost
-    # Seed has one oracle PASS (AFC Gemini) → partial 1. Catalog AFC 120b
-    # recorded S/R + failure_count without a check-count ratio.
+    # Seed has one oracle PASS (AFC Gemini) → partial 1. Catalog AFC
+    # 120b / Luna recorded S/R + failure_count without a check-count ratio.
     assert "data-partial-score=\"1.00\"" in partial
     assert "Gemini 3.8 Flash" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
+    assert "GPT-5.6 Luna" in partial
     assert "S=585 R=—" in partial
+    assert "S=68 R=—" in partial
     assert "no ratio" in partial
     assert "data-partial-score=\"0." not in partial
 
@@ -347,6 +395,8 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert 'data-partial-score="1.00"' in partial_text
     assert "0.50" not in partial_text
     assert "S=585 R=—" in partial_text
+    assert "S=68 R=—" in partial_text
+    assert "GPT-5.6 Luna" in partial_text
     assert "no ratio" in partial_text
 
 

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -72,6 +72,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
     assert (_REPO / board.source_of_truth).is_file()
     schema = json.loads(_SCHEMA.read_text(encoding="utf-8"))
     assert schema["properties"]["schema_version"]["const"] == 1
+    assert "BLOCKED" in schema["$defs"]["product_bar"]["enum"]
     assert "hard_pass_rate" not in schema["properties"]
     assert "hard_pass_rate" not in schema["$defs"]["result"]["properties"]
     result_props = schema["$defs"]["result"]["properties"]
@@ -114,6 +115,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "qwen/qwen3.8-27b",
         "qwen/qwen3.8-flash",
         "z-ai/glm-5.3-flash",
+        "upstage/solar-pro4",
     }
 
 
@@ -136,6 +138,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     qwen27 = "qwen/qwen3.8-27b"
     qwen_flash = "qwen/qwen3.8-flash"
     glm_flash = "z-ai/glm-5.3-flash"
+    solar = "upstage/solar-pro4"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -635,6 +638,37 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "n=1" in afc_glm_flash.oracle_note
     assert "15160" in afc_glm_flash.oracle_note
 
+    # Seventeenth catalog AFC stamp — infra BLOCKED, not a model fail.
+    afc_solar = board.result_for("afc", solar)
+    assert afc_solar is not None
+    assert afc_solar.product_bar == "BLOCKED"
+    assert afc_solar.product_bar != "NOT_HAPPY"
+    assert afc_solar.oracle is None
+    assert afc_solar.stamp == "20260912-0522-solar-pro4"
+    assert afc_solar.oracle_passed is None
+    assert afc_solar.oracle_failure_count is None
+    assert afc_solar.oracle_failures is None
+    assert afc_solar.oracle_check_count is None
+    assert afc_solar.partial_score is None
+    assert afc_solar.afc_s_flags is None
+    assert afc_solar.afc_r_required is None
+    assert afc_solar.husk_cells is None
+    assert afc_solar.scored_cells is None
+    assert afc_solar.input_tokens == 0
+    assert afc_solar.output_tokens == 0
+    assert afc_solar.total_tokens == 0
+    assert afc_solar.wall_time_s == 1080
+    assert afc_solar.total_cost_usd == pytest.approx(0.0)
+    assert afc_solar.intelligence_per_dollar is None
+    assert "20260912-0522-solar-pro4" in afc_solar.oracle_note
+    assert "message_store" in afc_solar.oracle_note
+    assert "6c6017b7" in afc_solar.oracle_note
+    assert pel.cell_label(afc_solar) == "BLOCKED / unscored"
+    assert not pel.has_recorded_partial(afc_solar)
+    assert board.scored_count(solar) == 0
+    assert board.blocked_count(solar) == 1
+    assert board.not_happy_count(solar) == 0
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -661,6 +695,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, qwen27) is None
         assert board.result_for(task_id, qwen_flash) is None
         assert board.result_for(task_id, glm_flash) is None
+        assert board.result_for(task_id, solar) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -680,6 +715,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", qwen27),
         ("afc", qwen_flash),
         ("afc", glm_flash),
+        ("afc", solar),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -746,6 +782,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "qwen/qwen3.8-27b"),
     ("afc", "qwen/qwen3.8-flash"),
     ("afc", "z-ai/glm-5.3-flash"),
+    ("afc", "upstage/solar-pro4"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -820,6 +857,9 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "HAPPY" in heatmap
     assert "0 HAPPY / 1 scored" in coverage
     assert "1 HAPPY / 1 scored" in coverage
+    assert "0 HAPPY / 0 scored" in coverage
+    assert "BLOCKED" in heatmap
+    assert "Solar Pro 4" in heatmap
     assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
     assert "data-cost-usd=\"0.004680\"" in cost
     assert "Mercury 2.5 Preview" in cost
@@ -841,6 +881,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Qwen3.8 27B" in partial
     assert "Qwen3.8 Flash" in partial
     assert "GLM 5.3 Flash" in partial
+    assert "Solar Pro 4" not in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -874,6 +915,9 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "no data" in cov
     assert "0 HAPPY / 1 scored" in cov
     assert "1 HAPPY / 1 scored" in cov
+    assert "0 HAPPY / 0 scored" in cov
+    assert "BLOCKED" in heat
+    assert "Solar Pro 4" in heat
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
     assert pel.COST_NAME != "pareto-fronts.svg"
@@ -908,6 +952,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Qwen3.8 27B" in partial_text
     assert "Qwen3.8 Flash" in partial_text
     assert "GLM 5.3 Flash" in partial_text
+    assert "Solar Pro 4" not in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text
     assert "2/—" in partial_text

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -104,6 +104,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "google/gemini-3.5-flash-lite",
         "google/gemma-4-31b-it",
         "google/gemma-4-26b-a4b-it",
+        "nvidia/nemotron-3.5-lightning",
         "x-ai/grok-4.6",
         "meta/muse-spark-1.3-contributor",
     }
@@ -118,6 +119,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     lite = "google/gemini-3.5-flash-lite"
     gemma = "google/gemma-4-31b-it"
     gemma26 = "google/gemma-4-26b-a4b-it"
+    nemo = "nvidia/nemotron-3.5-lightning"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -334,7 +336,36 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert "0.05011" in afc_gemma26.oracle_note
     assert "10 <<" in afc_gemma26.oracle_note or "sample_data_rows=10" in afc_gemma26.oracle_note
 
-    # No invented Luna / 20b / Flash Lite / Gemma scores outside AFC.
+    # Seventh catalog AFC stamp (Scrolly headed 20260912-0310).
+    afc_nemo = board.result_for("afc", nemo)
+    assert afc_nemo is not None
+    assert afc_nemo.product_bar == "NOT_HAPPY"
+    assert afc_nemo.oracle == "FAIL"
+    assert afc_nemo.stamp == "20260912-0310-nemotron-3.5-lightning"
+    assert afc_nemo.oracle_passed is False
+    assert afc_nemo.oracle_failure_count == 2
+    assert afc_nemo.oracle_failures == (
+        "missing sheet 'Sample'",
+        "missing sheet 'Sample Size Calculation'",
+    )
+    assert afc_nemo.oracle_check_count is None
+    assert afc_nemo.partial_score is None
+    assert afc_nemo.afc_s_flags == 0
+    assert afc_nemo.afc_r_required is None
+    assert afc_nemo.husk_cells == 0
+    assert afc_nemo.scored_cells == 0
+    assert afc_nemo.input_tokens == 760171
+    assert afc_nemo.output_tokens == 3189
+    assert afc_nemo.total_tokens == 763360
+    assert afc_nemo.wall_time_s == 540
+    assert afc_nemo.total_cost_usd == pytest.approx(0.04282)
+    assert afc_nemo.intelligence_per_dollar is None
+    assert "20260912-0310-nemotron-3.5-lightning" in afc_nemo.oracle_note
+    assert "0.06145" in afc_nemo.oracle_note
+    assert "second-send" in afc_nemo.oracle_note
+    assert "Err:507" in afc_nemo.oracle_note
+
+    # No invented Luna / 20b / Flash Lite / Gemma / Nemotron scores outside AFC.
     for task_id in (
         "tenant-retention",
         "cadaver-proposal",
@@ -350,6 +381,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, lite) is None
         assert board.result_for(task_id, gemma) is None
         assert board.result_for(task_id, gemma26) is None
+        assert board.result_for(task_id, nemo) is None
 
     # Remaining catalog peers stay empty until a real stamp lands.
     for mid in (
@@ -367,6 +399,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", lite),
         ("afc", gemma),
         ("afc", gemma26),
+        ("afc", nemo),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -400,6 +433,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_lite)
     assert pel.has_recorded_partial(afc_gemma)
     assert pel.has_recorded_partial(afc_gemma26)
+    assert pel.has_recorded_partial(afc_nemo)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -409,6 +443,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "google/gemini-3.5-flash-lite"),
     ("afc", "google/gemma-4-31b-it"),
     ("afc", "google/gemma-4-26b-a4b-it"),
+    ("afc", "nvidia/nemotron-3.5-lightning"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -491,6 +526,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Gemini 3.5 Flash Lite" in partial
     assert "Gemma 4 31B" in partial
     assert "Gemma 4 26B A4B" in partial
+    assert "Nemotron 3.5 Lightning" in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
     assert "GPT-5.6 Luna" in partial
@@ -499,6 +535,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "S=68 R=—" in partial
     assert "S=0 R=—" in partial
     assert "S=0 R=65" in partial
+    assert "2/—" in partial
     assert "no ratio" in partial
     assert "data-partial-score=\"0." not in partial
 
@@ -543,6 +580,8 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Gemini 3.5 Flash Lite" in partial_text
     assert "Gemma 4 31B" in partial_text
     assert "Gemma 4 26B A4B" in partial_text
+    assert "Nemotron 3.5 Lightning" in partial_text
+    assert "2/—" in partial_text
     assert "no ratio" in partial_text
 
 

--- a/tests/scripts/test_plot_eval2_leaderboard.py
+++ b/tests/scripts/test_plot_eval2_leaderboard.py
@@ -116,6 +116,7 @@ def test_seed_json_loads_and_matches_schema_enums() -> None:
         "qwen/qwen3.8-flash",
         "z-ai/glm-5.3-flash",
         "upstage/solar-pro4",
+        "ibm-granite/granite-4.2-8b",
     }
 
 
@@ -139,6 +140,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     qwen_flash = "qwen/qwen3.8-flash"
     glm_flash = "z-ai/glm-5.3-flash"
     solar = "upstage/solar-pro4"
+    granite = "ibm-granite/granite-4.2-8b"
 
     tenant = board.result_for("tenant-retention", gemini)
     assert tenant is not None
@@ -669,6 +671,41 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert board.blocked_count(solar) == 1
     assert board.not_happy_count(solar) == 0
 
+    # Eighteenth catalog AFC stamp (Scrolly headed 20260912-0546).
+    afc_granite = board.result_for("afc", granite)
+    assert afc_granite is not None
+    assert afc_granite.product_bar == "NOT_HAPPY"
+    assert afc_granite.oracle == "FAIL"
+    assert afc_granite.stamp == "20260912-0546-granite-4.2-8b"
+    assert afc_granite.oracle_passed is False
+    assert afc_granite.oracle_failure_count == 2
+    assert afc_granite.oracle_failures == (
+        "Sample has no data rows",
+        "R from Sample Size Calculation is missing or < 1",
+    )
+    assert afc_granite.oracle_check_count is None
+    assert afc_granite.partial_score is None
+    assert afc_granite.afc_s_flags == 0
+    assert afc_granite.afc_r_required is None
+    assert afc_granite.husk_cells == 0
+    assert afc_granite.scored_cells == 0
+    assert afc_granite.input_tokens == 2359996
+    assert afc_granite.output_tokens == 64282
+    assert afc_granite.total_tokens == 2424278
+    assert afc_granite.wall_time_s == 840
+    assert afc_granite.total_cost_usd == pytest.approx(0.14353)
+    assert afc_granite.intelligence_per_dollar is None
+    assert "20260912-0546-granite-4.2-8b" in afc_granite.oracle_note
+    assert "0.24564" in afc_granite.oracle_note
+    assert "71640e30" in afc_granite.oracle_note
+    assert "read_cell_range" in afc_granite.oracle_note
+    assert "n=48" in afc_granite.oracle_note
+    assert "finish_reason=tool_calls" in afc_granite.oracle_note
+    assert pel.has_recorded_partial(afc_granite)
+    assert board.scored_count(granite) == 1
+    assert board.not_happy_count(granite) == 1
+    assert board.blocked_count(granite) == 0
+
     # No invented catalog AFC-only scores outside AFC.
     for task_id in (
         "tenant-retention",
@@ -696,6 +733,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         assert board.result_for(task_id, qwen_flash) is None
         assert board.result_for(task_id, glm_flash) is None
         assert board.result_for(task_id, solar) is None
+        assert board.result_for(task_id, granite) is None
 
     # Other seed cells must not invent run costs or oracle-partial counts.
     recorded_afc = {
@@ -716,6 +754,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
         ("afc", qwen_flash),
         ("afc", glm_flash),
         ("afc", solar),
+        ("afc", granite),
     }
     for row in board.results:
         if (row.task_id, row.model) in recorded_afc:
@@ -763,6 +802,7 @@ def test_seed_cells_match_autopsy_and_leave_unknowns_empty() -> None:
     assert pel.has_recorded_partial(afc_qwen27)
     assert pel.has_recorded_partial(afc_qwen_flash)
     assert pel.has_recorded_partial(afc_glm_flash)
+    assert pel.has_recorded_partial(afc_granite)
 
 
 _RECORDED_AFC_CATALOG = {
@@ -783,6 +823,7 @@ _RECORDED_AFC_CATALOG = {
     ("afc", "qwen/qwen3.8-flash"),
     ("afc", "z-ai/glm-5.3-flash"),
     ("afc", "upstage/solar-pro4"),
+    ("afc", "ibm-granite/granite-4.2-8b"),
 }
 _OPTIONAL_COST_PARTIAL_KEYS = (
     "total_tokens",
@@ -860,6 +901,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "0 HAPPY / 0 scored" in coverage
     assert "BLOCKED" in heatmap
     assert "Solar Pro 4" in heatmap
+    assert "Granite 4.2 8B" in heatmap
     assert "No HAPPY cell has recorded total_cost_usd yet" not in cost
     assert "data-cost-usd=\"0.004680\"" in cost
     assert "Mercury 2.5 Preview" in cost
@@ -881,6 +923,7 @@ def test_scoreboard_markdown_matches_seed_matrix() -> None:
     assert "Qwen3.8 27B" in partial
     assert "Qwen3.8 Flash" in partial
     assert "GLM 5.3 Flash" in partial
+    assert "Granite 4.2 8B" in partial
     assert "Solar Pro 4" not in partial
     assert "AFC Population" in partial
     assert "GPT-OSS 120B" in partial
@@ -918,6 +961,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "0 HAPPY / 0 scored" in cov
     assert "BLOCKED" in heat
     assert "Solar Pro 4" in heat
+    assert "Granite 4.2 8B" in heat
     assert pel.HEATMAP_NAME != "pareto-fronts.svg"
     assert pel.COVERAGE_NAME != "pareto-distance.svg"
     assert pel.COST_NAME != "pareto-fronts.svg"
@@ -952,6 +996,7 @@ def test_plot_writes_distinct_svgs_with_honest_empty_cells(tmp_path: Path) -> No
     assert "Qwen3.8 27B" in partial_text
     assert "Qwen3.8 Flash" in partial_text
     assert "GLM 5.3 Flash" in partial_text
+    assert "Granite 4.2 8B" in partial_text
     assert "Solar Pro 4" not in partial_text
     assert "S=0 R=66" in partial_text
     assert "S=494 R=68" in partial_text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

AFC catalog FIFO is **complete** (oss-120b through DeepSeek V4.1 Flash) on the eval-2 headed scoreboard. Same branch for the whole sweep. No invented scores. The nine-task headed sweep has **not** happened.

This PR is a **merge candidate once CI is green**.

**Mercury 2.5 Preview** remains the only non-gate catalog HAPPY / oracle PASS and the only HAPPY cost-chart bar ($0.00468 → C²/$ ≈ 213.68). **Solar Pro 4** remains BLOCKED / unscored. **DeepSeek V4 Flash 0731** is still present (empty Sample + blank SSC). **DeepSeek V4.1 Flash** is the FIFO tail: NOT_HAPPY (API timed out mid `tool_loop`; Send ran; leftover workbook scored), oracle FAIL (missing Sample + SSC).

`--check`: 32 scored cells, 1 blocked.

| Model | Stamp | Bar / oracle | S / R / husks | rows | USD (OR) | notes |
|---|---|---|---|---|---|---|
| `openai/gpt-oss-120b` (`:nitro`) | `20260912-0142-gpt-oss-120b` | NOT_HAPPY / FAIL | 585 / — / 0 of 15159 | 1516 | 0.0052 | near-full dump |
| `openai/gpt-5.6-luna` | `20260912-0150-gpt-5.6-luna` | NOT_HAPPY / FAIL | 68 / — / 0 of 810 | 81 | 0.0419 | best incomplete shape |
| `openai/gpt-oss-20b` (`:nitro` → bare) | `20260912-0202-gpt-oss-20b-nitro` | NOT_HAPPY / FAIL | 0 / — / 0 of 800 | 80 | 0.00122 | S=0 |
| `google/gemini-3.5-flash-lite` | `20260912-0216-gemini-3.5-flash-lite` | NOT_HAPPY / FAIL | 0 / — / 0 of 648 | 81 | 0.00629 | attempt1 nitro abort |
| `google/gemma-4-31b-it` | `20260912-0224-gemma-4-31b-it` | NOT_HAPPY / FAIL | 0 / — / 81 of 810 | 81 | 0.10841 | SSC Err:508/#NAME? |
| `google/gemma-4-26b-a4b-it` | `20260912-0240-gemma-4-26b-a4b-it` | NOT_HAPPY / FAIL | 0 / 65 / 0 of 70 | 10 | 0.04316 | first catalog R=65 |
| `nvidia/nemotron-3.5-lightning` | `20260912-0310-nemotron-3.5-lightning` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.04282 | missing Sample+SSC |
| `inception/mercury-2.5-preview` | `20260912-0330-mercury-2.5-preview` | **HAPPY / PASS** | 494 / 68 / 2 of 16680 | 1518 | 0.00468 | first catalog HAPPY |
| `x-ai/grok-4.6` | `20260912-0342-grok-4.6` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.02375 | SSC present; Sample empty |
| `meta/muse-glimmer-30b` | `20260912-0353-muse-glimmer-30b` | NOT_HAPPY / FAIL | 0 / — / 0 of 729 | 81 | 0.15404 | B9 visually 65; max 50 tool rounds |
| `meta/muse-spark-1.3-contributor` | `20260912-0409-muse-spark-1.3-contributor` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.00157 | SSC present; Sample empty |
| `poolside/laguna-s-2.1` | `20260912-0419-laguna-s-2.1` | NOT_HAPPY / FAIL | 0 / 66 / 0 of 0 | 0 | 0.01480 | missing Sample; R=66 |
| `poolside/laguna-xs-2.1` | `20260912-0429-laguna-xs-2.1` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.04341 | SSC tab renamed; Sample empty |
| `qwen/qwen3.8-27b` | `20260912-0443-qwen3.8-27b` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 1.42823 | missing Sample+SSC; =PY on Population |
| `qwen/qwen3.8-flash` | `20260912-0502-qwen3.8-flash` | NOT_HAPPY / FAIL | 68 / — / 0 of 680 | 68 | 0.11382 | Luna-like Sample; SSC errors |
| `z-ai/glm-5.3-flash` | `20260912-0515-glm-5.3-flash` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.00900 | hung round 0; no tools; n=1 |
| `upstage/solar-pro4` | `20260912-0522-solar-pro4` | **BLOCKED / unscored** | — | — | 0 | Send never ran; sqlite `message_store` |
| `ibm-granite/granite-4.2-8b` | `20260912-0546-granite-4.2-8b` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.14353 | hung round 46 on `read_cell_range` |
| `mistralai/mistral-small-2603` | `20260912-0603-mistral-small-2603` | NOT_HAPPY / FAIL | 0 / — / 0 of 648 | 81 | 0.00973 | Ready Sample+SSC; R missing; S=0 |
| `bytedance-seed/seed-2.0-mini` | `20260912-0610-seed-2.0-mini` | NOT_HAPPY / FAIL | 0 / — / 1 of 1 | 1 | 0.00814 | first husk-dominated Sample |
| `minimax/minimax-m3` | `20260912-0617-minimax-m3` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.07965 | Ready; missing Sample+SSC |
| `deepseek/deepseek-v4-flash-0731` | `20260912-0621-deepseek-v4-flash-0731` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.17007 | empty Sample; blank SSC; PreContract 18; n=51 |
| `deepseek/deepseek-v4.1-flash` | `20260912-0630-deepseek-v4.1-flash` | NOT_HAPPY / FAIL | 0 / — / 0 of 0 | 0 | 0.01832 | **FIFO tail.** API timed out mid `read_cell_range`; missing Sample+SSC; n=5 |

[Eval-2 heatmap with DeepSeek V4.1 Flash FIFO tail](https://cursor.com/agents/bc-a97947fe-fb84-4977-aa4a-5fd91ec2a509/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feval2-heatmap-deepseek-v4.1-flash.svg)
[Eval-2 coverage including DeepSeek V4.1 Flash](https://cursor.com/agents/bc-a97947fe-fb84-4977-aa4a-5fd91ec2a509/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feval2-coverage-deepseek-v4.1-flash.svg)
[Eval-2 partial ranking including DeepSeek V4.1 Flash](https://cursor.com/agents/bc-a97947fe-fb84-4977-aa4a-5fd91ec2a509/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feval2-partial-deepseek-v4.1-flash.svg)

## Test plan

- `tests/scripts/test_plot_eval2_leaderboard.py`
- `make typecheck`
- `.venv/bin/python scripts/plot_eval2_leaderboard.py --check --print-matrix`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a97947fe-fb84-4977-aa4a-5fd91ec2a509?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a97947fe-fb84-4977-aa4a-5fd91ec2a509&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

