### PR TITLE
Harness: skip Hidden _blank factory after Windows system bitmap

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -288,6 +288,7 @@ POSIX still `close_doc`. Breadcrumbs:
 `create_native_doc: windows factory leftover_open=N url=… target=… flags=…`,
 `native_doc: leftover notebook host reuse`,
 `windows leftover skip: leftover simpress leftovers=`,
+`windows hidden skip: create_native_doc Hidden _blank after system bitmap`,
 `create_native_doc: load start/done` (leftover Windows factory),
 `document_research_uno: store budget via active start/done`,
 `document_research_uno: open_document_for_read start/done`,
@@ -412,6 +413,18 @@ After a Windows bitmap, later Hidden sibling opens
 `skip_windows_hidden_open_after_bitmap` — do not hang. Still attempt
 the first Hidden-open. Not a product change.
 
+GHA 34670295632 (PR #742, `f278ca78`): leftover Impress skip is not
+that hang. `document_research_uno` Hidden `Budget_read.ods` bitmap-failed;
+#734 skipped later siblings (`windows hidden skip: document_research
+Hidden Budget_read after system bitmap`, suite 3/3). Next suite
+`text_helpers` printed `native_doc: leftover writer reuse` then
+`create_native_doc leftover_open=0 url=private:factory/swriter
+target=_blank flags=0` and hung 30s. After bitmap, Hidden `_blank`
+factory is unsafe. `create_native_doc` now skips Hidden `_blank`
+(`windows hidden skip: create_native_doc Hidden _blank after system
+bitmap`). Named leftover factories (`_wa_factory` / `_wa_scalc` /
+`_wa_sdraw` / `_wa_simpress`) still load. Not a product change.
+
 GHA 34657826349 / 34657808315 (master `0bf7d223`, tip of #734):
 #734's Hidden-open skip is not that hang. `document_research_uno`
 3/3 and both text_helpers tests OK. Leftover Draw/Impress unique
@@ -457,7 +470,10 @@ swriter loads using `target=_wa_factory` (not `_blank` / not
 `create budget calc` / no leftover `scalc` `target=_wa_factory_1`),
 `copied budget for hidden open` then `open_document_for_read done err=-`
 or `windows hidden bitmap` / Hidden-open `TEST end … SKIP` after
-system bitmap (no 30s hang on the next sibling open) **before**
+system bitmap (no 30s hang on the next sibling open) **or**
+text_helpers `TEST end … SKIP` with
+`windows hidden skip: create_native_doc Hidden _blank after system
+bitmap` (no 30s Timeout on leftover_open=0 `target=_blank`) **before**
 `html_paste_writer: noted leftover_open` (formulas / rich_html are
 deferred),
 `create_native_doc: load done`, `native_doc: leftover writer reuse` and

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -811,6 +811,49 @@ def test_skip_windows_leftover_hidden_load_noop_without_leftovers(monkeypatch):
         tu._set_windows_leftover_open(saved)
 
 
+def test_create_native_doc_windows_skips_hidden_blank_after_bitmap(monkeypatch):
+    """GHA 34670295632: after Budget_read bitmap, Hidden _blank hung 30s.
+
+    #734 skipped later document_research Hidden siblings. Next suite
+    text_helpers leftover writer reuse then leftover_open=0
+    target=_blank hung. Skip Hidden _blank after bitmap; named leftover
+    factories still load.
+    """
+    import unittest
+    from unittest.mock import MagicMock, patch
+
+    from plugin.tests.testing_utils import TestingFactory
+    import plugin.tests.testing_utils as tu
+
+    desktop = MagicMock()
+    desktop.loadComponentFromURL.return_value = MagicMock()
+    saved_bitmap = tu._WINDOWS_HIDDEN_OPEN_BITMAP
+    monkeypatch.setattr(tu.sys, "platform", "win32")
+    tu._set_windows_hidden_open_bitmap(True)
+    try:
+        with (
+            patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
+            patch("uno.createUnoStruct", return_value=MagicMock()),
+            patch("plugin.testing_runner.probe_uno_bridge", return_value="alive"),
+        ):
+            monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 0)
+            try:
+                TestingFactory.create_native_doc(object(), "writer")
+            except unittest.SkipTest as exc:
+                assert "Hidden _blank" in str(exc)
+                assert "system bitmap" in str(exc)
+            else:
+                raise AssertionError("expected SkipTest")
+            desktop.loadComponentFromURL.assert_not_called()
+            monkeypatch.setattr(tu, "prepare_windows_writer_factory", lambda _ctx: 2)
+            TestingFactory.create_native_doc(object(), "writer")
+            args = desktop.loadComponentFromURL.call_args.args
+            assert args[0] == "private:factory/swriter"
+            assert args[1] == "_wa_factory"
+    finally:
+        tu._set_windows_hidden_open_bitmap(saved_bitmap)
+
+
 def test_windows_hidden_open_bitmap_err_and_skip(monkeypatch):
     """GHA 34655847157: leftover_open=0 Hidden Budget_read bitmap then hang."""
     import unittest

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1330,6 +1330,12 @@ def skip_windows_hidden_open_after_bitmap(reason: str) -> None:
     Hidden ``Budget_read.ods`` bitmap-failed; the next
     ``open_document_for_read`` hung 30s. Attempt the first Hidden-open
     (34652644656 was 3/3). After bitmap, skip — do not hang.
+
+    GHA 34670295632 (PR #742): #734 skipped later document_research
+    Hidden siblings. Next suite ``text_helpers`` leftover writer reuse
+    then Hidden ``_blank`` (leftover_open=0) hung 30s. ``create_native_doc``
+    also skips Hidden ``_blank`` after bitmap. Named leftover factories
+    still load.
     """
     if not _windows_hidden_open_bitmap():
         return
@@ -2150,6 +2156,16 @@ class TestingFactory:
             # when leftover Writer count is high — leftover swriter at
             # leftover_open=15 returned.
             skip_windows_cross_app_factory(factory_url, leftover_open)
+            # GHA 34670295632 (PR #742): #734 skipped later
+            # document_research Hidden siblings after Budget_read
+            # bitmap. Next suite text_helpers leftover writer reuse
+            # then Hidden _blank (leftover_open=0) hung 30s. After
+            # bitmap, Hidden _blank is unsafe. Named leftover
+            # factories still load.
+            if target == "_blank":
+                skip_windows_hidden_open_after_bitmap(
+                    "create_native_doc Hidden _blank"
+                )
 
         # Distinguish "bridge already dead" (previous test) from "died during load".
         pre_open = probe_uno_bridge(ctx)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #742. Windows `workflow_dispatch` [34670295632](https://github.com/KeithCu/writeragent/actions/runs/34670295632) (`ci_debug=true`) hung before leftover Impress ran.

## Why

#734 already skips later `document_research` Hidden siblings after `Budget_read.ods` raises `Could not create system bitmap!`. That suite ended 3/3 with skips. The next suite (`text_helpers`) then:

```
native_doc: leftover writer reuse
create_native_doc: leftover_open=0 url=private:factory/swriter target=_blank flags=0
Timeout (0:00:30)!
```

#742’s leftover-Impress skip never ran. After a Windows system bitmap, Hidden `_blank` factory is unsafe. Do not close leftover paste / leftover notebook Writers.

## Change

`create_native_doc` calls `skip_windows_hidden_open_after_bitmap` when the Windows factory target is `_blank` after a recorded system bitmap (`windows hidden skip: create_native_doc Hidden _blank after system bitmap`). Named leftover factories (`_wa_factory` / `_wa_scalc` / `_wa_sdraw` / `_wa_simpress`) still load.

## Tests

`tests/test_testing_utils.py` covers leftover_open=0 Hidden `_blank` skip after bitmap, and leftover_open>0 named `_wa_factory` still loads. Full file 72 passed. `make typecheck` passed.

## Windows + ci_debug proof

This cloud agent cannot run `windows-latest`. After Ubuntu PR CI is green, dispatch PR CI with:

- `os=windows-latest`
- `ci_debug=true`

Expect `windows hidden skip: create_native_doc Hidden _blank after system bitmap` after a Budget_read bitmap (no 30s Timeout on leftover_open=0 `target=_blank`), then leftover notebook host reuse and/or leftover Impress skip when leftover_open>4. Ubuntu PR CI is the automatic gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4e30aa1-e647-429e-8f7a-270ee7edaeb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4e30aa1-e647-429e-8f7a-270ee7edaeb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

