### PR TITLE
Fix OpenRouter Images payload: png default, omit aspect_ratio

### DIFF
--- a/docs/images/generation.md
+++ b/docs/images/generation.md
@@ -9,6 +9,7 @@ Image generation and editing in WriterAgent uses the **same endpoint URL and API
 [`plugin/writer/images/image_utils.py`](../../plugin/writer/images/image_utils.py):
 
 - **`EndpointImageProvider`**: requests images via `LlmClient` (routing dedicated text-to-image models to OpenRouter's dedicated Image API via `POST /api/v1/images`, falling back to standard `modalities: ["image"]` chat completions for multimodal models).
+- **OpenRouter `/images` payload** ([`OpenRouterShim.build_image_request`](../../plugin/framework/client/openai_shim.py)): `output_format` is `png` (not `webp` — models such as `black-forest-labs/flux.2-klein-4b` only accept png/jpeg). When width/height are set it sends `size` (`WxH`) and omits `aspect_ratio`; OpenRouter treats an explicit pixel size as authoritative and returns HTTP 400 if a paired `aspect_ratio` is considered mismatched.
 - **`ImageService`**: merges config defaults (base size, steps) and delegates to `EndpointImageProvider`.
 
 ### Tools and document insertion

--- a/plugin/framework/client/openai_shim.py
+++ b/plugin/framework/client/openai_shim.py
@@ -69,20 +69,16 @@ class OpenRouterShim(BaseProviderShim):
         endpoint = self.client._endpoint()
         api_path = self.client._api_path()
         url = endpoint + api_path + "/images"
-        data: dict[str, Any] = {"prompt": prompt, "model": model, "n": 1, "output_format": "webp"}
+        # What was wrong: output_format was hardcoded to webp. Models such as
+        # black-forest-labs/flux.2-klein-4b only accept png/jpeg and return HTTP 400.
+        # png is the Images API default and is accepted by webp-capable models too.
+        data: dict[str, Any] = {"prompt": prompt, "model": model, "n": 1, "output_format": "png"}
         if width and height:
+            # Explicit pixel size is authoritative. Sending inferred aspect_ratio
+            # alongside size is rejected with HTTP 400 when OpenRouter considers
+            # them mismatched (retries then sent other ratios). Size already
+            # encodes the intended dimensions.
             data["size"] = f"{width}x{height}"
-            ratio = width / height
-            if abs(ratio - 1.0) < 0.05:
-                data["aspect_ratio"] = "1:1"
-            elif abs(ratio - (16 / 9)) < 0.05:
-                data["aspect_ratio"] = "16:9"
-            elif abs(ratio - (4 / 3)) < 0.05:
-                data["aspect_ratio"] = "4:3"
-            elif abs(ratio - (9 / 16)) < 0.05:
-                data["aspect_ratio"] = "9:16"
-            elif abs(ratio - (3 / 4)) < 0.05:
-                data["aspect_ratio"] = "3:4"
 
         if image_url:
             data["image_url"] = image_url

--- a/tests/framework/test_client_llm.py
+++ b/tests/framework/test_client_llm.py
@@ -1036,9 +1036,48 @@ def test_openrouter_shim_image(client):
         assert body["prompt"] == "Draw a galaxy"
         assert body["model"] == "bytedance-seed/seedream-4.5"
         assert body["size"] == "1024x1024"
-        assert body["aspect_ratio"] == "1:1"
+        assert "aspect_ratio" not in body
         assert body["n"] == 1
-        assert body["output_format"] == "webp"
+        assert body["output_format"] == "png"
+
+
+def test_openrouter_shim_image_flux_klein_png_no_aspect(client):
+    """flux.2-klein-4b rejects webp and size+aspect_ratio pairs (create + img2img)."""
+    client.config["endpoint"] = "https://openrouter.ai/api"
+    with (
+        patch("plugin.framework.client.llm_client.LlmClient._resolve_auth") as mock_auth,
+        patch("plugin.framework.client.llm_client.sync_request") as mock_sync
+    ):
+        mock_auth.return_value = {"provider": "openrouter"}
+        mock_sync.return_value = {"data": [{"b64_json": "xyz"}]}
+
+        client.image_completion(
+            "Draw a galaxy",
+            model="black-forest-labs/flux.2-klein-4b",
+            width=1024,
+            height=576,
+        )
+
+        body = json.loads(mock_sync.call_args.kwargs["data"])
+        assert body["model"] == "black-forest-labs/flux.2-klein-4b"
+        assert body["size"] == "1024x576"
+        assert body["output_format"] == "png"
+        assert "aspect_ratio" not in body
+        assert "webp" not in json.dumps(body)
+
+        client.image_completion(
+            "Make it dusk",
+            model="black-forest-labs/flux.2-klein-4b",
+            width=1024,
+            height=1024,
+            source_image="abc123",
+        )
+
+        body = json.loads(mock_sync.call_args.kwargs["data"])
+        assert body["output_format"] == "png"
+        assert body["size"] == "1024x1024"
+        assert "aspect_ratio" not in body
+        assert body["image_url"] == "data:image/png;base64,abc123"
 
 
 def test_is_image_only_model(client):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Headed QA (Keith): OpenRouter image create with `black-forest-labs/flux.2-klein-4b` failed HTTP 400 because the dedicated Images payload hardcoded `output_format: "webp"` (that model accepts only png/jpeg). The same path also inferred `aspect_ratio` from width/height and sent it alongside explicit pixel `size`. OpenRouter treats pixel `size` as authoritative and 400s when a paired `aspect_ratio` is considered mismatched; retries then sent other ratios.

## Change

Minimal payload fix in `OpenRouterShim.build_image_request`:

- Default `output_format` to `png` (Images API default; accepted by png/jpeg-only models and still valid for webp-capable models).
- Send `size` (`WxH`) only; do not infer/send `aspect_ratio`.

Create and img2img share this builder, so both paths pick up the same payload.

Example create payload for `black-forest-labs/flux.2-klein-4b`:

```json
{
  "prompt": "Draw a galaxy",
  "model": "black-forest-labs/flux.2-klein-4b",
  "n": 1,
  "output_format": "png",
  "size": "1024x576"
}
```

## Tests

- Updated `test_openrouter_shim_image` to expect `png` and no `aspect_ratio`.
- Added `test_openrouter_shim_image_flux_klein_png_no_aspect` for flux.2-klein-4b create + img2img.

Local verification:

- `pytest tests/framework/test_client_llm.py -k openrouter_shim_image`: 2 passed
- `pytest tests/framework/test_client_llm.py`: 73 passed
- `make typecheck`: ruff, ty, bandit, pyspector, opengrep, basedpyright, mypy, thread-safety all clean

Docs: short note in `docs/images/generation.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b218719a-2d2a-4159-b70b-b06edcf76055?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b218719a-2d2a-4159-b70b-b06edcf76055&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

