### PR TITLE
Eval catalog: add paid Nemotron 3 Ultra 550B and Super 120B

### DIFF
--- a/docs/eval/eval-2/README.md
+++ b/docs/eval/eval-2/README.md
@@ -21,6 +21,10 @@ not rewrite them as CRLF.
 Living headed autopsy (product bar + peer polarity + next experiments): [`headed-failure-autopsy.md`](headed-failure-autopsy.md).
 Cross-model AFC catalog pain points (after #741 FIFO): [`afc-cross-model-pain-points.md`](afc-cross-model-pain-points.md).
 Scoreboard + SVG charts: [`benchmarks.md`](benchmarks.md).
+Paid Nemotron 3 Ultra 550B (`nvidia/nemotron-3-ultra-550b-a55b`) and
+Nemotron 3 Super 120B (`nvidia/nemotron-3-super-120b-a12b`) are
+registered on the eval catalog for later AFC/string stamps — no headed
+cells yet.
 
 Each subdirectory is one experiment. **Ready** means headed helper +
 oracle exist. **Stub** means fixture notes only — not headed-ready gold.

--- a/docs/eval/eval-2/benchmarks.md
+++ b/docs/eval/eval-2/benchmarks.md
@@ -36,10 +36,12 @@ partial and USD.
 **HAPPY** can sit on a soft oracle FAIL (false-red or a secondary
 cite). **NOT_HAPPY** + oracle FAIL is usually an empty or wrong-facts
 deliverable. **—** means no in-repo headed stamp; do not invent a
-score. Every catalog column now has an AFC stamp only (including Muse
+score. Every prior catalog column has an AFC stamp only (including Muse
 Glimmer 30B, Muse Spark 1.3, both Lagunas, both Qwen3.8s, GLM 5.3 Flash,
 Solar Pro 4, Granite 4.2 8B, Mistral Small 4, Seed 2.0 Mini,
 MiniMax M3, DeepSeek V4 Flash 0731, and DeepSeek V4.1 Flash).
+Paid Nemotron 3 Ultra 550B and Nemotron 3 Super 120B are registered
+with empty cells until a stamp lands.
 AFC catalog FIFO is complete (oss-120b through V4.1 Flash). Solar
 is **BLOCKED** infra (Send never ran) — not NOT_HAPPY. The
 catalog-wide headed
@@ -77,17 +79,17 @@ recorded USD.
 Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
 (+ [schema](eval2_benchmark_results.schema.json)).
 
-| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini | MiniMax M3 | DeepSeek V4 Flash 0731 | DeepSeek V4.1 Flash |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL |
-| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| # | Task | Gemini 3.8 Flash | GPT-OSS 120B | GPT-5.6 Luna | GPT-OSS 20B | Gemini 3.5 Flash Lite | Gemma 4 31B | Gemma 4 26B A4B | Nemotron 3.5 Lightning | Mercury 2.5 Preview | Grok 4.6 | Muse Glimmer 30B | Muse Spark 1.3 | Laguna S 2.1 | Laguna XS 2.1 | Qwen3.8 27B | Qwen3.8 Flash | GLM 5.3 Flash | Solar Pro 4 | Granite 4.2 8B | Mistral Small 4 | Seed 2.0 Mini | MiniMax M3 | DeepSeek V4 Flash 0731 | DeepSeek V4.1 Flash | Nemotron 3 Ultra 550B | Nemotron 3 Super 120B |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Tenant Retention | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 2 | Cadaver Proposal | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 3 | AFC Population | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | HAPPY / oracle PASS | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | BLOCKED / unscored | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — |
+| 4 | GMP Change Control | — | HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 5 | Floorstand Writer→Calc | NOT_HAPPY / oracle FAIL | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 6 | Calc-primary model | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 8 | Draw-primary | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 9 | Reverse Tenant | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| 10 | Long Writer pack | — | NOT_HAPPY / oracle FAIL | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
 
 <img src="eval2-heatmap.svg" alt="Eval-2 headed task by model heatmap. Green HAPPY, orange NOT_HAPPY, blue BLOCKED infra, gray no data." />
 
@@ -153,7 +155,8 @@ Artifacts: [`eval2_benchmark_results.json`](eval2_benchmark_results.json)
    recorded `total_cost_usd` (~$0.00468 OpenRouter). The cost chart
    now has one bar. Value is `partial_score`² ÷ that USD among HAPPY
    (≈213.68). Other catalog USD stays on NOT_HAPPY cells.
-4. **Coverage:** every catalog column now has AFC only. Gemini 3.8
+4. **Coverage:** every prior catalog column has AFC only. Ultra 550B
+   and Super 120B are catalog-registered with empty cells. Gemini 3.8
    has no stamp yet for GMP, Calc-primary, Draw-primary, Reverse
    Tenant, or Long Writer.
    gpt-oss-120b has no stamp for Tenant or Cadaver.

--- a/docs/eval/eval-2/eval2-coverage.svg
+++ b/docs/eval/eval-2/eval2-coverage.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="3072" height="414" viewBox="0 0 3072 414" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="3320" height="414" viewBox="0 0 3320 414" role="img">
   <title>Eval-2 headed coverage by model</title>
-  <rect width="3072" height="414" fill="#ffffff"/>
+  <rect width="3320" height="414" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed coverage (Ready tasks scored)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">9 Ready / Headed-ready rows. Catalog peers stay gray until a stamp lands.</text>
   <rect x="56.0" y="179.6" width="88" height="144.4" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
@@ -102,6 +102,12 @@
   <rect x="2908.0" y="64.0" width="88" height="28.9" fill="#D55E00" stroke="#dadce0" data-segment="NOT_HAPPY"/>
   <text x="2952.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">DeepSeek V4.1 Flash</text>
   <text x="2952.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 1 scored</text>
+  <rect x="3032.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="3076.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Nemotron 3 Ultra 550B</text>
+  <text x="3076.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
+  <rect x="3156.0" y="64.0" width="88" height="260.0" fill="#F1F3F4" stroke="#dadce0" data-segment="no data"/>
+  <text x="3200.0" y="344" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Nemotron 3 Super 120B</text>
+  <text x="3200.0" y="360" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">0 HAPPY / 0 scored</text>
   <rect x="24" y="376" width="12" height="12" fill="#009E73" stroke="#dadce0"/>
   <text x="42" y="386" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#202124">HAPPY</text>
   <rect x="134" y="376" width="12" height="12" fill="#D55E00" stroke="#dadce0"/>

--- a/docs/eval/eval-2/eval2-heatmap.svg
+++ b/docs/eval/eval-2/eval2-heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="3858" height="714" viewBox="0 0 3858 714" role="img">
+<svg xmlns="http://www.w3.org/2000/svg" width="4158" height="714" viewBox="0 0 4158 714" role="img">
   <title>Eval-2 headed task × model heatmap</title>
-  <rect width="3858" height="714" fill="#ffffff"/>
+  <rect width="4158" height="714" fill="#ffffff"/>
   <text x="24" y="28" font-family="DejaVu Sans, sans-serif" font-size="16" font-weight="700" fill="#202124">Eval-2 headed scoreboard (product bar × oracle)</text>
   <text x="24" y="46" font-family="DejaVu Sans, sans-serif" font-size="11" fill="#5f6368">Gate google/gemini-3.8-flash · updated 2026-09-12 · empty cells have no headed stamp</text>
   <text x="309.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Gemini 3.8 Flash (gate)</text>
@@ -52,6 +52,10 @@
   <text x="3609.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">deepseek/deepseek-v4-flash-0731</text>
   <text x="3759.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">DeepSeek V4.1 Flash</text>
   <text x="3759.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">deepseek/deepseek-v4.1-flash</text>
+  <text x="3909.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Nemotron 3 Ultra 550B</text>
+  <text x="3909.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">nvidia/nemotron-3-ultra-550b-a55b</text>
+  <text x="4059.0" y="84" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#202124">Nemotron 3 Super 120B</text>
+  <text x="4059.0" y="100" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">nvidia/nemotron-3-super-120b-a12b</text>
   <text x="224" y="154" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">1. Tenant Retention</text>
   <text x="224" y="170" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">tenant-retention-ed2bc14c</text>
   <rect x="238.0" y="134.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -126,6 +130,12 @@
   <rect x="3688.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3759.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3759.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3838.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="134.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="154.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="170.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="212" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">2. Cadaver Proposal</text>
   <text x="224" y="228" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">cadaver-proposal-61b0946a</text>
   <rect x="238.0" y="192.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -200,6 +210,12 @@
   <rect x="3688.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3759.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3759.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3838.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="192.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="212.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="228.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="270" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">3. AFC Population</text>
   <text x="224" y="286" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">afc-sample-83d10b06</text>
   <rect x="238.0" y="250.0" width="142" height="46" rx="6" fill="#009E73" stroke="#dadce0"/>
@@ -274,6 +290,12 @@
   <rect x="3688.0" y="250.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
   <text x="3759.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#ffffff">NOT_HAPPY</text>
   <text x="3759.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#ffffff">oracle FAIL</text>
+  <rect x="3838.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="250.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="270.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="286.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="328" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">4. GMP Change Control</text>
   <text x="224" y="344" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">gmp-change-control-58ac1cc5</text>
   <rect x="238.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -348,6 +370,12 @@
   <rect x="3688.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3759.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3759.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3838.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="308.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="328.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="344.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="386" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">5. Floorstand Writer→Calc</text>
   <text x="224" y="402" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">writer-calc-peer-write</text>
   <rect x="238.0" y="366.0" width="142" height="46" rx="6" fill="#D55E00" stroke="#dadce0"/>
@@ -422,6 +450,12 @@
   <rect x="3688.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3759.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3759.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3838.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="366.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="386.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="402.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="444" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">6. Calc-primary model</text>
   <text x="224" y="460" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">calc-primary-model</text>
   <rect x="238.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -496,6 +530,12 @@
   <rect x="3688.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3759.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3759.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3838.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="424.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="444.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="460.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="502" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">8. Draw-primary</text>
   <text x="224" y="518" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">draw-primary-deliverable</text>
   <rect x="238.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -570,6 +610,12 @@
   <rect x="3688.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3759.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3759.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3838.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="482.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="502.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="518.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="560" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">9. Reverse Tenant</text>
   <text x="224" y="576" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">reverse-tenant</text>
   <rect x="238.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -644,6 +690,12 @@
   <rect x="3688.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3759.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3759.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3838.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="540.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="560.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="576.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="224" y="618" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="12" fill="#202124">10. Long Writer pack</text>
   <text x="224" y="634" text-anchor="end" font-family="DejaVu Sans, sans-serif" font-size="9" fill="#5f6368">long-writer-pack</text>
   <rect x="238.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
@@ -718,5 +770,11 @@
   <rect x="3688.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
   <text x="3759.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
   <text x="3759.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3838.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="3909.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="3909.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
+  <rect x="3988.0" y="598.0" width="142" height="46" rx="6" fill="#F1F3F4" stroke="#dadce0"/>
+  <text x="4059.0" y="618.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="11" font-weight="700" fill="#5f6368">no data</text>
+  <text x="4059.0" y="634.0" text-anchor="middle" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">—</text>
   <text x="24" y="696" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#5f6368">Headed sibling of the string pack (hard / partial / cost). Empty = no in-repo stamp. Do not merge into hard_pass_rate JSON.</text>
 </svg>

--- a/docs/eval/eval-2/eval2_benchmark_results.json
+++ b/docs/eval/eval-2/eval2_benchmark_results.json
@@ -3,7 +3,7 @@
   "updated": "2026-09-12",
   "gate_model": "google/gemini-3.8-flash",
   "source_of_truth": "docs/eval/eval-2/headed-failure-autopsy.md",
-  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini, minimax-m3, deepseek-v4-flash-0731, deepseek-v4.1-flash). AFC catalog FIFO is complete. solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. The 9-task headed sweep has not happened. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Run dirs cited below are usually untracked on the shared machine.",
+  "notes": "Headed sibling of the 17-task string pack (hard / partial / cost). Seeded from in-repo autopsy / sibling notes plus Scrolly AFC catalog stamps (gpt-oss-120b, gpt-5.6-luna, gpt-oss-20b, gemini-3.5-flash-lite, gemma-4-31b-it, gemma-4-26b-a4b-it, nemotron-3.5-lightning, mercury-2.5-preview, grok-4.6, muse-glimmer-30b, muse-spark-1.3-contributor, laguna-s-2.1, laguna-xs-2.1, qwen3.8-27b, qwen3.8-flash, glm-5.3-flash, solar-pro4, granite-4.2-8b, mistral-small-2603, seed-2.0-mini, minimax-m3, deepseek-v4-flash-0731, deepseek-v4.1-flash). AFC catalog FIFO is complete. solar-pro4 is BLOCKED infra (Send never ran) — not a model NOT_HAPPY. The 9-task headed sweep has not happened. Empty (task, model) pairs are omitted — do not invent HAPPY or oracle scores. Optional cost/token/wall and oracle-partial fields are omitted until a stamp records them — do not invent run costs, check counts, or partial scores. Slot 7 writer-headed-template is PARKED and omitted. Paid Nemotron 3 Ultra 550B and Nemotron 3 Super 120B are catalog-registered for later AFC/string stamps — no headed cells yet. Run dirs cited below are usually untracked on the shared machine.",
   "tasks": [
     {
       "id": "tenant-retention",
@@ -188,6 +188,16 @@
     {
       "openrouter_id": "deepseek/deepseek-v4.1-flash",
       "display_name": "DeepSeek V4.1 Flash",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "nvidia/nemotron-3-ultra-550b-a55b",
+      "display_name": "Nemotron 3 Ultra 550B",
+      "role": "catalog"
+    },
+    {
+      "openrouter_id": "nvidia/nemotron-3-super-120b-a12b",
+      "display_name": "Nemotron 3 Super 120B",
       "role": "catalog"
     }
   ],

--- a/scripts/prompt_optimization/model_configs.py
+++ b/scripts/prompt_optimization/model_configs.py
@@ -221,6 +221,22 @@ MODELS: list[ModelConfig] = [
         output_cost_per_million=0.6,
         notes="DeepSeek V4.1 Flash; newer Flash tier vs V4 Flash 0731.",
     ),
+    ModelConfig(
+        openrouter_id="nvidia/nemotron-3-ultra-550b-a55b",
+        display_name="NVIDIA: Nemotron 3 Ultra 550B",
+        context_window_tokens=262_144,
+        input_cost_per_million=0.625,
+        output_cost_per_million=3.125,
+        notes="NVIDIA Nemotron 3 Ultra 550B; paid OpenRouter catalog (2026-09-12).",
+    ),
+    ModelConfig(
+        openrouter_id="nvidia/nemotron-3-super-120b-a12b",
+        display_name="NVIDIA: Nemotron 3 Super 120B",
+        context_window_tokens=262_144,
+        input_cost_per_million=0.085,
+        output_cost_per_million=0.4,
+        notes="NVIDIA Nemotron 3 Super 120B; paid OpenRouter id (not :free).",
+    ),
 ]
 
 # Smoke / optimize / run_eval.py student. :nitro is OpenRouter routing

--- a/tests/scripts/test_model_configs.py
+++ b/tests/scripts/test_model_configs.py
@@ -43,6 +43,8 @@ EXPECTED_DEFAULT_IDS = [
     "minimax/minimax-m3",
     "deepseek/deepseek-v4-flash-0731",
     "deepseek/deepseek-v4.1-flash",
+    "nvidia/nemotron-3-ultra-550b-a55b",
+    "nvidia/nemotron-3-super-120b-a12b",
 ]
 
 EXPECTED_GOLD_ONLY_IDS: list[str] = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Register two paid NVIDIA OpenRouter models on the eval-1 string-pack catalog and the eval-2 headed scoreboard so later AFC/string runs can land stamps.

**IDs added**
- `nvidia/nemotron-3-ultra-550b-a55b` — Nemotron 3 Ultra 550B
- `nvidia/nemotron-3-super-120b-a12b` — Nemotron 3 Super 120B

OpenRouter (2026-09-12): both exist; Ultra ~$0.625/M in $3.125/M out; Super ~$0.085/M in $0.40/M out; 262144 context each. Paid slugs only — the Super `:free` id stays in `DROPPED_SLUGS`.

**Lockstep**
- `scripts/prompt_optimization/model_configs.py` — append `ModelConfig` entries (same fields as Lightning)
- `tests/scripts/test_model_configs.py` — append both IDs to `EXPECTED_DEFAULT_IDS` in MODELS order
- `docs/eval/eval-2/eval2_benchmark_results.json` — append both as `role: catalog` (no result cells)
- `docs/eval/eval-2/README.md` — brief catalog-registration note
- `docs/eval/eval-2/benchmarks.md` + heatmap/coverage SVGs — empty columns only (`—` / no-data)

Catalog add only. No product tip, oracle, or invented HAPPY/FAIL. Rebased on master tip after #747/#748.

**Local check:** `tests/scripts/test_model_configs.py` + `tests/scripts/test_plot_eval2_leaderboard.py` 23 passed; `make typecheck` green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73181fab-dab8-4f5d-99dd-dea7c2734e70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73181fab-dab8-4f5d-99dd-dea7c2734e70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

