### PR TITLE
Harness: skip leftover Draw/Impress at leftover_open>2

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -14,7 +14,7 @@ Related: [archive/test_architecture_analysis.md](../archive/test_architecture_an
 |------|--------|------|-------|
 | Calc `@with_native_doc` | Yes (wipe-and-reuse pool) | Factory only on first use / dead pool | Close only if reset fails |
 | Writer `@with_native_doc` | Windows yes (leftover pool; leftover notebook host uses `_wa_notebook_host`) | Factory on first use / dead pool | `close_doc` (Windows **skips** Writer close while leftovers remain) |
-| Draw / Impress | **Never** | Factory each test (`private:factory/sdraw`); Windows **skips** leftover Draw/Impress when leftover_open>4 | `close_doc` (Windows **skips** close when the Draw still holds Math OLE) |
+| Draw / Impress | **Never** | Factory each test (`private:factory/sdraw`); Windows **skips** leftover Draw/Impress when leftover_open>2 | `close_doc` (Windows **skips** close when the Draw still holds Math OLE) |
 
 `create_native_doc` is a thin `loadComponentFromURL`. Draw tests do **not**
 share a pooled document. A keeper hidden Writer is opened once in
@@ -452,10 +452,16 @@ is **not** unique `_wa_factory_N` stacking. High leftover Writer
 count wedges a new app factory. Windows now (1) reuses leftover
 `_wa_notebook_host` so leftover_open does not climb
 (`native_doc: leftover notebook host reuse`) and (2) skips leftover
-Draw/Impress factory when leftover_open>4
+Draw/Impress factory when leftover_open>2
 (`windows leftover skip: leftover simpress leftovers=N`). Leftover
 Writer / leftover Calc still load. Do not close leftover paste /
 notebook Writers.
+
+GHA 34672065355 (master tip of #742+#743): leftover `_wa_simpress`
+at leftover_open=3 hung 30s (`test_lo_import_minimal_pptx_multi_slide`;
+leftovers uids 40/39/29 Writer leftovers from notebook/importer).
+Old max=4 only skipped leftover_open>4, so leftover_open=3 still
+loaded leftover Draw/Impress. Skip leftover_open>2.
 
 **Windows proof** still needs a `workflow_dispatch` of PR CI on the
 branch: `os=windows-latest`, `ci_debug=true`. Look for
@@ -498,7 +504,7 @@ exist (no 30s Timeout on `detect_without_filtername`), leftover
 (not `_wa_factory_10`) then
 `TEST end uno.test_ppt_master_pptx_import_uno.test_lo_import_minimal_pptx_multi_slide OK`
 or `TEST end … SKIP` with `windows leftover skip: leftover simpress`
-when leftover_open>4 (no 30s Timeout in `create_native_doc` on leftover
+when leftover_open>2 (no 30s Timeout in `create_native_doc` on leftover
 Impress), leftover notebook host using
 `native_doc: leftover notebook host reuse` (leftover_open stays low),
 **then**

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -607,9 +607,9 @@ def test_create_native_doc_windows_impress_reuses_stable_name(monkeypatch):
     returned; unique leftover simpress _wa_factory_10 hung in
     loadComponentFromURL. GHA 34661915875: leftover _wa_simpress is
     live and still hung. Consecutive leftover Hidden
-    create_native_doc(impress) at leftover_open<=4 must reuse one
+    create_native_doc(impress) at leftover_open<=2 must reuse one
     CREATE|GLOBAL name. Draw reuse uses _wa_sdraw and must not steal
-    leftover Impress.
+    leftover Impress. GHA 34672065355: leftover_open=3 hangs.
     """
     from unittest.mock import MagicMock, patch
 
@@ -623,7 +623,7 @@ def test_create_native_doc_windows_impress_reuses_stable_name(monkeypatch):
     tu._WINDOWS_FACTORY_SEQ = 0
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(
-        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 4
+        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 2
     )
     try:
         with (
@@ -665,11 +665,11 @@ def test_create_native_doc_windows_impress_reuses_stable_name(monkeypatch):
 def test_create_native_doc_windows_skips_leftover_impress_when_leftovers_high(
     monkeypatch,
 ):
-    """GHA 34661915875: leftover _wa_simpress at leftover_open=15 hung 30s.
+    """GHA 34661915875 / 34672065355: leftover _wa_simpress hung 30s.
 
     #737's stable name is live. Leftover _wa_factory swriter at
-    leftover_open=15 returned. Skip leftover Draw/Impress; leftover
-    Writer still loads.
+    leftover_open=15 returned. leftover_open=3 still hung (old max=4).
+    Skip leftover Draw/Impress; leftover Writer still loads.
     """
     import unittest
     from unittest.mock import MagicMock, patch
@@ -682,7 +682,7 @@ def test_create_native_doc_windows_skips_leftover_impress_when_leftovers_high(
     calls = []
     monkeypatch.setattr(tu.sys, "platform", "win32")
     monkeypatch.setattr(
-        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 15
+        tu, "prepare_windows_writer_factory", lambda _ctx: calls.append("prepare") or 3
     )
     with (
         patch("plugin.framework.uno_context.get_desktop", return_value=desktop),
@@ -693,7 +693,7 @@ def test_create_native_doc_windows_skips_leftover_impress_when_leftovers_high(
             TestingFactory.create_native_doc(object(), "impress")
         except unittest.SkipTest as exc:
             assert "simpress" in str(exc)
-            assert "leftovers=15" in str(exc)
+            assert "leftovers=3" in str(exc)
         else:
             raise AssertionError("expected SkipTest")
         desktop.loadComponentFromURL.assert_not_called()
@@ -711,15 +711,20 @@ def test_create_native_doc_windows_skips_leftover_impress_when_leftovers_high(
 
 
 def test_windows_cross_app_factory_unsafe_threshold(monkeypatch):
-    """Leftover Draw/Impress at leftover_open=1 succeeded (34657826349)."""
+    """Leftover Draw/Impress at leftover_open=1 succeeded (34657826349).
+
+    GHA 34672065355: leftover_open=3 hung 30s; old max=4 still loaded.
+    """
     import plugin.tests.testing_utils as tu
 
     monkeypatch.setattr(tu.sys, "platform", "win32")
     assert tu.windows_cross_app_factory_unsafe(1) is False
-    assert tu.windows_cross_app_factory_unsafe(4) is False
-    assert tu.windows_cross_app_factory_unsafe(5) is True
+    assert tu.windows_cross_app_factory_unsafe(2) is False
+    assert tu.windows_cross_app_factory_unsafe(3) is True
+    assert tu.windows_cross_app_factory_unsafe(4) is True
     assert tu.windows_cross_app_factory_unsafe(15) is True
     monkeypatch.setattr(tu.sys, "platform", "linux")
+    assert tu.windows_cross_app_factory_unsafe(3) is False
     assert tu.windows_cross_app_factory_unsafe(15) is False
     tu.skip_windows_cross_app_factory("private:factory/simpress", 15)
     tu.skip_windows_cross_app_factory("private:factory/swriter", 15)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1222,7 +1222,10 @@ def note_windows_html_paste_leftover() -> None:
 # in loadComponentFromURL. Leftover Draw/Impress unique names succeeded
 # at leftover_open=1 (34657826349). High leftover Writer count wedges
 # a new app factory — skip leftover Draw/Impress, do not close leftovers.
-_WINDOWS_CROSS_APP_LEFTOVER_MAX = 4
+# GHA 34672065355 (master #742+#743): leftover _wa_simpress hung 30s at
+# leftover_open=3 (uids 40/39/29 Writer leftovers from notebook/importer).
+# Old max=4 only skipped leftover_open>4, so leftover_open=3 still loaded.
+_WINDOWS_CROSS_APP_LEFTOVER_MAX = 2
 
 
 def windows_cross_app_factory_unsafe(leftover_open: int | None = None) -> bool:
@@ -1238,9 +1241,11 @@ def skip_windows_cross_app_factory(factory_url: str, leftover_open: int) -> None
     GHA 34661915875: leftover ``_wa_simpress`` at leftover_open=15 hung
     30s (office alive). #737's stable name is live — hang is not unique
     ``_wa_factory_N`` stacking. Leftover swriter at leftover_open=15
-    returned. Do not close leftover paste / notebook Writers
-    (34556185752 / 34646877587). Leftover Writer / leftover Calc still
-    load. Cached leftover count only.
+    returned. GHA 34672065355: leftover ``_wa_simpress`` at
+    leftover_open=3 hung 30s — skip leftover_open>2. Do not close
+    leftover paste / notebook Writers (34556185752 / 34646877587).
+    Leftover Writer / leftover Calc still load. Cached leftover count
+    only.
     """
     if factory_url not in ("private:factory/sdraw", "private:factory/simpress"):
         return
@@ -2151,10 +2156,11 @@ class TestingFactory:
                 "create_native_doc: windows factory leftover_open=%s url=%s target=%s flags=%s"
                 % (leftover_open, factory_url, target, flags)
             )
-            # GHA 34661915875: leftover _wa_simpress at leftover_open=15
-            # hung 30s. Stable name is live. Skip leftover Draw/Impress
-            # when leftover Writer count is high — leftover swriter at
-            # leftover_open=15 returned.
+            # GHA 34661915875 / 34672065355: leftover _wa_simpress hung
+            # 30s at leftover_open=15 and leftover_open=3. Stable name
+            # is live. Skip leftover Draw/Impress when leftover Writer
+            # count is >2 — leftover swriter at leftover_open=15
+            # returned.
             skip_windows_cross_app_factory(factory_url, leftover_open)
             # GHA 34670295632 (PR #742): #734 skipped later
             # document_research Hidden siblings after Budget_read


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Master Windows CI [34672065355](https://github.com/KeithCu/writeragent/actions/runs/34672065355) (tip of #742+#743) hung 30s in `create_native_doc` loading leftover `private:factory/simpress` `target=_wa_simpress` at `leftover_open=3` (`uno.test_ppt_master_pptx_import_uno.test_lo_import_minimal_pptx_multi_slide`; leftovers uids 40/39/29 from notebook/importer).

`_WINDOWS_CROSS_APP_LEFTOVER_MAX` was 4, so `skip_windows_cross_app_factory` only fired when leftover_open>4. leftover_open=3 still attempted leftover Draw/Impress and hung.

Lower the threshold to leftover_open>2. Linux is unchanged. Leftover Writer / leftover Calc still load. Do not close leftover paste / notebook Writers.

Windows proof [34673119585](https://github.com/KeithCu/writeragent/actions/runs/34673119585): leftover Impress skip fired (`windows leftover skip: leftover simpress leftovers=3`, `test_lo_import_minimal_pptx_multi_slide SKIP`). Then leftover Writer reuse + Hidden `_blank` Math `.mml` hung 30s in `convert_mathml_to_starmath` (`writer.math.test_latex_dialog_uno.test_insert_latex_math_dialog_success`). That leftover Hidden Math load is a later leftover hang, not this threshold change.

Not a product change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2faf304-ca83-48c5-a4de-b69af5bb341c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2faf304-ca83-48c5-a4de-b69af5bb341c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

