### PR TITLE
Images: parent edit steer + default source_image=selection when selected

### DIFF
--- a/docs/images/generation.md
+++ b/docs/images/generation.md
@@ -17,7 +17,7 @@ Image generation and editing in WriterAgent uses the **same endpoint URL and API
 [`plugin/writer/images/images.py`](../../plugin/writer/images/images.py) — `image_generate` tool (also via `delegate_to_specialized_*_toolset(domain="images")`):
 
 - Text-to-image from a prompt.
-- Img2img when `source_image='selection'` and an image is selected in the document.
+- Img2img when `source_image='selection'` and an image is selected in the document. Omitting `source_image` while a graphic is selected also edits in place (parent/specialist often drop the argument after rewriting an edit into a generate-new prompt).
 
 [`plugin/writer/images/image_tools.py`](../../plugin/writer/images/image_tools.py):
 
@@ -64,9 +64,11 @@ Single `generate_image(prompt, source_image=...)` API:
 | **OpenRouter** | Multimodal user message: text prompt + source image as `image_url` data URL; same response parsing as create. |
 | **OpenAI-compatible / Ollama / Together-style** | Same image endpoint as create; optional `source_image` / `image_url` in the request body where the shim supports it. |
 
-Tool usage: pass `source_image='selection'` with an image selected in the document; optional `strength` (default 0.75) controls edit strength.
+Tool usage: pass `source_image='selection'` with an image selected in the document; optional `strength` (default 0.75) controls edit strength. If `source_image` is omitted and a graphic is selected, `image_generate` treats that as an in-place edit. Clear the selection to create a new image.
 
-The images specialist is steered to that path: `images_specialized_sub_agent_hint()` plus `IMAGES_SPECIALIZED_EXAMPLES` (`writer:images` / `calc:images` / `draw:images`). Edit/change/restyle of an existing or selected image (e.g. “make it look like a wizard”) must call `image_generate` with `source_image='selection'` so img2img + `replace_image_in_place` keep the graphic in the same frame. A delete plus a prompt-only generate creates a new image instead of editing.
+The **parent** main agent is steered in `SPECIALIZED_TASK_RULES` and `DELEGATE_SPECIALIZED_TASK_PARAM_HINT`: when the user wants to edit/change/restyle an existing or selected image, the `delegate_to_specialized_*` `task` must instruct `image_generate(source_image='selection')` and keep the user's wording. A generate-new paraphrase (“Generate an image of … dressed as a wizard”) is what the specialist then executes as create-new.
+
+The images specialist is steered the same way: `images_specialized_sub_agent_hint()` plus `IMAGES_SPECIALIZED_EXAMPLES` (`writer:images` / `calc:images` / `draw:images`). Edit/change/restyle of an existing or selected image (e.g. “make it look like a wizard”) must call `image_generate` with `source_image='selection'` so img2img + `replace_image_in_place` keep the graphic in the same frame. A delete plus a prompt-only generate creates a new image instead of editing.
 
 ## Future Work
 

--- a/plugin/framework/prompts.py
+++ b/plugin/framework/prompts.py
@@ -150,11 +150,23 @@ def delegation_math_to_python_hint(*, delegate_toolset: str) -> str:
 
 
 # Brief hint for gateway tool JSON schemas (see SPECIALIZED_TASK_RULES in system prompt).
-DELEGATE_SPECIALIZED_TASK_PARAM_HINT = "What the specialized task should accomplish."
+# Parent Nemotron Super rewrote "make it look like a wizard" into a generate-new
+# task; the specialist then omitted source_image. Schema + task rules must
+# keep the user's edit wording and name source_image='selection'.
+DELEGATE_SPECIALIZED_TASK_PARAM_HINT = (
+    "What the specialized task should accomplish. For edit/change/restyle of an "
+    "existing or selected image, instruct image_generate(source_image='selection') "
+    "and keep the user's wording so img2img replaces the graphic in place."
+)
 
 # Shared guidance for writing `task` strings when delegating to specialized sub-agents.
+# Must stay a single line (delegation templates are one line; tests assert no newlines).
 SPECIALIZED_TASK_RULES = (
-    "Pass a clear `task` describing what the specialized task should accomplish."
+    "Pass a clear `task` describing what the specialized task should accomplish. "
+    "When the user wants to edit, change, or restyle an existing or selected image, "
+    "the task must instruct image_generate(source_image='selection') and keep the "
+    "user's wording (for example 'make it look like a wizard') so img2img replaces "
+    "the graphic in place."
 )
 
 
@@ -413,8 +425,9 @@ WRITER_NAVIGATION_RULES = """NAVIGATING LARGE DOCUMENTS (map first, then drill �
 - Reserve get_document_content(scope='full') for short documents or a deliberate full read."""
 
 WRITER_IMAGES_RULES = """IMAGES:
-- Image tools live in the 'images' domain: image_insert, image_delete, image_replace, image_list, image_get_info (includes crop_mm), image_download.
+- Image tools live in the 'images' domain: image_generate, image_insert, image_delete, image_replace, image_list, image_get_info (includes crop_mm), image_download.
   Extract text and structure (layout, tables) from images with extract_structure_from_image in the 'vision' domain; inserts a high-quality representation into the document.
+- To edit, change, or restyle an existing or selected image, delegate domain=images with a task that instructs image_generate(source_image='selection') and keeps the user's wording (e.g. 'make it look like a wizard'). That runs img2img and replace_image_in_place. A generate-new paraphrase inserts a new graphic.
 - Writer letterhead logos: image_insert(target='header'|'footer'). A different first page needs page_set_style_properties(first_is_shared=false) then target='header_first' (or footer_first) — otherwise the logo lands in the shared header and repeats on every page.
 - image_set_properties resizes (width_mm/height_mm), repositions (hori_orient/vert_orient — friendly values like left/center/right/top/bottom work), and crops (crop_top_mm / crop_bottom_mm / crop_left_mm / crop_right_mm — mm trimmed per edge).
 - To actually SEE an image (vision-capable models), call get_image — by graphic name, selection=true, or page=N to render that whole page.

--- a/plugin/writer/images/images.py
+++ b/plugin/writer/images/images.py
@@ -61,17 +61,39 @@ from .image_tools import (
 log = logging.getLogger("writeragent.writer")
 
 
+def resolve_image_generate_is_edit(source_image: typing.Any, *, selection_available: bool) -> bool:
+    """True when image_generate should img2img the selected graphic.
+
+    Explicit ``source_image='selection'`` always edits. Omitting ``source_image``
+    also edits when a graphic is selected: the parent often rewrites
+    "make it look like a wizard" into a generate-new task and drops the
+    argument; defaulting to the selection keeps ``replace_image_in_place``.
+    Create-new when nothing is selected (clear the selection to force create).
+    """
+    if isinstance(source_image, str):
+        source_image = source_image.strip() or None
+    if source_image and str(source_image).lower() == "selection":
+        return True
+    return source_image is None and selection_available
+
+
 class ImageGenerate(ToolWriterImageBase):
     """Generate a new image from a prompt, or edit an existing image (Img2Img)."""
 
     name = "image_generate"
     intent = "media"
-    description = "Generate an image from a text prompt and insert it. To edit an existing image, pass source_image='selection' and select an image first."
+    description = (
+        "Generate an image from a text prompt and insert it. "
+        "To edit an existing image, pass source_image='selection' (or omit it while a graphic is selected)."
+    )
     parameters = {
         "type": "object",
         "properties": {
             "prompt": {"type": "string", "description": "Descriptive prompt for image generation or editing"},
-            "source_image": {"type": "string", "description": ("Optional. Use 'selection' to edit the currently selected image (Img2Img). Omit to generate a new image.")},
+            "source_image": {"type": "string", "description": (
+                "Optional. Use 'selection' to edit the currently selected image (Img2Img). "
+                "Omit while a graphic is selected to edit in place; omit with no selection to create a new image."
+            )},
             "strength": {"type": "number", "description": "For editing: how much to change the image (0.0-1.0). Ignored when generating new.", "default": 0.75},
             "aspect_ratio": {"type": "string", "enum": ["square", "landscape_16_9", "portrait_9_16", "landscape_3_2", "portrait_2_3", "1:1", "4:3", "3:4", "16:9", "9:16"], "default": "square"},
             "base_size": {"type": "integer", "description": "Base dimension for scaling", "default": 512},
@@ -104,11 +126,14 @@ class ImageGenerate(ToolWriterImageBase):
         if isinstance(source_image, str):
             source_image = source_image.strip() or None
 
-        is_edit = source_image and source_image.lower() == "selection"
+        explicit_edit = bool(source_image and source_image.lower() == "selection")
         source_b64 = None
         edit_width, edit_height = 512, 512
+        is_edit = False
 
-        if is_edit:
+        # Peek selection when the caller asked to edit, or omitted source_image
+        # (omitted + selected graphic → img2img; omitted + no selection → create).
+        if explicit_edit or source_image is None:
 
             def _read_selection_for_edit():
                 b64 = get_selected_image_base64(ctx.doc, ctx.ctx)
@@ -120,11 +145,14 @@ class ImageGenerate(ToolWriterImageBase):
                 return ("ok", (b64, ew, eh))
 
             tag, payload = _run_on_main(_read_selection_for_edit, timeout=mt_timeout)
-            if tag == "no_selection":
+            selection_available = tag == "ok"
+            is_edit = resolve_image_generate_is_edit(source_image, selection_available=selection_available)
+            if explicit_edit and not selection_available:
                 return self._tool_error("No image selected. Please select an image in the document first.", code="NO_SELECTION", action="edit_image")
-            if not isinstance(payload, tuple) or len(payload) != 3 or payload[1] is None or payload[2] is None:
-                return self._tool_error("Could not read selected image.", code="SELECTION_READ_ERROR")
-            source_b64, edit_width, edit_height = (str(payload[0]), int(payload[1]), int(payload[2]))
+            if is_edit:
+                if not isinstance(payload, tuple) or len(payload) != 3 or payload[1] is None or payload[2] is None:
+                    return self._tool_error("Could not read selected image.", code="SELECTION_READ_ERROR")
+                source_b64, edit_width, edit_height = (str(payload[0]), int(payload[1]), int(payload[2]))
 
         base_size = args.get("base_size", get_config_int("image_base_size"))
         try:

--- a/tests/framework/test_constants.py
+++ b/tests/framework/test_constants.py
@@ -19,6 +19,9 @@ from plugin.framework.prompts import (
     get_core_directives,
     get_greeting_for_document,
     get_specialized_delegation_for_model,
+    DELEGATE_SPECIALIZED_TASK_PARAM_HINT,
+    SPECIALIZED_TASK_RULES,
+    WRITER_IMAGES_RULES,
     images_specialized_sub_agent_hint,
     python_specialized_sub_agent_hint,
 )
@@ -293,6 +296,7 @@ def test_specialized_delegation_block_is_single_line():
     block = get_specialized_delegation_for_model(model)
     assert "SPECIALIZED WRITER" in block
     assert SPECIALIZED_TASK_RULES in block
+    assert "source_image='selection'" in block
     assert "Enumerate what must be true" not in block
     assert "\n" not in block
     assert get_specialized_delegation_tool_hint(ToolWriterSpecialBase, "Writer") == block
@@ -464,6 +468,16 @@ def test_core_directives_prohibit_asking_user_to_paste():
     assert "MUST NOT ask the user where the file is stored" in DRAW_CORE_DIRECTIVES
     assert 'delegate_to_specialized_draw_toolset(domain="document_research") once' in DRAW_CORE_DIRECTIVES
     assert "described file(s)" in DRAW_CORE_DIRECTIVES
+
+
+def test_parent_images_edit_task_steers_source_image():
+    """Parent must pass an edit task, not a generate-new paraphrase."""
+    for text in (SPECIALIZED_TASK_RULES, DELEGATE_SPECIALIZED_TASK_PARAM_HINT, WRITER_IMAGES_RULES):
+        assert "source_image" in text
+        assert "selection" in text
+        assert "image_generate" in text
+    assert "make it look like a wizard" in SPECIALIZED_TASK_RULES
+    assert "\n" not in SPECIALIZED_TASK_RULES
 
 
 def test_images_specialized_sub_agent_hint_steers_source_image():

--- a/tests/writer/images/test_images.py
+++ b/tests/writer/images/test_images.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 from plugin.tests.testing_utils import TestingFactory, setup_uno_mocks
 setup_uno_mocks()
 
-from plugin.writer.images.images import ImageInsert, _resolve_orient
+from plugin.writer.images.images import ImageGenerate, ImageInsert, _resolve_orient, resolve_image_generate_is_edit
 
 
 def test_resolve_orient_named_positions():
@@ -99,3 +99,69 @@ def test_image_insert_routes_footer_first_to_region_helper():
     assert res["status"] == "ok"
     assert res["target"] == "footer_first"
     assert insert.call_args.args[2] == "footer_first"
+
+
+def test_resolve_image_generate_is_edit_defaults_to_selection():
+    assert resolve_image_generate_is_edit(None, selection_available=True) is True
+    assert resolve_image_generate_is_edit("", selection_available=True) is True
+    assert resolve_image_generate_is_edit("  ", selection_available=True) is True
+    assert resolve_image_generate_is_edit("selection", selection_available=True) is True
+    assert resolve_image_generate_is_edit("SELECTION", selection_available=False) is True
+    assert resolve_image_generate_is_edit(None, selection_available=False) is False
+    assert resolve_image_generate_is_edit("", selection_available=False) is False
+
+
+def test_image_generate_omitted_source_edits_when_selected():
+    """Omitted source_image + selected graphic → img2img replace, not a new insert."""
+    ctx = TestingFactory.create_context(doc_type="writer")
+    svc = MagicMock()
+    svc.generate_image.return_value = (["/tmp/edited.png"], None)
+
+    def _run(fn, *args, timeout=60.0, **kwargs):
+        return fn(*args, **kwargs)
+
+    with (
+        patch("plugin.writer.images.images._run_on_main", side_effect=_run),
+        patch("plugin.writer.images.images.get_selected_image_base64", return_value="b64sel"),
+        patch("plugin.writer.images.images.get_selected_image_dimensions_px", return_value=(640, 480)),
+        patch("plugin.writer.images.images.ImageService", return_value=svc),
+        patch("plugin.writer.images.images.replace_image_in_place", return_value=True) as replace,
+        patch("plugin.writer.images.images.insert_image") as insert,
+        patch("plugin.writer.images.images.get_config_int", return_value=512),
+        patch("plugin.writer.images.images.get_config_bool", return_value=False),
+        patch("plugin.writer.images.images.get_config_str", return_value="square"),
+        patch("plugin.writer.images.images.get_image_model", return_value=""),
+    ):
+        res = ImageGenerate().execute(ctx, prompt="make it look like a wizard")
+    assert res["status"] == "ok"
+    assert "edited" in res["message"].lower()
+    assert svc.generate_image.call_args.kwargs.get("source_image") == "b64sel"
+    replace.assert_called_once()
+    insert.assert_not_called()
+
+
+def test_image_generate_omitted_source_creates_when_no_selection():
+    ctx = TestingFactory.create_context(doc_type="writer")
+    svc = MagicMock()
+    svc.generate_image.return_value = (["/tmp/new.png"], None)
+
+    def _run(fn, *args, timeout=60.0, **kwargs):
+        return fn(*args, **kwargs)
+
+    with (
+        patch("plugin.writer.images.images._run_on_main", side_effect=_run),
+        patch("plugin.writer.images.images.get_selected_image_base64", return_value=None),
+        patch("plugin.writer.images.images.ImageService", return_value=svc),
+        patch("plugin.writer.images.images.replace_image_in_place") as replace,
+        patch("plugin.writer.images.images.insert_image") as insert,
+        patch("plugin.writer.images.images.get_config_int", return_value=512),
+        patch("plugin.writer.images.images.get_config_bool", return_value=False),
+        patch("plugin.writer.images.images.get_config_str", return_value="square"),
+        patch("plugin.writer.images.images.get_image_model", return_value=""),
+    ):
+        res = ImageGenerate().execute(ctx, prompt="a tabby cat")
+    assert res["status"] == "ok"
+    assert "generated" in res["message"].lower()
+    assert "source_image" not in svc.generate_image.call_args.kwargs
+    insert.assert_called_once()
+    replace.assert_not_called()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#757 steered the **images specialist**, and that hint/examples did land. Headed QA on the deployed tip still failed for chat/specialist edit:

1. User asked `make it look like a wizard` with a tabby already in the doc.
2. Parent (Nemotron Super) called `delegate_to_specialized_writer_toolset` with a **generate-new** task: “Generate an image of an orange and white longhair tabby cat … dressed as a wizard…”.
3. The specialist followed that task and called `image_generate` with prompt only → new frame `Image3`, not img2img/replace.

Delete+generate was the earlier bug; this one is the parent **rewriting** an edit into create-new, which poisons the specialist `task`.

## Change (DO + why)

1. **Parent steer** — `SPECIALIZED_TASK_RULES` (ambient delegation block) and `DELEGATE_SPECIALIZED_TASK_PARAM_HINT` (gateway `task` schema): when the user wants to edit/change/restyle an existing or selected image, the specialized `task` must instruct `image_generate(source_image='selection')` and keep the user’s wording. That keeps img2img + `replace_image_in_place`. A generate-new paraphrase is what the specialist then executes as create-new. Same note in on-demand `WRITER_IMAGES_RULES`.
2. **Tool default** — if a graphic is selected and `image_generate` omits `source_image`, treat as `source_image='selection'` (img2img + replace-in-place). Create-new when nothing is selected (clear the selection). No new API flag.

#757 specialist hint/examples are unchanged. Image-mode `_execute_direct_image_effect` is left alone (#759). Draft #750 is untouched.

## Tests

- Parent guidance (`SPECIALIZED_TASK_RULES`, task schema hint, `WRITER_IMAGES_RULES`, single-line delegation block) asserts `source_image='selection'`.
- `resolve_image_generate_is_edit` + `ImageGenerate.execute`: omitted `source_image` + selection → replace; no selection → insert.

## Docs

Short update in `docs/images/generation.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c610afe-f669-4174-99f3-6669b80e4646?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c610afe-f669-4174-99f3-6669b80e4646&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

