### PR TITLE
Harness: collapse leftover Hidden skip aliases; Windows CI cleanup note

### DIFF
--- a/docs/framework/uno-test-lifecycle.md
+++ b/docs/framework/uno-test-lifecycle.md
@@ -6,7 +6,9 @@
 proof that LibreOffice or WriterAgent is healthy.
 
 Related: [archive/test_architecture_analysis.md](../archive/test_architecture_analysis.md)
-(TEST start/end lines, Darwin URP abort, keeper document).
+(TEST start/end lines, Darwin URP abort, keeper document). Windows
+skip inventory (keep / simplify / delete):
+[windows-ci-harness-cleanup-note.md](windows-ci-harness-cleanup-note.md).
 
 ## What the fixture actually does
 
@@ -501,7 +503,7 @@ printed `native_doc: leftover writer reuse` and hung 30s in
 Hidden)` (office alive). XDL `LatexInputDialog` is patched — hang
 is leftover Hidden `_blank` `.mml`, not AWT TOP `createPeer` /
 `setVisible`. Converting latex-dialog UNO tests now
-`skip_windows_leftover_hidden_mathml` (`windows leftover skip: latex
+`skip_windows_leftover_hidden_load` (`windows leftover skip: latex
 dialog Hidden _blank .mml leftovers=N`).
 
 GHA 34678020608 (PR #746 tip `a9d44413`): latex converting tests
@@ -531,7 +533,7 @@ MathML leftover Hidden skips fired (suites green). Then
 "_default", Hidden)` (office alive). First leftover Hidden `_default`
 Writer + close returned; the second hung. Same leftover Hidden
 family. Apply-content UNO tests now
-`skip_windows_leftover_hidden_apply`
+`skip_windows_leftover_hidden_load`
 (`windows leftover skip: apply_document_content Hidden _default
 swriter leftovers=N`). Not a product change.
 
@@ -545,7 +547,7 @@ via `ApplyDocumentContent.execute` (office alive). Same leftover
 Hidden `_default` family as heading-rewrite `_b_uno`. Content-style
 write `_tool_ctx` plus later apply UNO files (`test_format_uno`,
 `test_track_changes_reviewable_uno`) now
-`skip_windows_leftover_hidden_apply`. Not a product change.
+`skip_windows_leftover_hidden_load`. Not a product change.
 Same run:
 `test_apply_style_known_limitation_direct_equals_old_default_uno`
 FAIL (`origin detection improved`) under leftover writer reuse;

--- a/docs/framework/windows-ci-harness-cleanup-note.md
+++ b/docs/framework/windows-ci-harness-cleanup-note.md
@@ -1,0 +1,169 @@
+# Windows CI harness cleanup note (Sep 9–12 trail)
+
+**Not a product fix.** Inventory of leftover / close / Hidden / peer
+harness on current master after #687–#746. Goal: keep what still
+earns leftover pressure; cut only aliases that add names without
+behavior. Logging stays. Do not gut a working skip without a simpler
+equivalent that still names the hang class.
+
+Hang-class breadcrumb contract lives in
+[uno-test-lifecycle.md](uno-test-lifecycle.md). This page is the
+keep / simplify / delete call, not a second GHA diary.
+
+## Hang classes (do not merge)
+
+These are different failure modes. One helper per class.
+
+| Class | Helper / mechanism | Skip log |
+|-------|--------------------|----------|
+| Leftover Writers → Hidden `_blank` / `_default` | `skip_windows_leftover_hidden_load(reason)` | `windows leftover skip: <reason>` |
+| Bitmap → later Hidden `_blank` | `skip_windows_hidden_open_after_bitmap` + `create_native_doc` `_blank` guard | `windows hidden skip:` |
+| leftover_open>2 cross-app Draw/Impress | `skip_windows_cross_app_factory` (`_WINDOWS_CROSS_APP_LEFTOVER_MAX=2`) | `windows leftover skip: leftover sdraw\|simpress` |
+| TOP `createPeer` / `setVisible` | `skip_windows_awt_top_dialog` | `windows awt skip:` |
+
+Leftover Hidden skip is leftover_open>0. Bitmap skip is leftover_open=0
+after a system-bitmap fail. AWT TOP skip is win32 headless VCL, leftover
+not required. Cross-app skip is leftover Draw/Impress factory only;
+leftover Writer / leftover Calc still load.
+
+## Keep as-is
+
+Each item has a named GHA hang. Closing leftovers or merging classes
+reopens it.
+
+- **#687 breadcrumbs + Draw soak.** `format_lifecycle_breadcrumb`,
+  `probe_uno_bridge`, `collect_post_test_death`, `make test-uno-soak`.
+  Still how a victim factory open names the previous TEST. Keep.
+- **#709 Windows UNO bootstrap.** Longer connect budget, one retry,
+  stderr_tail on pipe miss. Different class (accept, not leftover).
+  Keep.
+- **#710 settle after peer Impress close.**
+  `settle_after_draw_family_close` after dropping the proxy. Do **not**
+  fold into `close_doc` (taxes Writer/Calc). Keep.
+- **#716 / #717 peer Impress close.** Windows `close_doc` on Impress
+  hung (34518091151). Skip-teardown then wedged the next Writer
+  factory (34537826720). Raw `close(True)` + post-close settle is the
+  only sequence that returned. Keep `close_draw_family_doc` split.
+- **#718 skip Windows Writer/Calc `close_doc` in the peer suite.**
+  Dual hidden-Writer close hung before any Impress in that file
+  (34544965319). POSIX still closes. Keep.
+- **#719 skip second Windows Impress close; peer suite last.** First
+  raw close must run (leftover Impress poisons later Writer load).
+  Second raw close killed soffice (34547869791). Recycle flag must
+  write both runner modules (`python -m` vs `import
+  plugin.testing_runner`). In-process rebootstrap after recycle is
+  not a healthy office (34551644954) — skip rebootstrap when no
+  suites remain. Keep.
+- **#720 leftover HTML-paste Writers.** Title said “close”; the
+  shipped path does **not** close (34556185752 hung inside leftover
+  `close(True)`). `prepare_windows_writer_factory` logs leftovers and
+  `setActiveFrame`s the keeper. Keep. Do not restore a leftover close.
+- **#722 leftover Writer reuse + stable `_wa_factory`.** Consecutive
+  leftover Hidden `_blank` swriter hung even after keeper reactivate.
+  Unique `_wa_factory_N` stacked empty frames (`_wa_factory_5`).
+  Reuse one CREATE\|GLOBAL name; pool the first leftover Writer; skip
+  Writer `close_doc` while leftovers remain. Keep.
+- **#723 Draw close breadcrumbs + dual-module adopt.** Same `-m` vs
+  import split as #719 recycle. `close_doc` dispose printed
+  `previous=-` until lifecycle trail writes both runner copies. Keep.
+- **#724 skip Windows Draw close after `insert_math` OLE.**
+  `mark_windows_math_ole_doc` uid only. Do **not** walk pages/shapes
+  at teardown (34612145495 died on the first unmarked Draw close after
+  that walk). `_draw_doc_has_math_ole` stays a unit-test probe. Keep
+  both; do not wire the walk back into `close_doc`.
+- **#725 leftover Calc after HTML-paste.** Unique leftover scalc
+  failed then hung (`_wa_factory_1` / `_wa_factory_2`). Stable
+  `_wa_scalc`; later leftover Calc wipe-and-reuses the pooled
+  workbook. Keep.
+- **#731 Budget copy + leftover Calc reuse + `_wa_notebook_host`.**
+  Hidden-open of the `storeAsURL` path bitmap-failed; copy URL is the
+  harness workaround. Notebook host is not leftover HTML-paste
+  `_wa_factory` (34643210006 listener bleed). Keep. Product
+  `open_document_for_read` `_wa_doc_research` is out of this pass.
+- **#732 leftover `_wa_notebook` + leftover_open=0 Writer reuse.**
+  Do not close leftover notebook docs (34646877587). Consecutive
+  Hidden `_blank` swriter hung with leftovers=0 once paste suites
+  were deferred (34652644656). `_windows_should_reuse_writer` stays
+  true on Windows. Keep.
+- **#734 skip later Hidden sibling opens after bitmap.** Attempt the
+  first Hidden-open (34652644656 was 3/3). After
+  `Could not create system bitmap!`, skip — do not hang the next
+  sibling. Keep.
+- **#737 leftover Draw/Impress one CREATE\|GLOBAL name.**
+  `_wa_sdraw` / `_wa_simpress`. Unique `_wa_factory_10` hung at
+  leftover_open=15. Named leftover factories still load at
+  leftover_open<=2. Keep.
+- **#742 leftover Draw/Impress skip when leftover Writers stack +
+  leftover notebook-host reuse.** High leftover Writer count wedges a
+  new app factory; leftover swriter at leftover_open=15 returned.
+  Keep the skip helper + notebook-host reuse.
+- **#743 Hidden `_blank` after system bitmap in `create_native_doc`.**
+  #734 skipped later `document_research` siblings; next suite
+  leftover writer reuse then leftover_open=0 `target=_blank` hung
+  (34670295632). Named leftover factories still load. Keep.
+- **#744 Windows headless slash TOP dialog.** leftover_open not
+  required. `skip_windows_leftover_hidden_load` does not cover
+  `dlg.setVisible(True)` after `createPeer`. Keep
+  `skip_windows_awt_top_dialog` separate. ENABLE_SLASH stays parked.
+- **#745 `_WINDOWS_CROSS_APP_LEFTOVER_MAX` 4→2.** leftover_open=3
+  hung leftover `_wa_simpress` (34672065355). leftover_open=1
+  leftover Draw/Impress succeeded (34657826349). Threshold 2 is the
+  proven line. Keep.
+- **#746 leftover Hidden load skips (the skips themselves).** Latex /
+  MathML `.mml`, document-scripts reopen, apply Hidden `_default`,
+  apply-style canary, format `_blank` `finally` close, inline-review
+  view cursor, page-header / ops / html_export temp_doc, track-changes
+  wait-timeout on the **test** thread (SkipTest on the worker does
+  not skip the parent). Keep every skip; keep the reason string
+  (that is the log line).
+- **#711 pytest `import plugin.doc` before Layer B guard.** Import
+  order, not leftover. Keep. Do not touch.
+- **#708 LF on Windows checkout for eval gold/prompt.** `.gitattributes`
+  `eol=lf`. Not leftover. Not weird. Keep. Do not touch.
+
+## Simplify (this PR)
+
+- **#746 thin wrappers `skip_windows_leftover_hidden_apply` and
+  `skip_windows_leftover_hidden_mathml`.** Both only called
+  `skip_windows_leftover_hidden_load(reason)`. Collapse call sites to
+  the one helper + reason string. Log lines stay
+  `windows leftover skip: <reason> leftovers=N`. Per-file math
+  `_skip_windows_leftover_hidden_mathml()` locals stay: they hold the
+  GHA comment and one reason for many tests in that file; they now
+  call `skip_windows_leftover_hidden_load`.
+
+## Delete candidates (not this PR)
+
+Do not delete unless a later tip proves a simpler equivalent.
+
+- **Unique `_wa_factory_N` fallback** in `_windows_factory_load_args`.
+  Known leftover factories never hit it (swriter / scalc / sdraw /
+  simpress have stable names). Unknown leftover URLs still get a
+  unique CREATE name instead of `_blank`. Keep the fallback; do not
+  re-enable unique names for known apps.
+- **Generic dual-module adopt.** Keeper, leftover count, bitmap flag,
+  notebook host, Math OLE uids, recycle flag, and lifecycle trail
+  each write both module copies. A shared adopt helper would be a
+  behavior-risk refactor, not a leftover-pressure win. Keep the
+  copies.
+- **`_draw_doc_has_math_ole` walk.** Unused at teardown on purpose.
+  Unit tests still pin the CLSID. Keep as probe.
+- **Peer-suite local `_windows_skip_*` in `test_peer_message_uno.py`.**
+  File-local, hang-specific, already logged. Do not fold into the
+  leftover Hidden helper (different class).
+- **`uno-test-lifecycle.md` GHA diary.** Long, but it is the proof
+  trail. Do not rewrite into this note. Add only a pointer.
+
+## Out of this pass
+
+#738 tool-count/schema, #733 Calc fill-down, #736 / #727 / #726
+benchmarks, #700 `get_image`, #705 Calc RPS, #693 / #680 eval-2 ports.
+Product `_wa_doc_research` / `_wa_calc_html` names stay.
+
+## How to add the next leftover skip
+
+Call `skip_windows_leftover_hidden_load("<suite> <hang class>")` on
+the **test** thread before the Hidden load or leftover-poisoned
+assert. Do not add a new wrapper unless the hang class is new
+(bitmap, AWT TOP, leftover Draw/Impress). Keep the print. Do not
+close leftover paste / notebook Writers.

--- a/docs/framework/windows-ci-harness-cleanup-note.md
+++ b/docs/framework/windows-ci-harness-cleanup-note.md
@@ -10,6 +10,30 @@ Hang-class breadcrumb contract lives in
 [uno-test-lifecycle.md](uno-test-lifecycle.md). This page is the
 keep / simplify / delete call, not a second GHA diary.
 
+## In-scope leftover / Hidden trail
+
+This pass reviewed the leftover/Hidden path as one trail, not only
+#742–#746:
+
+| PR | What shipped | Call |
+|----|--------------|------|
+| #723 | Draw close breadcrumbs; lifecycle trail on both runner modules | **Keep** |
+| #724 | Skip Windows Draw `close_doc` after `insert_math` OLE (uid mark only) | **Keep** |
+| #725 | Leftover Calc factory: stable `_wa_scalc` after HTML-paste Writers | **Keep** |
+| #731 | Hidden-open a *copy* of stored Budget; leftover Calc reuse; `_wa_notebook_host` | **Keep** |
+| #732 | Do not reuse a just-closed leftover `_wa_notebook`; leftover_open=0 Writer reuse | **Keep** |
+| #734 | Skip later Hidden sibling opens after Windows system bitmap | **Keep** |
+| #737 | Leftover Draw/Impress reuse one CREATE\|GLOBAL name (`_wa_sdraw` / `_wa_simpress`) | **Keep** |
+| #742 | Skip leftover Draw/Impress when leftover Writers stack; leftover notebook-host reuse | **Keep** |
+| #743 | Skip Hidden `_blank` factory after system bitmap (`create_native_doc`) | **Keep** |
+| #744 | Skip Windows headless slash TOP `setVisible` | **Keep** (separate class) |
+| #745 | `_WINDOWS_CROSS_APP_LEFTOVER_MAX` 4→2 | **Keep** |
+| #746 | Broad leftover Hidden `_blank` / `_default` skips | **Keep skips**; **simplify** aliases only |
+
+Earlier same-week peer/bootstrap items (#687 / #709–#722, plus #711 /
+#708) stay **keep** and are listed below so nobody “simplifies” them
+back into leftover close.
+
 ## Hang classes (do not merge)
 
 These are different failure modes. One helper per class.
@@ -73,26 +97,35 @@ reopens it.
   both; do not wire the walk back into `close_doc`.
 - **#725 leftover Calc after HTML-paste.** Unique leftover scalc
   failed then hung (`_wa_factory_1` / `_wa_factory_2`). Stable
-  `_wa_scalc`; later leftover Calc wipe-and-reuses the pooled
-  workbook. Keep.
+  `_wa_scalc`. Do not merge this name into leftover Writer
+  `_wa_factory` — pooled leftover_open=0 Calc is still Hidden
+  `_blank`, so a shared leftover name would not replace it. Keep.
 - **#731 Budget copy + leftover Calc reuse + `_wa_notebook_host`.**
-  Hidden-open of the `storeAsURL` path bitmap-failed; copy URL is the
-  harness workaround. Notebook host is not leftover HTML-paste
-  `_wa_factory` (34643210006 listener bleed). Keep. Product
-  `open_document_for_read` `_wa_doc_research` is out of this pass.
+  Hidden-open of the live `storeAsURL` path bitmap-failed; the UNO
+  env copies `Budget_read.ods` (harness-only). Later leftover
+  `_wa_scalc` at leftover_open=5 hung (34643210006) — wipe-and-reuse
+  the pooled Calc instead of a leftover factory. Notebook host is
+  not leftover HTML-paste `_wa_factory` (listener bleed). Keep.
+  Product `open_document_for_read` `_wa_doc_research` is out of this
+  pass.
 - **#732 leftover `_wa_notebook` + leftover_open=0 Writer reuse.**
-  Do not close leftover notebook docs (34646877587). Consecutive
+  `windows_notebook_load_args` stays `_wa_notebook` (not `_blank`).
+  Do not close leftover notebook docs (34646877587). The detect
+  reload leftover-skips instead of a second Hidden load. Consecutive
   Hidden `_blank` swriter hung with leftovers=0 once paste suites
   were deferred (34652644656). `_windows_should_reuse_writer` stays
   true on Windows. Keep.
 - **#734 skip later Hidden sibling opens after bitmap.** Attempt the
   first Hidden-open (34652644656 was 3/3). After
-  `Could not create system bitmap!`, skip — do not hang the next
-  sibling. Keep.
+  `Could not create system bitmap!`, `note_windows_hidden_open_bitmap`
+  then `skip_windows_hidden_open_after_bitmap` — do not hang the
+  next sibling. Same helper #743 uses in `create_native_doc`. Keep;
+  do not fold into leftover Hidden skip (leftover_open was 0).
 - **#737 leftover Draw/Impress one CREATE\|GLOBAL name.**
   `_wa_sdraw` / `_wa_simpress`. Unique `_wa_factory_10` hung at
   leftover_open=15. Named leftover factories still load at
-  leftover_open<=2. Keep.
+  leftover_open<=2; #742 / #745 skip only when leftover_open>2.
+  Keep the names. Do not go back to unique `_wa_factory_N`.
 - **#742 leftover Draw/Impress skip when leftover Writers stack +
   leftover notebook-host reuse.** High leftover Writer count wedges a
   new app factory; leftover swriter at leftover_open=15 returned.

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -91,7 +91,7 @@ Start here by task.
 | Math / HTML import design | [writer/math-tex.md](writer/math-tex.md) |
 | Grammar pipeline (cache, queue) | [writer/grammar-checker-plan.md](writer/grammar-checker-plan.md) |
 | Test Architecture | [archive/test_architecture_analysis.md](archive/test_architecture_analysis.md) |
-| Native UNO lifecycle / URP dispose breadcrumbs | [framework/uno-test-lifecycle.md](framework/uno-test-lifecycle.md) |
+| Native UNO lifecycle / URP dispose breadcrumbs | [framework/uno-test-lifecycle.md](framework/uno-test-lifecycle.md), Windows skip inventory [framework/windows-ci-harness-cleanup-note.md](framework/windows-ci-harness-cleanup-note.md) |
 | Type checking | [framework/type-checking.md](framework/type-checking.md) |
 | UNO Dialogs & Wizards | [framework/uno-dialogs.md](framework/uno-dialogs.md) |
 | UNO exception policy (disposed vs leaf catches) | [framework/exception-policy.md](framework/exception-policy.md) |

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -796,60 +796,6 @@ def test_skip_windows_leftover_hidden_load_raises_on_win32(monkeypatch):
         tu._set_windows_leftover_open(saved)
 
 
-def test_skip_windows_leftover_hidden_mathml_raises_on_win32(monkeypatch):
-    """GHA 34675151298 / 34678020608: leftover Hidden _blank .mml hung 30s."""
-    import unittest
-
-    import plugin.tests.testing_utils as tu
-
-    saved = tu._WINDOWS_LEFTOVER_OPEN
-    monkeypatch.setattr(tu.sys, "platform", "win32")
-    tu._set_windows_leftover_open(3)
-    try:
-        try:
-            tu.skip_windows_leftover_hidden_mathml("math formula Hidden _blank .mml")
-        except unittest.SkipTest as exc:
-            assert "math formula" in str(exc)
-            assert "leftovers=3" in str(exc)
-        else:
-            raise AssertionError("expected SkipTest")
-    finally:
-        tu._set_windows_leftover_open(saved)
-    monkeypatch.setattr(tu.sys, "platform", "linux")
-    tu._set_windows_leftover_open(3)
-    try:
-        tu.skip_windows_leftover_hidden_mathml("math formula Hidden _blank .mml")
-    finally:
-        tu._set_windows_leftover_open(saved)
-
-
-def test_skip_windows_leftover_hidden_apply_raises_on_win32(monkeypatch):
-    """GHA 34681661844 / 34683742049: leftover Hidden _default apply hung 30s."""
-    import unittest
-
-    import plugin.tests.testing_utils as tu
-
-    saved = tu._WINDOWS_LEFTOVER_OPEN
-    monkeypatch.setattr(tu.sys, "platform", "win32")
-    tu._set_windows_leftover_open(3)
-    try:
-        try:
-            tu.skip_windows_leftover_hidden_apply()
-        except unittest.SkipTest as exc:
-            assert "apply_document_content" in str(exc)
-            assert "leftovers=3" in str(exc)
-        else:
-            raise AssertionError("expected SkipTest")
-    finally:
-        tu._set_windows_leftover_open(saved)
-    monkeypatch.setattr(tu.sys, "platform", "linux")
-    tu._set_windows_leftover_open(3)
-    try:
-        tu.skip_windows_leftover_hidden_apply()
-    finally:
-        tu._set_windows_leftover_open(saved)
-
-
 def test_skip_windows_leftover_hidden_load_noop_without_leftovers(monkeypatch):
     import plugin.tests.testing_utils as tu
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1266,7 +1266,7 @@ def skip_windows_cross_app_factory(factory_url: str, leftover_open: int) -> None
 
 
 def skip_windows_leftover_hidden_load(reason: str) -> None:
-    """Skip leftover-poisoned Hidden loads and AWT peers on Windows.
+    """Skip leftover-poisoned Hidden loads on Windows.
 
     GHA 34646877587: first leftover Hidden ``_wa_notebook`` + close
     returned; the next Hidden ``_wa_notebook`` hung 30s. Unique leftover
@@ -1275,19 +1275,20 @@ def skip_windows_leftover_hidden_load(reason: str) -> None:
     detect uses this; do **not** skip ``document_research_uno`` Hidden
     ``Budget_read.ods`` (34643210006 was 3/3). GHA 34675151298: leftover
     writer reuse then ``convert_mathml_to_starmath`` Hidden ``_blank``
-    ``.mml`` hung 30s — latex dialog UNO uses this (XDL is patched;
-    not AWT TOP). GHA 34678020608: that skip fired; next suite
-    ``test_convert_mathml_to_starmath_fraction`` hung the same load.
-    GHA 34679494812: leftover_open=3 (uids 40/39/29) then leftover
-    swriter ``create_native_doc`` uid=41 returned;
+    ``.mml`` hung 30s — latex / MathML UNO uses this + a reason string
+    (XDL is patched; not AWT TOP). GHA 34678020608: that skip fired;
+    next suite ``test_convert_mathml_to_starmath_fraction`` hung the
+    same load. GHA 34679494812: leftover_open=3 (uids 40/39/29) then
+    leftover swriter ``create_native_doc`` uid=41 returned;
     ``test_document_scripts_survive_save_reopen`` hung 30s in
     attach / storeAsURL / raw close / Hidden ``_blank`` reopen.
     GHA 34681661844: first ``html_to_plain_text`` Hidden ``_default``
     swriter returned; the next hung 30s. GHA 34683742049: those apply
     skips fired; next ``test_write_compact_heading1_resolves_to_spaced_uno``
-    hung the same leftover Hidden ``_default`` load. Cached leftover
-    count only — do not enum. Do not close leftover paste Writers
-    (34556185752).
+    hung the same leftover Hidden ``_default`` load. Apply and MathML
+    share this helper; do not add alias wrappers. Not AWT TOP (see
+    ``skip_windows_awt_top_dialog``). Cached leftover count only — do
+    not enum. Do not close leftover paste Writers (34556185752).
     """
     if not windows_leftover_hidden_load_unsafe():
         return
@@ -1302,32 +1303,6 @@ def skip_windows_leftover_hidden_load(reason: str) -> None:
         "Windows leftover Hidden/AWT skip (%s, leftovers=%s)"
         % (reason, _windows_leftover_open())
     )
-
-
-def skip_windows_leftover_hidden_apply(reason: str = "apply_document_content Hidden _default swriter") -> None:
-    """Skip leftover Hidden ``html_to_plain_text`` factory loads.
-
-    GHA 34681661844: document-scripts / MathML leftover skips fired.
-    ``test_apply_document_content_preserves_heading_level_span_uno``
-    OK, then ``…_heading_level_b_uno`` hung 30s in
-    ``html_to_plain_text`` ``loadComponentFromURL(private:factory/swriter,
-    "_default", Hidden)``. GHA 34683742049: those apply skips fired;
-    next ``test_write_compact_heading1_resolves_to_spaced_uno`` hung
-    the same leftover Hidden ``_default`` load. Consecutive leftover
-    Hidden Writer factory.
-    """
-    skip_windows_leftover_hidden_load(reason)
-
-
-def skip_windows_leftover_hidden_mathml(reason: str) -> None:
-    """Skip leftover Hidden Math loads (``.mml`` or ``smath`` factory).
-
-    GHA 34675151298 hung in latex-dialog ``convert_mathml_to_starmath``
-    Hidden ``_blank`` ``.mml``. GHA 34678020608 skipped that test, then
-    ``test_convert_mathml_to_starmath_fraction`` hung at the same call.
-    Export uses Hidden ``private:factory/smath`` ``_blank``. Not AWT TOP.
-    """
-    skip_windows_leftover_hidden_load(reason)
 
 
 def windows_leftover_hidden_load_unsafe() -> bool:

--- a/tests/writer/math/test_latex_dialog.py
+++ b/tests/writer/math/test_latex_dialog.py
@@ -35,9 +35,9 @@ def test_latex_dialog_uno_skips_windows_leftover_hidden_mml() -> None:
     from pathlib import Path
 
     src = Path(__file__).with_name("test_latex_dialog_uno.py").read_text(encoding="utf-8")
-    assert "skip_windows_leftover_hidden_mathml" in src
+    assert "skip_windows_leftover_hidden_load" in src
     assert "latex dialog Hidden _blank .mml" in src
     assert "34675151298" in src
     # AWT TOP is cited as the wrong class; leftover Hidden is the skip.
-    assert 'skip_windows_leftover_hidden_mathml("latex dialog Hidden _blank .mml")' in src
+    assert 'skip_windows_leftover_hidden_load("latex dialog Hidden _blank .mml")' in src
     assert "is the wrong class" in src

--- a/tests/writer/math/test_latex_dialog_uno.py
+++ b/tests/writer/math/test_latex_dialog_uno.py
@@ -16,7 +16,7 @@ from plugin.writer.math.latex_dialog import insert_latex_math_dialog
 from plugin.framework.config import get_config
 from plugin.writer.math.math_mml_convert import MATH_CLSID
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import skip_windows_leftover_hidden_mathml, with_native_doc
+from plugin.tests.testing_utils import skip_windows_leftover_hidden_load, with_native_doc
 
 
 def _skip_windows_leftover_hidden_mathml() -> None:
@@ -32,7 +32,7 @@ def _skip_windows_leftover_hidden_mathml() -> None:
     ``skip_windows_awt_top_dialog`` is the wrong class.
     GHA 34678020608: this skip fired; next suite hung the same load.
     """
-    skip_windows_leftover_hidden_mathml("latex dialog Hidden _blank .mml")
+    skip_windows_leftover_hidden_load("latex dialog Hidden _blank .mml")
 
 
 def _embed_count(doc: Any) -> int:

--- a/tests/writer/math/test_math_formula_insert_uno.py
+++ b/tests/writer/math/test_math_formula_insert_uno.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 from typing import Any
 
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import skip_windows_leftover_hidden_mathml, with_native_doc
+from plugin.tests.testing_utils import skip_windows_leftover_hidden_load, with_native_doc
 from plugin.writer import format as format_support
 from plugin.writer.math.math_mml_convert import MATH_CLSID, convert_mathml_to_starmath, insert_writer_math_formula
 
 
 def _skip_windows_leftover_hidden_mathml() -> None:
     """GHA 34678020608: latex skip fired; this Hidden ``_blank`` ``.mml`` hung 30s."""
-    skip_windows_leftover_hidden_mathml("math formula Hidden _blank .mml")
+    skip_windows_leftover_hidden_load("math formula Hidden _blank .mml")
 
 
 def _embed_count(doc: Any) -> int:

--- a/tests/writer/math/test_math_mml_convert.py
+++ b/tests/writer/math/test_math_mml_convert.py
@@ -71,7 +71,7 @@ def test_math_formula_insert_uno_skips_windows_leftover_hidden_mml() -> None:
     from pathlib import Path
 
     src = Path(__file__).with_name("test_math_formula_insert_uno.py").read_text(encoding="utf-8")
-    assert "skip_windows_leftover_hidden_mathml" in src
+    assert "skip_windows_leftover_hidden_load" in src
     assert "math formula Hidden _blank .mml" in src
     assert "34678020608" in src
 

--- a/tests/writer/math/test_math_mml_export.py
+++ b/tests/writer/math/test_math_mml_export.py
@@ -124,5 +124,5 @@ def test_math_mml_export_uno_skips_windows_leftover_hidden_smath() -> None:
     from pathlib import Path
 
     src = Path(__file__).with_name("test_math_mml_export_uno.py").read_text(encoding="utf-8")
-    assert "skip_windows_leftover_hidden_mathml" in src
+    assert "skip_windows_leftover_hidden_load" in src
     assert "math export Hidden _blank smath" in src

--- a/tests/writer/math/test_math_mml_export_uno.py
+++ b/tests/writer/math/test_math_mml_export_uno.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 from typing import Any
 
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import skip_windows_leftover_hidden_mathml, with_native_doc
+from plugin.tests.testing_utils import skip_windows_leftover_hidden_load, with_native_doc
 
 
 def _skip_windows_leftover_hidden_mathml() -> None:
     """GHA 34678020608: leftover Hidden ``_blank`` ``.mml`` / ``smath`` hang."""
-    skip_windows_leftover_hidden_mathml("math export Hidden _blank smath")
+    skip_windows_leftover_hidden_load("math export Hidden _blank smath")
 from plugin.writer.math.math_mml_convert import convert_latex_to_starmath, insert_writer_math_formula
 from plugin.writer.math.math_mml_export import (
     convert_starmath_to_latex,

--- a/tests/writer/test_apply_document_content_heading_rewrite_uno.py
+++ b/tests/writer/test_apply_document_content_heading_rewrite_uno.py
@@ -17,7 +17,7 @@ from plugin.testing_runner import native_test
 from plugin.writer.content import ApplyDocumentContent
 from plugin.tests.testing_utils import (
     TestingFactory,
-    skip_windows_leftover_hidden_apply,
+    skip_windows_leftover_hidden_load,
     with_native_doc,
 )
 
@@ -27,7 +27,7 @@ _HEADING_TEXT = "4.1.1 Engine selection"
 def _doc_with_heading3(doc):
     # GHA 34681661844: span apply OK; next <b> apply hung 30s in
     # html_to_plain_text Hidden _default swriter (leftover_open=3).
-    skip_windows_leftover_hidden_apply()
+    skip_windows_leftover_hidden_load("apply_document_content Hidden _default swriter")
     text = doc.getText()
     cur = text.createTextCursor()
     cur.gotoStart(False)

--- a/tests/writer/test_apply_document_content_structured_return.py
+++ b/tests/writer/test_apply_document_content_structured_return.py
@@ -26,7 +26,8 @@ def test_heading_rewrite_uno_skips_windows_leftover_hidden_apply() -> None:
     src = Path(__file__).with_name(
         "test_apply_document_content_heading_rewrite_uno.py"
     ).read_text(encoding="utf-8")
-    assert "skip_windows_leftover_hidden_apply" in src
+    assert "skip_windows_leftover_hidden_load" in src
+    assert "apply_document_content Hidden _default swriter" in src
     assert "34681661844" in src
     assert "html_to_plain_text" in src
 
@@ -42,7 +43,8 @@ def test_later_apply_uno_skips_windows_leftover_hidden_apply() -> None:
         "test_track_changes_reviewable_uno.py",
     ):
         src = (writer / name).read_text(encoding="utf-8")
-        assert "skip_windows_leftover_hidden_apply" in src, name
+        assert "skip_windows_leftover_hidden_load" in src, name
+        assert "apply_document_content Hidden _default swriter" in src, name
     style_src = (writer / "test_content_style_model_uno.py").read_text(encoding="utf-8")
     assert "34683742049" in style_src
     assert "html_to_plain_text" in style_src

--- a/tests/writer/test_apply_document_content_structured_return_uno.py
+++ b/tests/writer/test_apply_document_content_structured_return_uno.py
@@ -17,13 +17,13 @@ from plugin.testing_runner import native_test
 from plugin.writer.content import ApplyDocumentContent
 from plugin.tests.testing_utils import (
     TestingFactory,
-    skip_windows_leftover_hidden_apply,
+    skip_windows_leftover_hidden_load,
     with_native_doc,
 )
 
 
 def _set_body(doc, text_value):
-    skip_windows_leftover_hidden_apply()
+    skip_windows_leftover_hidden_load("apply_document_content Hidden _default swriter")
     text = doc.getText()
     cur = text.createTextCursor()
     cur.gotoStart(False)

--- a/tests/writer/test_apply_document_content_table_cell_uno.py
+++ b/tests/writer/test_apply_document_content_table_cell_uno.py
@@ -18,7 +18,7 @@ from plugin.testing_runner import native_test
 from plugin.writer.content import ApplyDocumentContent
 from plugin.tests.testing_utils import (
     TestingFactory,
-    skip_windows_leftover_hidden_apply,
+    skip_windows_leftover_hidden_load,
     with_native_doc,
 )
 
@@ -28,7 +28,7 @@ from plugin.tests.testing_utils import (
 def test_apply_document_content_edits_table_cell_uno(ctx, doc):
     """Editing a cell's text via target='search' should work; it used to raise a
     cursor RuntimeException (body XText vs the cell's XText)."""
-    skip_windows_leftover_hidden_apply()
+    skip_windows_leftover_hidden_load("apply_document_content Hidden _default swriter")
     text = doc.getText()
     tbl = doc.createInstance("com.sun.star.text.TextTable")
     tbl.initialize(3, 2)

--- a/tests/writer/test_apply_document_content_whitespace_uno.py
+++ b/tests/writer/test_apply_document_content_whitespace_uno.py
@@ -11,7 +11,7 @@ from plugin.testing_runner import native_test
 from plugin.writer.content import ApplyDocumentContent
 from plugin.tests.testing_utils import (
     TestingFactory,
-    skip_windows_leftover_hidden_apply,
+    skip_windows_leftover_hidden_load,
     with_native_doc,
 )
 
@@ -19,7 +19,7 @@ _NBSP = chr(0xA0)  # non-breaking space U+00A0 (ASCII-safe in source)
 
 
 def _tool_ctx(doc, ctx):
-    skip_windows_leftover_hidden_apply()
+    skip_windows_leftover_hidden_load("apply_document_content Hidden _default swriter")
     return TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
 
 

--- a/tests/writer/test_content_style_model_uno.py
+++ b/tests/writer/test_content_style_model_uno.py
@@ -17,7 +17,7 @@ import uno  # noqa: F401
 from plugin.testing_runner import native_test
 from plugin.tests.testing_utils import (
     TestingFactory,
-    skip_windows_leftover_hidden_apply,
+    skip_windows_leftover_hidden_load,
     with_native_doc,
 )
 from plugin.writer.content import ApplyDocumentContent
@@ -29,7 +29,7 @@ def _tool_ctx(doc, ctx):
     # leftover Hidden apply skips fired. Next
     # test_write_compact_heading1_resolves_to_spaced_uno hung 30s in
     # html_to_plain_text Hidden _default swriter (leftover_open=3).
-    skip_windows_leftover_hidden_apply()
+    skip_windows_leftover_hidden_load("apply_document_content Hidden _default swriter")
     return TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
 
 

--- a/tests/writer/test_document_helpers.py
+++ b/tests/writer/test_document_helpers.py
@@ -267,7 +267,7 @@ def test_document_helpers_uno_skips_windows_leftover_hidden_mml() -> None:
     from pathlib import Path
 
     src = Path(__file__).with_name("test_document_helpers_uno.py").read_text(encoding="utf-8")
-    assert "skip_windows_leftover_hidden_mathml" in src
+    assert "skip_windows_leftover_hidden_load" in src
     assert "document helpers Hidden _blank .mml" in src
 
 

--- a/tests/writer/test_document_helpers_uno.py
+++ b/tests/writer/test_document_helpers_uno.py
@@ -5,7 +5,7 @@ from plugin.doc.paragraph_search import get_paragraph_ranges
 from plugin.doc.text_helpers import get_document_length
 from plugin.writer.edit_review import WriterStreamedRewriteSession
 from plugin.testing_runner import native_test
-from plugin.tests.testing_utils import TestingFactory, skip_windows_leftover_hidden_mathml, with_native_doc
+from plugin.tests.testing_utils import TestingFactory, skip_windows_leftover_hidden_load, with_native_doc
 
 
 def _populate_doc_helpers(doc):
@@ -141,7 +141,7 @@ def test_get_document_context_for_chat_hints_math_ole(ctx):
     from plugin.writer.math.math_mml_convert import convert_latex_to_starmath, insert_writer_math_formula
 
     # GHA 34678020608: leftover Hidden _blank .mml hung after latex skip.
-    skip_windows_leftover_hidden_mathml("document helpers Hidden _blank .mml")
+    skip_windows_leftover_hidden_load("document helpers Hidden _blank .mml")
     with TestingFactory.native_doc(ctx, "writer") as doc:
         text = doc.getText()
         cursor = text.createTextCursor()

--- a/tests/writer/test_format.py
+++ b/tests/writer/test_format.py
@@ -747,9 +747,9 @@ def test_format_uno_skips_windows_leftover_hidden_apply() -> None:
     from pathlib import Path
 
     src = Path(__file__).with_name("test_format_uno.py").read_text(encoding="utf-8")
-    assert "skip_windows_leftover_hidden_apply" in src
-    assert "34683742049" in src
     assert "skip_windows_leftover_hidden_load" in src
+    assert "apply_document_content Hidden _default swriter" in src
+    assert "34683742049" in src
     assert "format_uno Hidden _blank small_doc" in src
     assert "34685648395" in src
     assert "format_uno cross-paragraph color leftover reuse" in src

--- a/tests/writer/test_format_uno.py
+++ b/tests/writer/test_format_uno.py
@@ -62,7 +62,7 @@ def _apply_document_content(doc, ctx, params):
     """Call real apply_document_content tool; returns dict."""
     # GHA 34683742049: leftover Hidden _default apply hung after the
     # first apply-suite skips. Later apply UNO files skip the same load.
-    skip_windows_leftover_hidden_apply()
+    skip_windows_leftover_hidden_load("apply_document_content Hidden _default swriter")
     from plugin.main import get_tools
     content = params.get("content", "")
     if isinstance(content, list):
@@ -93,7 +93,6 @@ def _find_text(doc, ctx, params):
 
 from plugin.testing_runner import native_test
 from plugin.tests.testing_utils import (
-    skip_windows_leftover_hidden_apply,
     skip_windows_leftover_hidden_load,
     with_native_doc,
 )

--- a/tests/writer/test_track_changes_reviewable_uno.py
+++ b/tests/writer/test_track_changes_reviewable_uno.py
@@ -18,7 +18,6 @@ import contextlib
 from plugin.testing_runner import native_test
 from plugin.tests.testing_utils import (
     TestingFactory,
-    skip_windows_leftover_hidden_apply,
     skip_windows_leftover_hidden_load,
     with_native_doc,
 )
@@ -108,7 +107,7 @@ def _tool_ctx(doc, ctx):
     # GHA 34683742049: leftover Hidden _default apply hung after the
     # first apply-suite skips. This file is the next ApplyDocumentContent
     # victim on leftover_open>0.
-    skip_windows_leftover_hidden_apply()
+    skip_windows_leftover_hidden_load("apply_document_content Hidden _default swriter")
     return TestingFactory.create_context(doc=doc, ctx=ctx, env="native")
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Review of the leftover / Hidden Windows harness trail as one path: #723–#725, #731, #732, #734, #737, then #742–#746 (plus same-week peer/bootstrap keep so those are not “simplified” back into leftover close). Harness and docs only. Logging stays. Working skips stay unless a simpler equivalent still names the hang class.

Inventory: `docs/framework/windows-ci-harness-cleanup-note.md`

## Keep / simplify / delete TLDR

- **Keep #723–#737 leftover/Hidden stack:** dual-module Draw-close breadcrumbs; Math OLE uid skip (do not walk at teardown); stable `_wa_scalc`; Budget *copy* Hidden-open + leftover Calc reuse + `_wa_notebook_host`; leftover `_wa_notebook` (do not close / do not second Hidden load); leftover_open=0 Writer reuse; bitmap → later Hidden sibling skip; leftover Draw/Impress `_wa_sdraw` / `_wa_simpress`.
- **Keep #742–#745:** leftover Draw/Impress skip when leftover Writers stack (max leftover_open>2); Hidden `_blank` after system bitmap in `create_native_doc`; AWT TOP `setVisible` as its own class; do not merge those four hang classes.
- **Keep #746 skips** (latex/MathML, document-scripts, apply `_default`, style canary, format `_blank` `finally`, view cursor, page/ops/html_export, track-changes wait on the test thread). Keep the reason string — that is the log line.
- **Keep** earlier peer/bootstrap (#687 / #709–#722): raw first Impress close + settle, skip peer Writer/Calc `close_doc`, skip second Impress close, peer last, no leftover `close(True)` (#720 title vs shipped path).
- **Simplify** #746 aliases only: `skip_windows_leftover_hidden_apply` / `_mathml` were pass-throughs. Call sites now use `skip_windows_leftover_hidden_load(reason)`. Skip logs unchanged.
- **Do not delete** unique `_wa_factory_N` fallback, generic dual-module adopt, `_draw_doc_has_math_ole` probe, or the lifecycle GHA diary.
- **Do not restore** leftover `close(True)` or unique leftover factory names for known apps.
- **Out of pass:** #738 / #733 / #736 / #727 / #726 / #700 / #705 / #693 / #680; product `_wa_doc_research`.

Windows `workflow_dispatch` is still the proof for leftover skips. Ubuntu PR CI is the automatic gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bdd469e-a11d-404f-890a-1420ec08f275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bdd469e-a11d-404f-890a-1420ec08f275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

